### PR TITLE
Binance is default provider

### DIFF
--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -85,7 +85,7 @@ def parse_args():
     parser.add_argument('--no-cache', action='store_true', help='Disable data caching')
     parser.add_argument('--cache-ttl', type=int, default=24, help='Cache TTL in hours (default: 24)')
     parser.add_argument('--no-db', action='store_true', help='Disable database logging for this backtest')
-    parser.add_argument('--provider', choices=['coinbase', 'binance'], default='coinbase', help='Exchange provider to use (default: coinbase)')
+    parser.add_argument('--provider', choices=['coinbase', 'binance'], default='binance', help='Exchange provider to use (default: binance)')
     return parser.parse_args()
 
 def get_date_range(args):
@@ -115,12 +115,12 @@ def main():
         logger.info(f"Loaded strategy: {strategy.name}")
         
         # Initialize data provider with caching
-        if args.provider == 'binance':
-            from data_providers.binance_provider import BinanceProvider
-            provider = BinanceProvider()
-        else:
+        if args.provider == 'coinbase':
             from data_providers.coinbase_provider import CoinbaseProvider
             provider = CoinbaseProvider()
+        else:
+            from data_providers.binance_provider import BinanceProvider
+            provider = BinanceProvider()
         if args.no_cache:
             data_provider = provider
             logger.info("Data caching disabled")

--- a/scripts/run_live_trading.py
+++ b/scripts/run_live_trading.py
@@ -7,13 +7,13 @@ It supports both paper trading (simulation) and live trading with real money.
 
 Usage:
     # Paper trading (default - safe)
-    python run_live_trading.py adaptive --symbol BTC-USD --paper-trading
+    python run_live_trading.py adaptive --symbol BTCUSDT --paper-trading
     
     # Live trading (requires explicit confirmation)
-    python run_live_trading.py adaptive --symbol BTC-USD --live-trading --i-understand-the-risks
+    python run_live_trading.py adaptive --symbol BTCUSDT --live-trading --i-understand-the-risks
     
     # With custom settings
-    python run_live_trading.py ml_with_sentiment --symbol BTC-USD --balance 5000 --max-position 0.05
+    python run_live_trading.py ml_with_sentiment --symbol BTCUSDT --balance 5000 --max-position 0.05
 """
 
 import argparse
@@ -100,7 +100,7 @@ def parse_args():
     parser.add_argument('strategy', help='Strategy name (e.g., adaptive, ml_with_sentiment)')
     
     # Trading parameters
-    parser.add_argument('--symbol', default='BTC-USD', help='Trading pair symbol (e.g., BTC-USD, ETH-USD)')
+    parser.add_argument('--symbol', default='BTCUSDT', help='Trading pair symbol (e.g., BTCUSDT, ETHUSDT)')
     parser.add_argument('--timeframe', default='1h', help='Candle timeframe')
     parser.add_argument('--balance', type=float, default=DEFAULT_INITIAL_BALANCE, help='Initial balance')
     parser.add_argument('--max-position', type=float, default=0.1, help='Max position size (0.1 = 10% of balance)')
@@ -121,7 +121,7 @@ def parse_args():
     parser.add_argument('--use-sentiment', action='store_true', help='Use sentiment analysis')
     parser.add_argument('--no-cache', action='store_true', help='Disable data caching')
     parser.add_argument('--mock-data', action='store_true', help='Use mock data provider for rapid testing')
-    parser.add_argument('--provider', choices=['coinbase', 'binance'], default='coinbase', help='Exchange provider to use (default: coinbase)')
+    parser.add_argument('--provider', choices=['coinbase', 'binance'], default='binance', help='Exchange provider to use (default: binance)')
     
     # Monitoring
     parser.add_argument('--webhook-url', help='Webhook URL for alerts')
@@ -229,12 +229,12 @@ def main():
             data_provider = MockDataProvider(interval_seconds=5)  # 5s candles for rapid testing
             logger.info("Using MockDataProvider for rapid testing")
         else:
-            if args.provider == 'binance':
-                from data_providers.binance_provider import BinanceProvider
-                provider = BinanceProvider()
-            else:
+            if args.provider == 'coinbase':
                 from data_providers.coinbase_provider import CoinbaseProvider
                 provider = CoinbaseProvider()
+            else:
+                from data_providers.binance_provider import BinanceProvider
+                provider = BinanceProvider()
             if args.no_cache:
                 data_provider = provider
                 logger.info("Data caching disabled")

--- a/scripts/train_price_model.py
+++ b/scripts/train_price_model.py
@@ -130,7 +130,7 @@ def export_onnx(model: nn.Module, seq_len: int, output_path: Path):
 
 def parse_args():
     p = argparse.ArgumentParser()
-    p.add_argument("--symbol", default="BTC-USD")
+    p.add_argument("--symbol", default="BTCUSDT")
     p.add_argument("--timeframe", default="1h", choices=["1h", "4h"], help="Candle timeframe for training")
     p.add_argument("--seq_len", type=int, default=120)
     p.add_argument("--start", default="2018-01-01")

--- a/src/live/trading_engine.py
+++ b/src/live/trading_engine.py
@@ -70,20 +70,20 @@ class Trade:
     
 def _create_exchange_provider(provider: str, config: dict):
     """Factory to create exchange provider and return (provider_instance, provider_name)."""
-    if provider == 'binance':
-        api_key = config.get('BINANCE_API_KEY')
-        api_secret = config.get('BINANCE_API_SECRET')
-        if api_key and api_secret:
-            return BinanceProvider(api_key, api_secret, testnet=False), 'Binance'
-        else:
-            return None, 'Binance (no credentials)'
-    else:
+    if provider == 'coinbase':
         api_key = config.get('COINBASE_API_KEY')
         api_secret = config.get('COINBASE_API_SECRET')
         if api_key and api_secret:
             return CoinbaseProvider(api_key, api_secret, testnet=False), 'Coinbase'
         else:
             return None, 'Coinbase (no credentials)'
+    else:
+        api_key = config.get('BINANCE_API_KEY')
+        api_secret = config.get('BINANCE_API_SECRET')
+        if api_key and api_secret:
+            return BinanceProvider(api_key, api_secret, testnet=False), 'Binance'
+        else:
+            return None, 'Binance (no credentials)'
 
 class LiveTradingEngine:
     """
@@ -117,7 +117,7 @@ class LiveTradingEngine:
         database_url: Optional[str] = None,  # Database connection URL
         max_consecutive_errors: int = 10,  # Maximum consecutive errors before shutdown
         account_snapshot_interval: int = 1800,  # Account snapshot interval in seconds (30 minutes)
-        provider: str = 'coinbase',  # 'coinbase' (default) or 'binance'
+        provider: str = 'binance',  # 'binance' (default) or 'coinbase'
     ):
         """
         Initialize the live trading engine.

--- a/src/strategies/base.py
+++ b/src/strategies/base.py
@@ -8,7 +8,7 @@ class BaseStrategy(ABC):
     """
     Abstract base class for all trading strategies.
     All concrete strategy implementations must inherit from this class.
-    Default trading pair is Coinbase style (e.g., BTC-USD).
+    Default trading pair is Binance style (e.g., BTCUSDT).
     """
     
     def __init__(self, name: str):
@@ -16,7 +16,7 @@ class BaseStrategy(ABC):
         self.logger = logging.getLogger(name)
         
         # Default trading pair - strategies can override this
-        self.trading_pair = 'BTC-USD'
+        self.trading_pair = 'BTCUSDT'
         
         # Strategy execution logging
         self.db_manager = None


### PR DESCRIPTION
## Switch Default Data Provider to Binance for Live Trading and Backtesting

### Summary

This PR changes the default data provider from **Coinbase** to **Binance** for both the live trading and backtesting engines. Coinbase will now only be used if explicitly specified using the `--provider` flag. This update ensures that all new runs and strategies default to Binance, which is more widely used and offers greater liquidity for most trading pairs.

---

### Key Changes

- **scripts/run_live_trading.py**
  - Default `--provider` is now `'binance'` instead of `'coinbase'`.
  - Default `--symbol` is now `'BTCUSDT'` (Binance style) instead of `'BTC-USD'`.
  - Usage examples updated to reflect Binance defaults.
  - Provider selection logic updated: Coinbase is only used if explicitly requested.

- **scripts/run_backtest.py**
  - Default `--provider` is now `'binance'`.
  - Provider selection logic updated to match live trading.

- **src/live/trading_engine.py**
  - Default `provider` parameter is now `'binance'`.
  - `_create_exchange_provider` factory logic updated to use Binance unless `'coinbase'` is explicitly specified.

- **src/strategies/base.py**
  - Default `trading_pair` is now `'BTCUSDT'` (Binance style) instead of `'BTC-USD'`.
  - Class docstring updated to clarify the default symbol style.

- **scripts/train_price_model.py**
  - Default `--symbol` is now `'BTCUSDT'`.

---

### Rationale

- **Market Standardization:** Binance is the most widely used exchange for algorithmic trading and offers the highest liquidity for most pairs.
- **User Experience:** Reduces friction for new users who expect Binance-style symbols and data by default.
- **Flexibility:** Coinbase remains available for users who explicitly require it, via the `--provider` flag.
- **Consistency:** Symbol handling and conversion is managed by the existing `SymbolFactory` utility, ensuring compatibility across exchanges.

---

### Testing

- All tests pass:  
  `python tests/run_tests.py all -q`
- Manual verification confirms:
  - Binance is the default provider in all relevant scripts and engines.
  - Default trading pairs and usage examples are consistent with Binance conventions.
  - Explicitly specifying `--provider coinbase` still works as expected.

---

### Special Attention

- If you have custom scripts or integrations that assume Coinbase-style symbols or defaults, please update them accordingly.
- No breaking changes for users who specify the provider explicitly.

---

**Please review and merge if approved.**  
Let me know if you have any questions or need further details!