### PR TITLE
CI: align Python to 3.11 to match runtime

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         split-index: [1, 2, 3, 4]
-        python-version: [3.12]
+        python-version: [3.11]
       fail-fast: false  # Continue running other groups if one fails
     
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #78. Align CI Python version to 3.11 to match Docker runtime and avoid TF/ABI mismatches.