### PR TITLE
Cache binance historical data for backtesting

### DIFF
--- a/src/data_providers/cached_data_provider.py
+++ b/src/data_providers/cached_data_provider.py
@@ -172,7 +172,8 @@ class CachedDataProvider(DataProvider):
         cache_path = self._get_cache_path(cache_key)
 
         # Try to load from cache first
-        if self._is_cache_valid(cache_path):
+        # For historical years (before current year), treat cache as always valid if file exists
+        if os.path.exists(cache_path) and (year < current_year or self._is_cache_valid(cache_path)):
             cached_data = self._load_from_cache(cache_path)
             if cached_data is not None:
                 logger.debug(f"Loaded {year} data from cache for {symbol} {timeframe}")
@@ -274,7 +275,8 @@ class CachedDataProvider(DataProvider):
             cache_key = self._generate_year_cache_key(symbol, timeframe, year)
             cache_path = self._get_cache_path(cache_key)
 
-            if self._is_cache_valid(cache_path):
+            # Historical years (before current year) are considered valid if the file exists
+            if os.path.exists(cache_path) and (year < datetime.now().year or self._is_cache_valid(cache_path)):
                 cached_years.append(year)
             else:
                 missing_years.append(year)


### PR DESCRIPTION
Add `warm` command to `cache_manager.py` to prefetch and cache 8 years of historical data for backtesting, and ensure historical cache does not expire.

---
<a href="https://cursor.com/background-agent?bcId=bc-d63a3c38-ce84-4fb9-950a-74733a9ba6e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d63a3c38-ce84-4fb9-950a-74733a9ba6e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

