### PR TITLE
Fix get_performance_metrics naming conflict

### DIFF
--- a/scripts/test_database.py
+++ b/scripts/test_database.py
@@ -113,7 +113,7 @@ def test_database_logging():
         logger.info(f"  - {trade['symbol']} P&L: ${trade['pnl']:.2f} ({trade['pnl_percent']:.2f}%)")
 
     # Get performance metrics
-    metrics = db_manager.get_performance_metrics(session_id=session_id)
+    metrics = db_manager.get_recent_performance_metrics(session_id=session_id)
     logger.info("Performance metrics:")
     logger.info(f"  - Total trades: {metrics['total_trades']}")
     logger.info(f"  - Win rate: {metrics['win_rate']:.1f}%")

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -1586,7 +1586,7 @@ class DatabaseManager:
             logger.error(f"Failed to log risk adjustment: {e}")
             raise
 
-    def get_performance_metrics(
+    def get_recent_performance_metrics(
         self,
         session_id: int,
         start_date: datetime = None,

--- a/tests/integration/live_trading/test_database_logging.py
+++ b/tests/integration/live_trading/test_database_logging.py
@@ -212,7 +212,7 @@ class TestDatabaseLogging:
             "session_id": session_id,
         }
         db_manager.log_trade(**trade_data)
-        metrics = db_manager.get_performance_metrics(session_id=session_id)
+        metrics = db_manager.get_recent_performance_metrics(session_id=session_id)
         assert metrics["total_trades"] >= 1
         db_manager.end_trading_session(session_id)
 

--- a/tests/mocks/mock_database.py
+++ b/tests/mocks/mock_database.py
@@ -338,6 +338,11 @@ class MockDatabaseManager:
 
     def get_performance_metrics(self, session_id: Optional[int] = None) -> dict[str, Any]:
         """Get performance metrics"""
+        # Backwards-compat delegator: historical callers may use this name
+        return self.get_recent_performance_metrics(session_id=session_id)
+
+    def get_recent_performance_metrics(self, session_id: Optional[int] = None) -> dict[str, Any]:
+        """Get recent performance metrics (session-scoped)"""
         if session_id is None:
             session_id = self._current_session_id
 

--- a/tests/unit/position_management/test_dynamic_risk_database.py
+++ b/tests/unit/position_management/test_dynamic_risk_database.py
@@ -264,7 +264,7 @@ class TestDatabaseManagerMethods:
         mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = mock_trades
 
         # Test calculation
-        metrics = db_manager.get_performance_metrics(
+        metrics = db_manager.get_recent_performance_metrics(
             session_id=123,
             start_date=datetime.utcnow() - timedelta(days=30)
         )
@@ -288,7 +288,7 @@ class TestDatabaseManagerMethods:
         mock_session.query.return_value.filter.return_value.filter.return_value.filter.return_value.filter.return_value.all.return_value = []
 
         # Test calculation with no data
-        metrics = db_manager.get_performance_metrics(session_id=123)
+        metrics = db_manager.get_recent_performance_metrics(session_id=123)
 
         # Should return safe defaults
         assert metrics["total_trades"] == 0

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -410,8 +410,8 @@ class TestDataRetrieval(TestDatabaseManager):
         mock_query.all.return_value = [mock_trade]
         mock_postgresql_db._mock_session.query.return_value = mock_query
 
-        # Use the second get_performance_metrics method (which requires session_id)
-        metrics = mock_postgresql_db.get_performance_metrics(session_id=123)
+        # Use the recent performance metrics method (which requires session_id)
+        metrics = mock_postgresql_db.get_recent_performance_metrics(session_id=123)
 
         assert isinstance(metrics, dict)
         assert "total_trades" in metrics


### PR DESCRIPTION
Rename session-scoped `get_performance_metrics` to `get_recent_performance_metrics` to resolve method signature conflict and prevent breakage.

---
<a href="https://cursor.com/background-agent?bcId=bc-43ea7124-0633-46c4-9d2c-f3b7601aabdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43ea7124-0633-46c4-9d2c-f3b7601aabdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

