### PR TITLE
Fix pytest pythonpath to include src directory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,8 +9,9 @@ timeout = 120
 timeout_method = signal
 norecursedirs = .git .venv venv dist build logs .mypy_cache __pycache__
 
-# Ensure project root is on sys.path so `import src.*` resolves consistently
-pythonpath = .
+# Ensure both the project root and the `src` directory are available on sys.path during tests
+# so imports like `import live.trading_engine` resolve correctly when using the src/ layout.
+pythonpath = . src
 
 # Use importlib to avoid test module import mismatches across identical basenames
 import_mode = importlib


### PR DESCRIPTION
## Summary
- ensure pytest adds both the repository root and src directory to sys.path so src-layout packages like `live` import correctly

## Testing
- pytest tests/integration/live_trading/test_engine_core.py::TestLiveTradingEngine::test_engine_initialization -q

------
https://chatgpt.com/codex/tasks/task_e_68cb22f60eb0832fb2f214adb45fedce