### PR TITLE
Add regression safeguard for rolling OLS helper

### DIFF
--- a/tests/unit/regime/test_regime_detector.py
+++ b/tests/unit/regime/test_regime_detector.py
@@ -2,8 +2,89 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from src.regime import RegimeConfig, RegimeDetector
+
+
+@pytest.fixture(scope="module")
+def rolling_ols_regression_baseline():
+    """Deterministic baseline for the rolling OLS regression helper."""
+
+    prices = pd.Series(np.linspace(100.0, 200.0, 25), name="close")
+    window = 10
+    baseline_slopes = np.array(
+        [
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            3.5301395907215532e-02,
+            3.4090813820782596e-02,
+            3.2960937086141493e-02,
+            3.1903916497827214e-02,
+            3.0912893331543825e-02,
+            2.9981847233983377e-02,
+            2.9105471417943810e-02,
+            2.8279069589811904e-02,
+            2.7498470303878066e-02,
+            2.6759955389056985e-02,
+            2.6060199813985914e-02,
+            2.5396220906882251e-02,
+            2.4765335270506460e-02,
+            2.4165122061650814e-02,
+            2.3593391561837376e-02,
+            2.3048158168403280e-02,
+        ]
+    )
+    baseline_r2 = np.array(
+        [
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            np.nan,
+            9.9800119874779356e-01,
+            9.9813624573380360e-01,
+            9.9825800003010322e-01,
+            9.9836815710894969e-01,
+            9.9846814955810634e-01,
+            9.9855919467675505e-01,
+            9.9864233228278224e-01,
+            9.9871845497277623e-01,
+            9.9878833251332530e-01,
+            9.9885263163254431e-01,
+            9.9891193217951106e-01,
+            9.9896674039563061e-01,
+            9.9901749987441204e-01,
+            9.9906460065957061e-01,
+            9.9910838683500984e-01,
+            9.9914916288631137e-01,
+        ]
+    )
+    return prices, window, baseline_slopes, baseline_r2
+
+
+def test_rolling_ols_regression(rolling_ols_regression_baseline):
+    prices, window, baseline_slopes, baseline_r2 = rolling_ols_regression_baseline
+
+    slopes, r2 = RegimeDetector._rolling_ols_slope_and_r2(prices, window)
+
+    np.testing.assert_allclose(
+        slopes.to_numpy(), baseline_slopes, rtol=1e-12, atol=1e-12, equal_nan=True
+    )
+    np.testing.assert_allclose(
+        r2.to_numpy(), baseline_r2, rtol=1e-12, atol=1e-12, equal_nan=True
+    )
 
 
 def make_trend_series(n=200, slope=0.001, noise=0.0, start=30000.0):


### PR DESCRIPTION
## Summary
- add a deterministic fixture that provides baseline slope and R² outputs for the rolling OLS helper
- add a regression test that compares current helper outputs against the stored baselines with tight tolerances

## Testing
- pytest tests/unit/regime/test_regime_detector.py::test_rolling_ols_regression

------
https://chatgpt.com/codex/tasks/task_e_68dbce604470832f94963a86a7db282b