### PR TITLE
Ensure deterministic regime detector tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ especially for setting up mock data, test environments, and common objects.
 """
 
 import os
+import random
 import tempfile
 import time
 from datetime import datetime, timedelta
@@ -20,6 +21,24 @@ import pytest
 from src.data_providers.data_provider import DataProvider
 from src.risk.risk_manager import RiskParameters
 from src.strategies.base import BaseStrategy
+
+REGIME_TEST_SEED = 1337
+
+
+def _is_regime_test(item: pytest.Item) -> bool:
+    try:
+        path = Path(str(item.fspath))
+    except Exception:
+        return False
+    return "tests/unit/regime" in str(path)
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Ensure deterministic randomness for regime detector tests."""
+
+    if _is_regime_test(item):
+        random.seed(REGIME_TEST_SEED)
+        np.random.seed(REGIME_TEST_SEED)
 
 # Import account sync dependencies
 try:

--- a/tests/unit/regime/test_regime_detector.py
+++ b/tests/unit/regime/test_regime_detector.py
@@ -1,15 +1,33 @@
 from datetime import datetime, timedelta
+from typing import Optional
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from src.regime import RegimeConfig, RegimeDetector
 
+TEST_RANDOM_SEED = 1337
 
-def make_trend_series(n=200, slope=0.001, noise=0.0, start=30000.0):
+
+@pytest.fixture()
+def seeded_rng() -> np.random.Generator:
+    """Provide a deterministic RNG for synthetic trend series."""
+
+    return np.random.default_rng(TEST_RANDOM_SEED)
+
+
+def make_trend_series(
+    n=200,
+    slope=0.001,
+    noise=0.0,
+    start=30000.0,
+    rng: Optional[np.random.Generator] = None,
+):
+    rng = rng or np.random.default_rng()
     t = np.arange(n)
     base = start * (1.0 + slope * t)
-    noise_arr = np.random.normal(0.0, noise * start, size=n)
+    noise_arr = rng.normal(0.0, noise * start, size=n)
     prices = np.maximum(1.0, base + noise_arr)
     ts = [datetime(2024, 1, 1) + timedelta(hours=i) for i in range(n)]
     return pd.DataFrame(
@@ -18,14 +36,14 @@ def make_trend_series(n=200, slope=0.001, noise=0.0, start=30000.0):
             "high": prices * 1.001,
             "low": prices * 0.999,
             "close": prices,
-            "volume": np.random.uniform(1.0, 2.0, size=n),
+            "volume": rng.uniform(1.0, 2.0, size=n),
         },
         index=pd.to_datetime(ts),
     )
 
 
-def test_regime_detector_trend_up_basic():
-    df = make_trend_series(n=300, slope=0.001, noise=0.0)
+def test_regime_detector_trend_up_basic(seeded_rng):
+    df = make_trend_series(n=300, slope=0.001, noise=0.0, rng=seeded_rng)
     cfg = RegimeConfig(
         slope_window=50, atr_window=14, atr_percentile_lookback=60, hysteresis_k=2, min_dwell=5
     )
@@ -35,9 +53,8 @@ def test_regime_detector_trend_up_basic():
     # Expect last label to be trend_up
     assert str(out["trend_label"].iloc[-1]) == "trend_up"
 
-
-def test_regime_detector_trend_down_basic():
-    df = make_trend_series(n=300, slope=-0.001, noise=0.0)
+def test_regime_detector_trend_down_basic(seeded_rng):
+    df = make_trend_series(n=300, slope=-0.001, noise=0.0, rng=seeded_rng)
     cfg = RegimeConfig(
         slope_window=50, atr_window=14, atr_percentile_lookback=60, hysteresis_k=2, min_dwell=5
     )
@@ -45,9 +62,8 @@ def test_regime_detector_trend_down_basic():
     out = rd.annotate(df)
     assert str(out["trend_label"].iloc[-1]) == "trend_down"
 
-
-def test_regime_detector_range_label_under_low_slope():
-    df = make_trend_series(n=300, slope=0.0, noise=0.0001)
+def test_regime_detector_range_label_under_low_slope(seeded_rng):
+    df = make_trend_series(n=300, slope=0.0, noise=0.0001, rng=seeded_rng)
     cfg = RegimeConfig(
         slope_window=50,
         atr_window=14,
@@ -61,13 +77,20 @@ def test_regime_detector_range_label_under_low_slope():
     # With near-zero slope, should be range or not strongly trending
     assert str(out["trend_label"].iloc[-1]) in {"range", "trend_up", "trend_down"}
 
-
-def test_regime_hysteresis_prevents_flips():
+def test_regime_hysteresis_prevents_flips(seeded_rng):
     # Alternate slight up/down segments to try to force flips
     parts = []
     for j in range(6):
         slope = 0.001 if j % 2 == 0 else -0.001
-        parts.append(make_trend_series(n=50, slope=slope, noise=0.0, start=30000 + j * 10))
+        parts.append(
+            make_trend_series(
+                n=50,
+                slope=slope,
+                noise=0.0,
+                start=30000 + j * 10,
+                rng=seeded_rng,
+            )
+        )
     df = pd.concat(parts)
     cfg = RegimeConfig(
         slope_window=30, atr_window=14, atr_percentile_lookback=60, hysteresis_k=5, min_dwell=30
@@ -79,9 +102,8 @@ def test_regime_hysteresis_prevents_flips():
     switches = sum(1 for i in range(1, len(labels)) if labels[i] != labels[i - 1])
     assert switches < 4
 
-
-def test_confidence_in_0_1_range():
-    df = make_trend_series(n=200, slope=0.002, noise=0.001)
+def test_confidence_in_0_1_range(seeded_rng):
+    df = make_trend_series(n=200, slope=0.002, noise=0.001, rng=seeded_rng)
     rd = RegimeDetector(RegimeConfig(slope_window=40, atr_window=14, atr_percentile_lookback=80))
     out = rd.annotate(df)
     conf = out["regime_confidence"].dropna()


### PR DESCRIPTION
## Summary
- seed Python and NumPy RNGs before regime detector tests via a pytest hook
- refactor regime detector unit tests to use a deterministic Generator for synthetic data

## Testing
- pytest tests/unit/regime/test_regime_detector.py

------
https://chatgpt.com/codex/tasks/task_e_68dbcea4a004832fbc998c4214a3f84a