### PR TITLE
Add strategy runtime scaffolding and feature pipeline

### DIFF
--- a/src/strategies/runtime/__init__.py
+++ b/src/strategies/runtime/__init__.py
@@ -1,0 +1,16 @@
+"""Public exports for the strategy runtime package."""
+from .feature_generator import (
+    FeatureGenerator,
+    FeatureGeneratorResult,
+    IncrementalFeatureUpdate,
+)
+from .runtime import RuntimeContext, StrategyDataset, StrategyRuntime
+
+__all__ = [
+    "FeatureGenerator",
+    "FeatureGeneratorResult",
+    "IncrementalFeatureUpdate",
+    "RuntimeContext",
+    "StrategyDataset",
+    "StrategyRuntime",
+]

--- a/src/strategies/runtime/feature_generator.py
+++ b/src/strategies/runtime/feature_generator.py
@@ -1,0 +1,94 @@
+"""Feature generator interfaces for the strategy runtime."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Mapping, MutableMapping
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass(slots=True)
+class FeatureGeneratorResult:
+    """Result returned by :class:`FeatureGenerator.generate`.
+
+    The runtime expects feature generators to return a frame containing the
+    derived columns. Implementations may optionally provide a cache payload
+    that will be stored on the :class:`StrategyDataset` so incremental updates
+    during live trading can reuse expensive intermediate values.
+    """
+
+    features: pd.DataFrame
+    cache: MutableMapping[str, Any] | None = None
+
+
+@dataclass(slots=True)
+class IncrementalFeatureUpdate:
+    """Represents the outcome of an incremental feature update."""
+
+    row: Mapping[str, Any]
+    cache: MutableMapping[str, Any] | None = None
+
+
+class FeatureGenerator(ABC):
+    """Base interface for declaring strategy feature requirements.
+
+    Feature generators run once during :meth:`StrategyRuntime.prepare_data`
+    to extend the shared market data frame with derived columns. Implementations
+    can optionally override :meth:`update` to support constant time updates for
+    streaming data.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        required_columns: Iterable[str] | None = None,
+        warmup_period: int = 0,
+    ) -> None:
+        self.name = name
+        self.required_columns = frozenset(required_columns or [])
+        self._warmup_period = warmup_period
+
+    @property
+    def warmup_period(self) -> int:
+        """Return the minimum history length required by the generator."""
+
+        return self._warmup_period
+
+    def validate(self, df: pd.DataFrame) -> None:
+        """Validate that the incoming frame contains the required columns."""
+
+        missing = self.required_columns.difference(df.columns)
+        if missing:
+            raise ValueError(
+                f"Feature generator '{self.name}' missing required columns: {sorted(missing)}"
+            )
+
+    @abstractmethod
+    def generate(self, df: pd.DataFrame) -> FeatureGeneratorResult:
+        """Produce vectorised feature columns for the provided data frame."""
+
+    def update(
+        self,
+        df: pd.DataFrame,
+        index: int,
+        previous_cache: MutableMapping[str, Any] | None = None,
+    ) -> IncrementalFeatureUpdate | None:
+        """Compute the next row of features for streaming contexts.
+
+        Implementations may override this method when incremental updates can be
+        computed more efficiently than recomputing the full feature frame. The
+        default implementation returns ``None`` signalling that the runtime
+        should fall back to batch generation if incremental updates are not
+        supported.
+        """
+
+        return None
+
+
+__all__ = [
+    "FeatureGenerator",
+    "FeatureGeneratorResult",
+    "IncrementalFeatureUpdate",
+]

--- a/src/strategies/runtime/runtime.py
+++ b/src/strategies/runtime/runtime.py
@@ -1,0 +1,130 @@
+"""Runtime orchestration layer for component strategies."""
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import pandas as pd
+
+from ..components.risk_manager import Position
+from ..components.strategy import Strategy
+from .feature_generator import FeatureGenerator, FeatureGeneratorResult
+
+
+@dataclass(slots=True)
+class StrategyDataset:
+    """Container describing the prepared market data for a strategy run."""
+
+    data: pd.DataFrame
+    warmup_period: int
+    feature_caches: MutableMapping[str, MutableMapping[str, Any]] = field(
+        default_factory=dict
+    )
+
+
+@dataclass(slots=True)
+class RuntimeContext:
+    """Mutable context passed to :meth:`StrategyRuntime.process` calls."""
+
+    balance: float
+    current_positions: list[Position] | None = None
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+
+class StrategyRuntime:
+    """Prepare and execute component strategies over a dataset."""
+
+    def __init__(self, strategy: Strategy) -> None:
+        self.strategy = strategy
+        self._dataset: StrategyDataset | None = None
+        self._feature_generators: list[FeatureGenerator] = []
+
+    @property
+    def dataset(self) -> StrategyDataset | None:
+        """Return the currently prepared dataset, if any."""
+
+        return self._dataset
+
+    def prepare_data(self, df: pd.DataFrame) -> StrategyDataset:
+        """Prepare the dataframe and return the runtime dataset."""
+
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError("StrategyRuntime.prepare_data expects a pandas DataFrame")
+
+        prepared = df.copy(deep=False)
+        feature_caches: MutableMapping[str, MutableMapping[str, Any]] = {}
+
+        generators = list(self.strategy.get_feature_generators())
+        self._feature_generators = generators
+
+        warmup = max(
+            [self.strategy.warmup_period, *[g.warmup_period for g in generators]]
+            or [0]
+        )
+
+        for generator in generators:
+            generator.validate(prepared)
+            result = generator.generate(prepared)
+            if not isinstance(result, FeatureGeneratorResult):
+                raise TypeError(
+                    f"Feature generator '{generator.name}' must return FeatureGeneratorResult"
+                )
+
+            if not isinstance(result.features, pd.DataFrame):
+                raise TypeError(
+                    f"Feature generator '{generator.name}' returned non-DataFrame features"
+                )
+
+            for column in result.features.columns:
+                prepared[column] = result.features[column]
+
+            if result.cache is not None:
+                feature_caches[generator.name] = result.cache
+
+        dataset = StrategyDataset(prepared, warmup, feature_caches)
+        self._dataset = dataset
+
+        if hasattr(self.strategy, "prepare_runtime"):
+            self.strategy.prepare_runtime(dataset)
+
+        return dataset
+
+    def process(self, index: int, context: RuntimeContext) -> Any:
+        """Process a single index using the prepared dataset."""
+
+        if self._dataset is None:
+            raise RuntimeError("StrategyRuntime.process called before prepare_data")
+
+        if index < 0 or index >= len(self._dataset.data):
+            raise IndexError(
+                f"Index {index} out of bounds for dataset of length {len(self._dataset.data)}"
+            )
+
+        return self.strategy.process_candle(
+            self._dataset.data,
+            index,
+            balance=context.balance,
+            current_positions=context.current_positions,
+        )
+
+    def finalize(self) -> StrategyDataset | None:
+        """Finalize the run and allow the strategy to clean up state."""
+
+        dataset = self._dataset
+        if dataset is None:
+            return None
+
+        if hasattr(self.strategy, "finalize_runtime"):
+            self.strategy.finalize_runtime(dataset)
+
+        self._dataset = None
+        self._feature_generators = []
+        return dataset
+
+
+__all__ = [
+    "RuntimeContext",
+    "StrategyDataset",
+    "StrategyRuntime",
+]

--- a/tests/strategies/runtime/test_strategy_runtime.py
+++ b/tests/strategies/runtime/test_strategy_runtime.py
@@ -1,0 +1,148 @@
+import pandas as pd
+import pytest
+
+from src.strategies.components.position_sizer import PositionSizer
+from src.strategies.components.regime_context import EnhancedRegimeDetector
+from src.strategies.components.risk_manager import MarketData, Position, RiskManager
+from src.strategies.components.signal_generator import (
+    Signal,
+    SignalDirection,
+    SignalGenerator,
+)
+from src.strategies.components.strategy import Strategy
+from src.strategies.runtime import (
+    FeatureGenerator,
+    FeatureGeneratorResult,
+    RuntimeContext,
+    StrategyDataset,
+    StrategyRuntime,
+)
+
+
+class DummySignalGenerator(SignalGenerator):
+    def __init__(self) -> None:
+        super().__init__("dummy_signal")
+
+    def generate_signal(self, df: pd.DataFrame, index: int, regime=None) -> Signal:  # type: ignore[override]
+        self.validate_inputs(df, index)
+        return Signal(
+            direction=SignalDirection.BUY,
+            strength=1.0,
+            confidence=1.0,
+            metadata={"index": index},
+        )
+
+    def get_confidence(self, df: pd.DataFrame, index: int) -> float:  # type: ignore[override]
+        self.validate_inputs(df, index)
+        return 1.0
+
+
+class DummyRiskManager(RiskManager):
+    def __init__(self) -> None:
+        super().__init__("dummy_risk")
+
+    def calculate_position_size(self, signal: Signal, balance: float, regime=None) -> float:  # type: ignore[override]
+        self.validate_inputs(balance)
+        return balance * 0.1 if signal.direction != SignalDirection.HOLD else 0.0
+
+    def should_exit(self, position: Position, current_data: MarketData, regime=None) -> bool:  # type: ignore[override]
+        return False
+
+    def get_stop_loss(self, entry_price: float, signal: Signal, regime=None) -> float:  # type: ignore[override]
+        return entry_price * 0.95
+
+
+class DummyPositionSizer(PositionSizer):
+    def __init__(self) -> None:
+        super().__init__("dummy_sizer")
+
+    def calculate_size(self, signal: Signal, balance: float, risk_amount: float, regime=None) -> float:  # type: ignore[override]
+        budget = balance * 0.1 if risk_amount <= 0 else min(risk_amount, balance)
+        self.validate_inputs(balance, budget)
+        return budget
+
+
+class DummyFeatureGenerator(FeatureGenerator):
+    def __init__(self) -> None:
+        super().__init__("dummy_feature", required_columns={"close"}, warmup_period=2)
+
+    def generate(self, df: pd.DataFrame) -> FeatureGeneratorResult:
+        features = pd.DataFrame({"close_mean": df["close"].rolling(2).mean()})
+        return FeatureGeneratorResult(features=features, cache={"window": 2})
+
+
+class DummyStrategy(Strategy):
+    def __init__(self) -> None:
+        super().__init__(
+            name="dummy",
+            signal_generator=DummySignalGenerator(),
+            risk_manager=DummyRiskManager(),
+            position_sizer=DummyPositionSizer(),
+            regime_detector=EnhancedRegimeDetector(),
+            enable_logging=False,
+        )
+        self._prepared: StrategyDataset | None = None
+        self._finalized: StrategyDataset | None = None
+
+    @property
+    def warmup_period(self) -> int:
+        return 3
+
+    def get_feature_generators(self):  # type: ignore[override]
+        return [DummyFeatureGenerator()]
+
+    def prepare_runtime(self, dataset: StrategyDataset) -> None:  # type: ignore[override]
+        self._prepared = dataset
+
+    def finalize_runtime(self, dataset: StrategyDataset) -> None:  # type: ignore[override]
+        self._finalized = dataset
+
+
+@pytest.fixture()
+def sample_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open": [1, 2, 3, 4, 5],
+            "high": [1, 2, 3, 4, 5],
+            "low": [1, 2, 3, 4, 5],
+            "close": [1, 2, 3, 4, 5],
+            "volume": [1, 2, 3, 4, 5],
+        }
+    )
+
+
+def test_prepare_data_runs_feature_generators(sample_dataframe: pd.DataFrame) -> None:
+    strategy = DummyStrategy()
+    runtime = StrategyRuntime(strategy)
+
+    dataset = runtime.prepare_data(sample_dataframe)
+
+    assert "close_mean" in dataset.data.columns
+    assert dataset.feature_caches["dummy_feature"]["window"] == 2
+    assert dataset.warmup_period == 3
+    assert strategy._prepared is dataset
+
+
+def test_process_uses_prepared_dataset(sample_dataframe: pd.DataFrame) -> None:
+    strategy = DummyStrategy()
+    runtime = StrategyRuntime(strategy)
+    runtime.prepare_data(sample_dataframe)
+
+    context = RuntimeContext(balance=1000.0, current_positions=[])
+
+    decision = runtime.process(3, context)
+
+    assert decision.signal.direction == SignalDirection.BUY
+    assert decision.position_size > 0
+
+
+def test_finalize_returns_dataset(sample_dataframe: pd.DataFrame) -> None:
+    strategy = DummyStrategy()
+    runtime = StrategyRuntime(strategy)
+    dataset = runtime.prepare_data(sample_dataframe)
+
+    returned = runtime.finalize()
+
+    assert returned is dataset
+    assert runtime.dataset is None
+    assert strategy._finalized is dataset


### PR DESCRIPTION
## Summary
- add the new strategy runtime module with dataset orchestration hooks
- define feature generator contracts for vectorised batch preparation
- document runtime responsibilities and add unit tests for runtime lifecycle

## Testing
- ruff check src/strategies/runtime tests/strategies/runtime
- pytest tests/strategies/runtime/test_strategy_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68ea0bca2b50832f85849cbae878ddbc