### PR TITLE
Implement strategy runtime foundations

### DIFF
--- a/src/strategies/components/__init__.py
+++ b/src/strategies/components/__init__.py
@@ -14,6 +14,13 @@ Components:
 """
 
 from .strategy import Strategy
+from .runtime import (
+    FeatureGeneratorSpec,
+    FeatureCache,
+    StrategyDataset,
+    RuntimeContext,
+    StrategyRuntime,
+)
 from .signal_generator import (
     SignalGenerator, Signal, SignalDirection,
     HoldSignalGenerator, RandomSignalGenerator,
@@ -61,6 +68,11 @@ __all__ = [
     "TrendLabel",
     "VolLabel",
     "EnhancedRegimeDetector",
+    "FeatureGeneratorSpec",
+    "FeatureCache",
+    "StrategyDataset",
+    "RuntimeContext",
+    "StrategyRuntime",
     
     # Management classes
     "StrategyManager",

--- a/src/strategies/components/position_sizer.py
+++ b/src/strategies/components/position_sizer.py
@@ -7,12 +7,13 @@ strategy architecture.
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 import numpy as np
 
 if TYPE_CHECKING:
     from .regime_context import RegimeContext
+    from .runtime import FeatureGeneratorSpec
     from .signal_generator import Signal
 
 
@@ -96,7 +97,7 @@ class PositionSizer(ABC):
     def get_parameters(self) -> dict[str, Any]:
         """
         Get position sizer parameters for logging and serialization
-        
+
         Returns:
             Dictionary of parameter names and values
         """
@@ -104,6 +105,17 @@ class PositionSizer(ABC):
             'name': self.name,
             'type': self.__class__.__name__
         }
+
+    @property
+    def warmup_period(self) -> int:
+        """Return the minimum history required for the position sizer."""
+
+        return 0
+
+    def get_feature_generators(self) -> Sequence['FeatureGeneratorSpec']:
+        """Return feature generators required by the position sizer."""
+
+        return []
 
 
 class FixedFractionSizer(PositionSizer):

--- a/src/strategies/components/regime_context.py
+++ b/src/strategies/components/regime_context.py
@@ -7,10 +7,13 @@ for providing market regime information to strategy components.
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Sequence, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+
+if TYPE_CHECKING:
+    from .runtime import FeatureGeneratorSpec
 
 # Import existing regime detection components
 from src.regime.detector import RegimeDetector as BaseRegimeDetector
@@ -163,6 +166,17 @@ class EnhancedRegimeDetector:
         # Current regime state
         self.current_regime: Optional[RegimeContext] = None
         self.regime_start_index: int = 0
+
+    @property
+    def warmup_period(self) -> int:
+        """Return the minimum history required for regime detection."""
+
+        return 0
+
+    def get_feature_generators(self) -> Sequence['FeatureGeneratorSpec']:
+        """Return feature generators used to enrich regime analysis."""
+
+        return []
     
     def detect_regime(self, df: pd.DataFrame, index: int) -> RegimeContext:
         """

--- a/src/strategies/components/risk_manager.py
+++ b/src/strategies/components/risk_manager.py
@@ -9,10 +9,11 @@ strategy architecture.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 if TYPE_CHECKING:
     from .regime_context import RegimeContext
+    from .runtime import FeatureGeneratorSpec
     from .signal_generator import Signal
 
 
@@ -233,7 +234,7 @@ class RiskManager(ABC):
     def get_parameters(self) -> dict[str, Any]:
         """
         Get risk manager parameters for logging and serialization
-        
+
         Returns:
             Dictionary of parameter names and values
         """
@@ -241,6 +242,17 @@ class RiskManager(ABC):
             'name': self.name,
             'type': self.__class__.__name__
         }
+
+    @property
+    def warmup_period(self) -> int:
+        """Return the minimum history required for the risk manager."""
+
+        return 0
+
+    def get_feature_generators(self) -> Sequence['FeatureGeneratorSpec']:
+        """Return feature generators used by the risk manager."""
+
+        return []
 
 
 class FixedRiskManager(RiskManager):

--- a/src/strategies/components/runtime.py
+++ b/src/strategies/components/runtime.py
@@ -1,0 +1,173 @@
+"""Runtime orchestration utilities for component-based strategies."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+import pandas as pd
+from pandas import Series
+
+if TYPE_CHECKING:
+    from .risk_manager import Position
+    from .strategy import TradingDecision
+
+
+@dataclass(frozen=True)
+class FeatureGeneratorSpec:
+    """Descriptor for a vectorised feature generator.
+
+    Attributes:
+        name: Human readable identifier for the generator.
+        generate: Callable that receives the working DataFrame and returns the
+            computed feature columns as a DataFrame aligned to the input index.
+        required_columns: Columns that must exist on the DataFrame before
+            `generate` is invoked.
+        warmup_period: Minimum number of rows required before the generated
+            features are considered reliable.
+        incremental: Optional callable that can update the feature set for a
+            new row without recomputing the entire batch.
+        metadata: Free-form metadata describing the generator configuration.
+    """
+
+    name: str
+    generate: Callable[[pd.DataFrame], pd.DataFrame]
+    required_columns: Sequence[str] = ()
+    warmup_period: int = 0
+    incremental: Callable[[pd.DataFrame, Series], Series] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FeatureCache:
+    """Cached information about features produced during preparation."""
+
+    name: str
+    columns: Sequence[str]
+    incremental: Callable[[pd.DataFrame, Series], Series] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def supports_incremental(self) -> bool:
+        """Return True when incremental updates are available."""
+
+        return self.incremental is not None
+
+
+@dataclass
+class StrategyDataset:
+    """Dataset prepared for runtime execution."""
+
+    data: pd.DataFrame
+    warmup_period: int
+    feature_caches: dict[str, FeatureCache] = field(default_factory=dict)
+
+
+@dataclass
+class RuntimeContext:
+    """Per-candle execution context provided to the runtime."""
+
+    balance: float
+    current_positions: list[Position] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class SupportsRuntimeHooks(Protocol):
+    """Protocol describing the methods required by :class:`StrategyRuntime`."""
+
+    name: str
+
+    @property
+    def warmup_period(self) -> int:  # pragma: no cover - protocol definition
+        ...
+
+    def get_feature_generators(self) -> Sequence[FeatureGeneratorSpec]:  # pragma: no cover - protocol definition
+        ...
+
+    def prepare_runtime(self, dataset: StrategyDataset) -> None:  # pragma: no cover - protocol definition
+        ...
+
+    def process_candle(
+        self,
+        df: pd.DataFrame,
+        index: int,
+        balance: float,
+        current_positions: list[Position] | None = None,
+    ) -> TradingDecision:  # pragma: no cover - protocol definition
+        ...
+
+    def finalize_runtime(self) -> None:  # pragma: no cover - protocol definition
+        ...
+
+
+class StrategyRuntime:
+    """Orchestrates dataset preparation and per-candle strategy execution."""
+
+    def __init__(self, strategy: SupportsRuntimeHooks):
+        self._strategy = strategy
+        self._dataset: StrategyDataset | None = None
+
+    @property
+    def dataset(self) -> StrategyDataset:
+        """Return the prepared dataset or raise if preparation has not happened."""
+
+        if self._dataset is None:
+            raise RuntimeError("Strategy data has not been prepared. Call prepare_data first.")
+        return self._dataset
+
+    def prepare_data(self, df: pd.DataFrame) -> StrategyDataset:
+        """Enrich the provided DataFrame with component-declared features."""
+
+        working_df = df.copy(deep=True)
+        feature_caches: dict[str, FeatureCache] = {}
+        warmup = max(0, int(self._strategy.warmup_period))
+
+        specs = list(self._strategy.get_feature_generators() or [])
+        for spec in specs:
+            missing = [col for col in spec.required_columns if col not in working_df.columns]
+            if missing:
+                raise ValueError(
+                    f"Feature generator '{spec.name}' missing column(s): {missing}"
+                )
+
+            generated = spec.generate(working_df)
+            if not isinstance(generated, pd.DataFrame):
+                raise TypeError(
+                    f"Feature generator '{spec.name}' must return a pandas DataFrame, "
+                    f"got {type(generated)!r}"
+                )
+
+            for column in generated.columns:
+                working_df[column] = generated[column]
+
+            feature_caches[spec.name] = FeatureCache(
+                name=spec.name,
+                columns=tuple(generated.columns),
+                incremental=spec.incremental,
+                metadata=dict(spec.metadata),
+            )
+            warmup = max(warmup, int(spec.warmup_period))
+
+        dataset = StrategyDataset(data=working_df, warmup_period=warmup, feature_caches=feature_caches)
+        self._dataset = dataset
+        self._strategy.prepare_runtime(dataset)
+        return dataset
+
+    def process(self, index: int, context: RuntimeContext) -> TradingDecision:
+        """Process a single candle using the prepared dataset."""
+
+        dataset = self.dataset
+        return self._strategy.process_candle(
+            dataset.data,
+            index,
+            context.balance,
+            context.current_positions,
+        )
+
+    def finalize(self) -> None:
+        """Finalize runtime execution and release dataset references."""
+
+        try:
+            self._strategy.finalize_runtime()
+        finally:
+            self._dataset = None

--- a/src/strategies/components/signal_generator.py
+++ b/src/strategies/components/signal_generator.py
@@ -8,12 +8,13 @@ for generating trading signals in the component-based strategy architecture.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 import pandas as pd
 
 if TYPE_CHECKING:
     from .regime_context import RegimeContext
+    from .runtime import FeatureGeneratorSpec
 
 
 class SignalDirection(Enum):
@@ -139,7 +140,7 @@ class SignalGenerator(ABC):
     def get_parameters(self) -> dict[str, Any]:
         """
         Get signal generator parameters for logging and serialization
-        
+
         Returns:
             Dictionary of parameter names and values
         """
@@ -147,6 +148,17 @@ class SignalGenerator(ABC):
             'name': self.name,
             'type': self.__class__.__name__
         }
+
+    @property
+    def warmup_period(self) -> int:
+        """Declare the minimum history required by the generator."""
+
+        return 0
+
+    def get_feature_generators(self) -> Sequence['FeatureGeneratorSpec']:
+        """Return feature generators required by this signal generator."""
+
+        return []
 
 
 class HoldSignalGenerator(SignalGenerator):

--- a/tests/strategies/components/test_strategy_runtime.py
+++ b/tests/strategies/components/test_strategy_runtime.py
@@ -1,0 +1,206 @@
+"""Unit tests for the StrategyRuntime orchestration layer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pandas as pd
+import pytest
+
+from src.strategies.components import (
+    FeatureGeneratorSpec,
+    RuntimeContext,
+    Strategy,
+    StrategyRuntime,
+)
+from src.strategies.components.position_sizer import PositionSizer
+from src.strategies.components.regime_context import RegimeContext
+from src.strategies.components.risk_manager import MarketData, Position, RiskManager
+from src.strategies.components.signal_generator import Signal, SignalDirection, SignalGenerator
+
+
+class DummySignalGenerator(SignalGenerator):
+    """Signal generator used for runtime tests."""
+
+    def __init__(self):
+        super().__init__("dummy_signal")
+
+    def generate_signal(self, df: pd.DataFrame, index: int, regime: RegimeContext | None = None) -> Signal:
+        self.validate_inputs(df, index)
+        return Signal(direction=SignalDirection.BUY, strength=1.0, confidence=0.9, metadata={})
+
+    def get_confidence(self, df: pd.DataFrame, index: int) -> float:
+        self.validate_inputs(df, index)
+        return 0.9
+
+    @property
+    def warmup_period(self) -> int:
+        return 5
+
+    def get_feature_generators(self) -> list[FeatureGeneratorSpec]:
+        def _generate_features(frame: pd.DataFrame) -> pd.DataFrame:
+            return pd.DataFrame(
+                {
+                    'dummy_feature': frame['close'].rolling(window=2, min_periods=1).mean()
+                }
+            )
+
+        def _incremental(frame: pd.DataFrame, new_row: pd.Series) -> pd.Series:
+            return pd.Series({'dummy_feature': float(new_row['close'])})
+
+        return [
+            FeatureGeneratorSpec(
+                name="dummy_signal_features",
+                required_columns=("close",),
+                warmup_period=3,
+                generate=_generate_features,
+                incremental=_incremental,
+            )
+        ]
+
+
+class DummyRiskManager(RiskManager):
+    """Risk manager returning a fixed fraction of balance."""
+
+    def __init__(self):
+        super().__init__("dummy_risk")
+
+    @property
+    def warmup_period(self) -> int:
+        return 2
+
+    def calculate_position_size(self, signal: Signal, balance: float, regime: RegimeContext | None = None) -> float:
+        self.validate_inputs(balance)
+        if signal.direction is SignalDirection.HOLD:
+            return 0.0
+        return balance * 0.1
+
+    def should_exit(self, position: Position, current_data: MarketData, regime: RegimeContext | None = None) -> bool:
+        return False
+
+    def get_stop_loss(self, entry_price: float, signal: Signal, regime: RegimeContext | None = None) -> float:
+        return entry_price * 0.9
+
+
+class DummyPositionSizer(PositionSizer):
+    """Position sizer that passes through the risk amount."""
+
+    def __init__(self):
+        super().__init__("dummy_sizer")
+
+    def calculate_size(self, signal: Signal, balance: float, risk_amount: float, regime: RegimeContext | None = None) -> float:
+        self.validate_inputs(balance, risk_amount)
+        return risk_amount
+
+
+@dataclass
+class DummyRegimeDetector:
+    """Minimal regime detector that opts out of regime analysis."""
+
+    warmup_period: int = 0
+
+    def get_feature_generators(self) -> list[FeatureGeneratorSpec]:
+        return []
+
+    def detect_regime(self, df: pd.DataFrame, index: int) -> RegimeContext | None:
+        return None
+
+
+class RecordingStrategy(Strategy):
+    """Strategy subclass that records runtime hook invocations."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.prepared_with = None
+        self.finalized = False
+
+    def prepare_runtime(self, dataset):  # type: ignore[override]
+        super().prepare_runtime(dataset)
+        self.prepared_with = dataset
+
+    def finalize_runtime(self) -> None:  # type: ignore[override]
+        self.finalized = True
+        super().finalize_runtime()
+
+
+@pytest.fixture
+def sample_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            'open': [100, 101, 102, 103, 104],
+            'high': [101, 102, 103, 104, 105],
+            'low': [99, 100, 101, 102, 103],
+            'close': [100, 101, 102, 103, 104],
+            'volume': [10, 11, 12, 13, 14],
+        }
+    )
+
+
+@pytest.fixture
+def runtime_strategy() -> RecordingStrategy:
+    return RecordingStrategy(
+        name="runtime_test",
+        signal_generator=DummySignalGenerator(),
+        risk_manager=DummyRiskManager(),
+        position_sizer=DummyPositionSizer(),
+        regime_detector=DummyRegimeDetector(),
+    )
+
+
+def test_prepare_data_enriches_dataset(runtime_strategy: RecordingStrategy, sample_dataframe: pd.DataFrame) -> None:
+    runtime = StrategyRuntime(runtime_strategy)
+    dataset = runtime.prepare_data(sample_dataframe)
+
+    assert runtime_strategy.prepared_with is dataset
+    assert 'dummy_feature' in dataset.data.columns
+    assert dataset.feature_caches['dummy_signal_features'].supports_incremental()
+    assert dataset.warmup_period == runtime_strategy.warmup_period
+
+
+def test_process_produces_trading_decision(runtime_strategy: RecordingStrategy, sample_dataframe: pd.DataFrame) -> None:
+    runtime = StrategyRuntime(runtime_strategy)
+    runtime.prepare_data(sample_dataframe)
+
+    context = RuntimeContext(balance=1_000.0)
+    decision = runtime.process(index=2, context=context)
+
+    assert decision.signal.direction is SignalDirection.BUY
+    assert decision.position_size > 0
+    assert decision.metadata['components']['signal_generator'] == runtime_strategy.signal_generator.name
+
+
+def test_finalize_clears_dataset(runtime_strategy: RecordingStrategy, sample_dataframe: pd.DataFrame) -> None:
+    runtime = StrategyRuntime(runtime_strategy)
+    runtime.prepare_data(sample_dataframe)
+    runtime.finalize()
+
+    assert runtime_strategy.finalized is True
+    with pytest.raises(RuntimeError):
+        _ = runtime.dataset
+
+
+def test_prepare_data_validates_required_columns(sample_dataframe: pd.DataFrame) -> None:
+    class MissingColumnSignalGenerator(DummySignalGenerator):
+        def get_feature_generators(self) -> list[FeatureGeneratorSpec]:
+            def _generate_features(frame: pd.DataFrame) -> pd.DataFrame:
+                return pd.DataFrame({'feature': frame['missing']})
+
+            return [
+                FeatureGeneratorSpec(
+                    name="missing_column",
+                    required_columns=("missing",),
+                    generate=_generate_features,
+                )
+            ]
+
+    strategy = Strategy(
+        name="invalid",
+        signal_generator=MissingColumnSignalGenerator(),
+        risk_manager=DummyRiskManager(),
+        position_sizer=DummyPositionSizer(),
+        regime_detector=DummyRegimeDetector(),
+    )
+    runtime = StrategyRuntime(strategy)
+
+    with pytest.raises(ValueError, match="missing column"):
+        runtime.prepare_data(sample_dataframe)


### PR DESCRIPTION
## Summary
- add a StrategyRuntime orchestration layer with feature generator descriptors, dataset caching, and runtime context handling
- expose warmup periods and feature generator hooks on the Strategy facade and core component bases, updating exports and documentation accordingly
- add unit tests covering the runtime lifecycle and feature preparation contract

## Testing
- ruff check src/strategies/components/runtime.py tests/strategies/components/test_strategy_runtime.py
- pytest tests/strategies/components/test_strategy_runtime.py

------
https://chatgpt.com/codex/tasks/task_e_68ea0bca2b50832f85849cbae878ddbc