### PR TITLE
Support StrategyRuntime inputs for engines

### DIFF
--- a/src/strategies/components/runtime.py
+++ b/src/strategies/components/runtime.py
@@ -108,6 +108,18 @@ class StrategyRuntime:
         self._dataset: StrategyDataset | None = None
 
     @property
+    def strategy(self) -> SupportsRuntimeHooks:
+        """Return the underlying strategy instance driving this runtime."""
+
+        return self._strategy
+
+    @property
+    def name(self) -> str:
+        """Expose the strategy name for convenient logging and diagnostics."""
+
+        return getattr(self._strategy, "name", self._strategy.__class__.__name__)
+
+    @property
     def dataset(self) -> StrategyDataset:
         """Return the prepared dataset or raise if preparation has not happened."""
 

--- a/src/strategies/migration/runtime_regression.py
+++ b/src/strategies/migration/runtime_regression.py
@@ -1,0 +1,113 @@
+"""Regression harness comparing legacy and runtime backtests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable
+
+import pandas as pd
+
+from src.backtesting.engine import Backtester
+from src.data_providers.data_provider import DataProvider
+from src.strategies.base import BaseStrategy
+from src.strategies.components import Strategy as ComponentStrategy, StrategyRuntime
+
+
+class DataFrameProvider(DataProvider):
+    """Simple data provider that serves a static DataFrame."""
+
+    def __init__(self, frame: pd.DataFrame):
+        self._frame = frame.copy()
+
+    def get_historical_data(
+        self,
+        symbol: str,
+        timeframe: str,
+        start: datetime | None,
+        end: datetime | None,
+    ) -> pd.DataFrame:
+        return self._frame.copy()
+
+    def get_current_price(self, symbol: str) -> float:
+        if self._frame.empty:
+            return 0.0
+        return float(self._frame["close"].iloc[-1])
+
+    def get_live_data(self, symbol: str, timeframe: str) -> pd.DataFrame:
+        return self._frame.copy()
+
+    def update_live_data(self, symbol: str, timeframe: str) -> None:
+        return None
+
+
+@dataclass
+class BacktestComparisonResult:
+    """Structured comparison output for regression harness."""
+
+    legacy_results: dict[str, Any]
+    runtime_results: dict[str, Any]
+    matching: bool
+    differences: dict[str, Any]
+
+
+def _default_metric_extractor(results: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "final_balance": round(float(results.get("final_balance", 0.0)), 8),
+        "total_trades": int(results.get("total_trades", 0)),
+        "win_rate": round(float(results.get("win_rate", 0.0)), 8),
+        "max_drawdown": round(float(results.get("max_drawdown", 0.0)), 8),
+        "total_return": round(float(results.get("total_return", 0.0)), 8),
+    }
+
+
+def compare_backtests(
+    legacy_strategy: BaseStrategy,
+    runtime_strategy: BaseStrategy | ComponentStrategy | StrategyRuntime,
+    market_data: pd.DataFrame,
+    metric_extractor: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+) -> BacktestComparisonResult:
+    """Run the same dataset through both strategies and compare metrics."""
+
+    if metric_extractor is None:
+        metric_extractor = _default_metric_extractor
+
+    provider = DataFrameProvider(market_data)
+    start = market_data.index[0] if len(market_data.index) else datetime.utcnow()
+    end = market_data.index[-1] if len(market_data.index) else None
+
+    legacy_backtester = Backtester(
+        strategy=legacy_strategy,
+        data_provider=provider,
+        log_to_database=False,
+        enable_dynamic_risk=False,
+    )
+    runtime_backtester = Backtester(
+        strategy=runtime_strategy,
+        data_provider=provider,
+        log_to_database=False,
+        enable_dynamic_risk=False,
+    )
+
+    legacy_results = legacy_backtester.run(symbol="TEST", timeframe="1h", start=start, end=end)
+    runtime_results = runtime_backtester.run(symbol="TEST", timeframe="1h", start=start, end=end)
+
+    legacy_metrics = metric_extractor(legacy_results)
+    runtime_metrics = metric_extractor(runtime_results)
+
+    differences: dict[str, Any] = {}
+    matching = True
+    for key in sorted(set(legacy_metrics) | set(runtime_metrics)):
+        if legacy_metrics.get(key) != runtime_metrics.get(key):
+            matching = False
+            differences[key] = {
+                "legacy": legacy_metrics.get(key),
+                "runtime": runtime_metrics.get(key),
+            }
+
+    return BacktestComparisonResult(
+        legacy_results=legacy_results,
+        runtime_results=runtime_results,
+        matching=matching,
+        differences=differences,
+    )

--- a/tests/strategies/migration/test_runtime_regression.py
+++ b/tests/strategies/migration/test_runtime_regression.py
@@ -1,0 +1,106 @@
+"""Tests for the runtime regression harness."""
+
+import pandas as pd
+
+from src.strategies.adapters.legacy_adapter import LegacyStrategyAdapter
+from src.strategies.components import (
+    FixedFractionSizer,
+    FixedRiskManager,
+    HoldSignalGenerator,
+    Signal,
+    SignalDirection,
+    SignalGenerator,
+    Strategy,
+    StrategyRuntime,
+)
+from src.strategies.migration.runtime_regression import compare_backtests
+
+
+def _build_market_data(rows: int = 24) -> pd.DataFrame:
+    index = pd.date_range("2024-01-01", periods=rows, freq="h")
+    prices = pd.Series(100.0 + pd.RangeIndex(len(index)), index=index)
+    frame = pd.DataFrame(
+        {
+            "open": prices,
+            "high": prices + 1.0,
+            "low": prices - 1.0,
+            "close": prices,
+            "volume": 1000.0,
+        },
+        index=index,
+    )
+    frame.index.name = "timestamp"
+    return frame
+
+
+class BuySignalGenerator(SignalGenerator):
+    def __init__(self):
+        super().__init__("always_buy")
+
+    def generate_signal(self, df: pd.DataFrame, index: int, regime=None) -> Signal:
+        return Signal(SignalDirection.BUY, 1.0, 1.0, {})
+
+    def get_confidence(self, df: pd.DataFrame, index: int) -> float:
+        return 1.0
+
+
+def _build_component_strategy(
+    fraction: float = 0.02,
+    generator: SignalGenerator | None = None,
+) -> Strategy:
+    signal = generator or HoldSignalGenerator()
+    risk = FixedRiskManager(risk_per_trade=0.01, stop_loss_pct=0.05)
+    sizer = FixedFractionSizer(fraction=fraction)
+    return Strategy("hold_component", signal, risk, sizer)
+
+
+def test_compare_backtests_matches_for_identical_strategies():
+    data = _build_market_data()
+    component_strategy = _build_component_strategy()
+    legacy_adapter = LegacyStrategyAdapter(
+        component_strategy.signal_generator,
+        component_strategy.risk_manager,
+        component_strategy.position_sizer,
+    )
+
+    result = compare_backtests(legacy_adapter, component_strategy, data)
+
+    assert result.matching is True
+    assert result.differences == {}
+    assert result.legacy_results["total_trades"] == 0
+    assert result.runtime_results["total_trades"] == 0
+
+
+def test_compare_backtests_reports_differences_when_metrics_diverge():
+    data = _build_market_data()
+    component_strategy = _build_component_strategy(generator=BuySignalGenerator())
+    legacy_adapter = LegacyStrategyAdapter(
+        component_strategy.signal_generator,
+        component_strategy.risk_manager,
+        component_strategy.position_sizer,
+    )
+
+    # Modify component strategy to force different sizing for runtime
+    component_strategy.position_sizer = FixedFractionSizer(fraction=0.05)
+
+    result = compare_backtests(legacy_adapter, component_strategy, data)
+
+    assert result.matching is False
+    assert "final_balance" in result.differences
+
+
+def test_compare_backtests_accepts_strategy_runtime_instance():
+    data = _build_market_data()
+    component_strategy = _build_component_strategy()
+    legacy_adapter = LegacyStrategyAdapter(
+        component_strategy.signal_generator,
+        component_strategy.risk_manager,
+        component_strategy.position_sizer,
+    )
+
+    runtime = StrategyRuntime(component_strategy)
+
+    result = compare_backtests(legacy_adapter, runtime, data)
+
+    assert result.matching is True
+    assert result.differences == {}


### PR DESCRIPTION
## Summary
- normalise strategy configuration in the backtesting and live engines so StrategyRuntime instances can be supplied directly while keeping runtime bookkeeping in sync during swaps
- expose the underlying strategy and name on StrategyRuntime and allow the migration regression harness to accept runtime strategies for comparisons
- extend the regression and live engine unit suites with coverage for StrategyRuntime usage alongside existing parity checks

## Testing
- pytest tests/strategies/migration/test_runtime_regression.py
- pytest tests/unit/backtesting/test_backtesting_execution.py
- pytest tests/unit/live/test_close_position_parity.py

------
https://chatgpt.com/codex/tasks/task_e_68eaabd9c0a8832fab696c2114e6267f