### PR TITLE
Fix legacy adapter parity and stabilize regime detector

### DIFF
--- a/src/regime/detector.py
+++ b/src/regime/detector.py
@@ -161,18 +161,19 @@ class RegimeDetector:
     @staticmethod
     def _percentile_rank(series: pd.Series, lookback: int) -> pd.Series:
         """Optimized percentile rank calculation"""
-        def rank_last(window: pd.Series) -> float:
-            if window.isna().any():
+        def rank_last(window) -> float:
+            arr = window if isinstance(window, np.ndarray) else np.asarray(window)
+            if np.isnan(arr).any():
                 return np.nan
-            last = window.iloc[-1]
-            return (window <= last).mean()
+            last = arr[-1]
+            return float(np.mean(arr <= last))
 
         # Use engine='numba' for better performance if available
         try:
-            return series.rolling(window=lookback, min_periods=lookback).apply(rank_last, raw=False, engine='numba')
+            return series.rolling(window=lookback, min_periods=lookback).apply(rank_last, raw=True, engine='numba')
         except Exception:
             # Fallback to default engine
-            return series.rolling(window=lookback, min_periods=lookback).apply(rank_last, raw=False)
+            return series.rolling(window=lookback, min_periods=lookback).apply(rank_last, raw=True)
 
     def annotate(self, df: pd.DataFrame) -> pd.DataFrame:
         cfg = self.config


### PR DESCRIPTION
## Summary
- ensure the legacy adapter only opens longs on BUY signals, adds a dedicated short-entry hook, and reuses cached signal evaluations so legacy and component strategies stay aligned
- update adapter performance metrics bookkeeping to cover the new short-entry checks and reuse a helper for downstream sizing/stop-loss logic
- make the regime detector percentile rank helper operate on raw numpy windows so pandas numba execution no longer raises

## Testing
- pytest tests/unit/strategies/test_ml_basic_unit.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ed2de9850c832fa5327a5901345566