### PR TITLE
Fix optimizer parameter overrides for component strategies

### DIFF
--- a/src/optimizer/runner.py
+++ b/src/optimizer/runner.py
@@ -164,17 +164,81 @@ class ExperimentRunner:
         raise ValueError(f"Unknown strategy: {strategy_name}")
 
     def _apply_parameter_overrides(self, strategy: Strategy, config: ExperimentConfig) -> None:
-        if config.parameters and config.parameters.values:
-            for key, value in config.parameters.values.items():
-                if key.startswith("MlBasic."):
-                    attr = key.split(".", 1)[1]
-                    if hasattr(strategy, attr):
-                        try:
-                            setattr(strategy, attr, value)
-                        except Exception as e:
-                            # Ignore invalid attribute assignments to keep runner robust
-                            self.logger.debug(f"Failed to set attribute {attr}={value}: {e}")
-                            pass
+        if not (config.parameters and config.parameters.values):
+            return
+
+        strategy_key = config.strategy_name.replace("_", "").lower()
+
+        for key, value in config.parameters.values.items():
+            if "." not in key:
+                continue
+
+            namespace, attr = key.split(".", 1)
+            if namespace.replace("_", "").lower() != strategy_key:
+                continue
+
+            if not self._apply_strategy_attribute(strategy, attr, value):
+                self.logger.debug(
+                    "Failed to apply override %s for strategy %s", key, config.strategy_name
+                )
+
+    def _apply_strategy_attribute(self, strategy: Strategy, attr: str, value: object) -> bool:
+        """Apply overrides to the correct component on a component-based strategy."""
+
+        component_targets: dict[str, list[Strategy | object | None]] = {
+            # Risk manager attributes
+            "stop_loss_pct": [strategy, getattr(strategy, "risk_manager", None)],
+            "risk_per_trade": [getattr(strategy, "risk_manager", None)],
+            # Position sizer attributes
+            "base_fraction": [getattr(strategy, "position_sizer", None)],
+            "min_confidence": [getattr(strategy, "position_sizer", None)],
+            # Signal generator attributes
+            "sequence_length": [getattr(strategy, "signal_generator", None)],
+            "model_path": [strategy, getattr(strategy, "signal_generator", None)],
+            "use_prediction_engine": [
+                strategy,
+                getattr(strategy, "signal_generator", None),
+            ],
+            "model_name": [strategy, getattr(strategy, "signal_generator", None)],
+            "model_type": [strategy, getattr(strategy, "signal_generator", None)],
+            "timeframe": [strategy, getattr(strategy, "signal_generator", None)],
+            # Strategy level attributes
+            "take_profit_pct": [strategy],
+        }
+
+        targets = component_targets.get(attr, [strategy])
+        applied = False
+
+        for target in targets:
+            if target is None or not hasattr(target, attr):
+                continue
+            try:
+                current = getattr(target, attr)
+                coerced = self._coerce_value(current, value)
+                setattr(target, attr, coerced)
+                applied = True
+            except Exception as exc:  # pragma: no cover - defensive logging
+                self.logger.debug("Failed to set %s on %s: %s", attr, target, exc)
+
+        if applied and attr in {"stop_loss_pct", "take_profit_pct"}:
+            overrides = getattr(strategy, "_risk_overrides", None) or {}
+            overrides[attr] = getattr(strategy, attr, value)
+            strategy._risk_overrides = overrides
+
+        return applied
+
+    @staticmethod
+    def _coerce_value(current: object, new_value: object) -> object:
+        """Coerce overrides to the same type as the existing attribute when possible."""
+
+        if current is None:
+            return new_value
+
+        target_type = type(current)
+        try:
+            return target_type(new_value)
+        except Exception:
+            return new_value
 
     def run(self, config: ExperimentConfig) -> ExperimentResult:
         strategy = self._load_strategy(config.strategy_name)

--- a/tests/unit/optimizer/test_runner.py
+++ b/tests/unit/optimizer/test_runner.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from src.optimizer.runner import ExperimentRunner
-from src.optimizer.schemas import ExperimentConfig
+from src.optimizer.schemas import ExperimentConfig, ParameterSet
 
 
 def test_runner_with_mock_provider_executes():
@@ -28,3 +28,35 @@ def test_runner_with_mock_provider_executes():
     assert isinstance(result.total_trades, int)
     assert isinstance(result.win_rate, float)
     assert isinstance(result.sharpe_ratio, float)
+
+
+def test_runner_applies_parameter_overrides_to_components():
+    runner = ExperimentRunner()
+    strategy = runner._load_strategy("ml_basic")
+
+    start = datetime.now() - timedelta(days=1)
+    end = datetime.now()
+    cfg = ExperimentConfig(
+        strategy_name="ml_basic",
+        symbol="BTCUSDT",
+        timeframe="1h",
+        start=start,
+        end=end,
+        initial_balance=1000.0,
+        parameters=ParameterSet(
+            name="override",
+            values={
+                "MlBasic.stop_loss_pct": 0.05,
+                "MlBasic.risk_per_trade": 0.03,
+                "MlBasic.base_fraction": 0.15,
+                "MlBasic.sequence_length": 60,
+            },
+        ),
+    )
+
+    runner._apply_parameter_overrides(strategy, cfg)
+
+    assert strategy.risk_manager.stop_loss_pct == 0.05
+    assert strategy.risk_manager.risk_per_trade == 0.03
+    assert strategy.position_sizer.base_fraction == 0.15
+    assert strategy.signal_generator.sequence_length == 60


### PR DESCRIPTION
## Summary
- ensure the optimizer applies MlBasic parameter overrides to the migrated component strategy
- normalize override keys and coerce values so attributes on the signal generator, risk manager, and sizer update safely
- cover the regression with a unit test that exercises the override flow

## Testing
- pytest tests/unit/optimizer/test_analyzer.py tests/unit/optimizer/test_validator.py tests/unit/optimizer/test_runner.py
- ruff check src/optimizer tests/unit/optimizer/test_runner.py

------
https://chatgpt.com/codex/tasks/task_e_68f6a558157c832fa44a387968f89249