### PR TITLE
Refactor strategy manager version metadata (#343)

### DIFF
--- a/src/strategies/versioning.py
+++ b/src/strategies/versioning.py
@@ -1,0 +1,52 @@
+"""Shared strategy version metadata structures."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass
+class StrategyVersionRecord:
+    """Metadata describing a concrete strategy version.
+
+    The record is intentionally generic so it can be consumed by both the
+    component-oriented strategy manager (which needs rich component metadata)
+    and the live trading strategy manager (which focuses on deployment state).
+    """
+
+    version_id: str
+    created_at: datetime
+    name: str | None = None
+    description: str | None = None
+    strategy_name: str | None = None
+    version: str | None = None
+    config: dict[str, Any] | None = None
+    components: dict[str, dict[str, Any]] | None = None
+    parameters: dict[str, Any] | None = None
+    model_path: str | None = None
+    performance_metrics: dict[str, Any] | None = None
+    is_active: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the record to a plain dictionary."""
+
+        data = asdict(self)
+        data["created_at"] = self.created_at.isoformat()
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StrategyVersionRecord:
+        """Reconstruct a record from ``to_dict`` output."""
+
+        payload = dict(data)
+        created_at = payload.get("created_at")
+        if isinstance(created_at, str):
+            payload["created_at"] = datetime.fromisoformat(created_at)
+        elif created_at is None:
+            payload["created_at"] = datetime.now()
+        return cls(**payload)
+
+
+__all__ = ["StrategyVersionRecord"]

--- a/tests/unit/live/test_strategy_manager_unit.py
+++ b/tests/unit/live/test_strategy_manager_unit.py
@@ -139,15 +139,16 @@ class TestStrategyManagerThreadSafety:
 class TestStrategyVersioning:
     def test_strategy_version_creation(self, temp_directory):
         version = StrategyVersion(
+            version_id="ml_basic_v1.0",
             strategy_name="ml_basic",
             version="v1.0",
-            timestamp=datetime.now(),
+            created_at=datetime.now(),
             config={"sequence_length": 120},
         )
         assert version.strategy_name == "ml_basic"
         assert version.version == "v1.0"
         assert version.config["sequence_length"] == 120
-        assert isinstance(version.timestamp, datetime)
+        assert isinstance(version.created_at, datetime)
 
     def test_version_comparison_capability(self, temp_directory):
         manager = StrategyManager(staging_dir=str(temp_directory))


### PR DESCRIPTION
## Summary
- add a shared `StrategyVersionRecord` for live and component strategy managers
- update the live strategy manager to use the shared metadata record and modern typing
- align the component strategy manager and unit tests with the shared version metadata

## Testing
- ruff check src/live/strategy_manager.py src/strategies/components/strategy_manager.py src/strategies/versioning.py tests/unit/live/test_strategy_manager_unit.py
- pytest tests/unit/live/test_strategy_manager_unit.py
- pytest tests/strategies/components/test_strategy_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68f6a638d6e0832fb06c657b07c79279