### PR TITLE
Fix cached data coverage for cached provider timeframe alignment

### DIFF
--- a/src/data_providers/cached_data_provider.py
+++ b/src/data_providers/cached_data_provider.py
@@ -183,6 +183,30 @@ class CachedDataProvider(DataProvider):
 
         return ranges
 
+    @staticmethod
+    def _get_timeframe_timedelta(timeframe: str) -> Optional[timedelta]:
+        """Convert timeframe string (e.g. ``1h``) to a ``timedelta``."""
+
+        if not timeframe:
+            return None
+
+        try:
+            unit = timeframe[-1].lower()
+            value = int(timeframe[:-1]) if len(timeframe) > 1 else 1
+        except (ValueError, TypeError):
+            return None
+
+        if unit == "m":
+            return timedelta(minutes=value)
+        if unit == "h":
+            return timedelta(hours=value)
+        if unit == "d":
+            return timedelta(days=value)
+        if unit == "w":
+            return timedelta(weeks=value)
+
+        return None
+
     def _load_year_data(
         self, symbol: str, timeframe: str, year: int, year_start: datetime, year_end: datetime
     ) -> Optional[pd.DataFrame]:
@@ -220,9 +244,16 @@ class CachedDataProvider(DataProvider):
                 if hasattr(cached_data.index, "to_pydatetime"):
                     cache_start = cached_data.index.min()
                     cache_end = cached_data.index.max()
-                    
+
+                    # Expand the cached end by one timeframe interval to account for
+                    # candle timestamps representing the *start* of the interval.
+                    timeframe_delta = self._get_timeframe_timedelta(timeframe)
+                    effective_cache_end = cache_end
+                    if timeframe_delta is not None:
+                        effective_cache_end = cache_end + timeframe_delta - timedelta(seconds=1)
+
                     # Check if cached data covers the requested range
-                    if cache_start <= year_start and cache_end >= year_end:
+                    if cache_start <= year_start and effective_cache_end >= year_end:
                         # Cached data fully covers the requested range
                         mask = (cached_data.index >= year_start) & (cached_data.index <= year_end)
                         filtered_data = cached_data[mask]


### PR DESCRIPTION
## Summary
- add timeframe-aware tolerance when checking cached year coverage in `CachedDataProvider`
- avoid unnecessary remote fetches that caused ml_basic backtests to miss cached candles

## Testing
- make backtest STRATEGY=ml_basic DAYS=365

------
https://chatgpt.com/codex/tasks/task_e_68f76cdb6f58832f9fb18077dedbf1f0