### PR TITLE
Add GPU provider selection for macOS ONNX inference (#156)

### DIFF
--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -92,3 +92,33 @@ Use the following knobs when running `atb train model` locally:
 - `--disable-mixed-precision` falls back to float32 math if you encounter GPU/MPS precision glitches. Mixed precision remains enabled by default when a GPU is present to speed up long jobs.
 
 The defaults remain equivalent to the legacy behavior (300 epochs, batch size 32, sequence length 120, diagnostics on, ONNX on), so unattended jobs continue to produce identical artifacts unless you override the flags explicitly.
+
+## macOS GPU inference verification
+
+macOS users can confirm that ONNX Runtime is activating the CoreML/MPS execution providers introduced in [issue #156](https://github.com/bumpy-croc/ai-trading-bot/issues/156) with the following steps:
+
+1. **Install the GPU-enabled ONNX Runtime build.**
+   ```bash
+   pip install onnxruntime-silicon
+   ```
+   The `onnxruntime` PyPI package only enables CPU execution on Apple Silicon. The `onnxruntime-silicon` wheel ships the CoreML and MPS providers required for GPU acceleration.
+
+2. **Inspect the detected providers.**
+   ```bash
+   python -m src.prediction.models.execution_providers --include-missing
+   ```
+   The command prints every provider exposed by the host runtime followed by the prioritized list used by the trading bot. On an Apple Silicon Mac with `onnxruntime-silicon` installed you should see `CoreMLExecutionProvider` and `MPSExecutionProvider` in both lists.
+
+3. **(Optional) Validate against a model.**
+   ```bash
+   python -m src.prediction.models.execution_providers --model path/to/model.onnx
+   ```
+   When a model path is supplied, the helper loads the session with the preferred providers and echoes the providers ONNX Runtime actually activated. This confirms that the GPU-capable backend is used instead of falling back to CPU.
+
+4. **Run the prediction unit tests.**
+   ```bash
+   pytest tests/unit/predictions/test_models.py tests/unit/predictions/test_prediction_caching.py -k provider
+   ```
+   The focused tests validate that the provider utility feeds the ONNX runner and caching layers correctly.
+
+If any of the above steps omit the GPU providers, reinstall `onnxruntime-silicon`, ensure the Python environment is using that interpreter, and repeat the checks.

--- a/src/live/strategy_manager.py
+++ b/src/live/strategy_manager.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from src.prediction.models.execution_providers import get_preferred_providers
 from src.strategies.components import Strategy
 from src.strategies.versioning import StrategyVersionRecord
 
@@ -370,8 +371,9 @@ class StrategyManager:
             model = onnx.load(model_path)
             onnx.checker.check_model(model)
 
-            # Test inference session
-            session = ort.InferenceSession(model_path)
+            # Test inference session using the preferred execution providers
+            providers = get_preferred_providers()
+            session = ort.InferenceSession(model_path, providers=providers)
             input_shape = session.get_inputs()[0].shape
 
             logger.info(f"Model validation passed: {model_path} (input shape: {input_shape})")

--- a/src/prediction/models/execution_providers.py
+++ b/src/prediction/models/execution_providers.py
@@ -1,0 +1,128 @@
+"""Utilities for selecting ONNX Runtime execution providers."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import platform
+from pathlib import Path
+
+import onnxruntime as ort
+
+logger = logging.getLogger(__name__)
+
+# Provider priorities by platform
+_MAC_GPU_PROVIDERS = ["CoreMLExecutionProvider", "MPSExecutionProvider"]
+_WINDOWS_GPU_PROVIDERS = ["DmlExecutionProvider"]
+_UNIX_GPU_PROVIDERS = ["CUDAExecutionProvider", "ROCMExecutionProvider"]
+
+
+def get_preferred_providers() -> list[str]:
+    """Return the preferred ONNX Runtime providers for the current host.
+
+    The function prioritizes GPU-capable providers when available, including
+    CoreML on Apple Silicon Macs. It always falls back to the CPU execution
+    provider to ensure inference can proceed even if GPU backends are
+    unavailable.
+    """
+
+    available_providers = list(ort.get_available_providers())
+    system_name = platform.system()
+
+    prioritized: list[str] = []
+    if system_name == "Darwin":
+        prioritized.extend(_MAC_GPU_PROVIDERS)
+    elif system_name == "Windows":
+        prioritized.extend(_WINDOWS_GPU_PROVIDERS)
+    else:
+        prioritized.extend(_UNIX_GPU_PROVIDERS)
+
+    prioritized.append("CPUExecutionProvider")
+
+    selected: list[str] = []
+    seen: set[str] = set()
+    for provider in prioritized:
+        if provider in available_providers and provider not in seen:
+            selected.append(provider)
+            seen.add(provider)
+
+    if not selected:
+        # Ensure we always return at least the CPU provider.
+        selected.append("CPUExecutionProvider")
+
+    logger.debug("Available ONNX Runtime providers: %s", available_providers)
+    logger.info("Using ONNX Runtime providers: %s", selected)
+    return selected
+
+
+def _load_model_for_validation(model_path: Path, providers: list[str]) -> list[str]:
+    """Load a model with the supplied providers and return the active providers."""
+
+    session = ort.InferenceSession(str(model_path), providers=providers)
+    return session.get_providers()
+
+
+def _print_provider_report(include_all: bool, model_path: Path | None) -> None:
+    """Print diagnostic information about available and selected providers."""
+
+    available = list(ort.get_available_providers())
+    selected = get_preferred_providers()
+
+    print("Detected ONNX Runtime providers on this host:\n")
+    for provider in available:
+        print(f"  - {provider}")
+
+    print("\nProvider priority after applying ai-trading-bot selection logic:\n")
+    for provider in selected:
+        print(f"  - {provider}")
+
+    if include_all:
+        unsupported = [p for p in selected if p not in available]
+        if unsupported:
+            print("\nThe following preferred providers are not currently available:")
+            for provider in unsupported:
+                print(f"  - {provider}")
+
+    if model_path is None:
+        return
+
+    active = _load_model_for_validation(model_path, selected)
+    print("\nSuccessfully initialized the model. ONNX Runtime activated providers:\n")
+    for provider in active:
+        print(f"  - {provider}")
+
+
+def main() -> None:
+    """Entry point for verifying ONNX Runtime provider selection."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect ONNX Runtime execution providers and validate the "
+            "ai-trading-bot provider preference ordering."
+        )
+    )
+    parser.add_argument(
+        "--include-missing",
+        action="store_true",
+        help="Show preferred providers that are not currently available on this host.",
+    )
+    parser.add_argument(
+        "--model",
+        type=Path,
+        help=(
+            "Optional path to an ONNX model. When supplied, the script attempts to "
+            "load the model with the preferred providers to confirm GPU activation."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    model_path = args.model
+    if model_path is not None and not model_path.exists():
+        raise FileNotFoundError(f"Model path does not exist: {model_path}")
+
+    _print_provider_report(args.include_missing, model_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/predictions/test_prediction_caching.py
+++ b/tests/unit/predictions/test_prediction_caching.py
@@ -219,6 +219,15 @@ class TestOnnxRunnerCaching:
 
         self.mock_cache_manager = MagicMock()
         self.features = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        self.providers_patcher = patch(
+            "src.prediction.models.onnx_runner.get_preferred_providers",
+            return_value=["CPUExecutionProvider"],
+        )
+        self.providers_patcher.start()
+
+    def teardown_method(self):
+        """Stop patched providers"""
+        self.providers_patcher.stop()
 
     @patch("src.prediction.models.onnx_runner.ort.InferenceSession")
     def test_predict_with_cache_hit(self, mock_inference_session):


### PR DESCRIPTION
## Summary
- add an execution provider utility that prioritizes CoreML/MPS on macOS while keeping CPU fallback
- update the ONNX runner and live strategy validation to use the provider list for GPU-aware inference
- extend prediction unit tests to cover provider selection and updated session initialization
- document macOS verification steps and provide a CLI helper to inspect active ONNX Runtime providers

## Testing
- ruff check src/prediction/models/execution_providers.py
- pytest tests/unit/predictions/test_models.py tests/unit/predictions/test_prediction_caching.py -k provider

------
https://chatgpt.com/codex/tasks/task_e_69049192a260832fac47aa26afbba197