### PR TITLE
Nightly documentation audit and update

### DIFF
--- a/.cursor/rules/commands.md
+++ b/.cursor/rules/commands.md
@@ -18,7 +18,7 @@ alwaysApply: false
 ### Live Trading
 - Paper: `atb live ml_basic --symbol BTCUSDT --paper-trading`
 - Live (requires explicit ack): `atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks`
-- Health: `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- Health: `PORT=8000 atb live-health ml_basic --symbol BTCUSDT --paper-trading`
 
 ### Monitoring & Utilities
 - Dashboard: `atb dashboards run monitoring --port 8000`

--- a/.cursor/rules/trading-bot-core.md
+++ b/.cursor/rules/trading-bot-core.md
@@ -102,7 +102,7 @@ max_drawdown = 0.20
 atb live-control emergency-stop
 
 # Check current positions and health
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+PORT=8000 atb live-health ml_basic --symbol BTCUSDT --paper-trading
 
 # Emergency database backup
 python scripts/backup_database.py --emergency
@@ -175,7 +175,7 @@ atb live-control emergency-stop
 - "start dashboard" → `atb dashboards run monitoring --port 8000`
 
 ### Health & Monitoring
-- "check health" → `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- "check health" → `PORT=8000 atb live-health ml_basic --symbol BTCUSDT --paper-trading`
 - "check positions" → `atb db verify`
 - "check cache" → `atb data cache-manager info`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ atb backtest ml_basic --symbol BTCUSDT --timeframe 1h --days 30
 atb live ml_basic --symbol BTCUSDT --paper-trading
 
 # Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+PORT=8000 atb live-health ml_basic --paper-trading
 ```
 
 ### ML Model Training & Deployment

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (requires explicit confirmation)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading + health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+# Live trading + health endpoint (PORT/HEALTH_CHECK_PORT controls server port)
+PORT=8000 atb live-health ml_basic --paper-trading
 ```
+
+The `live-health` helper always reads the HTTP port from the `PORT` environment variable (falling back to `HEALTH_CHECK_PORT` or `8000`), so pass the desired port before the command rather than as a CLI flag.
 
 6) Utilities
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development workflow
 
-> **Last Updated**: 2025-11-10
+> **Last Updated**: 2025-11-16
 
 This project ships a command-line interface and Makefile targets that standardise local setup, quality checks, and diagnostics.
 
@@ -45,6 +45,8 @@ Run `atb dev setup` to execute helper scripts (pre-commit hooks, git config) use
 - `atb tests heartbeat` – insert a `SystemEvent` row for monitoring pipelines.
 - `atb tests db` – verify database connectivity end-to-end.
 - `atb tests download` – smoke test data downloads via CCXT.
+- `atb tests secrets` – confirm Railway/local secrets are reachable from the current shell.
+- `atb tests parse-junit reports/unit.xml --label unit` – summarise failing tests from a stored JUnit XML report.
 
 ## Code quality
 
@@ -66,10 +68,12 @@ succinct changelog, bumps the semantic version, and auto-stages the updated mani
 
 - `atb backtest ml_basic --days 30` – quick simulations while iterating on strategies.
 - `atb live ml_basic --paper-trading` – start the live runner in paper trading mode.
-- `atb live-health --port 8000 -- ml_basic --paper-trading` – start live trading with health endpoint.
+- `PORT=8000 atb live-health ml_basic --paper-trading` – start live trading with the embedded health endpoint.
 - `atb optimizer --strategy ml_basic --days 30` – trigger the optimisation CLI.
 
 Use these commands to mirror CI behaviour locally before opening pull requests.
+
+`atb live-health` always reads its HTTP port from the `PORT` environment variable (falling back to `HEALTH_CHECK_PORT`), so set the variable inline as shown above instead of passing a `--port` flag.
 
 ## Codex auto-review workflow
 

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -1,6 +1,6 @@
 # Live trading
 
-> **Last Updated**: 2025-11-10  
+> **Last Updated**: 2025-11-16  
 > **Related Documentation**: [Backtesting](backtesting.md), [Monitoring](monitoring.md), [Database](database.md)
 
 `src/live/trading_engine.py` powers the real-time execution stack. It shares core building blocks with the backtester while adding
@@ -79,6 +79,16 @@ The control surface lives under `atb live-control`:
   directory.
 - `atb live-control list-models` / `status` / `emergency-stop` – quick operational actions when supervising a running engine.
 
+## Health endpoints
+
+Use `atb live-health` to embed the HTTP `/health` and `/status` endpoints alongside the runner:
+
+```bash
+PORT=9000 atb live-health ml_basic --paper-trading
+```
+
+The command reads the listening port from the `PORT` environment variable (falling back to `HEALTH_CHECK_PORT` or `8000`) and forwards all remaining arguments directly to `src/live/runner.py`. Set the variable inline, as shown, when you need to override the default port.
+
 ## Programmatic usage
 
 ```python
@@ -96,6 +106,8 @@ engine = LiveTradingEngine(
 )
 engine.start("BTCUSDT", "1h")
 ```
+
+`LiveTradingEngine` performs an immediate health check against the configured `DATABASE_URL`, so ensure PostgreSQL is running (or set `DATABASE_URL=postgresql://...`) before instantiating it in scripts or notebooks.
 
 In production deployments wrap the engine in a supervisor (systemd, Docker, Kubernetes) so that `SIGTERM` triggers the graceful
 shutdown path implemented in the runner.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring & observability
 
-> **Last Updated**: 2025-11-10  
+> **Last Updated**: 2025-11-16  
 > **Related Documentation**: [Live trading](live_trading.md), [Database](database.md)
 
 Instrumentation is delivered through structured logging, database events, and interactive dashboards. The goal is to provide the
@@ -40,9 +40,10 @@ underlying dashboard supports them.
 
 ## Health endpoints
 
-`atb live-health --port 9000 -- ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
-`/status`. The status payload checks configuration providers, database connectivity, and Binance API reachability so you can wire
-it into uptime monitors or Kubernetes liveness probes.
+`PORT=9000 atb live-health ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
+`/status`. The command derives its port from the `PORT` environment variable (falling back to `HEALTH_CHECK_PORT` or `8000`) and
+forwards every remaining argument to the live runner. The status payload checks configuration providers, database connectivity, and
+Binance API reachability so you can wire it into uptime monitors or Kubernetes liveness probes.
 
 ## Operational tips
 

--- a/src/live/README.md
+++ b/src/live/README.md
@@ -1,6 +1,6 @@
 # Live Trading Engine
 
-> **Last Updated**: 2025-11-10  
+> **Last Updated**: 2025-11-16  
 > **Related Documentation**: See [docs/live_trading.md](../../docs/live_trading.md) for comprehensive guide and safety controls
 
 Executes strategies in real time with risk controls, data providers, and database logging.
@@ -13,8 +13,8 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (explicit confirmation required)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+# Live trading with health endpoint (PORT/HEALTH_CHECK_PORT controls server port)
+PORT=8000 atb live-health ml_basic --symbol BTCUSDT --paper-trading
 ```
 
 ## Programmatic
@@ -30,3 +30,5 @@ engine = LiveTradingEngine(
 )
 engine.start("BTCUSDT", "1h")
 ```
+
+`atb live-health` reads the HTTP port from the `PORT` environment variable (falling back to `HEALTH_CHECK_PORT`), so export or prefix the variable when you need a non-default port.


### PR DESCRIPTION
## Context
This PR is part of the nightly documentation maintenance task, aimed at ensuring all documentation is up-to-date and accurate without altering any code behavior. The primary goal is to fix outdated content and align examples with the current codebase.

## Description
This PR addresses several documentation inconsistencies and omissions. It standardizes the usage of the `atb live-health` command, clarifies its port configuration, and updates development-related guides. It also adds a critical note regarding PostgreSQL requirements for the live trading engine.

## Changes in the codebase
- **`atb live-health` command usage**: All instances of `atb live-health` across `README.md`, `docs/development.md`, `docs/live_trading.md`, `docs/monitoring.md`, `src/live/README.md`, `CLAUDE.md`, and `.cursor/rules/*.md` have been updated to use the `PORT=<port>` environment variable for specifying the health server port, replacing the deprecated `--port` flag.
- **`docs/development.md` enhancements**: Added documentation for `atb tests secrets` and `atb tests parse-junit` diagnostics, and refreshed "Helpful shortcuts".
- **`docs/live_trading.md` updates**: Introduced a dedicated "Health endpoints" section and a note on PostgreSQL readiness for the `LiveTradingEngine`.
- **Timestamp updates**: "Last Updated" timestamps have been refreshed in all modified documentation files.

## Breaking changes
None. All changes are purely documentation-related and do not affect runtime behavior or core functionality.

## Additional information
These updates ensure that the documentation accurately reflects the current CLI behavior, development diagnostics, and operational requirements for the live trading engine, improving clarity and reducing potential user confusion.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2676919-f0c9-48df-8b18-2c83e66cfdff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2676919-f0c9-48df-8b18-2c83e66cfdff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

