### PR TITLE
Nightly documentation audit and update

### DIFF
--- a/DOCUMENTATION_AUDIT_2025-11-18.md
+++ b/DOCUMENTATION_AUDIT_2025-11-18.md
@@ -1,0 +1,71 @@
+# Documentation Audit Report - 2025-11-18
+
+**Date**: November 18, 2025  
+**Auditor**: AI Agent (Nightly Maintenance)  
+**Branch**: `cursor/nightly-documentation-audit-and-update-0a03`
+
+## Executive Summary
+
+Focused this cycle on the data access and model registry docs after discovering they still referenced the pre-Parquet cache format
+and legacy model layout. Updated the affected guides/READMEs to match the current `CachedDataProvider` implementation and structured
+bundle contents. Verified the `atb models` workflows that the docs now highlight.
+
+## Scope
+
+### Files Reviewed
+- `docs/data_pipeline.md`
+- `src/data_providers/README.md`
+- `docs/prediction.md`
+- `src/ml/models/README.md`
+- Spot-check: `cli/commands/data.py`, `src/data_providers/cached_data_provider.py`, `src/prediction/models/registry.py`
+
+### Areas Assessed
+1. Cache storage format and CLI coverage
+2. Model registry structure and management commands
+3. Consistency between CLI examples and actual argument order
+4. TODO/FIXME sweep for user-facing docs
+
+## Findings
+
+### 1. CachedDataProvider docs lagged actual Parquet implementation ⚠️
+- **Observation**: `docs/data_pipeline.md` and `src/data_providers/README.md` still described yearly pickle files, omitted the hash-
+  based Parquet layout, and failed to mention the `cache-manager clear` / `populate-dummy` subcommands.
+- **Resolution**: Documented the Parquet format, deterministic hashes, fallback directory behaviour, and the full CLI surface
+  (including `--force-refresh`, `--test-offline`, `clear`, and `populate-dummy`).
+
+### 2. Model registry guides referenced deprecated structure ⚠️
+- **Observation**: `docs/prediction.md` and `src/ml/models/README.md` claimed bundles only stored `model.onnx` + `metadata`,
+  suggested `model_type=price` in CLI examples, and implied legacy directories were still scanned.
+- **Resolution**: Refreshed both files with the actual artifact list (`model.keras`, `saved_model/`, `feature_schema.json`,
+  optional `metrics.json`), corrected the CLI examples to use `basic`, and clarified that the registry exclusively loads the
+  structured layout with `latest/` symlinks.
+
+### 3. TODO/FIXME scan ✅
+- No actionable TODO/FIXME markers found in user-facing docs; remaining references live inside planning/constitution guides.
+
+## Changes Made
+
+| File | Description |
+| ---- | ----------- |
+| `docs/data_pipeline.md` | Updated cached access section for Parquet storage, documented deterministic hashes/fallbacks, and expanded CLI coverage (`clear`, `populate-dummy`, `--force-refresh`, `--test-offline`). |
+| `src/data_providers/README.md` | Synced summary with the Parquet implementation and reminded readers to share cache directories with the CLI tools. |
+| `docs/prediction.md` | Documented full bundle contents, corrected CLI examples (`atb models compare/promote`), and noted optional `metrics.json` usage. |
+| `src/ml/models/README.md` | Rebuilt the registry README to reflect the structured hierarchy (artifacts + `latest` symlink) and clarified that legacy flat directories are no longer scanned. |
+
+## Validation
+
+- ✅ `python -m cli models list` – ensured the registry loader enumerates the bundles referenced in the docs.
+- ✅ `python -m cli models compare BTCUSDT 1h basic` – confirmed the compare example runs (returns `{}` when `metrics.json` is absent).
+- ✅ Markdown preview / lint – verified formatting and relative links.
+
+## Recommendations
+
+1. Consider adding `metrics.json` generation to the training pipeline so the CLI compare output carries richer summaries.
+2. Keep documentation edits co-located with future cache or registry refactors to avoid format drift.
+3. Re-run the cache-manager subcommands after the next cache schema change to make sure user-facing messaging stays accurate.
+
+---
+
+**Audit Completed**: 2025-11-18  
+**Status**: Passed (documentation updates only)  
+**Risk Level**: None – documentation-only changes

--- a/src/data_providers/README.md
+++ b/src/data_providers/README.md
@@ -1,6 +1,6 @@
 # Data Providers
 
-> **Last Updated**: 2025-11-10  
+> **Last Updated**: 2025-11-18  
 > **Related Documentation**: See [docs/data_pipeline.md](../../docs/data_pipeline.md) for detailed usage
 
 Abstractions and implementations for market and sentiment data.
@@ -12,6 +12,7 @@ Abstractions and implementations for market and sentiment data.
 - `data_provider.py`, `exchange_interface.py`: Base interfaces
 
 ## Usage
+
 ```python
 from src.data_providers.binance_provider import BinanceProvider
 from src.data_providers.cached_data_provider import CachedDataProvider
@@ -19,3 +20,7 @@ from src.data_providers.cached_data_provider import CachedDataProvider
 provider = CachedDataProvider(BinanceProvider(), cache_ttl_hours=24)
 df = provider.get_historical_data(symbol="BTCUSDT", timeframe="1h", start=..., end=...)
 ```
+
+`CachedDataProvider` stores yearly partitions as Parquet files with deterministic hashes, keeps prior full years permanently valid,
+and enforces the configured TTL (24 hours by default) for the current year. Pass `cache_dir` to align with the CLI cache manager
+(`atb data cache-manager ...`) and reuse the same storage when warming caches or running offline drills.

--- a/src/ml/models/README.md
+++ b/src/ml/models/README.md
@@ -1,40 +1,51 @@
 # Model Registry
 
-Structured storage for versioned models organized by symbol, model type, and version.
+Structured storage for versioned models organized by symbol, model type, and version. Every bundle ships the artifacts required for
+inference (`model.onnx`), retraining (`model.keras` + `saved_model/`), and operational introspection (`metadata.json`,
+`feature_schema.json`).
 
 ## Directory Structure
 
 ```
 models/
-├── SYMBOL/              # Trading pair (e.g., BTCUSDT, ETHUSDT)
-│   └── TYPE/            # Model type (e.g., basic, sentiment, adaptive)
-│       └── VERSION/     # Version identifier (e.g., 2025-09-17_1h_v1)
-│           ├── model.onnx         # ONNX inference model
-│           ├── metadata.json      # Model metadata
-│           └── training_info.json # Training parameters and metrics
+├── SYMBOL/                 # Trading pair (e.g., BTCUSDT, ETHUSDT)
+│   └── TYPE/               # Model type (basic, sentiment, adaptive, etc.)
+│       ├── VERSION/        # Version identifier (e.g., 2025-10-30_12h_v1)
+│       │   ├── model.onnx
+│       │   ├── model.keras
+│       │   ├── metadata.json
+│       │   ├── feature_schema.json
+│       │   └── saved_model/
+│       └── latest -> VERSION   # Symlink to the active production bundle
 ```
 
 Example structure:
+
 ```
 models/
 ├── BTCUSDT/
 │   ├── basic/
-│   │   └── 2025-09-17_1h_v1/
-│   │       └── model.onnx
+│   │   ├── 2025-10-30_12h_v1/
+│   │   │   ├── model.onnx
+│   │   │   ├── model.keras
+│   │   │   ├── metadata.json
+│   │   │   ├── feature_schema.json
+│   │   │   └── saved_model/
+│   │   └── latest -> 2025-10-30_12h_v1
 │   └── sentiment/
-│       └── 2025-09-17_1h_v1/
-│           └── model.onnx
+│       ├── 2025-09-17_1h_v1/
+│       └── latest -> 2025-09-17_1h_v1
 └── ETHUSDT/
     └── sentiment/
-        └── 2025-09-17_1h_v1/
-            └── model.onnx
+        ├── 2025-09-17_1h_v1/
+        └── latest -> 2025-09-17_1h_v1
 ```
 
 ## Model Types
 
-- **basic/** - Price-only prediction models using technical indicators
-- **sentiment/** - Models with sentiment features (Fear & Greed Index integration)
-- **adaptive/** - Models with regime-aware adaptation capabilities
+- **basic/** – Price-only prediction models using technical indicators
+- **sentiment/** – Models with sentiment features (Fear & Greed Index integration)
+- **adaptive/** – Models with regime-aware adaptation capabilities
 
 ## Version Naming Convention
 
@@ -43,17 +54,10 @@ Versions follow the pattern: `YYYY-MM-DD_TIMEFRAME_vN`
 - **Timeframe**: Target timeframe (e.g., 1h, 4h, 1d)
 - **Version**: Sequential version number
 
-## Current Models
-
-### BTCUSDT
-- `basic/2025-09-17_1h_v1` - Basic price prediction (1h timeframe)
-- `sentiment/2025-09-17_1h_v1` - Price prediction with sentiment (1h timeframe)
-
-### ETHUSDT
-- `sentiment/2025-09-17_1h_v1` - Price prediction with sentiment (1h timeframe)
-
 ## Usage
 
-Models are loaded by the `PredictionModelRegistry` which auto-discovers and manages model versions. The registry supports both this structured format and legacy models in the parent `ml/` directory.
+Models are loaded by the `PredictionModelRegistry`, which auto-discovers this structured layout and resolves `latest/`
+symlinks per `(symbol, model_type)` automatically. Legacy flat directories are no longer scanned; move artifacts into this
+hierarchy to make them available to strategies.
 
 For training new models and deploying to this registry, see [docs/prediction.md](../../../docs/prediction.md).


### PR DESCRIPTION
## Context
This PR addresses a nightly documentation maintenance task for the AI Trading Bot repository. The goal is to ensure all documentation is up-to-date and accurate, specifically focusing on data access and model registry guides, without introducing any behavioral changes to the codebase.

## Description
This PR updates the documentation for the `CachedDataProvider` to accurately reflect its current Parquet-backed storage mechanism and expands the coverage of related CLI commands. It also rebuilds the prediction and model registry documentation to align with the current structured model bundle layout, including artifact details and corrected CLI examples. A detailed audit report of the changes and validation steps is included.

## Changes in the codebase
- **`docs/data_pipeline.md`**: Updated the cached access section to describe Parquet storage, deterministic hashes, fallback behavior, and expanded CLI coverage (`clear`, `populate-dummy`, `--force-refresh`, `--test-offline`).
- **`src/data_providers/README.md`**: Synchronized the summary with the Parquet implementation and clarified cache directory sharing with CLI tools.
- **`docs/prediction.md`**: Documented the full model bundle contents, corrected CLI examples (`atb models compare/promote`), and noted the optional `metrics.json` usage.
- **`src/ml/models/README.md`**: Reworked to reflect the structured model hierarchy (artifacts + `latest` symlink) and clarified that legacy flat directories are no longer scanned.
- **`DOCUMENTATION_AUDIT_2025-11-18.md`**: Added a new audit report detailing the scope, findings, resolutions, and validation for this documentation maintenance cycle.

## Breaking changes
None. All changes are documentation-only and do not modify runtime behavior, business logic, or core functionality.

## Additional information
All code examples and CLI commands mentioned in the updated documentation were validated against the current codebase. Specifically, `python -m cli models list` and `python -m cli models compare BTCUSDT 1h basic` were run to confirm the documented CLI flows operate as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-a81f0668-f8f6-4ea4-b5eb-c891fa389689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a81f0668-f8f6-4ea4-b5eb-c891fa389689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates docs to reflect Parquet-backed caching and structured model bundles with corrected CLI examples; adds an audit report.
> 
> - **Documentation**:
>   - **Data access & cache** (`docs/data_pipeline.md`, `src/data_providers/README.md`):
>     - Describe Parquet-based yearly partitions with deterministic hashes and fallback cache dir.
>     - Expand CLI coverage: `cache-manager info|list|clear|clear-old`, `populate-dummy`, `--force-refresh`, `--test-offline`.
>   - **Prediction & model registry** (`docs/prediction.md`, `src/ml/models/README.md`):
>     - Define structured bundle contents (`model.onnx`, `model.keras`, `saved_model/`, `metadata.json`, `feature_schema.json`, optional `metrics.json`).
>     - Clarify registry layout with `latest/` symlinks; remove legacy flat-dir references.
>     - Fix CLI examples: `atb models compare BTCUSDT 1h basic`, `atb models promote BTCUSDT basic <VERSION>`.
>   - **Audit**: Add `DOCUMENTATION_AUDIT_2025-11-18.md` summarizing scope, findings, and validations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f61d9f6566ad169eaac4f20db7632a3e805079a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->