### PR TITLE
docs: nightly documentation maintenance

### DIFF
--- a/.cursor/rules/commands.md
+++ b/.cursor/rules/commands.md
@@ -18,7 +18,7 @@ alwaysApply: false
 ### Live Trading
 - Paper: `atb live ml_basic --symbol BTCUSDT --paper-trading`
 - Live (requires explicit ack): `atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks`
-- Health: `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- Health (set `PORT`/`HEALTH_CHECK_PORT`): `PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading`
 
 ### Monitoring & Utilities
 - Dashboard: `atb dashboards run monitoring --port 8000`

--- a/.cursor/rules/trading-bot-core.md
+++ b/.cursor/rules/trading-bot-core.md
@@ -101,8 +101,8 @@ max_drawdown = 0.20
 # Stop live trading immediately
 atb live-control emergency-stop
 
-# Check current positions and health
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+# Check current positions and health (set PORT/HEALTH_CHECK_PORT if needed)
+PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading
 
 # Emergency database backup
 python scripts/backup_database.py --emergency
@@ -175,7 +175,7 @@ atb live-control emergency-stop
 - "start dashboard" → `atb dashboards run monitoring --port 8000`
 
 ### Health & Monitoring
-- "check health" → `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- "check health" → `PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading`
 - "check positions" → `atb db verify`
 - "check cache" → `atb data cache-manager info`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,12 @@ atb backtest ml_basic --symbol BTCUSDT --timeframe 1h --days 30
 # Live trading (paper mode - safe)
 atb live ml_basic --symbol BTCUSDT --paper-trading
 
-# Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+# Live trading with health endpoint (PORT/HEALTH_CHECK_PORT controls HTTP port)
+PORT=8000 atb live-health -- ml_basic --paper-trading
 ```
+
+`atb live-health` reads the `PORT` (or `HEALTH_CHECK_PORT`) environment variable and defaults to `8000`, so export the value you
+need before launching the health server.
 
 ### ML Model Training & Deployment
 ```bash

--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (requires explicit confirmation)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading + health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+# Live trading + health endpoint (uses PORT/HEALTH_CHECK_PORT for HTTP port)
+PORT=8000 atb live-health -- ml_basic --paper-trading
 ```
+
+> **Health server port**: `atb live-health` reads the `PORT` (or `HEALTH_CHECK_PORT`) environment variable and defaults to `8000`. Export the variable before the command instead of passing `--port`, which is forwarded to the trading runner args.
 
 6) Utilities
 

--- a/docs/data_pipeline.md
+++ b/docs/data_pipeline.md
@@ -19,8 +19,10 @@ underlying exchange format.
 ## Sentiment data
 
 `FearGreedProvider` (`src/data_providers/feargreed_provider.py`) downloads the Alternative.me Fear & Greed index and exposes
-`get_historical_sentiment()` plus aggregation helpers that align the series with OHLCV data. Both the backtesting CLI (`--use-sentiment`)
-and the live trading engine accept an optional `SentimentDataProvider` to enrich decisions.
+`get_historical_sentiment()` plus aggregation helpers that align the series with OHLCV data. The backtesting CLI wires the provider
+through the `--use-sentiment` flag today. The live trading engine still supports `SentimentDataProvider` instances, but the CLI’s
+`--use-sentiment` flag currently issues a warning and no-ops while the ingestion refresh stabilises, so attach the provider directly
+when instantiating `LiveTradingEngine` in long-running services.
 
 ## Cached access
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -67,7 +67,7 @@ succinct changelog, bumps the semantic version, and auto-stages the updated mani
 
 - `atb backtest ml_basic --days 30` – quick simulations while iterating on strategies.
 - `atb live ml_basic --paper-trading` – start the live runner in paper trading mode.
-- `atb live-health --port 8000 -- ml_basic --paper-trading` – start live trading with health endpoint.
+- `PORT=8000 atb live-health -- ml_basic --paper-trading` – start live trading with health endpoint (reads `PORT`/`HEALTH_CHECK_PORT`, defaults to 8000).
 - `atb optimizer --strategy ml_basic --days 30` – trigger the optimisation CLI.
 
 Use these commands to mirror CI behaviour locally before opening pull requests.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -40,9 +40,10 @@ underlying dashboard supports them.
 
 ## Health endpoints
 
-`atb live-health --port 9000 -- ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
-`/status`. The status payload checks configuration providers, database connectivity, and Binance API reachability so you can wire
-it into uptime monitors or Kubernetes liveness probes.
+`PORT=9000 atb live-health -- ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
+`/status`. The helper reads the `PORT` (or `HEALTH_CHECK_PORT`) environment variable and defaults to `8000`, so export the value
+you need before running the command. The status payload checks configuration providers, database connectivity, and Binance API
+reachability so you can wire it into uptime monitors or Kubernetes liveness probes.
 
 ## Operational tips
 

--- a/src/live/README.md
+++ b/src/live/README.md
@@ -13,19 +13,29 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (explicit confirmation required)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+# Live trading with health endpoint (set PORT/HEALTH_CHECK_PORT to control HTTP port)
+PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading
 ```
+
+`atb live-health` reads the `PORT` (or `HEALTH_CHECK_PORT`) environment variable, defaulting to `8000`, before launching the
+embedded HTTP server.
+
+Sentiment enrichment is currently wired manually: the CLI keeps the `--use-sentiment` flag for backwards compatibility but it
+emits a warning and does not attach a provider. Pass a `SentimentDataProvider` directly when constructing the engine if you need
+live sentiment features.
 
 ## Programmatic
 ```python
+from src.data_providers.binance_provider import BinanceProvider
+from src.data_providers.cached_data_provider import CachedDataProvider
+from src.data_providers.feargreed_provider import FearGreedProvider
 from src.live.trading_engine import LiveTradingEngine
 from src.strategies.ml_basic import create_ml_basic_strategy
-from src.data_providers.binance_provider import BinanceProvider
 
 engine = LiveTradingEngine(
     strategy=create_ml_basic_strategy(),
-    data_provider=BinanceProvider(),
+    data_provider=CachedDataProvider(BinanceProvider(), cache_ttl_hours=1),
+    sentiment_provider=FearGreedProvider(),
     initial_balance=10000,
 )
 engine.start("BTCUSDT", "1h")


### PR DESCRIPTION
## Summary
- clarify that `atb live-health` takes its port from `PORT`/`HEALTH_CHECK_PORT` across README, docs, and contributor guides
- document the current live sentiment pathway, including the CLI warning and how to attach `FearGreedProvider` programmatically
- refresh module READMEs and Codex helper docs so operational playbooks stay in sync

## Testing
- not run (docs only)