### PR TITLE
docs: nightly documentation audit 2025-11-29

### DIFF
--- a/DOCUMENTATION_AUDIT_2025-11-29.md
+++ b/DOCUMENTATION_AUDIT_2025-11-29.md
@@ -1,0 +1,49 @@
+# Documentation Audit Report - 2025-11-29
+
+**Date**: November 29, 2025  
+**Auditor**: AI Agent (Nightly Maintenance)  
+**Branch**: `cursor/nightly-documentation-audit-and-update-675b`
+
+## Executive Summary
+
+Ran the documentation validator across `docs/` and every module README. The sweep caught a broken relative link inside the
+prediction-model registry guide and surfaced a non-functional code example in the position-management README where the
+`DatabaseManager` dependency was never created. Both issues were corrected, and the validator now passes without errors.
+
+## Scope
+
+### Files Reviewed
+- `src/prediction/models/README.md`
+- `src/position_management/README.md`
+- Automated scan: all markdown under `docs/` plus `src/**/README.md`
+
+### Areas Assessed
+1. Relative link accuracy for module READMEs.
+2. Executability of code samples in risk/position-management docs.
+3. Outstanding documentation validation failures detected by `atb docs validate`.
+
+## Findings
+
+### 1. Prediction registry README pointed to non-existent `src/docs` path ⚠️
+- **Observation**: The closing paragraph linked to `../../docs/prediction.md`, which resolves to `src/docs/prediction.md` (missing).
+- **Resolution**: Updated the relative path to `../../../docs/prediction.md`, restoring the documented cross-reference.
+
+### 2. Position management example referenced undefined `database_manager` ⚠️
+- **Observation**: The "Typical usage" snippet instantiated `RiskManager` and `DynamicRiskManager` but passed an undefined `database_manager` variable, making the example unusable as written.
+- **Resolution**: Imported `DatabaseManager`, added an explicit instantiation, and wired it into `DynamicRiskManager` so readers can run the sample without guessing the missing dependency.
+
+## Changes Made
+
+| File | Description |
+| ---- | ----------- |
+| `src/prediction/models/README.md` | Corrected the relative link to the main prediction guide to prevent broken-link errors during validation. |
+| `src/position_management/README.md` | Extended the usage example with the proper `DatabaseManager` import and instantiation to keep the snippet runnable end-to-end. |
+
+## Validation
+
+- ✅ `python -m cli.__main__ docs validate` – confirms 61 markdown files now pass link and structural checks with zero warnings.
+
+## Recommendations
+
+1. Add `python -m cli.__main__ docs validate` to the nightly pipeline so link regressions surface immediately.
+2. Continue spot-checking README code samples whenever risk/position management APIs change to keep the snippets executable.

--- a/src/position_management/README.md
+++ b/src/position_management/README.md
@@ -31,9 +31,11 @@ rewriting strategy logic.
 ## Typical usage
 
 ```python
+from src.database.manager import DatabaseManager
 from src.risk.risk_manager import RiskManager
 from src.position_management.dynamic_risk import DynamicRiskConfig, DynamicRiskManager
 
+database_manager = DatabaseManager()
 risk = RiskManager()
 dyn = DynamicRiskManager(DynamicRiskConfig(enabled=True), database_manager)
 

--- a/src/prediction/models/README.md
+++ b/src/prediction/models/README.md
@@ -49,4 +49,4 @@ Models are automatically discovered from the structured registry rooted at `src/
 - `model.keras` and `saved_model/` preserve the TensorFlow export for retracing.
 - `metadata.json`, `feature_schema.json`, and optional `metrics.json` drive selection, validation, and CLI summaries.
 
-CLI helpers under `atb models` (`list`, `compare`, `validate`, `promote`) and `atb live-control` reuse this registry, so documentation changes here should stay in sync with [docs/prediction.md](../../docs/prediction.md).
+CLI helpers under `atb models` (`list`, `compare`, `validate`, `promote`) and `atb live-control` reuse this registry, so documentation changes here should stay in sync with [docs/prediction.md](../../../docs/prediction.md).


### PR DESCRIPTION
## Context
Nightly documentation maintenance run for 2025-11-29 focusing on link integrity and runnable README examples.

## Description
- Fixed the broken relative link in `src/prediction/models/README.md` that doc validation flagged.
- Updated the `src/position_management/README.md` usage sample so it instantiates `DatabaseManager` before handing it to `DynamicRiskManager`.
- Recorded the work in `DOCUMENTATION_AUDIT_2025-11-29.md` per the nightly audit trail convention.

## Changes in the codebase
- Documentation-only updates under `src/prediction/models`, `src/position_management`, and the root audit log.

## Breaking changes
- None.

## Aditional information
- Validation: `python -m cli.__main__ docs validate`