### PR TITLE
docs: align live-health documentation

### DIFF
--- a/.cursor/rules/commands.md
+++ b/.cursor/rules/commands.md
@@ -18,7 +18,7 @@ alwaysApply: false
 ### Live Trading
 - Paper: `atb live ml_basic --symbol BTCUSDT --paper-trading`
 - Live (requires explicit ack): `atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks`
-- Health: `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- Health: `PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading`
 
 ### Monitoring & Utilities
 - Dashboard: `atb dashboards run monitoring --port 8000`

--- a/.cursor/rules/trading-bot-core.md
+++ b/.cursor/rules/trading-bot-core.md
@@ -102,7 +102,7 @@ max_drawdown = 0.20
 atb live-control emergency-stop
 
 # Check current positions and health
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading
 
 # Emergency database backup
 python scripts/backup_database.py --emergency
@@ -175,7 +175,7 @@ atb live-control emergency-stop
 - "start dashboard" → `atb dashboards run monitoring --port 8000`
 
 ### Health & Monitoring
-- "check health" → `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- "check health" → `PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading`
 - "check positions" → `atb db verify`
 - "check cache" → `atb data cache-manager info`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,8 @@ atb backtest ml_basic --symbol BTCUSDT --timeframe 1h --days 30
 # Live trading (paper mode - safe)
 atb live ml_basic --symbol BTCUSDT --paper-trading
 
-# Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+# Live trading with health endpoint (override port via PORT/HEALTH_CHECK_PORT)
+PORT=8000 atb live-health -- ml_basic --paper-trading
 ```
 
 ### ML Model Training & Deployment

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modular cryptocurrency trading system focused on long-term, risk-balanced trend following. It supports backtesting, live trading (paper and live), ML-driven models (price and sentiment), PostgreSQL logging, and optional Railway deployment.
 
-[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/) [![DB](https://img.shields.io/badge/DB-PostgreSQL-informational)](docs/database.md) [![License](https://img.shields.io/badge/license-MIT-lightgrey)](#)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/) [![DB](https://img.shields.io/badge/DB-PostgreSQL-informational)](docs/database.md) [![License](https://img.shields.io/badge/license-MIT-lightgrey)](LICENSE)
 
 > **Requirements**: Python 3.11+ (the repository uses 3.11+ typing features)
 
@@ -78,9 +78,11 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (requires explicit confirmation)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading + health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+# Live trading + health endpoint (override port via PORT/HEALTH_CHECK_PORT)
+PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading
 ```
+
+Set `PORT` (or `HEALTH_CHECK_PORT`) before running to change the HTTP listener; arguments after `--` are forwarded to the live runner just like `atb live`.
 
 6) Utilities
 
@@ -246,6 +248,7 @@ Sentiment data and ML training are supported. Pretrained models live in `src/ml`
 ## Logging
 - Centralized logging via `src.infrastructure.logging.config.configure_logging()` with env `LOG_LEVEL` and `LOG_JSON`.
 - JSON logs default to enabled in production-like environments (Railway or ENV/APP_ENV=production).
+- Health/`live-health` endpoints read the `PORT` (or `HEALTH_CHECK_PORT`) env var; set it before invoking `atb live-health` to override the default 8000 listener.
 - See `docs/monitoring.md` for structured events, context, and operations guidance.
 
 ---

--- a/docs/development.md
+++ b/docs/development.md
@@ -67,7 +67,7 @@ succinct changelog, bumps the semantic version, and auto-stages the updated mani
 
 - `atb backtest ml_basic --days 30` – quick simulations while iterating on strategies.
 - `atb live ml_basic --paper-trading` – start the live runner in paper trading mode.
-- `atb live-health --port 8000 -- ml_basic --paper-trading` – start live trading with health endpoint.
+- `PORT=8000 atb live-health -- ml_basic --paper-trading` – start live trading with the health endpoint (override the port via `PORT`/`HEALTH_CHECK_PORT` before running).
 - `atb optimizer --strategy ml_basic --days 30` – trigger the optimisation CLI.
 
 Use these commands to mirror CI behaviour locally before opening pull requests.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -40,9 +40,10 @@ underlying dashboard supports them.
 
 ## Health endpoints
 
-`atb live-health --port 9000 -- ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
-`/status`. The status payload checks configuration providers, database connectivity, and Binance API reachability so you can wire
-it into uptime monitors or Kubernetes liveness probes.
+`PORT=9000 atb live-health -- ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
+`/status`. The health listener reads the `PORT` (or `HEALTH_CHECK_PORT`) environment variable—set it before invoking the CLI to
+override the default 8000 port. The status payload checks configuration providers, database connectivity, and Binance API
+reachability so you can wire it into uptime monitors or Kubernetes liveness probes.
 
 ## Operational tips
 

--- a/src/backtesting/dashboard/README.md
+++ b/src/backtesting/dashboard/README.md
@@ -4,5 +4,9 @@ Simple Flask dashboard for visualizing backtest results.
 
 ## Run
 ```bash
-python src/backtesting/dashboard/dashboard.py --host 0.0.0.0 --port 8050
+# Preferred: use the dashboards CLI to discover and launch the UI
+atb dashboards run backtesting --port 8050
+
+# Direct module execution (if you need custom flags)
+python -m src.dashboards.backtesting.dashboard --host 0.0.0.0 --port 8050
 ```

--- a/src/config/providers/README.md
+++ b/src/config/providers/README.md
@@ -19,7 +19,7 @@ Environment-specific configuration providers for the configuration system.
 Configuration providers are automatically initialized by the `ConfigManager` and should not be used directly. Use the config manager instead:
 
 ```python
-from config import get_config
+from src.config import get_config
 
 config = get_config()
 value = config.get_required("API_KEY")

--- a/src/live/README.md
+++ b/src/live/README.md
@@ -13,9 +13,12 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (explicit confirmation required)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+# Live trading with health endpoint (override port via PORT/HEALTH_CHECK_PORT)
+PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading
 ```
+
+`live-health` reads the HTTP listener port from `PORT` (falling back to `HEALTH_CHECK_PORT` or 8000). Set it before running if you
+need the health server on a custom port; arguments after `--` flow directly into the `atb live` runner.
 
 ## Programmatic
 ```python

--- a/src/tech/adapters/README.md
+++ b/src/tech/adapters/README.md
@@ -14,5 +14,6 @@ Guidelines:
   how to persist it.
 
 The `row_extractors.py` module exposes `extract_indicators`,
-`extract_sentiment_data`, and `extract_ml_predictions`, which replace duplicated
-helpers in `src/trading/shared/indicators.py` and `src/backtesting/utils.py`.
+`extract_sentiment_data`, and `extract_ml_predictions`, which replaced the duplicated
+helpers that used to live in the now-removed `src/trading/shared/indicators.py` shim
+and in `src/backtesting/utils.py`.

--- a/src/trading/README.md
+++ b/src/trading/README.md
@@ -4,7 +4,7 @@ Base classes and shared utilities for trading strategies and components.
 
 ## Overview
 
-This module provides the foundational interfaces and shared functionality used across the trading system. It defines base strategy classes, component interfaces, and common helpers for backtesting and live trading, including symbol utilities under `symbols/`.
+This module provides the foundational interfaces and shared functionality used across the trading system. It defines the component-based strategy wiring, shared helpers, and symbol utilities under `symbols/` that both the backtester and live engine reuse.
 
 ## Modules
 
@@ -12,8 +12,10 @@ This module provides the foundational interfaces and shared functionality used a
 
 ## Key Components
 
-### Base Strategy Classes
-Abstract base classes for implementing trading strategies. All custom strategies should inherit from `BaseStrategy`.
+### Strategy Composition
+Strategies are composed from `SignalGenerator`, `RiskManager`, and `PositionSizer` components via the `Strategy` class in
+`src/strategies/components`. Each component has a clear interface so you can swap implementations without rewriting the rest of the
+stack.
 
 ### Component Interfaces
 Contracts defining the interface for:
@@ -28,21 +30,47 @@ Common helpers used by strategies and engines including validation, error handli
 ## Usage
 
 ```python
-# Import base strategy class
-from src.strategies.base import BaseStrategy
+import pandas as pd
 
-class MyStrategy(BaseStrategy):
-    def calculate_indicators(self, df):
-        # Add indicators to dataframe
-        return df
-    
-    def check_entry_conditions(self, df):
-        # Return entry signal
-        return signal
-    
-    def check_exit_conditions(self, df, position):
-        # Return exit signal
-        return signal
+from src.strategies.components import (
+    Strategy,
+    Signal,
+    SignalDirection,
+    SignalGenerator,
+    FixedRiskManager,
+    FixedFractionSizer,
+)
+
+
+class SimpleMASignalGenerator(SignalGenerator):
+    def __init__(self, fast_period: int = 10, slow_period: int = 30):
+        super().__init__("simple_ma")
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+
+    def generate_signal(self, df: pd.DataFrame, index: int, regime=None) -> Signal:
+        if index < self.slow_period:
+            return Signal(SignalDirection.HOLD, strength=0.0, confidence=0.0, metadata={})
+        fast = df["close"].rolling(self.fast_period).mean().iloc[index]
+        slow = df["close"].rolling(self.slow_period).mean().iloc[index]
+        if fast > slow:
+            direction = SignalDirection.BUY
+        elif fast < slow:
+            direction = SignalDirection.SELL
+        else:
+            direction = SignalDirection.HOLD
+        return Signal(direction, strength=1.0, confidence=self.get_confidence(df, index), metadata={"fast": fast, "slow": slow})
+
+    def get_confidence(self, df: pd.DataFrame, index: int) -> float:
+        return 0.6  # plug in whatever heuristic you need
+
+
+strategy = Strategy(
+    name="simple_ma",
+    signal_generator=SimpleMASignalGenerator(),
+    risk_manager=FixedRiskManager(risk_per_trade=0.02),
+    position_sizer=FixedFractionSizer(fraction=0.1),
+)
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary
- document that the health server reads PORT/HEALTH_CHECK_PORT and update all user-facing guides plus helper rulebooks accordingly
- refresh module READMEs (trading core, tech adapters, config providers, live engine) and fix the backtesting dashboard instructions so they point at the dashboards CLI
- ensure the main README badge links to LICENSE and clarify logging guidance around the health endpoint

## Test Plan
- Not run (docs only)