### PR TITLE
docs: nightly doc maintenance 2025-12-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ bandit -c pyproject.toml -r src
 src/
   backtesting/          # Vectorised simulation engine and utilities
   config/               # Typed configuration loader, constants, feature flags
-  dashboards/           # Web monitoring and analytics dashboards
+  dashboards/           # Monitoring, backtesting, and prediction dashboards
   data_providers/       # Market, sentiment, and cache-aware data sources
   database/             # SQLAlchemy models, DatabaseManager, admin UI
-  infrastructure/       # Logging config, runtime helpers, secrets/paths
+  infrastructure/       # Logging config, runtime helpers, cache/secret tooling
   live/                 # Live trading engine, runners, sync utilities
   ml/                   # Training pipeline plus versioned model registry artifacts
   optimizer/            # Parameter optimization and analyzer tooling
-  performance/          # Performance metrics and reporting helpers
+  performance/          # Shared performance and diagnostics helpers
   position_management/  # Partial exits, trailing stops, dynamic risk policies
   prediction/           # Prediction engine, feature pipeline, ONNX runners
   regime/               # Market regime detection and analysis
@@ -161,7 +161,7 @@ src/
   sentiment/            # Sentiment adapters and data mergers
   strategies/           # Component-based strategies and factories
   tech/                 # Indicator math, feature builders, adapters
-  trading/              # Trading interfaces, symbols, and shared helpers
+  trading/              # Trading interfaces plus symbol utilities
   indicators/           # Legacy shim that re-exports `src.tech` (kept for compatibility)
 ```
 
@@ -176,8 +176,8 @@ src/
 - Live engine: `live.trading_engine.LiveTradingEngine` (CLI: `atb live`, `atb live-health`)
 - Risk: `risk.risk_manager.RiskManager`
 - Database: `database.manager.DatabaseManager` (PostgreSQL)
-- Monitoring: `dashboards.monitoring.MonitoringDashboard` (CLI: `atb dashboards run monitoring`)
-- Admin UI: `database.admin_ui.app` (Flask-Admin), run `python src/database/admin_ui/app.py`
+- Monitoring dashboard: `src.dashboards.monitoring.dashboard.MonitoringDashboard` (CLI: `atb dashboards run monitoring`)
+- Admin UI: `src.database.admin_ui.app:create_app` (Flask-Admin), run `python src/database/admin_ui/app.py`
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-> **Last Updated**: 2025-11-10  
+> **Last Updated**: 2025-12-01  
 > **Maintained By**: AI Trading Bot Team
 
 This folder contains reference guides for the main subsystems that make up the AI trading platform. Each document focuses on how the runtime works today and includes links to relevant code and operational commands.
@@ -21,6 +21,9 @@ This folder contains reference guides for the main subsystems that make up the A
 ### Operations
 - [Database](database.md) - PostgreSQL setup, migrations, and backups
 - [Monitoring & observability](monitoring.md) - Logging, dashboards, and health endpoints
+
+### Architecture
+- [Component risk integration](architecture/component_risk_integration.md) - Coordination between position management, risk, and strategy layers
 
 ## Quick Links
 

--- a/docs/architecture/component_risk_integration.md
+++ b/docs/architecture/component_risk_integration.md
@@ -32,21 +32,21 @@ This note summarises recommended architectural adjustments for aligning `positio
 
 ## Clarify Strategy Management Responsibilities
 
-### Rename and Align Managers
+### Align Managers
 
-1. Rename `src/strategies/components/strategy_manager.py:StrategyManager` to `ComponentStrategyManager`, updating imports across `src/strategies/components/__init__.py`, tests, and any factory modules.
+1. Keep `src/strategies/components/strategy_manager.py:ComponentStrategyManager` clearly documented so developers can distinguish it from the live-engine `StrategyManager`. Update any lingering imports or comments that still reference the legacy class name.
 2. Extract shared versioning helpers (e.g., semantic version comparison, component registry caching) into `src/strategies/management/versioning.py`.
 3. Update `src/live/strategy_manager.py` to import the helpers instead of re-implementing them. Where behaviour differs (such as hot-swap orchestration), document the divergence in module-level docstrings to avoid future confusion.
 
 ### Provide a Consistent Adapter Wiring Path
 
-- The renamed component manager should accept adapters (risk, execution, data) as constructor dependencies. When creating strategy instances, it should inject the `CoreRiskAdapter` so every component has a consistent risk surface.
+- The component manager should accept adapters (risk, execution, data) as constructor dependencies. When creating strategy instances, it should inject the `CoreRiskAdapter` so every component has a consistent risk surface.
 - The live manager should likewise receive adapter instances (or factories) so that hot-swapped strategies inherit the same wiring. This also makes it easier to reuse the managers in integration tests.
 
 ### Documentation and Migration Notes
 
 - Add module docstrings describing the division of responsibilities and the shared helpers.
-- Update any developer onboarding docs referencing the old `StrategyManager` name.
+- Update any developer onboarding docs to call out that `ComponentStrategyManager` handles component-level orchestration while `src/live/strategy_manager.py` owns hot-swapping.
 - Consider documenting the migration path (recommended location: `docs/architecture/strategy_management.md`) so teams know which imports to update and how to plug the new helpers into custom strategies.
 
 ## Testing Implications

--- a/docs/data_pipeline.md
+++ b/docs/data_pipeline.md
@@ -48,8 +48,8 @@ Cache metadata (file count, disk usage, entry age) is exposed through `get_cache
 
 The `atb data` command family in `cli/commands/data.py` covers the most common workflows:
 
-- `atb data download --symbol BTCUSDT --timeframe 1h --start-date 2024-01-01` – export a CSV/Feather dataset via CCXT without
-  touching the cache.
+- `atb data download BTCUSDT --timeframe 1h --start_date 2024-01-01 --end_date 2024-03-01` – export a CSV/Feather dataset via CCXT without
+  touching the cache (both `--start_date` and `--end_date` are optional; omit `--end_date` to pull through “now”).
 - `atb data prefill-cache --symbols BTCUSDT ETHUSDT --timeframes 1h 4h --years 3` – eagerly fetches year chunks so backtests can
   run offline.
 - `atb data preload-offline --symbols BTCUSDT --timeframes 1h --years-back 10 --test-offline` – ensures the cache contains enough

--- a/src/performance/README.md
+++ b/src/performance/README.md
@@ -1,132 +1,73 @@
 # Performance Utilities
 
-Comprehensive utilities for computing performance metrics used across backtesting, live trading, and monitoring.
+Lightweight helpers for computing the performance numbers surfaced by the
+backtester, live engine, dashboards, and tests.
 
-## Overview
+## Module overview
 
-This module provides a complete suite of performance analysis tools for evaluating trading strategies. Metrics include risk-adjusted returns, drawdown analysis, win/loss statistics, and advanced portfolio analytics.
+- `metrics.py` – Pure, side-effect free helpers used throughout the stack.
 
-## Contents
-- `metrics.py` - Core performance metrics and analysis functions
+### Included helpers
 
-## Available Metrics
+| Helper | Purpose |
+| ------ | ------- |
+| `pnl_percent` | Sized percentage return for a trade based on entry/exit and side |
+| `cash_pnl` | Converts sized percentage returns into account currency |
+| `total_return` | Cumulative percentage return between two balances |
+| `cagr` | Compound annual growth rate for a period (percentage) |
+| `sharpe` | Annualised Sharpe ratio for a daily equity curve |
+| `max_drawdown` | Maximum drawdown (percentage) for an equity curve |
+| `directional_accuracy` | Percentage of correct up/down predictions |
+| `mean_absolute_error` | Absolute error between prediction and actual series |
+| `mean_absolute_percentage_error` | Same as above expressed as a percentage |
+| `brier_score_direction` | Brier score for binary directional probabilities |
 
-### Risk-Adjusted Returns
-- **Sharpe Ratio** - Return per unit of volatility
-- **Sortino Ratio** - Return per unit of downside volatility
-- **Calmar Ratio** - Return per unit of maximum drawdown
-- **Information Ratio** - Excess return per unit of tracking error
-
-### Drawdown Analysis
-- **Maximum Drawdown** - Largest peak-to-trough decline
-- **Average Drawdown** - Mean of all drawdowns
-- **Drawdown Duration** - Time spent in drawdown
-- **Recovery Time** - Time to recover from drawdowns
-
-### Win/Loss Statistics
-- **Win Rate** - Percentage of profitable trades
-- **Profit Factor** - Gross profit / gross loss
-- **Average Win** - Mean profit of winning trades
-- **Average Loss** - Mean loss of losing trades
-- **Expectancy** - Expected value per trade
-
-### Portfolio Analytics
-- **Total Return** - Cumulative return over period
-- **Annualized Return** - CAGR (Compound Annual Growth Rate)
-- **Volatility** - Standard deviation of returns
-- **Beta** - Correlation with benchmark
-- **Alpha** - Excess return over benchmark
+All helpers accept pandas Series/DataFrames (or scalars) and never mutate their
+inputs, which keeps them easy to test and reason about.
 
 ## Usage
 
-### Basic Metrics
 ```python
-from src.performance.metrics import sharpe, max_drawdown
+from datetime import datetime
 
-# Calculate metrics from daily balance series
-sharpe_ratio = sharpe(daily_balance_series)
-max_dd = max_drawdown(daily_balance_series)
-
-print(f"Sharpe: {sharpe_ratio:.2f}, Max DD: {max_dd:.2%}")
-```
-
-### Trade-Based Metrics
-```python
-import pandas as pd
-import numpy as np
-
-# Calculate win rate from trades
-trades_df = pd.DataFrame([
-    {'pnl': 100, 'exit_time': '2024-01-01'},
-    {'pnl': -50, 'exit_time': '2024-01-02'},
-    {'pnl': 150, 'exit_time': '2024-01-03'}
-])
-
-winning_trades = len(trades_df[trades_df['pnl'] > 0])
-total_trades = len(trades_df)
-win_rate = winning_trades / total_trades if total_trades > 0 else 0
-
-print(f"Win Rate: {win_rate:.1%}")
-print(f"Total Trades: {total_trades}")
-print(f"Average PnL: ${trades_df['pnl'].mean():.2f}")
-```
-
-### Rolling Metrics
-```python
-from src.performance.metrics import sharpe
 import pandas as pd
 
-# Calculate rolling Sharpe ratio
-window = 30
-rolling_returns = daily_balance_series.pct_change()
-rolling_sharpe = rolling_returns.rolling(window=window).apply(
-    lambda x: sharpe(pd.Series(x)) if len(x) == window else np.nan
+from src.performance.metrics import (
+    cash_pnl,
+    cagr,
+    max_drawdown,
+    pnl_percent,
+    sharpe,
+    total_return,
 )
 
-print(f"Current Rolling Sharpe (30d): {rolling_sharpe.iloc[-1]:.2f}")
+# Example trade
+trade_return = pnl_percent(entry_price=100, exit_price=105, side="long", fraction=0.5)
+assert round(trade_return, 4) == 0.025  # +2.5 % on total balance
+print(f"Cash PnL on $20k account: ${cash_pnl(trade_return, balance_before=20_000):.2f}")
+
+# Equity curve metrics
+index = pd.date_range(end=datetime.utcnow(), periods=120, freq="D")
+equity_curve = pd.Series(10_000).reindex(index)
+equity_curve += (pd.Series(range(len(index)), index=index) * 25)  # toy growth
+
+print(f"Total return: {total_return(10_000, equity_curve.iloc[-1]):.2f}%")
+print(f"CAGR: {cagr(10_000, equity_curve.iloc[-1], days=len(equity_curve)):.2f}%")
+print(f"Sharpe: {sharpe(equity_curve):.2f}")
+print(f"Max drawdown: {max_drawdown(equity_curve):.2f}%")
 ```
 
-## Performance Analysis
+## Integration points
 
-```python
-import matplotlib.pyplot as plt
+- **Backtesting** – `src/backtesting/utils.compute_performance_metrics` consumes
+  these helpers before emitting CLI summaries or persisting results.
+- **Live trading** – Live PnL, drawdown, and Sharpe readouts in
+  `src/dashboards/monitoring` rely on the same functions so offline and live
+  views stay consistent.
+- **Prediction diagnostics** – The ML evaluation pipeline uses
+  `directional_accuracy`, `mean_absolute_error`, `mean_absolute_percentage_error`,
+  and `brier_score_direction` when validating model outputs.
 
-# Plot balance curve
-plt.figure(figsize=(12, 6))
-plt.plot(daily_balance_series.index, daily_balance_series.values)
-plt.title('Balance Over Time')
-plt.xlabel('Date')
-plt.ylabel('Balance ($)')
-plt.grid(True)
-plt.savefig('balance_curve.png')
-plt.close()
-
-# Calculate cumulative returns
-cumulative_returns = (daily_balance_series / daily_balance_series.iloc[0] - 1) * 100
-print(f"Total Return: {cumulative_returns.iloc[-1]:.2f}%")
-```
-
-## Integration
-
-### Backtesting
-Performance metrics are automatically calculated and displayed in backtest results:
-```bash
-atb backtest ml_basic --symbol BTCUSDT --days 365
-```
-
-### Live Trading
-Real-time performance metrics are available through the monitoring dashboard:
-```bash
-atb dashboards run monitoring --port 8000
-```
-
-### Database
-Historical performance metrics are stored in the `performance_metrics` table for trend analysis.
-
-## Best Practices
-
-1. **Use annualized metrics** for comparing strategies across different time periods
-2. **Consider risk-adjusted returns** (Sharpe, Sortino) over raw returns
-3. **Monitor drawdown metrics** to ensure risk tolerance is maintained
-4. **Track multiple timeframes** (daily, weekly, monthly) for complete picture
-5. **Compare to benchmarks** (buy-and-hold, index) for context
+Because each helper is a pure function, you can safely call them from unit
+tests, CLI tooling, or ad-hoc notebooks without pulling in any runtime
+dependencies beyond pandas/numpy.

--- a/src/prediction/ensemble/README.md
+++ b/src/prediction/ensemble/README.md
@@ -1,3 +1,43 @@
 # Prediction Ensembles
 
-Hooks for combining multiple model predictions (reserved for future expansion).
+Utilities for combining multiple `ModelPrediction` objects into a single
+decision.
+
+## Modules
+
+- `__init__.py` – Defines `SimpleEnsembleAggregator` (mean/median/weighted) and
+  the `EnsembleResult` dataclass returned after aggregation.
+
+## SimpleEnsembleAggregator
+
+```python
+from src.prediction.ensemble import SimpleEnsembleAggregator
+from src.prediction.models.onnx_runner import ModelPrediction
+
+aggregator = SimpleEnsembleAggregator(method="weighted")
+prediction = aggregator.aggregate([
+    ModelPrediction(price=100.5, confidence=0.6, direction=1, model_name="model_a", inference_time=0.01),
+    ModelPrediction(price=101.2, confidence=0.8, direction=1, model_name="model_b", inference_time=0.02),
+    ModelPrediction(price=99.4, confidence=0.4, direction=-1, model_name="model_c", inference_time=0.01),
+])
+
+print(prediction.price, prediction.confidence, prediction.direction)
+```
+
+- `method="mean"` – arithmetic mean of price/confidence.
+- `method="median"` – median of price/confidence.
+- `method="weighted"` – confidence-weighted averages (automatically falls back
+  to equal weights when all confidences are zero).
+
+Direction is determined via majority vote (`1` for bullish, `-1` for bearish,
+`0` on ties).
+
+## When to use
+
+- Blend predictions from multiple ONNX bundles before handing the result to a
+  trading strategy.
+- Perform quick what-if experiments on ensemble weighting without wiring up a
+  full strategy component.
+
+The aggregator intentionally has no dependencies on the strategy subsystem,
+which keeps it easy to reuse inside notebooks, CLI tooling, and unit tests.

--- a/src/prediction/features/README.md
+++ b/src/prediction/features/README.md
@@ -1,3 +1,53 @@
 # Prediction Features
 
-Feature engineering helpers for ML models (reserved for future expansion).
+Compatibility shims and helpers that bridge legacy prediction pipelines with the
+new `src/tech` feature stack.
+
+## Structure
+
+- `base.py`, `technical.py`, `market.py`, `price_only.py`, `sentiment.py` –
+  thin wrappers that re-export the canonical implementations in
+  `src.tech.features.*`. Importing from either location continues to work, but
+  new code should depend on the `src.tech` packages directly.
+- `schemas.py` – Shared pydantic helpers for validating feature schemas saved in
+  model bundles.
+- `selector.py` – Home of `FeatureSelector`, the utility that slices a prepared
+  feature DataFrame into the exact ordering required by a model’s
+  `feature_schema.json`.
+
+## FeatureSelector example
+
+```python
+import pandas as pd
+
+from src.prediction.features.selector import FeatureSelector
+
+schema = {
+    "sequence_length": 120,
+    "features": [
+        {"name": "close_normalized", "required": True, "normalization": {"mean": 0.0, "std": 1.0}},
+        {"name": "rsi", "required": True},
+    ],
+}
+
+selector = FeatureSelector(schema)
+features_df = pd.DataFrame({
+    "close_normalized": [0.1] * 200,
+    "rsi": [55] * 200,
+})
+tensor = selector.select(features_df)
+print(tensor.shape)  # (120, 2)
+```
+
+## When to use this package
+
+- Maintain backward compatibility for modules that still import from
+  `src.prediction.features.*`.
+- Load feature schemas embedded in model metadata without reaching into
+  `src.tech` internals.
+- Convert enriched DataFrames produced by the `TechnicalFeatureExtractor` into
+  numpy tensors ready for the ONNX runtime.
+
+For new feature builders, implement them inside `src/tech/features` so training
+and inference share the exact same code path, then optionally expose a shim here
+if older modules still expect the historical import location.

--- a/src/strategies/components/README.md
+++ b/src/strategies/components/README.md
@@ -178,7 +178,6 @@ Abstract base class for managing position sizing and risk controls.
 - `FixedRiskManager` - Fixed percentage risk per trade
 - `VolatilityRiskManager` - Risk adjusted for market volatility
 - `RegimeAdaptiveRiskManager` - Risk adjusted for market regime
-- `KellyRiskManager` - Kelly criterion-based sizing
 
 **Usage**:
 ```python
@@ -322,7 +321,7 @@ custom_strategy = (StrategyBuilder("MyCustom")
     .build())
 ```
 
-### 2. StrategyManager (`strategy_manager.py`)
+### 2. ComponentStrategyManager (`strategy_manager.py`)
 
 Strategy orchestration with versioning capabilities for A/B testing and rollbacks.
 
@@ -336,10 +335,10 @@ Strategy orchestration with versioning capabilities for A/B testing and rollback
 
 **Usage**:
 ```python
-    from src.strategies.components import ComponentStrategyManager
+from src.strategies.components import ComponentStrategyManager
 
 # Create strategy manager
-manager = StrategyManager(
+manager = ComponentStrategyManager(
     name="my_strategy_manager",
     signal_generator=MLSignalGenerator(),
     risk_manager=VolatilityRiskManager(),
@@ -683,10 +682,10 @@ for i, result in enumerate(results, 1):
 ### Example 3: Strategy Version Management
 
 ```python
-    from src.strategies.components import ComponentStrategyManager, StrategyRegistry
+from src.strategies.components import ComponentStrategyManager, StrategyRegistry
 
 # Create strategy manager
-manager = StrategyManager(
+manager = ComponentStrategyManager(
     name="production_strategy",
     signal_generator=MLSignalGenerator(),
     risk_manager=VolatilityRiskManager(),
@@ -895,7 +894,7 @@ strategy = Strategy(
 
 - **StrategyFactory**: Pre-configured strategy creation
 - **StrategyBuilder**: Fluent interface for custom strategies
-- **StrategyManager**: Strategy execution with versioning
+- **ComponentStrategyManager**: Strategy execution with versioning
 - **StrategyRegistry**: Centralized strategy management
 
 ### Specialized Classes
@@ -926,12 +925,12 @@ strategy = Strategy(
 For questions or issues:
 
 1. Check this README and the testing framework documentation
-2. Review the design documentation in `.kiro/specs/strategy-system-redesign/`
+2. Review the exec plan in `docs/execplans/platform_modularization_plan.md`
 3. Look at existing tests in `tests/unit/strategies/components/`
 4. Check the main strategy system documentation
 
 ---
 
-**Last Updated**: November 2025  
+**Last Updated**: December 2025  
 **Version**: 1.0.0  
 **Status**: Production Ready

--- a/src/strategies/components/testing/README.md
+++ b/src/strategies/components/testing/README.md
@@ -1069,9 +1069,9 @@ When adding new test capabilities:
 
 ## Related Documentation
 
-- **Strategy System Design**: `.kiro/specs/strategy-system-redesign/design.md`
+- **Strategy System Design**: `docs/execplans/platform_modularization_plan.md`
 - **Component Interfaces**: `src/strategies/components/README.md`
-- **Strategy Manager**: `src/strategies/components/strategy_registry.py`
+- **Strategy Manager**: `src/strategies/components/strategy_manager.py`
 - **Example Usage**: `examples/component_testing_example.py`
 
 ---
@@ -1081,7 +1081,7 @@ When adding new test capabilities:
 For questions or issues with the testing framework:
 
 1. Check this README and the examples
-2. Review the design documentation in `.kiro/specs/strategy-system-redesign/`
+2. Review the design documentation in `docs/execplans/platform_modularization_plan.md`
 3. Look at existing tests in `tests/unit/strategies/components/test_component_testing_framework.py`
 4. Check the main strategy system documentation
 

--- a/src/trading/README.md
+++ b/src/trading/README.md
@@ -1,52 +1,43 @@
 # Trading Core
 
-Base classes and shared utilities for trading strategies and components.
+`src/trading` is a small package that keeps exchange-specific glue isolated from
+strategies. Today it primarily exposes the shared `SymbolFactory`, which turns
+human-friendly tickers into the formats required by each exchange adapter.
 
-## Overview
+## Symbol utilities
 
-This module provides the foundational interfaces and shared functionality used across the trading system. It defines base strategy classes, component interfaces, and common helpers for backtesting and live trading, including symbol utilities under `symbols/`.
+- `symbols/factory.py` – Implements `SymbolFactory`, the single point of truth
+  for mapping tickers such as `BTCUSDT`, `BTC-USD`, or `btc/usd` to whatever the
+  underlying provider expects. The factory also performs light validation so CLI
+  commands and engines can fail fast when a symbol is unknown.
 
-## Modules
-
-- `symbols/`: Symbol normalization helpers for exchange-specific formats.
-
-## Key Components
-
-### Base Strategy Classes
-Abstract base classes for implementing trading strategies. All custom strategies should inherit from `BaseStrategy`.
-
-### Component Interfaces
-Contracts defining the interface for:
-- Signal generators
-- Risk managers
-- Position sizers
-- Entry/exit logic
-
-### Shared Utilities
-Common helpers used by strategies and engines including validation, error handling, and data processing utilities.
-
-## Usage
+### Example
 
 ```python
-# Import base strategy class
-from src.strategies.base import BaseStrategy
+from src.trading.symbols.factory import SymbolFactory
 
-class MyStrategy(BaseStrategy):
-    def calculate_indicators(self, df):
-        # Add indicators to dataframe
-        return df
-    
-    def check_entry_conditions(self, df):
-        # Return entry signal
-        return signal
-    
-    def check_exit_conditions(self, df, position):
-        # Return exit signal
-        return signal
+# Normalize a user-supplied value before handing it to providers
+symbol = SymbolFactory.to_exchange_symbol("btc-usd", "binance")
+assert symbol == "BTCUSDT"
+
+# Convert a Binance symbol back to a dash-separated variant for logging/UI
+display = SymbolFactory.to_exchange_symbol("ETHUSDT", "coinbase")
+assert display == "ETH-USD"
 ```
 
-## See Also
+## When to use this package
 
-- [strategies/README.md](../strategies/README.md) - Strategy implementation examples
-- [docs/backtesting.md](../../docs/backtesting.md) - Backtesting strategies
-- [docs/live_trading.md](../../docs/live_trading.md) - Live trading usage
+- CLI commands need to accept flexible inputs (`BTC-USD`, `BTCUSDT`, etc.) while
+  still calling provider methods with canonical names.
+- Backtesting and live trading engines must log symbols consistently so metrics
+  and dashboards can be merged across venues.
+- New exchanges or quote formats should be added to `SymbolFactory` instead of
+  scattering `replace("USDT", "-USD")` logic throughout the codebase.
+
+## Related documentation
+
+- [docs/data_pipeline.md](../../docs/data_pipeline.md) – explains how data
+  providers rely on `SymbolFactory`.
+- [docs/backtesting.md](../../docs/backtesting.md) and
+  [docs/live_trading.md](../../docs/live_trading.md) – both describe how engines
+  normalise symbols before running strategies.


### PR DESCRIPTION
## Summary
- align the main README, doc index, and data pipeline guide with the current module layout and CLI flag names
- refresh the trading, performance, strategies, and prediction READMEs plus the architecture note to match the implemented APIs and remove stale `.kiro` references
- document the ensemble/feature selector helpers and clarify testing guidance for ComponentStrategyManager consumers

## Test plan
- python - <<'PY'
from src.trading.symbols.factory import SymbolFactory
print(SymbolFactory.to_exchange_symbol('btc-usd', 'binance'))
print(SymbolFactory.to_exchange_symbol('ETHUSDT', 'coinbase'))
PY
- python - <<'PY'
import pandas as pd
from src.prediction.features.selector import FeatureSelector
schema = {"sequence_length": 4, "features": [{"name": "close_normalized", "required": True, "normalization": {"mean": 0.0, "std": 1.0}}, {"name": "rsi", "required": True}]}
selector = FeatureSelector(schema)
df = pd.DataFrame({"close_normalized": [0.1] * 10, "rsi": [55] * 10})
print(selector.select(df).shape)
PY
- python - <<'PY'
from src.prediction.ensemble import SimpleEnsembleAggregator
from src.prediction.models.onnx_runner import ModelPrediction
agg = SimpleEnsembleAggregator(method='weighted')
res = agg.aggregate([
    ModelPrediction(price=100.5, confidence=0.6, direction=1, model_name='model_a', inference_time=0.01),
    ModelPrediction(price=101.2, confidence=0.8, direction=1, model_name='model_b', inference_time=0.02),
    ModelPrediction(price=99.4, confidence=0.4, direction=-1, model_name='model_c', inference_time=0.01),
])
print(res.price, res.confidence, res.direction)
PY
- python - <<'PY'
from datetime import datetime
import pandas as pd
from src.performance.metrics import cash_pnl, cagr, max_drawdown, pnl_percent, sharpe, total_return
trade_return = pnl_percent(entry_price=100, exit_price=105, side='long', fraction=0.5)
print(round(trade_return, 4))
print(round(cash_pnl(trade_return, balance_before=20_000), 2))
index = pd.date_range(end=datetime.utcnow(), periods=120, freq='D')
eq = pd.Series(10_000, index=index)
eq = eq + (pd.Series(range(len(index)), index=index) * 25)
print(round(total_return(10_000, eq.iloc[-1]), 2))
print(round(cagr(10_000, eq.iloc[-1], days=len(eq)), 2))
print(round(sharpe(eq), 2))
print(round(max_drawdown(eq), 2))
PY