### PR TITLE
docs: clarify live-health usage

### DIFF
--- a/.cursor/rules/commands.md
+++ b/.cursor/rules/commands.md
@@ -18,7 +18,7 @@ alwaysApply: false
 ### Live Trading
 - Paper: `atb live ml_basic --symbol BTCUSDT --paper-trading`
 - Live (requires explicit ack): `atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks`
-- Health: `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- Health: `PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading`
 
 ### Monitoring & Utilities
 - Dashboard: `atb dashboards run monitoring --port 8000`

--- a/.cursor/rules/trading-bot-core.md
+++ b/.cursor/rules/trading-bot-core.md
@@ -102,7 +102,7 @@ max_drawdown = 0.20
 atb live-control emergency-stop
 
 # Check current positions and health
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading
 
 # Emergency database backup
 python scripts/backup_database.py --emergency
@@ -175,7 +175,7 @@ atb live-control emergency-stop
 - "start dashboard" → `atb dashboards run monitoring --port 8000`
 
 ### Health & Monitoring
-- "check health" → `atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading`
+- "check health" → `PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading`
 - "check positions" → `atb db verify`
 - "check cache" → `atb data cache-manager info`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ atb backtest ml_basic --symbol BTCUSDT --timeframe 1h --days 30
 atb live ml_basic --symbol BTCUSDT --paper-trading
 
 # Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+PORT=8000 atb live-health -- ml_basic --paper-trading
 ```
 
 ### ML Model Training & Deployment

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (requires explicit confirmation)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading + health endpoint
-atb live-health --port 8000 -- ml_basic --paper-trading
+# Live trading + health endpoint (set PORT or HEALTH_CHECK_PORT to override)
+PORT=8000 atb live-health -- ml_basic --paper-trading
 ```
 
 6) Utilities

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development workflow
 
-> **Last Updated**: 2025-11-17
+> **Last Updated**: 2025-12-14
 
 This project ships a command-line interface and Makefile targets that standardise local setup, quality checks, and diagnostics.
 
@@ -67,7 +67,7 @@ succinct changelog, bumps the semantic version, and auto-stages the updated mani
 
 - `atb backtest ml_basic --days 30` – quick simulations while iterating on strategies.
 - `atb live ml_basic --paper-trading` – start the live runner in paper trading mode.
-- `atb live-health --port 8000 -- ml_basic --paper-trading` – start live trading with health endpoint.
+- `PORT=8000 atb live-health -- ml_basic --paper-trading` – start live trading with the embedded health endpoint (override with `PORT` or `HEALTH_CHECK_PORT`).
 - `atb optimizer --strategy ml_basic --days 30` – trigger the optimisation CLI.
 
 Use these commands to mirror CI behaviour locally before opening pull requests.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,6 +1,6 @@
 # Monitoring & observability
 
-> **Last Updated**: 2025-11-10  
+> **Last Updated**: 2025-12-14  
 > **Related Documentation**: [Live trading](live_trading.md), [Database](database.md)
 
 Instrumentation is delivered through structured logging, database events, and interactive dashboards. The goal is to provide the
@@ -40,9 +40,10 @@ underlying dashboard supports them.
 
 ## Health endpoints
 
-`atb live-health --port 9000 -- ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
-`/status`. The status payload checks configuration providers, database connectivity, and Binance API reachability so you can wire
-it into uptime monitors or Kubernetes liveness probes.
+`PORT=9000 atb live-health -- ml_basic --paper-trading` runs the trading engine with an HTTP server exposing `/health` and
+`/status`. Set either the `PORT` or `HEALTH_CHECK_PORT` environment variable (default: 8000) to pick the HTTP port. The status payload
+checks configuration providers, database connectivity, and Binance API reachability so you can wire it into uptime monitors or
+Kubernetes liveness probes.
 
 ## Operational tips
 

--- a/src/live/README.md
+++ b/src/live/README.md
@@ -1,6 +1,6 @@
 # Live Trading Engine
 
-> **Last Updated**: 2025-11-10  
+> **Last Updated**: 2025-12-14  
 > **Related Documentation**: See [docs/live_trading.md](../../docs/live_trading.md) for comprehensive guide and safety controls
 
 Executes strategies in real time with risk controls, data providers, and database logging.
@@ -13,8 +13,8 @@ atb live ml_basic --symbol BTCUSDT --paper-trading
 # Live trading (explicit confirmation required)
 atb live ml_basic --symbol BTCUSDT --live-trading --i-understand-the-risks
 
-# Live trading with health endpoint
-atb live-health --port 8000 -- ml_basic --symbol BTCUSDT --paper-trading
+# Live trading with health endpoint (set PORT/HEALTH_CHECK_PORT to override, default 8000)
+PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading
 ```
 
 ## Programmatic


### PR DESCRIPTION
## Summary
- document that the `live-health` helper uses the PORT/HEALTH_CHECK_PORT env vars across README, developer docs, live module README, CLAUDE guidance, and agent rule sheets
- tighten the monitoring guide and platform modularization execplan so they no longer reference the removed `make live-health` target and refresh the affected docs' timestamps

## Test plan
- python -m cli live-health --help

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes live-health examples to use PORT/HEALTH_CHECK_PORT env vars and removes stale --port/make targets across docs and rule sheets.
> 
> - **Docs & Guides**
>   - Replace `--port` flag with environment-based usage for `live-health` across `README.md`, `CLAUDE.md`, `src/live/README.md`, `.cursor/rules/{commands,trading-bot-core}.md`, `docs/{monitoring,development}.md`, and exec plan.
>     - Use: `PORT=8000 atb live-health -- ml_basic --symbol BTCUSDT --paper-trading`
>     - Note: supports `PORT` or `HEALTH_CHECK_PORT` (default 8000).
>   - Clean up references to deprecated `make live-health` wrapper in `docs/execplans/platform_modularization_plan.md`; update validation commands accordingly.
>   - Refresh "Last Updated" timestamps in `docs/{development,monitoring}.md` and `src/live/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04a8caf171d81a5f2437dee1b13d655fb0c360c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->