### PR TITLE
Documentation maintenance and updates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-> **Last Updated**: 2025-12-01  
+> **Last Updated**: 2025-12-16  
 > **Maintained By**: AI Trading Bot Team
 
 This folder contains reference guides for the main subsystems that make up the AI trading platform. Each document focuses on how the runtime works today and includes links to relevant code and operational commands.
@@ -31,3 +31,4 @@ This folder contains reference guides for the main subsystems that make up the A
 - **Running backtests**: See [Backtesting](backtesting.md#cli-usage)
 - **Live trading**: Review [Live trading](live_trading.md#engine-highlights) safety controls
 - **Troubleshooting**: Check [Database](database.md#cli-tooling) diagnostics
+- **Documentation maintenance**: Run `atb docs validate` (or `python -m cli docs validate`) before merging doc changes to catch broken links and missing module READMEs

--- a/docs/execplans/codex_auto_review.md
+++ b/docs/execplans/codex_auto_review.md
@@ -20,12 +20,12 @@ Ship a repeatable command-line workflow that pairs the local Codex CLI with our 
 ## Surprises & Discoveries
 
 - Observation: Running the CLI with the system Python 3.9 interpreter crashes because the codebase assumes 3.10+ union syntax.
-  Evidence: `python -m cli codex auto-review --help` raised `TypeError: unsupported operand type(s) for |`.
+  Evidence: invoking the workflow via `python -m cli codex auto-review --help` raised `TypeError: unsupported operand type(s) for |`.
   Mitigation: Use the project’s Python 3.11 environment (`python3.11` or `.venv/bin/python`) when invoking the workflow.
 
 ## Decision Log
 
-- Decision: Manage the workflow through a new `python -m cli codex auto-review` command instead of an ad-hoc shell script so it benefits from existing CLI ergonomics.
+- Decision: Manage the workflow through the `atb codex auto-review` command (also available via `python -m cli codex auto-review`) instead of an ad-hoc shell script so it benefits from existing CLI ergonomics.
   Rationale: Keeps tooling discoverable, reuses logging, and aligns with how other automation lives under `cli/`.
   Date/Author: 2025-10-23, Codex agent.
 - Decision: Default validation commands to `atb test unit` and `atb dev quality`, with `--check` extensions when contributors need a tighter loop.
@@ -46,7 +46,7 @@ Ship a repeatable command-line workflow that pairs the local Codex CLI with our 
 
 ## Outcomes & Retrospective
 
-The automated loop now lives under `python -m cli codex auto-review`, storing artefacts per run and enforcing structured review output. Unit tests cover helper logic and guard-rails, while manual smoke checks confirm the CLI wiring and early-exit behaviour. Next improvement opportunity: once Codex credentials are available in CI, add an integration test (or recorded transcript) that demonstrates a full review/fix cycle on a seeded failing scenario.
+The automated loop now lives under `atb codex auto-review` (still invokable directly via `python -m cli codex auto-review`), storing artefacts per run and enforcing structured review output. Unit tests cover helper logic and guard-rails, while manual smoke checks confirm the CLI wiring and early-exit behaviour. Next improvement opportunity: once Codex credentials are available in CI, add an integration test (or recorded transcript) that demonstrates a full review/fix cycle on a seeded failing scenario.
 
 ## Context and Orientation
 


### PR DESCRIPTION
## Context
This PR is part of a comprehensive documentation analysis and maintenance effort to ensure all documentation is up-to-date and accurate without altering code behavior. The goal is to improve clarity and usability for contributors maintaining the documentation and using the AI Trading Bot's automated review workflows.

## Description
This task involved reviewing and updating documentation related to the markdown validator and the Codex auto-review workflow. The changes clarify how to run these tools, including fallback options when the `atb` entry point is not directly available, and ensure consistency across relevant documentation files.

## Changes in the codebase
- **`docs/README.md`**:
    - Updated the "Last Updated" timestamp.
    - Added a quick link for "Documentation maintenance" to the main index.
- **`docs/development.md`**:
    - Updated the "Last Updated" timestamp.
    - Introduced a new section "Documentation maintenance" detailing the `atb docs validate` command and its `python -m cli` fallback.
    - Updated the `Codex auto-review workflow` section to use `atb codex auto-review` as the primary command, while clarifying the `python -m cli` fallback and Python environment requirements.
- **`docs/execplans/codex_auto_review.md`**:
    - Updated references in the "Decision Log" and "Outcomes & Retrospective" sections to primarily use `atb codex auto-review`, while explicitly mentioning the `python -m cli` equivalent for historical context and clarity.

## Breaking changes
None. All changes are documentation-only and do not affect runtime behavior or core functionality.

## Additional information
The documented `python -m cli` fallbacks for `docs validate` and `codex auto-review` were tested and confirmed to be functional in environments where the `atb` entry point is not directly on the PATH.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8bfb444-b35b-44a8-a0b8-a38fc3510c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f8bfb444-b35b-44a8-a0b8-a38fc3510c8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

