### PR TITLE
Debug sessionStart hook error in container

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,44 +1,51 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 # Only run in Claude Code on the web
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Check if gh CLI is already installed
-if command -v gh &> /dev/null; then
-  echo "GitHub CLI (gh) is already installed (version: $(gh --version | head -n1))"
-  exit 0
-fi
-
-echo "GitHub CLI (gh) not found. Installing..."
-
-# Install GitHub CLI using official installation script
-# This method is more reliable and handles various environments
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg 2>/dev/null || {
-  echo "Warning: Unable to download keyring via curl, trying alternative method..."
-  # Fallback: Install via apt without custom keyring (if available in default repos)
-  sudo apt-get update -qq
-  if apt-cache show gh >/dev/null 2>&1; then
-    sudo apt-get install -y --no-install-recommends gh
-    echo "GitHub CLI (gh) installed successfully (version: $(gh --version | head -n1))"
-    exit 0
-  else
-    echo "Error: Unable to install GitHub CLI. Please install manually."
-    exit 1
+# Install gh CLI if not present (non-fatal - continues with venv setup on failure)
+install_gh_cli() {
+  if command -v gh &> /dev/null; then
+    echo "GitHub CLI (gh) is already installed (version: $(gh --version | head -n1))"
+    return 0
   fi
+
+  echo "GitHub CLI (gh) not found. Attempting installation..."
+
+  # Try to download keyring
+  if ! curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /tmp/githubcli-archive-keyring.gpg 2>/dev/null; then
+    echo "Warning: Unable to download GitHub CLI keyring. Trying apt fallback..."
+    if sudo apt-get update -qq 2>/dev/null && apt-cache show gh >/dev/null 2>&1; then
+      if sudo apt-get install -y --no-install-recommends gh 2>/dev/null; then
+        echo "GitHub CLI (gh) installed successfully (version: $(gh --version | head -n1))"
+        return 0
+      fi
+    fi
+    echo "Warning: Could not install GitHub CLI. Continuing without it."
+    return 1
+  fi
+
+  # Keyring downloaded, proceed with installation
+  if sudo dd if=/tmp/githubcli-archive-keyring.gpg of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null && \
+     sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+     sudo apt-get update -qq 2>/dev/null && \
+     sudo apt-get install -y --no-install-recommends gh 2>/dev/null; then
+    rm -f /tmp/githubcli-archive-keyring.gpg
+    echo "GitHub CLI (gh) installed successfully (version: $(gh --version | head -n1))"
+    return 0
+  fi
+
+  rm -f /tmp/githubcli-archive-keyring.gpg
+  echo "Warning: Could not install GitHub CLI. Continuing without it."
+  return 1
 }
 
-# If curl succeeded, proceed with keyring-based installation
-sudo dd if=/tmp/githubcli-archive-keyring.gpg of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-sudo apt-get update -qq
-sudo apt-get install -y --no-install-recommends gh
-rm -f /tmp/githubcli-archive-keyring.gpg
-
-echo "GitHub CLI (gh) installed successfully (version: $(gh --version | head -n1))"
+# Attempt gh installation (non-blocking)
+install_gh_cli || true
 
 # Set up Python virtual environment
 VENV_PATH=".venv"


### PR DESCRIPTION
- Remove set -e so script doesn't exit on first error
- Wrap gh CLI installation in a function with proper return codes
- Use || true to make gh installation non-blocking
- Venv setup now always runs regardless of gh install success
- Suppress apt-get stderr noise during network failures