### PR TITLE
fix: Use direct GitHub download for gh CLI in sessionStart hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 .vscode/
 .claude/
+!.claude/hooks/
 .cursor/mcp.json
 .codex/
 


### PR DESCRIPTION
Replace apt-based gh CLI installation with direct download from GitHub
releases. This avoids DNS resolution failures with Ubuntu apt repositories
that occur in restricted network environments like Claude Code web.

Also update .gitignore to allow version-controlling .claude/hooks/.