### PR TITLE
Documentation maintenance and updates

### DIFF
--- a/src/engines/backtest/README.md
+++ b/src/engines/backtest/README.md
@@ -1,7 +1,7 @@
 # Backtesting Engine
 
 > **Last Updated**: 2025-11-10  
-> **Related Documentation**: See [docs/backtesting.md](../../docs/backtesting.md) for comprehensive guide
+> **Related Documentation**: See [docs/backtesting.md](../../../docs/backtesting.md) for comprehensive guide
 
 Vectorized historical simulation engine for evaluating strategies.
 

--- a/src/engines/live/README.md
+++ b/src/engines/live/README.md
@@ -1,7 +1,7 @@
 # Live Trading Engine
 
 > **Last Updated**: 2025-12-14  
-> **Related Documentation**: See [docs/live_trading.md](../../docs/live_trading.md) for comprehensive guide and safety controls
+> **Related Documentation**: See [docs/live_trading.md](../../../docs/live_trading.md) for comprehensive guide and safety controls
 
 Executes strategies in real time with risk controls, data providers, and database logging.
 


### PR DESCRIPTION
Fix broken internal documentation links in `src/engines` READMEs to point to the correct `docs/` paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-c83d37d6-d0a9-4bb7-b0bd-deb0c821c696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c83d37d6-d0a9-4bb7-b0bd-deb0c821c696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

