### PR TITLE
fix: make regime regression test deterministic with dependency injection

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -63,7 +63,7 @@ monkeypatch.setattr("src.module.ClassName", StubClass)
 backtester = Backtester(
     strategy=test_strategy,
     _regime_switcher_class=StubRegimeStrategySwitcher,  # Internal testing param
-    _strategy_manager_class=stub_manager,  # Can be class or instance
+    _strategy_manager=stub_manager,  # Can be class or instance
 )
 ```
 
@@ -94,7 +94,7 @@ The regime regression test (`tests/integration/backtesting/test_regime_regressio
 
 1. **Deterministic fixtures**: `_build_fixture_dataframe()` creates reproducible OHLCV data
 2. **Stub components**: `StubRegimeStrategySwitcher` and `StubStrategyManager` provide controlled behavior
-3. **Dependency injection**: Backtester accepts `_regime_switcher_class` and `_strategy_manager_class` for testing
+3. **Dependency injection**: Backtester accepts `_regime_switcher_class` and `_strategy_manager` for testing
 4. **Snapshot validation**: Results are compared against a committed JSON snapshot
 
 ## Code quality

--- a/tests/integration/backtesting/test_regime_regression.py
+++ b/tests/integration/backtesting/test_regime_regression.py
@@ -374,7 +374,7 @@ def test_regime_backtester_regression(monkeypatch):
         log_to_database=False,
         enable_dynamic_risk=False,
         _regime_switcher_class=StubRegimeStrategySwitcher,
-        _strategy_manager_class=strategy_manager,
+        _strategy_manager=strategy_manager,
     )
 
     start = frame.index[0].to_pydatetime()


### PR DESCRIPTION
## Summary

Fixes the regime regression test to produce deterministic results across all environments (local macOS, CI Linux) by replacing broken monkeypatching with proper dependency injection.

Resolves #503

## Problem

The regime regression test (`tests/integration/backtesting/test_regime_regression.py`) produced different results on CI vs locally:
- Local: `total_return = -0.001737383983146934`
- CI: `total_return = -0.0025730682591151854`
- Difference: ~0.00084 (~8.4 basis points)

**Root cause**: Monkeypatching `RegimeStrategySwitcher` at module level failed because the class is imported inside `Backtester._init_regime_switching()` at runtime, after the patch was applied. Both environments were using the real `RegimeDetector` instead of the test stub.

## Solution

### 1. Dependency Injection in Backtester

Added optional internal testing parameters to `Backtester.__init__`:
- `_regime_switcher_class`: Inject regime switcher class for testing
- `_strategy_manager`: Inject strategy manager (class or instance) for testing

These parameters are prefixed with `_` to indicate they're internal testing hooks, not public API.

### 2. Robust Implementation

**Class vs Instance Detection**:
```python
# Uses inspect.isclass() instead of callable() for accurate detection
if inspect.isclass(self._strategy_manager):
    strategy_manager = self._strategy_manager()
else:
    strategy_manager = self._strategy_manager
```

**Partial Injection Prevention**:
```python
# Validates both or neither are provided
if (_regime_switcher_class is None) != (_strategy_manager is None):
    raise ValueError(
        "Test injection requires both _regime_switcher_class and _strategy_manager, "
        "or neither. Partial injection silently falls back to production classes."
    )
```

### 3. Test Updates

- Removed broken monkeypatch approach
- Now injects `StubRegimeStrategySwitcher` and `StubStrategyManager` directly
- Fixed deprecated pandas frequency string (`freq='H'` → `freq='h'`)

### 4. Documentation

Added reproducibility guidelines to `docs/development.md`:
- When to use dependency injection vs monkeypatching
- How to verify test determinism (10 consecutive runs)
- Example implementation from the regime regression test

## Testing Performed

✅ Regression test passes 10 consecutive runs with identical results  
✅ All backtest unit tests pass (79/79)  
✅ Code quality checks pass (ruff, mypy)  
✅ Partial injection validation confirmed working  
✅ Code review found zero issues  

## Verification Commands

```bash
# Run regression test 10 times
for i in {1..10}; do
  pytest tests/integration/backtesting/test_regime_regression.py -v || exit 1
done

# Run all backtest unit tests
pytest tests/unit/backtesting/ -v

# Quality checks
ruff check src/engines/backtest/engine.py tests/integration/backtesting/test_regime_regression.py
```

## Changes Summary

- `src/engines/backtest/engine.py`: Added dependency injection parameters and validation
- `tests/integration/backtesting/test_regime_regression.py`: Updated to use injection instead of monkeypatch
- `docs/development.md`: Added test reproducibility guidelines

## Migration Notes

No migration needed - this is an internal testing change. The public API of `Backtester` is unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>