### PR TITLE
feat: save feature schema with trained ML models

### DIFF
--- a/src/ml/training_pipeline/artifacts.py
+++ b/src/ml/training_pipeline/artifacts.py
@@ -334,6 +334,17 @@ def save_artifacts(
     with open(metadata_path, "w", encoding="utf-8") as f:
         json.dump(metadata, f, indent=2, default=str)
 
+    # Save feature schema for validation and inference alignment
+    feature_names = metadata.get("feature_names", [])
+    sequence_length = metadata.get("sequence_length", 120)
+    feature_schema = {
+        "sequence_length": sequence_length,
+        "features": [{"name": name, "required": True} for name in feature_names],
+    }
+    feature_schema_path = version_dir / "feature_schema.json"
+    with open(feature_schema_path, "w", encoding="utf-8") as f:
+        json.dump(feature_schema, f, indent=2)
+
     # Atomic symlink update to avoid race conditions (TOCTOU vulnerability)
     # Create temporary symlink, then atomically replace the existing symlink
     latest_link = type_dir / "latest"


### PR DESCRIPTION
## Summary
- Adds `feature_schema.json` output alongside saved models
- Documents expected sequence length and required feature names
- Enables validation at inference time to prevent silent failures

## Motivation
When deploying ML models to production, there's a risk of feature drift or mismatched feature sets between training and inference. This change adds a feature schema that documents the exact features and input shape a model expects, enabling validation before inference.

## Changes
- `src/ml/training_pipeline/artifacts.py`: Save `feature_schema.json` during model training
- Schema includes:
  - `sequence_length`: Expected input sequence length (default: 120)
  - `features`: List of required feature names with `required: true` flag

## Output Location
```
src/ml/models/{SYMBOL}/{TYPE}/{VERSION}/
├── model.keras
├── model.onnx
├── metadata.json
└── feature_schema.json  # NEW
```

## Testing
- Verified schema is created during model training
- Schema correctly captures feature_names and sequence_length from metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)