### PR TITLE
feat: add minimal CI deps for Claude GitHub Actions tests

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,18 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements-github.txt
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements-github.txt
+          pip install -e . --no-deps
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AGENTS other than Claude Code. If you are Claude 
 
 ## Project Overview
 
-This is a modular cryptocurrency trading system focused on long-term, risk-balanced trend following. It supports backtesting, live trading (paper and live), ML-driven predictions (price and sentiment), PostgreSQL logging, and Railway deployment.
+This is a modular cryptocurrency trading system capable of multiple strategies with different risk and return profiles. It supports backtesting, live trading (paper and live), ML-driven predictions (price and sentiment), PostgreSQL logging, and Railway deployment.
 
 **Tech Stack**: Python 3.11+, PostgreSQL, TensorFlow/ONNX, Flask, SQLAlchemy, pandas, scikit-learn
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a modular cryptocurrency trading system focused on long-term, risk-balanced trend following. It supports backtesting, live trading (paper and live), ML-driven predictions (price and sentiment), PostgreSQL logging, and Railway deployment.
+This is a modular cryptocurrency trading system capable of multiple strategies with different risk and return profiles. It supports backtesting, live trading (paper and live), ML-driven predictions (price and sentiment), PostgreSQL logging, and Railway deployment.
 
 **Tech Stack**: Python 3.11+, PostgreSQL, TensorFlow/ONNX, Flask, SQLAlchemy, pandas, scikit-learn
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Crypto Trend-Following Trading Bot
+# Versatile Crypto Trading Bot
 
-A modular cryptocurrency trading system focused on long-term, risk-balanced trend following. It supports backtesting, live trading (paper and live), ML-driven models (price and sentiment), PostgreSQL logging, and optional Railway deployment.
+A modular cryptocurrency trading system capable of multiple strategies with different risk and return profiles. It supports backtesting, live trading (paper and live), ML-driven models (price and sentiment), PostgreSQL logging, and optional Railway deployment.
 
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/) [![DB](https://img.shields.io/badge/DB-PostgreSQL-informational)](docs/database.md) [![License](https://img.shields.io/badge/license-MIT-lightgrey)](#)
 

--- a/docs/PSB_SYSTEM_ANALYSIS.md
+++ b/docs/PSB_SYSTEM_ANALYSIS.md
@@ -29,7 +29,7 @@ The AI trading bot project **already implements many PSB best practices**, parti
 ### ✅ What's Already Strong
 
 1. **Clear Project Goals** - The CLAUDE.md clearly states:
-   - What: "Modular cryptocurrency trading system focused on long-term, risk-balanced trend following"
+   - What: "Modular cryptocurrency trading system capable of multiple strategies with different risk and return profiles"
    - Tech Stack: Explicitly defined (Python 3.11+, PostgreSQL, TensorFlow/ONNX, etc.)
    - Architecture: Well-documented data flow and component boundaries
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The AI Trading Bot is a modular cryptocurrency trading system focused on long-term, risk-balanced trend following. It supports backtesting, live trading (paper and live modes), ML-driven predictions, and Railway deployment.
+The AI Trading Bot is a modular cryptocurrency trading system capable of multiple strategies with different risk and return profiles. It supports backtesting, live trading (paper and live modes), ML-driven predictions, and Railway deployment.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
@@ -216,7 +216,7 @@ class Strategy:
 **Available Strategies:**
 | Strategy | Description |
 |----------|-------------|
-| `ml_basic` | Core ML-driven trend following |
+| `ml_basic` | Core ML-driven trading strategy |
 | `ml_adaptive` | Regime-aware dynamic strategy |
 | `ml_sentiment` | ML with sentiment integration |
 | `ensemble_weighted` | Weighted signal combination |

--- a/docs/project_status.md
+++ b/docs/project_status.md
@@ -51,7 +51,7 @@ Reducing backtest/live engine duplication by centralizing shared entry and exit 
 
 | Strategy | Status | Description |
 |----------|--------|-------------|
-| `ml_basic` | Production | Core ML-driven trend following |
+| `ml_basic` | Production | Core ML-driven trading strategy |
 | `ml_adaptive` | Production | Regime-adaptive ML strategy |
 | `ml_sentiment` | Production | ML with sentiment integration |
 | `ensemble_weighted` | Production | Weighted ensemble of signals |

--- a/requirements-github.txt
+++ b/requirements-github.txt
@@ -1,0 +1,47 @@
+# Minimal dependencies for running unit tests in GitHub Actions CI
+# Excludes heavy/unnecessary packages: tensorflow, tf2onnx, onnxruntime, onnx,
+# gevent, gevent-websocket, gunicorn, testcontainers, code quality tools
+#
+# Note: onnxruntime is stubbed automatically by tests/conftest.py
+
+# Core runtime
+python-binance==1.0.19
+pandas==2.2.0
+python-dotenv==1.0.0
+numpy==1.26.4
+scikit-learn==1.3.2
+scipy==1.16.1
+statsmodels==0.14.1
+requests==2.31.0
+textblob==0.17.1
+nltk==3.9.1
+ccxt==4.4.85
+tqdm==4.66.3
+matplotlib==3.8.2
+psutil==5.9.6
+pyarrow==20.0.0
+
+# Database
+sqlalchemy==2.0.23
+psycopg2-binary==2.9.9
+alembic==1.13.1
+
+# Web framework (imported by source modules)
+Flask==2.3.3
+Flask-Admin==1.6.1
+Flask-Limiter==3.7.0
+Flask-Login==0.6.3
+Flask-SocketIO==5.3.6
+Flask-WTF==1.2.1
+Werkzeug==2.3.7
+
+# Testing
+testcontainers[postgresql]==3.7.1
+pytest==7.4.4
+pytest-asyncio>=0.18.0
+pytest-mock==3.12.0
+pytest-xdist==3.5.0
+pytest-timeout==2.2.0
+pytest-cov==5.0.0
+pytest-randomly==3.15.0
+pytest-split==0.9.0

--- a/src/strategies/components/momentum_signal_generator.py
+++ b/src/strategies/components/momentum_signal_generator.py
@@ -1,7 +1,7 @@
 """
 Momentum Signal Generator Component
 
-Generates momentum/trend-based signals derived from the prior MomentumLeverage
+Generates momentum-based signals derived from the prior MomentumLeverage
 strategy, designed for component-based composition.
 """
 

--- a/src/strategies/components/technical_signal_generator.py
+++ b/src/strategies/components/technical_signal_generator.py
@@ -366,7 +366,7 @@ class TechnicalSignalGenerator(SignalGenerator):
 
         # Adjust weights based on regime if available
         if regime:
-            # In trending markets, give more weight to trend-following indicators
+            # In trending markets, give more weight to directional indicators
             if regime.trend.value in ["trend_up", "trend_down"]:
                 weights["ma"] = 0.4
                 weights["macd"] = 0.3

--- a/src/tech/features/technical.py
+++ b/src/tech/features/technical.py
@@ -350,8 +350,8 @@ class TechnicalFeatureExtractor(FeatureExtractor):
         """
         Get feature importance weights based on common usage in strategies.
 
-        These are heuristic weights based on typical usage patterns in momentum and
-        trend-following strategies, not empirically derived from model training.
+        These are heuristic weights based on typical usage patterns in various
+        trading strategies, not empirically derived from model training.
         Normalized features (1.0) are most important for ML models, technical indicators
         and derived features (0.8) provide strong signals, moving averages (0.5) are
         supporting indicators, and other features (0.6) are secondary.


### PR DESCRIPTION
## Summary
- Add `requirements-github.txt` with minimal dependencies for running unit/integration tests in GitHub Actions (excludes tensorflow, onnxruntime, gevent, code quality tools)
- Update `claude.yml` workflow to set up Python 3.11 with pip caching and install deps before Claude Code runs
- Update project description across docs to reflect multi-strategy capability

## Test plan
- [x] Trigger Claude workflow via `@claude` mention and verify deps install successfully
- [x] Confirm Claude can run `python tests/run_tests.py unit` in the GitHub Actions environment
- [x] Verify pip cache works on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)