### PR TITLE
fix: don't reuse inactive session ID on clean restart

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -3502,7 +3502,12 @@ class LiveTradingEngine:
             logger.info("🔍 Found %s session #%s", source, session_id)
             recovered_balance = self.db_manager.recover_last_balance(session_id)
             if recovered_balance and recovered_balance > 0:
-                self.trading_session_id = session_id
+                # For crash recovery (active session), reuse the existing session ID so
+                # trades continue to be attributed to the same session row.
+                # For clean restarts (inactive session), only recover the balance — a new
+                # session will be created below, preventing writes to a closed session.
+                if source == "active":
+                    self.trading_session_id = session_id
                 logger.info(
                     "💾 Recovered balance $%.2f from %s session #%s",
                     recovered_balance,

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -50,7 +50,12 @@ def make_engine(enable_live_trading: bool = False) -> LiveTradingEngine:
 
 @pytest.mark.fast
 def test_recovery_falls_back_to_recent_inactive_session():
-    """No active session → falls back to most-recent session within 24 hours."""
+    """No active session → falls back to most-recent session within 24 hours.
+
+    Critically: trading_session_id must remain None so start() creates a
+    fresh session. Reusing the closed session ID would cause every balance
+    update to fail with "No active trading session".
+    """
     engine = make_engine()
     engine.db_manager.get_active_session_id = MagicMock(return_value=None)
     engine.db_manager.get_last_session_id = MagicMock(return_value=42)
@@ -60,6 +65,25 @@ def test_recovery_falls_back_to_recent_inactive_session():
 
     assert result == 1234.56
     engine.db_manager.get_last_session_id.assert_called_once()
+    # Session ID must NOT be set — start() must create a new active session.
+    assert engine.trading_session_id is None
+
+
+@pytest.mark.fast
+def test_active_session_recovery_reuses_session_id():
+    """Crash recovery (active session) reuses the existing session ID.
+
+    This ensures trades after a crash are still attributed to the same
+    session row rather than opening a duplicate.
+    """
+    engine = make_engine()
+    engine.db_manager.get_active_session_id = MagicMock(return_value=77)
+    engine.db_manager.recover_last_balance = MagicMock(return_value=850.0)
+
+    result = engine._recover_existing_session()
+
+    assert result == 850.0
+    assert engine.trading_session_id == 77
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## Summary

- **Bug**: `_recover_existing_session()` set `self.trading_session_id` to the old closed session's ID when recovering balance from a recent inactive session. The `if self.trading_session_id is None` guard in `start()` then skipped creating a new active session. Every subsequent DB write failed with `"No active trading session for balance update. Aborting entry."` — causing zero trades despite valid SELL signals.
- **Fix**: Only set `trading_session_id` in the crash-recovery path (active session). Clean restarts recover balance only; `start()` creates a fresh session normally.
- **Test**: Added two new assertions — inactive recovery leaves `session_id` as `None`; active recovery reuses it.

## Test plan

- [x] `pytest tests/unit/engines/live/test_session_recovery.py` — all 9 pass
- [ ] Railway deployment should redeploy and successfully execute paper trades

🤖 Generated with [Claude Code](https://claude.com/claude-code)