### PR TITLE
feat: track margin borrow interest in PnL and balance accounting

### DIFF
--- a/.claude/plans/binance-margin-api.md
+++ b/.claude/plans/binance-margin-api.md
@@ -23,11 +23,13 @@ The bot is live on production trading ETHUSDT with $100, but the funds are in th
 
 ### 1. Add `_use_margin` flag and fail-fast to BinanceProvider.__init__
 
-Read `BINANCE_ACCOUNT_TYPE` from config (default `"margin"`). Read `TRADING_MODE` to determine live vs paper.
+Read `BINANCE_ACCOUNT_TYPE` from config (default `"spot"` — safe for dashboards, Binance.US, and read-only contexts; production sets `margin` explicitly via Railway env var). Read `TRADING_MODE` to determine live vs paper.
 
 ```python
-self._use_margin = config.get("BINANCE_ACCOUNT_TYPE", "margin").lower() == "margin"
-self._is_live = config.get("TRADING_MODE", "paper").lower() == "live"
+account_type = config.get("BINANCE_ACCOUNT_TYPE", "spot") or "spot"
+self._use_margin = account_type.lower() == "margin"
+trading_mode = config.get("TRADING_MODE", "paper") or "paper"
+self._is_live = trading_mode.lower() == "live"
 ```
 
 **Fail-fast rule:** If `_use_margin=True` AND `_is_live=True` AND client init fails → raise immediately. Do NOT fall back to offline stub. A fake client placing dummy margin orders is a fund-loss path.

--- a/migrations/versions/0010_add_margin_interest_cost.py
+++ b/migrations/versions/0010_add_margin_interest_cost.py
@@ -1,0 +1,33 @@
+"""Add margin_interest_cost column to trades table
+
+Revision ID: 0010_margin_interest_cost
+Revises: 0009_widen_order_status
+Create Date: 2026-03-31 22:00:00.000000
+
+Tracks cumulative margin borrow interest deducted from realized PnL
+when closing short positions. Defaults to 0 for spot/long trades.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0010_margin_interest_cost"
+down_revision = "0009_widen_order_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trades",
+        sa.Column(
+            "margin_interest_cost",
+            sa.Numeric(precision=18, scale=8),
+            server_default="0",
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("trades", "margin_interest_cost")

--- a/skills/update-code-rules/SKILL.md
+++ b/skills/update-code-rules/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: update-code-rules
+description: Update CODE.md with lessons learned from recent work. Use after long sessions, code reviews, debugging, or when patterns of mistakes emerge. Trigger phrases include "update code rules", "update CODE.md", "lessons learned", "add coding rules", "what did we learn".
+---
+
+# Update CODE.md with Lessons Learned
+
+Analyse recent work in this session (reviews, fixes, debugging, new features) and distill reusable coding rules into `CODE.md`.
+
+## Process
+
+1. **Gather context.** Read the current `CODE.md` and recent git history:
+   ```
+   git log --oneline -30
+   git log --format="%s%n%b" -15
+   ```
+   Also review any review comments, fix iterations, or debugging cycles from the current session.
+
+2. **Identify patterns.** Look for:
+   - Bugs that were caught in review or testing — what rule would have prevented them?
+   - Mistakes repeated across multiple files or sessions
+   - Non-obvious pitfalls specific to this codebase's tech stack
+   - Thread safety, state management, or data integrity lessons
+   - Patterns that worked well and should be codified
+
+3. **Filter ruthlessly.** Only add rules that are:
+   - **Generic** — applicable beyond the specific feature. "Use `or` for null-safe dict access" not "Use `or` for Binance commission fields"
+   - **Non-obvious** — an experienced developer might not think of it. Don't add "write tests" or "handle errors"
+   - **Actionable** — tells the reader exactly what to do, not just what to avoid
+   - **Not already covered** — check existing rules first. Update/strengthen existing rules rather than duplicating
+
+4. **Write rules.** Follow these style conventions:
+   - **Imperative mood, present tense.** "Lock shared state" not "Shared state should be locked"
+   - **One line per rule.** Use `—` for inline clarification. No multi-paragraph explanations
+   - **Lead with the action.** "Snapshot values before mutation" not "When you need to compare state..."
+   - **Include the WHY only when non-obvious**, after a `—`. "Cap collections — prevents memory leaks"
+   - **Use code snippets sparingly** — only when the pattern is genuinely hard to express in prose
+   - **No project-specific language.** "Exchange API" not "Binance API". "Rolling buffer" not "KlineBuffer"
+
+5. **Place rules in the right section.** Match existing CODE.md structure:
+   - Thread safety → Thread Safety & Concurrency
+   - API handling → External API Calls
+   - Data validation → Input Validation
+   - Financial correctness → Arithmetic & Financial Calculations
+   - Create a new section only if 3+ rules don't fit anywhere
+
+6. **Enforce the 500-line cap.** If CODE.md exceeds 500 lines after additions:
+   - Merge overlapping rules
+   - Remove rules that are now common knowledge to the team
+   - Consolidate verbose rules into terser form
+   - Remove code examples that can be expressed as one-line rules
+
+7. **Present changes.** Show the user:
+   - Each new/modified rule with a one-line rationale (which bug or review finding inspired it)
+   - Any rules removed or consolidated to stay under the cap
+   - Ask for approval before writing
+
+## Anti-patterns — do NOT add rules like:
+
+- ❌ "Always write tests" (too obvious)
+- ❌ "Handle the PENDING_CANCEL status from Binance" (too specific)
+- ❌ "Remember to check for None" (too vague)
+- ❌ Rules that duplicate existing entries
+- ❌ Multi-sentence explanations — compress to one line
+- ❌ Rules only relevant to one file or feature
+
+## Good examples:
+
+- ✅ "Snapshot mutable values before calling a mutation, then compare. The 'before' reference may alias the mutated object."
+- ✅ "`dict.get(key, default)` returns `None` when the key exists with JSON `null`. Use `or`: `float(d.get('n') or 0)`."
+- ✅ "On reconnect, pass a fresh callback — stale callbacks may reference stopped consumers."
+- ✅ "Gate producer→consumer queues with a lock-protected `_closed` flag."

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -953,7 +953,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         if not self._use_margin or not BINANCE_AVAILABLE or not self._client:
             return []
         try:
-            params: dict[str, Any] = {"asset": asset}
+            params: dict[str, Any] = {"asset": asset, "size": 100}
             if start_time is not None:
                 params["startTime"] = start_time
             if end_time is not None:

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -515,6 +515,9 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             def get_margin_trades(self, *args, **kwargs):
                 return []
 
+            def get_margin_interest_history(self, *args, **kwargs):
+                return []
+
             def get_margin_symbol(self, *args, **kwargs):
                 return {"isMarginTrade": True, "isBuyAllowed": True, "isSellAllowed": True}
 
@@ -933,6 +936,34 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         except Exception as e:
             logger.warning("Failed to get borrowed amount for %s: %s", asset, e)
             return None  # Unknown — caller must not assume position is closed
+
+    def get_margin_interest_history(
+        self,
+        asset: str,
+        start_time: int | None = None,
+        end_time: int | None = None,
+    ) -> list[dict]:
+        """Get margin interest accrual history for an asset.
+
+        Queries Binance /sapi/v1/margin/interestHistory endpoint.
+        Returns list of dicts with keys: txId, interestAccuredTime, asset,
+        interest, interestRate, principal, type.
+        Returns empty list on error or if not in margin mode.
+        """
+        if not self._use_margin or not BINANCE_AVAILABLE or not self._client:
+            return []
+        try:
+            params: dict[str, Any] = {"asset": asset}
+            if start_time is not None:
+                params["startTime"] = start_time
+            if end_time is not None:
+                params["endTime"] = end_time
+            return self._client.get_margin_interest_history(**params)
+        except Exception as e:
+            logger.warning(
+                "Failed to get margin interest history for %s: %s", asset, e
+            )
+            return []
 
     def get_balance(self, asset: str) -> AccountBalance | None:
         """Get balance for a specific asset"""

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -949,27 +949,22 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         Queries Binance /sapi/v1/margin/interestHistory endpoint.
         Returns list of dicts with keys: txId, interestAccuredTime, asset,
         interest, interestRate, principal, type.
-        Returns empty list on error or if not in margin mode.
+        Returns empty list if not in margin mode or no client available.
+        Raises on API/network errors so callers can retry.
         Uses page-based pagination (current=page, size=100).
         """
         if not self._use_margin or not BINANCE_AVAILABLE or not self._client:
             return []
-        try:
-            params: dict[str, Any] = {"asset": asset, "size": 100, "current": page}
-            if start_time is not None:
-                params["startTime"] = start_time
-            if end_time is not None:
-                params["endTime"] = end_time
-            response = self._client.get_margin_interest_history(**params)
-            # Binance returns {rows: [...], total: N} envelope
-            if isinstance(response, dict):
-                return response.get("rows", [])
-            return response if isinstance(response, list) else []
-        except Exception as e:
-            logger.warning(
-                "Failed to get margin interest history for %s: %s", asset, e
-            )
-            return []
+        params: dict[str, Any] = {"asset": asset, "size": 100, "current": page}
+        if start_time is not None:
+            params["startTime"] = start_time
+        if end_time is not None:
+            params["endTime"] = end_time
+        response = self._client.get_margin_interest_history(**params)
+        # Binance returns {rows: [...], total: N} envelope
+        if isinstance(response, dict):
+            return response.get("rows", [])
+        return response if isinstance(response, list) else []
 
     def get_balance(self, asset: str) -> AccountBalance | None:
         """Get balance for a specific asset"""

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -942,6 +942,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         asset: str,
         start_time: int | None = None,
         end_time: int | None = None,
+        page: int = 1,
     ) -> list[dict]:
         """Get margin interest accrual history for an asset.
 
@@ -949,16 +950,21 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         Returns list of dicts with keys: txId, interestAccuredTime, asset,
         interest, interestRate, principal, type.
         Returns empty list on error or if not in margin mode.
+        Uses page-based pagination (current=page, size=100).
         """
         if not self._use_margin or not BINANCE_AVAILABLE or not self._client:
             return []
         try:
-            params: dict[str, Any] = {"asset": asset, "size": 100}
+            params: dict[str, Any] = {"asset": asset, "size": 100, "current": page}
             if start_time is not None:
                 params["startTime"] = start_time
             if end_time is not None:
                 params["endTime"] = end_time
-            return self._client.get_margin_interest_history(**params)
+            response = self._client.get_margin_interest_history(**params)
+            # Binance returns {rows: [...], total: N} envelope
+            if isinstance(response, dict):
+                return response.get("rows", [])
+            return response if isinstance(response, list) else []
         except Exception as e:
             logger.warning(
                 "Failed to get margin interest history for %s: %s", asset, e

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -64,6 +64,18 @@ class QueryTimeout:
 # This cap indicates "extremely profitable" while remaining storable in Numeric(18, 8).
 MAX_PROFIT_FACTOR = 999999.99
 
+
+def _trade_net_pnl(trade: Any) -> float:
+    """Return trade PnL net of margin interest cost.
+
+    Handles float, int, and Decimal types from SQLAlchemy Numeric columns.
+    Gracefully returns gross PnL when margin_interest_cost is missing or invalid.
+    """
+    raw = getattr(trade, "margin_interest_cost", None)
+    interest = float(raw) if isinstance(raw, (int, float, Decimal)) else 0.0
+    return float(trade.pnl) - interest
+
+
 # Connection pool configuration constants.
 # Used for QueuePool (PostgreSQL) - keep in sync with _get_engine_config().
 POOL_SIZE = 10  # Base pool size for concurrent operations
@@ -695,14 +707,13 @@ class DatabaseManager:
             trading_session.total_trades = len(trades)
 
             if trades:
-                winning_trades = [t for t in trades if t.pnl > 0]
+                winning_trades = [t for t in trades if _trade_net_pnl(t) > 0]
                 # Protect against division by zero
                 trading_session.win_rate = (
                     (len(winning_trades) / len(trades) * 100) if trades else 0
                 )
                 trading_session.total_pnl = sum(
-                    t.pnl - (float(getattr(t, "margin_interest_cost", 0)) if isinstance(getattr(t, "margin_interest_cost", None), (int, float)) else 0.0)
-                    for t in trades
+                    _trade_net_pnl(t) for t in trades
                 )
 
                 # Calculate max drawdown from account history
@@ -1750,30 +1761,25 @@ class DatabaseManager:
 
             # Calculate metrics with division by zero protection.
             # Net PnL subtracts margin interest cost (stored per-trade).
-            def _net_pnl(t: Trade) -> float:
-                raw = getattr(t, "margin_interest_cost", None)
-                interest = float(raw) if isinstance(raw, (int, float)) else 0.0
-                return t.pnl - interest
+            winning_trades = [t for t in trades if _trade_net_pnl(t) > 0]
+            losing_trades = [t for t in trades if _trade_net_pnl(t) < 0]
 
-            winning_trades = [t for t in trades if _net_pnl(t) > 0]
-            losing_trades = [t for t in trades if _net_pnl(t) < 0]
-
-            total_pnl = sum(_net_pnl(t) for t in trades)
+            total_pnl = sum(_trade_net_pnl(t) for t in trades)
             win_rate = (len(winning_trades) / len(trades) * 100) if trades else 0
 
             avg_win = (
-                (sum(_net_pnl(t) for t in winning_trades) / len(winning_trades))
+                (sum(_trade_net_pnl(t) for t in winning_trades) / len(winning_trades))
                 if winning_trades
                 else 0
             )
             avg_loss = (
-                (sum(_net_pnl(t) for t in losing_trades) / len(losing_trades))
+                (sum(_trade_net_pnl(t) for t in losing_trades) / len(losing_trades))
                 if losing_trades
                 else 0
             )
 
-            gross_profit = sum(_net_pnl(t) for t in winning_trades)
-            gross_loss = abs(sum(_net_pnl(t) for t in losing_trades))
+            gross_profit = sum(_trade_net_pnl(t) for t in winning_trades)
+            gross_loss = abs(sum(_trade_net_pnl(t) for t in losing_trades))
             if gross_loss > 0:
                 profit_factor = min(gross_profit / gross_loss, MAX_PROFIT_FACTOR)
             else:
@@ -1821,8 +1827,8 @@ class DatabaseManager:
                 "avg_loss": avg_loss,
                 "profit_factor": profit_factor,
                 "max_drawdown": max_drawdown,
-                "best_trade": max((t.pnl for t in trades), default=0),
-                "worst_trade": min((t.pnl for t in trades), default=0),
+                "best_trade": max((_trade_net_pnl(t) for t in trades), default=0),
+                "worst_trade": min((_trade_net_pnl(t) for t in trades), default=0),
                 "avg_trade_duration": (
                     sum((t.exit_time - t.entry_time).total_seconds() / 3600 for t in trades)
                     / len(trades)
@@ -2066,8 +2072,7 @@ class DatabaseManager:
 
             # Calculate current balance from initial balance + net PnL
             total_pnl = sum(
-                trade.pnl - (float(getattr(trade, "margin_interest_cost", 0)) if isinstance(getattr(trade, "margin_interest_cost", None), (int, float)) else 0.0)
-                for trade in trades
+                _trade_net_pnl(trade) for trade in trades
             )
             current_balance = trading_session.initial_balance + total_pnl
 
@@ -2872,19 +2877,14 @@ class DatabaseManager:
                     }
 
                 # Calculate basic metrics (net of margin interest)
-                def _net(t: Trade) -> float:
-                    raw = getattr(t, "margin_interest_cost", None)
-                    interest = float(raw) if isinstance(raw, (int, float)) else 0.0
-                    return float(t.pnl) - float(interest)
-
                 total_trades = len(trades)
-                winning_trades = [t for t in trades if _net(t) > 0]
-                losing_trades = [t for t in trades if _net(t) < 0]
+                winning_trades = [t for t in trades if _trade_net_pnl(t) > 0]
+                losing_trades = [t for t in trades if _trade_net_pnl(t) < 0]
 
                 win_rate = len(winning_trades) / total_trades if total_trades > 0 else 0.0
 
-                gross_profit = sum(_net(t) for t in winning_trades)
-                gross_loss = abs(sum(_net(t) for t in losing_trades))
+                gross_profit = sum(_trade_net_pnl(t) for t in winning_trades)
+                gross_loss = abs(sum(_trade_net_pnl(t) for t in losing_trades))
 
                 # Calculate profit factor consistently with get_performance_metrics
                 if gross_loss > 0:
@@ -2893,7 +2893,7 @@ class DatabaseManager:
                     profit_factor = MAX_PROFIT_FACTOR if gross_profit > 0 else 1.0
 
                 # Calculate expectancy
-                total_pnl = sum(_net(t) for t in trades)
+                total_pnl = sum(_trade_net_pnl(t) for t in trades)
                 expectancy = total_pnl / total_trades if total_trades > 0 else 0.0
 
                 # Calculate average trade duration

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -770,6 +770,7 @@ class DatabaseManager:
         mae_price: float | None = None,
         mfe_time: datetime | None = None,
         mae_time: datetime | None = None,
+        margin_interest_cost: float | None = None,
     ) -> int:
         """Logs a completed trade to the database.
 
@@ -852,6 +853,7 @@ class DatabaseManager:
                 mae_price=mae_price,
                 mfe_time=mfe_time,
                 mae_time=mae_time,
+                margin_interest_cost=margin_interest_cost or 0.0,
             )
 
             session.add(trade)

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -700,7 +700,10 @@ class DatabaseManager:
                 trading_session.win_rate = (
                     (len(winning_trades) / len(trades) * 100) if trades else 0
                 )
-                trading_session.total_pnl = sum(t.pnl for t in trades)
+                trading_session.total_pnl = sum(
+                    t.pnl - (float(getattr(t, "margin_interest_cost", 0)) if isinstance(getattr(t, "margin_interest_cost", None), (int, float)) else 0.0)
+                    for t in trades
+                )
 
                 # Calculate max drawdown from account history
                 account_history = (
@@ -1745,22 +1748,32 @@ class DatabaseManager:
                     "max_drawdown": 0.0,
                 }
 
-            # Calculate metrics with division by zero protection
-            winning_trades = [t for t in trades if t.pnl > 0]
-            losing_trades = [t for t in trades if t.pnl < 0]
+            # Calculate metrics with division by zero protection.
+            # Net PnL subtracts margin interest cost (stored per-trade).
+            def _net_pnl(t: Trade) -> float:
+                raw = getattr(t, "margin_interest_cost", None)
+                interest = float(raw) if isinstance(raw, (int, float)) else 0.0
+                return t.pnl - interest
 
-            total_pnl = sum(t.pnl for t in trades)
+            winning_trades = [t for t in trades if _net_pnl(t) > 0]
+            losing_trades = [t for t in trades if _net_pnl(t) < 0]
+
+            total_pnl = sum(_net_pnl(t) for t in trades)
             win_rate = (len(winning_trades) / len(trades) * 100) if trades else 0
 
             avg_win = (
-                (sum(t.pnl for t in winning_trades) / len(winning_trades)) if winning_trades else 0
+                (sum(_net_pnl(t) for t in winning_trades) / len(winning_trades))
+                if winning_trades
+                else 0
             )
             avg_loss = (
-                (sum(t.pnl for t in losing_trades) / len(losing_trades)) if losing_trades else 0
+                (sum(_net_pnl(t) for t in losing_trades) / len(losing_trades))
+                if losing_trades
+                else 0
             )
 
-            gross_profit = sum(t.pnl for t in winning_trades)
-            gross_loss = abs(sum(t.pnl for t in losing_trades))
+            gross_profit = sum(_net_pnl(t) for t in winning_trades)
+            gross_loss = abs(sum(_net_pnl(t) for t in losing_trades))
             if gross_loss > 0:
                 profit_factor = min(gross_profit / gross_loss, MAX_PROFIT_FACTOR)
             else:
@@ -2051,8 +2064,11 @@ class DatabaseManager:
             # Get all trades for this session
             trades = session.query(Trade).filter(Trade.session_id == session_id).all()
 
-            # Calculate current balance from initial balance + total PnL
-            total_pnl = sum(trade.pnl for trade in trades)
+            # Calculate current balance from initial balance + net PnL
+            total_pnl = sum(
+                trade.pnl - (float(getattr(trade, "margin_interest_cost", 0)) if isinstance(getattr(trade, "margin_interest_cost", None), (int, float)) else 0.0)
+                for trade in trades
+            )
             current_balance = trading_session.initial_balance + total_pnl
 
             # Update the balance tracking and warn if persistence fails
@@ -2855,15 +2871,20 @@ class DatabaseManager:
                         "total_pnl": 0.0,
                     }
 
-                # Calculate basic metrics
+                # Calculate basic metrics (net of margin interest)
+                def _net(t: Trade) -> float:
+                    raw = getattr(t, "margin_interest_cost", None)
+                    interest = float(raw) if isinstance(raw, (int, float)) else 0.0
+                    return float(t.pnl) - float(interest)
+
                 total_trades = len(trades)
-                winning_trades = [t for t in trades if float(t.pnl) > 0]
-                losing_trades = [t for t in trades if float(t.pnl) < 0]
+                winning_trades = [t for t in trades if _net(t) > 0]
+                losing_trades = [t for t in trades if _net(t) < 0]
 
                 win_rate = len(winning_trades) / total_trades if total_trades > 0 else 0.0
 
-                gross_profit = sum(float(t.pnl) for t in winning_trades)
-                gross_loss = abs(sum(float(t.pnl) for t in losing_trades))
+                gross_profit = sum(_net(t) for t in winning_trades)
+                gross_loss = abs(sum(_net(t) for t in losing_trades))
 
                 # Calculate profit factor consistently with get_performance_metrics
                 if gross_loss > 0:
@@ -2872,7 +2893,7 @@ class DatabaseManager:
                     profit_factor = MAX_PROFIT_FACTOR if gross_profit > 0 else 1.0
 
                 # Calculate expectancy
-                total_pnl = sum(float(t.pnl) for t in trades)
+                total_pnl = sum(_net(t) for t in trades)
                 expectancy = total_pnl / total_trades if total_trades > 0 else 0.0
 
                 # Calculate average trade duration

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -853,7 +853,7 @@ class DatabaseManager:
                 mae_price=mae_price,
                 mfe_time=mfe_time,
                 mae_time=mae_time,
-                margin_interest_cost=margin_interest_cost or 0.0,
+                margin_interest_cost=margin_interest_cost if margin_interest_cost is not None else 0.0,
             )
 
             session.add(trade)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -149,6 +149,7 @@ class Trade(Base):
     pnl = Column(Numeric(18, 8), nullable=False)  # Dollar P&L
     pnl_percent = Column(Numeric(18, 8), nullable=False)  # Percentage P&L
     commission = Column(Numeric(18, 8), default=0.0)
+    margin_interest_cost = Column(Numeric(18, 8), default=0.0)  # Margin borrow interest deducted
 
     # Risk management
     stop_loss = Column(Numeric(18, 8))

--- a/src/engines/live/account_sync.py
+++ b/src/engines/live/account_sync.py
@@ -119,11 +119,11 @@ class AccountSynchronizer:
             # row. Syncing USDT alone would oversize the next trade.
             # Proper margin equity requires account-level totalNetAssetOfBtc,
             # which is a future enhancement. Internal tracking is authoritative.
-            # TODO: Implement margin equity sync using get_margin_account()
-            # totalNetAssetOfBtc field, and deduct borrow interest from PnL
-            # on position close. Current gap: interest accrual on shorts is
-            # not deducted from current_balance, causing minor overstatement
-            # (~0.01%/day on borrowed amount).
+            # Margin interest tracking is implemented in MarginInterestTracker
+            # (src/engines/live/margin_interest_tracker.py). Interest is deducted
+            # from realized PnL on position close and logged during reconciliation.
+            # Balance/position sync remains skipped in margin mode because USDT
+            # netAsset doesn't reflect true equity when shorts are open.
             if not self._use_margin:
                 balance_sync_result = self._sync_balances(
                     exchange_data.get("balances", [])

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -14,7 +14,8 @@ class _ExchangeWithInterestHistory(Protocol):
     """Protocol for exchanges that support margin interest history queries."""
 
     def get_margin_interest_history(
-        self, asset: str, start_time: int, end_time: int | None = None
+        self, asset: str, start_time: int, end_time: int | None = None,
+        page: int = 1,
     ) -> list[dict[str, Any]]: ...
 
 
@@ -97,13 +98,12 @@ class MarginInterestTracker:
     def _fetch_all_records(
         self, asset: str, start_time_ms: int
     ) -> list[dict[str, Any]]:
-        """Fetch all interest records, paginating if Binance returns a full page."""
+        """Fetch all interest records using page-number pagination."""
         all_records: list[dict[str, Any]] = []
-        current_start = start_time_ms
 
-        for page in range(self._MAX_PAGES):
+        for page_num in range(1, self._MAX_PAGES + 1):
             records = self._exchange.get_margin_interest_history(
-                asset=asset, start_time=current_start
+                asset=asset, start_time=start_time_ms, page=page_num
             )
             if not records:
                 break
@@ -113,23 +113,13 @@ class MarginInterestTracker:
             if len(records) < self._PAGE_SIZE:
                 break
 
-            # Use last record's timestamp + 1ms as next page start
-            last_time = records[-1].get("interestAccuredTime")
-            if last_time is None:
-                logger.warning(
-                    "Cannot paginate interest history for %s — missing timestamp",
-                    asset,
-                )
-                break
-            current_start = int(last_time) + 1
-
-            if page > 0:
+            if page_num > 1:
                 logger.info(
                     "Paginating interest history for %s (page %d, %d records so far)",
-                    asset, page + 1, len(all_records),
+                    asset, page_num, len(all_records),
                 )
         else:
-            # Loop exhausted MAX_PAGES without breaking — results may be truncated
+            # Loop exhausted MAX_PAGES without breaking
             logger.warning(
                 "Interest history for %s hit %d-page limit (%d records) — "
                 "total may be understated for very long-held positions",

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -50,6 +50,14 @@ class MarginInterestTracker:
         if not records:
             return 0.0
 
+        # Binance returns max 500 records per call; warn if truncated
+        if len(records) >= 500:
+            logger.warning(
+                "Interest history for %s returned %d records (may be truncated)",
+                asset,
+                len(records),
+            )
+
         total = 0.0
         for record in records:
             try:
@@ -70,14 +78,10 @@ class MarginInterestTracker:
 
             total += value
 
-        logger.info(
+        logger.debug(
             "Total margin interest for %s since %s: %.8f",
             asset,
             entry_time.isoformat(),
             total,
         )
         return total
-
-    def is_margin_position(self, side: str) -> bool:
-        """Return True if the position side borrows (only SHORT borrows)."""
-        return side == "SHORT"

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -14,7 +14,7 @@ class _ExchangeWithInterestHistory(Protocol):
     """Protocol for exchanges that support margin interest history queries."""
 
     def get_margin_interest_history(
-        self, *, asset: str, start_time: int
+        self, asset: str, start_time: int, end_time: int | None = None
     ) -> list[dict[str, Any]]: ...
 
 
@@ -36,27 +36,24 @@ class MarginInterestTracker:
         Sums interest from all exchange records since the position was opened.
         Returns 0.0 on error or when no records exist.
         """
+        if entry_time.tzinfo is None:
+            logger.warning(
+                "entry_time for %s is naive (no timezone) — assuming UTC",
+                asset,
+            )
+
         try:
             start_time_ms = int(entry_time.timestamp() * 1000)
-            records = self._exchange.get_margin_interest_history(
-                asset=asset, start_time=start_time_ms
-            )
-        except Exception:
+            records = self._fetch_all_records(asset, start_time_ms)
+        except Exception as e:
             logger.warning(
-                "Failed to fetch margin interest history for %s", asset
+                "Failed to fetch margin interest history for %s: %s",
+                asset, e, exc_info=True,
             )
             return 0.0
 
         if not records:
             return 0.0
-
-        # Binance returns max 500 records per call; warn if truncated
-        if len(records) >= 500:
-            logger.warning(
-                "Interest history for %s returned %d records (may be truncated)",
-                asset,
-                len(records),
-            )
 
         total = 0.0
         for record in records:
@@ -92,3 +89,43 @@ class MarginInterestTracker:
             total,
         )
         return total
+
+    _MAX_PAGES = 10  # Safety limit to prevent runaway pagination
+    _PAGE_SIZE = 500  # Binance returns max 500 records per call
+
+    def _fetch_all_records(
+        self, asset: str, start_time_ms: int
+    ) -> list[dict[str, Any]]:
+        """Fetch all interest records, paginating if Binance returns a full page."""
+        all_records: list[dict[str, Any]] = []
+        current_start = start_time_ms
+
+        for page in range(self._MAX_PAGES):
+            records = self._exchange.get_margin_interest_history(
+                asset=asset, start_time=current_start
+            )
+            if not records:
+                break
+
+            all_records.extend(records)
+
+            if len(records) < self._PAGE_SIZE:
+                break
+
+            # Use last record's timestamp + 1ms as next page start
+            last_time = records[-1].get("interestAccuredTime")
+            if last_time is None:
+                logger.warning(
+                    "Cannot paginate interest history for %s — missing timestamp",
+                    asset,
+                )
+                break
+            current_start = int(last_time) + 1
+
+            if page > 0:
+                logger.info(
+                    "Paginating interest history for %s (page %d, %d records so far)",
+                    asset, page + 1, len(all_records),
+                )
+
+        return all_records

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import logging
 import math
+import time
 from datetime import UTC, datetime
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
+
+_RETRY_DELAY_SECONDS = 1.0
 
 
 class _ExchangeWithInterestHistory(Protocol):
@@ -30,12 +33,17 @@ class MarginInterestTracker:
         self._exchange = exchange
 
     def get_position_interest_cost(
-        self, asset: str, entry_time: datetime
+        self, asset: str, entry_time: datetime, retries: int = 1
     ) -> float:
         """Return total margin interest cost for an asset since entry_time.
 
         Sums interest from all exchange records since the position was opened.
         Returns 0.0 on error or when no records exist.
+
+        Args:
+            asset: Base asset symbol (e.g. "BTC").
+            entry_time: Position open time.
+            retries: Number of retry attempts on API failure (default 1).
         """
         if entry_time.tzinfo is None:
             logger.warning(
@@ -44,13 +52,28 @@ class MarginInterestTracker:
             )
             entry_time = entry_time.replace(tzinfo=UTC)
 
-        try:
-            start_time_ms = int(entry_time.timestamp() * 1000)
-            records = self._fetch_all_records(asset, start_time_ms)
-        except Exception as e:
+        start_time_ms = int(entry_time.timestamp() * 1000)
+        records: list[dict[str, Any]] = []
+        last_error: Exception | None = None
+
+        for attempt in range(1 + retries):
+            try:
+                records = self._fetch_all_records(asset, start_time_ms)
+                last_error = None
+                break
+            except Exception as e:
+                last_error = e
+                if attempt < retries:
+                    logger.info(
+                        "Retrying margin interest fetch for %s (attempt %d/%d): %s",
+                        asset, attempt + 1, 1 + retries, e,
+                    )
+                    time.sleep(_RETRY_DELAY_SECONDS)
+
+        if last_error is not None:
             logger.warning(
-                "Failed to fetch margin interest history for %s: %s",
-                asset, e, exc_info=True,
+                "Failed to fetch margin interest history for %s after %d attempts: %s",
+                asset, 1 + retries, last_error, exc_info=True,
             )
             return 0.0
 
@@ -59,6 +82,11 @@ class MarginInterestTracker:
 
         total = 0.0
         for record in records:
+            if not isinstance(record, dict):
+                logger.warning(
+                    "Skipping non-dict interest record: %s", type(record).__name__
+                )
+                continue
             try:
                 value = float(record["interest"])
             except (ValueError, KeyError, TypeError):

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -1,0 +1,83 @@
+"""Margin interest tracker for calculating borrow costs on short positions."""
+
+from __future__ import annotations
+
+import logging
+import math
+from datetime import datetime
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class _ExchangeWithInterestHistory(Protocol):
+    """Protocol for exchanges that support margin interest history queries."""
+
+    def get_margin_interest_history(
+        self, *, asset: str, start_time: int
+    ) -> list[dict[str, Any]]: ...
+
+
+class MarginInterestTracker:
+    """Query wrapper for margin borrow interest costs.
+
+    Calculates total margin borrow interest accrued on a position
+    between its entry time and the present by querying the exchange API.
+    """
+
+    def __init__(self, exchange: _ExchangeWithInterestHistory) -> None:
+        self._exchange = exchange
+
+    def get_position_interest_cost(
+        self, asset: str, entry_time: datetime
+    ) -> float:
+        """Return total margin interest cost for an asset since entry_time.
+
+        Sums interest from all exchange records since the position was opened.
+        Returns 0.0 on error or when no records exist.
+        """
+        try:
+            start_time_ms = int(entry_time.timestamp() * 1000)
+            records = self._exchange.get_margin_interest_history(
+                asset=asset, start_time=start_time_ms
+            )
+        except Exception:
+            logger.warning(
+                "Failed to fetch margin interest history for %s", asset
+            )
+            return 0.0
+
+        if not records:
+            return 0.0
+
+        total = 0.0
+        for record in records:
+            try:
+                value = float(record["interest"])
+            except (ValueError, KeyError, TypeError):
+                logger.warning(
+                    "Skipping record with invalid interest value: %s",
+                    record.get("interest", "<missing>"),
+                )
+                continue
+
+            if not math.isfinite(value):
+                logger.warning(
+                    "Skipping non-finite interest value: %s",
+                    record["interest"],
+                )
+                continue
+
+            total += value
+
+        logger.info(
+            "Total margin interest for %s since %s: %.8f",
+            asset,
+            entry_time.isoformat(),
+            total,
+        )
+        return total
+
+    def is_margin_position(self, side: str) -> bool:
+        """Return True if the position side borrows (only SHORT borrows)."""
+        return side == "SHORT"

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -76,6 +76,13 @@ class MarginInterestTracker:
                 )
                 continue
 
+            if value <= 0:
+                logger.warning(
+                    "Skipping non-positive interest value: %s",
+                    record["interest"],
+                )
+                continue
+
             total += value
 
         logger.debug(

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -91,7 +91,7 @@ class MarginInterestTracker:
         return total
 
     _MAX_PAGES = 10  # Safety limit to prevent runaway pagination
-    _PAGE_SIZE = 500  # Binance returns max 500 records per call
+    _PAGE_SIZE = 100  # Must match size param passed to Binance API
 
     def _fetch_all_records(
         self, asset: str, start_time_ms: int

--- a/src/engines/live/margin_interest_tracker.py
+++ b/src/engines/live/margin_interest_tracker.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
@@ -38,9 +38,10 @@ class MarginInterestTracker:
         """
         if entry_time.tzinfo is None:
             logger.warning(
-                "entry_time for %s is naive (no timezone) — assuming UTC",
+                "entry_time for %s is naive (no timezone) — normalizing to UTC",
                 asset,
             )
+            entry_time = entry_time.replace(tzinfo=UTC)
 
         try:
             start_time_ms = int(entry_time.timestamp() * 1000)
@@ -127,5 +128,12 @@ class MarginInterestTracker:
                     "Paginating interest history for %s (page %d, %d records so far)",
                     asset, page + 1, len(all_records),
                 )
+        else:
+            # Loop exhausted MAX_PAGES without breaking — results may be truncated
+            logger.warning(
+                "Interest history for %s hit %d-page limit (%d records) — "
+                "total may be understated for very long-held positions",
+                asset, self._MAX_PAGES, len(all_records),
+            )
 
         return all_records

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2018,6 +2018,30 @@ class PositionReconciler:
         else:
             pnl = (exit_price - entry_price) * qty
 
+        # Deduct margin interest for short positions closed during reconciliation
+        if self._use_margin and side_is_short:
+            try:
+                interest_tracker = MarginInterestTracker(self.exchange)
+                base_asset = PositionReconciler._extract_base_asset(position.symbol)
+                entry_time = getattr(position, "entry_time", None)
+                if entry_time is not None:
+                    interest_cost = interest_tracker.get_position_interest_cost(
+                        base_asset, entry_time
+                    )
+                    if interest_cost > 0:
+                        pnl -= interest_cost
+                        logger.info(
+                            "Deducted margin interest $%.2f from reconciliation PnL for %s",
+                            interest_cost,
+                            position.symbol,
+                        )
+            except Exception as e:
+                logger.warning(
+                    "Failed to query margin interest during reconciliation close for %s: %s",
+                    getattr(position, "symbol", "?"),
+                    e,
+                )
+
         try:
             current_balance = self.db_manager.get_current_balance(self.session_id)
             if current_balance is None or current_balance < 0:

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -27,6 +27,7 @@ from src.config.constants import (
     DEFAULT_STOP_LOSS_PCT,
 )
 from src.data_providers.exchange_interface import SideEffectType
+from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.shared.models import PositionSide
 
 if TYPE_CHECKING:
@@ -2398,6 +2399,38 @@ class PeriodicReconciler:
                 except Exception as e:
                     logger.warning(
                         "Margin position check failed for %s: %s",
+                        getattr(position, "symbol", "?"),
+                        e,
+                    )
+
+            # Log accumulated margin interest for open short positions
+            # (informational only — no corrections or balance changes)
+            interest_tracker = MarginInterestTracker(self.exchange)
+            for _key, position in list(positions_snapshot.items()):
+                try:
+                    side = getattr(position, "side", None)
+                    is_short = (
+                        side == PositionSide.SHORT or str(side).lower() == "short"
+                    )
+                    if not is_short:
+                        continue
+                    entry_time = getattr(position, "entry_time", None)
+                    if entry_time is None:
+                        continue
+                    base_asset = PositionReconciler._extract_base_asset(
+                        position.symbol
+                    )
+                    interest = interest_tracker.get_position_interest_cost(
+                        base_asset, entry_time
+                    )
+                    logger.info(
+                        "Margin interest accrued for %s: $%.4f",
+                        position.symbol,
+                        interest,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to query margin interest for %s: %s",
                         getattr(position, "symbol", "?"),
                         e,
                     )

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2433,8 +2433,15 @@ class PeriodicReconciler:
                     )
 
             # Log accumulated margin interest for open short positions
-            # (informational only — no corrections or balance changes)
+            # (informational only — no corrections or balance changes).
+            # Uses a per-position cache (5-minute TTL) to avoid hitting the
+            # SAPI endpoint every reconciliation cycle (default 60s).
+            now = time.time()
             interest_tracker = MarginInterestTracker(self.exchange)
+            interest_cache_ttl = 300  # seconds
+            if not hasattr(self, "_interest_cache"):
+                self._interest_cache: dict[str, tuple[float, float]] = {}
+
             for _key, position in list(positions_snapshot.items()):
                 try:
                     side = getattr(position, "side", None)
@@ -2446,14 +2453,21 @@ class PeriodicReconciler:
                     entry_time = getattr(position, "entry_time", None)
                     if entry_time is None:
                         continue
+
                     base_asset = PositionReconciler._extract_base_asset(
                         position.symbol
                     )
-                    interest_base = interest_tracker.get_position_interest_cost(
-                        base_asset, entry_time
-                    )
+                    cache_key = f"{position.symbol}_{_key}"
+                    cached = self._interest_cache.get(cache_key)
+                    if cached and (now - cached[1]) < interest_cache_ttl:
+                        interest_base = cached[0]
+                    else:
+                        interest_base = interest_tracker.get_position_interest_cost(
+                            base_asset, entry_time
+                        )
+                        self._interest_cache[cache_key] = (interest_base, now)
+
                     if interest_base > 0:
-                        # Get current price for USDT conversion
                         current_price = getattr(position, "current_price", None)
                         if current_price and float(current_price) > 0:
                             interest_usdt = interest_base * float(current_price)

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2449,15 +2449,28 @@ class PeriodicReconciler:
                     base_asset = PositionReconciler._extract_base_asset(
                         position.symbol
                     )
-                    interest = interest_tracker.get_position_interest_cost(
+                    interest_base = interest_tracker.get_position_interest_cost(
                         base_asset, entry_time
                     )
-                    if interest > 0:
-                        logger.info(
-                            "Margin interest accrued for %s: $%.4f",
-                            position.symbol,
-                            interest,
-                        )
+                    if interest_base > 0:
+                        # Get current price for USDT conversion
+                        current_price = getattr(position, "current_price", None)
+                        if current_price and float(current_price) > 0:
+                            interest_usdt = interest_base * float(current_price)
+                            logger.info(
+                                "Margin interest accrued for %s: $%.4f (%.8f %s)",
+                                position.symbol,
+                                interest_usdt,
+                                interest_base,
+                                base_asset,
+                            )
+                        else:
+                            logger.info(
+                                "Margin interest accrued for %s: %.8f %s (no price for USDT conversion)",
+                                position.symbol,
+                                interest_base,
+                                base_asset,
+                            )
                 except Exception as e:
                     logger.warning(
                         "Failed to query margin interest for %s: %s",

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2025,14 +2025,19 @@ class PositionReconciler:
                 base_asset = PositionReconciler._extract_base_asset(position.symbol)
                 entry_time = getattr(position, "entry_time", None)
                 if entry_time is not None:
-                    interest_cost = interest_tracker.get_position_interest_cost(
+                    interest_base = interest_tracker.get_position_interest_cost(
                         base_asset, entry_time
                     )
+                    # Convert from base asset units to USDT using exit price
+                    interest_cost = interest_base * exit_price
                     if interest_cost > 0:
                         pnl -= interest_cost
                         logger.info(
-                            "Deducted margin interest $%.2f from reconciliation PnL for %s",
+                            "Deducted margin interest $%.4f (%.8f %s @ %.2f) from reconciliation PnL for %s",
                             interest_cost,
+                            interest_base,
+                            base_asset,
+                            exit_price,
                             position.symbol,
                         )
             except Exception as e:

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2423,11 +2423,12 @@ class PeriodicReconciler:
                     interest = interest_tracker.get_position_interest_cost(
                         base_asset, entry_time
                     )
-                    logger.info(
-                        "Margin interest accrued for %s: $%.4f",
-                        position.symbol,
-                        interest,
-                    )
+                    if interest > 0:
+                        logger.info(
+                            "Margin interest accrued for %s: $%.4f",
+                            position.symbol,
+                            interest,
+                        )
                 except Exception as e:
                     logger.warning(
                         "Failed to query margin interest for %s: %s",

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4243,6 +4243,37 @@ class LiveTradingEngine:
                     gross_pnl = pnl_pct_sized * basis_balance
                     realized_pnl = gross_pnl - exit_fee  # Net P&L for balance update
 
+                    # Deduct margin interest for short positions closed offline
+                    offline_interest_cost = 0.0
+                    if (
+                        getattr(self.exchange_interface, "is_margin_mode", False)
+                        and position.side == PositionSide.SHORT
+                    ):
+                        try:
+                            from src.engines.live.reconciliation import PositionReconciler
+
+                            tracker = MarginInterestTracker(self.exchange_interface)
+                            base_asset = PositionReconciler._extract_base_asset(
+                                position.symbol
+                            )
+                            interest_base = tracker.get_position_interest_cost(
+                                base_asset, position.entry_time
+                            )
+                            offline_interest_cost = interest_base * exit_price
+                            if offline_interest_cost > 0:
+                                realized_pnl -= offline_interest_cost
+                                logger.info(
+                                    "Deducted margin interest $%.4f from offline SL PnL for %s",
+                                    offline_interest_cost,
+                                    position.symbol,
+                                )
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to query margin interest for offline SL %s: %s",
+                                position.symbol,
+                                e,
+                            )
+
                     # Atomic balance update for offline stop-loss reconciliation
                     if self.trading_session_id is not None:
                         try:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -3381,8 +3381,12 @@ class LiveTradingEngine:
                 exit_reason=reason,
             )
 
+            # Include margin interest in performance tracker fees so
+            # reported PnL, win rate, and net metrics account for financing.
             self.performance_tracker.record_trade(
-                trade=trade, fee=total_fee, slippage=total_slippage
+                trade=trade,
+                fee=total_fee + interest_cost,
+                slippage=total_slippage,
             )
 
             self.completed_trades.append(trade)
@@ -4317,11 +4321,30 @@ class LiveTradingEngine:
                         exit_reason="stop_loss_offline",
                     )
                     self.performance_tracker.record_trade(
-                        trade=trade, fee=exit_fee, slippage=exit_slippage_cost
+                        trade=trade,
+                        fee=exit_fee + offline_interest_cost,
+                        slippage=exit_slippage_cost,
                     )
                     self.completed_trades.append(trade)
                     if self.log_trades:
                         self._log_trade(trade)
+
+                    # Persist trade to DB with margin interest cost
+                    if self.trading_session_id is not None:
+                        self.db_manager.log_trade(
+                            symbol=position.symbol,
+                            side=position.side.value,
+                            entry_price=position.entry_price,
+                            exit_price=exit_price,
+                            size=fraction,
+                            pnl=gross_pnl,
+                            strategy_name=self._strategy_name(),
+                            exit_reason="stop_loss_offline",
+                            entry_time=position.entry_time,
+                            exit_time=datetime.now(UTC),
+                            session_id=self.trading_session_id,
+                            margin_interest_cost=offline_interest_cost,
+                        )
 
                 # Stop tracking the SL order to prevent memory leak
                 if position.stop_loss_order_id and self.order_tracker:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -3294,6 +3294,11 @@ class LiveTradingEngine:
                     if symbol.endswith(quote) and len(symbol) > len(quote):
                         base_asset = symbol[: -len(quote)]
                         break
+                if base_asset == position.symbol:
+                    logger.warning(
+                        "Could not extract base asset from %s — margin interest may not be queried correctly",
+                        position.symbol,
+                    )
                 interest_cost = tracker.get_position_interest_cost(
                     base_asset, position.entry_time
                 )
@@ -3343,7 +3348,7 @@ class LiveTradingEngine:
 
             entry_fee = float(position.metadata.get("entry_fee", 0.0))
             entry_slippage_cost = float(position.metadata.get("entry_slippage_cost", 0.0))
-            total_fee = entry_fee + exit_fee
+            total_fee = entry_fee + exit_fee + interest_cost
             total_slippage = entry_slippage_cost + exit_slippage_cost
 
             # Store GROSS P&L in Trade.pnl for parity with backtest engine

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -3286,14 +3286,12 @@ class LiveTradingEngine:
                 getattr(self.exchange_interface, "is_margin_mode", False)
                 and position.side == PositionSide.SHORT
             ):
+                from src.engines.live.reconciliation import PositionReconciler
+
                 tracker = MarginInterestTracker(self.exchange_interface)
-                # Extract base asset: strip quote currency from symbol
-                symbol = position.symbol
-                base_asset = symbol
-                for quote in ("USDT", "BUSD", "USD"):
-                    if symbol.endswith(quote) and len(symbol) > len(quote):
-                        base_asset = symbol[: -len(quote)]
-                        break
+                base_asset = PositionReconciler._extract_base_asset(
+                    position.symbol
+                )
                 if base_asset == position.symbol:
                     logger.warning(
                         "Could not extract base asset from %s — margin interest may not be queried correctly",

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -3286,26 +3286,33 @@ class LiveTradingEngine:
                 getattr(self.exchange_interface, "is_margin_mode", False)
                 and position.side == PositionSide.SHORT
             ):
-                from src.engines.live.reconciliation import PositionReconciler
+                try:
+                    from src.engines.live.reconciliation import PositionReconciler
 
-                tracker = MarginInterestTracker(self.exchange_interface)
-                base_asset = PositionReconciler._extract_base_asset(
-                    position.symbol
-                )
-                if base_asset == position.symbol:
-                    logger.warning(
-                        "Could not extract base asset from %s — margin interest may not be queried correctly",
-                        position.symbol,
+                    tracker = MarginInterestTracker(self.exchange_interface)
+                    base_asset = PositionReconciler._extract_base_asset(
+                        position.symbol
                     )
-                interest_cost = tracker.get_position_interest_cost(
-                    base_asset, position.entry_time
-                )
-                if interest_cost > 0:
-                    realized_pnl -= interest_cost
-                    logger.info(
-                        "Deducted margin interest $%.2f from PnL for %s",
-                        interest_cost,
+                    if base_asset == position.symbol:
+                        logger.warning(
+                            "Could not extract base asset from %s — margin interest may not be queried correctly",
+                            position.symbol,
+                        )
+                    interest_cost = tracker.get_position_interest_cost(
+                        base_asset, position.entry_time
+                    )
+                    if interest_cost > 0:
+                        realized_pnl -= interest_cost
+                        logger.info(
+                            "Deducted margin interest $%.2f from PnL for %s",
+                            interest_cost,
+                            position.symbol,
+                        )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to query margin interest for %s — proceeding without deduction: %s",
                         position.symbol,
+                        e,
                     )
 
             # Atomic balance update with full audit trail for realized P&L
@@ -3346,7 +3353,7 @@ class LiveTradingEngine:
 
             entry_fee = float(position.metadata.get("entry_fee", 0.0))
             entry_slippage_cost = float(position.metadata.get("entry_slippage_cost", 0.0))
-            total_fee = entry_fee + exit_fee + interest_cost
+            total_fee = entry_fee + exit_fee
             total_slippage = entry_slippage_cost + exit_slippage_cost
 
             # Store GROSS P&L in Trade.pnl for parity with backtest engine

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -54,6 +54,7 @@ from src.engines.live.data.market_data_handler import MarketDataHandler
 from src.engines.live.execution.entry_handler import LiveEntryHandler, LiveEntrySignal
 from src.engines.live.execution.execution_engine import LiveExecutionEngine
 from src.engines.live.execution.exit_handler import LiveExitHandler
+from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.execution.position_tracker import (
     LivePosition,
     LivePositionTracker,
@@ -3279,6 +3280,31 @@ class LiveTradingEngine:
 
             realized_pnl = exit_result.realized_pnl - exit_result.exit_fee
 
+            # Deduct margin interest for short positions in margin mode
+            interest_cost = 0.0
+            if (
+                getattr(self.exchange_interface, "is_margin_mode", False)
+                and position.side == PositionSide.SHORT
+            ):
+                tracker = MarginInterestTracker(self.exchange_interface)
+                # Extract base asset: strip quote currency from symbol
+                symbol = position.symbol
+                base_asset = symbol
+                for quote in ("USDT", "BUSD", "USD"):
+                    if symbol.endswith(quote) and len(symbol) > len(quote):
+                        base_asset = symbol[: -len(quote)]
+                        break
+                interest_cost = tracker.get_position_interest_cost(
+                    base_asset, position.entry_time
+                )
+                if interest_cost > 0:
+                    realized_pnl -= interest_cost
+                    logger.info(
+                        "Deducted margin interest $%.2f from PnL for %s",
+                        interest_cost,
+                        position.symbol,
+                    )
+
             # Atomic balance update with full audit trail for realized P&L
             if self.trading_session_id is not None:
                 try:
@@ -3371,6 +3397,7 @@ class LiveTradingEngine:
                     mae_price=(metrics.mae_price if metrics else None),
                     mfe_time=(metrics.mfe_time if metrics else None),
                     mae_time=(metrics.mae_time if metrics else None),
+                    margin_interest_cost=interest_cost,
                 )
 
             if (

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -3298,14 +3298,19 @@ class LiveTradingEngine:
                             "Could not extract base asset from %s — margin interest may not be queried correctly",
                             position.symbol,
                         )
-                    interest_cost = tracker.get_position_interest_cost(
+                    interest_base = tracker.get_position_interest_cost(
                         base_asset, position.entry_time
                     )
+                    # Convert from base asset units to USDT using exit price
+                    interest_cost = interest_base * float(exit_result.exit_price)
                     if interest_cost > 0:
                         realized_pnl -= interest_cost
                         logger.info(
-                            "Deducted margin interest $%.2f from PnL for %s",
+                            "Deducted margin interest $%.4f (%.8f %s @ %.2f) from PnL for %s",
                             interest_cost,
+                            interest_base,
+                            base_asset,
+                            float(exit_result.exit_price),
                             position.symbol,
                         )
                 except Exception as e:

--- a/tests/mocks/mock_database.py
+++ b/tests/mocks/mock_database.py
@@ -199,6 +199,7 @@ class MockDatabaseManager:
             "mae_price": kwargs.get("mae_price"),
             "mfe_time": kwargs.get("mfe_time"),
             "mae_time": kwargs.get("mae_time"),
+            "margin_interest_cost": kwargs.get("margin_interest_cost"),
         }
 
         return trade_id

--- a/tests/unit/test_binance_provider_interest.py
+++ b/tests/unit/test_binance_provider_interest.py
@@ -105,7 +105,7 @@ class TestGetMarginInterestHistory:
         )
 
         margin_provider._client.get_margin_interest_history.assert_called_once_with(
-            asset="ETH", startTime=1000, endTime=2000
+            asset="ETH", size=100, startTime=1000, endTime=2000
         )
 
     def test_filters_none_params(self, margin_provider):
@@ -115,7 +115,7 @@ class TestGetMarginInterestHistory:
         margin_provider.get_margin_interest_history(asset="BTC")
 
         margin_provider._client.get_margin_interest_history.assert_called_once_with(
-            asset="BTC"
+            asset="BTC", size=100
         )
 
     def test_filters_only_end_time_none(self, margin_provider):
@@ -125,7 +125,7 @@ class TestGetMarginInterestHistory:
         margin_provider.get_margin_interest_history(asset="BTC", start_time=5000)
 
         margin_provider._client.get_margin_interest_history.assert_called_once_with(
-            asset="BTC", startTime=5000
+            asset="BTC", size=100, startTime=5000
         )
 
 

--- a/tests/unit/test_binance_provider_interest.py
+++ b/tests/unit/test_binance_provider_interest.py
@@ -35,8 +35,8 @@ class TestGetMarginInterestHistory:
     """Tests for get_margin_interest_history method."""
 
     def test_returns_data_in_margin_mode(self, margin_provider):
-        """Should return interest history when in margin mode."""
-        expected = [
+        """Should unwrap rows from Binance envelope and return interest records."""
+        expected_rows = [
             {
                 "txId": 1,
                 "interestAccuredTime": 1672531200000,
@@ -47,11 +47,14 @@ class TestGetMarginInterestHistory:
                 "type": "ON_BORROW",
             }
         ]
-        margin_provider._client.get_margin_interest_history.return_value = expected
+        # Binance API returns {rows: [...], total: N} envelope
+        margin_provider._client.get_margin_interest_history.return_value = {
+            "rows": expected_rows, "total": 1
+        }
 
         result = margin_provider.get_margin_interest_history(asset="BTC")
 
-        assert result == expected
+        assert result == expected_rows
 
     def test_returns_empty_list_when_not_margin_mode(self, spot_provider):
         """Should return empty list when not in margin mode."""
@@ -98,34 +101,34 @@ class TestGetMarginInterestHistory:
 
     def test_passes_correct_params_all_specified(self, margin_provider):
         """Should pass asset, startTime, endTime to client when all provided."""
-        margin_provider._client.get_margin_interest_history.return_value = []
+        margin_provider._client.get_margin_interest_history.return_value = {"rows": [], "total": 0}
 
         margin_provider.get_margin_interest_history(
             asset="ETH", start_time=1000, end_time=2000
         )
 
         margin_provider._client.get_margin_interest_history.assert_called_once_with(
-            asset="ETH", size=100, startTime=1000, endTime=2000
+            asset="ETH", size=100, current=1, startTime=1000, endTime=2000
         )
 
     def test_filters_none_params(self, margin_provider):
         """Should not pass startTime/endTime when they are None."""
-        margin_provider._client.get_margin_interest_history.return_value = []
+        margin_provider._client.get_margin_interest_history.return_value = {"rows": [], "total": 0}
 
         margin_provider.get_margin_interest_history(asset="BTC")
 
         margin_provider._client.get_margin_interest_history.assert_called_once_with(
-            asset="BTC", size=100
+            asset="BTC", size=100, current=1
         )
 
     def test_filters_only_end_time_none(self, margin_provider):
         """Should pass startTime but not endTime when only end_time is None."""
-        margin_provider._client.get_margin_interest_history.return_value = []
+        margin_provider._client.get_margin_interest_history.return_value = {"rows": [], "total": 0}
 
         margin_provider.get_margin_interest_history(asset="BTC", start_time=5000)
 
         margin_provider._client.get_margin_interest_history.assert_called_once_with(
-            asset="BTC", size=100, startTime=5000
+            asset="BTC", size=100, current=1, startTime=5000
         )
 
 

--- a/tests/unit/test_binance_provider_interest.py
+++ b/tests/unit/test_binance_provider_interest.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.fast
+
 
 @pytest.fixture
 def margin_provider():
@@ -50,8 +52,6 @@ class TestGetMarginInterestHistory:
         result = margin_provider.get_margin_interest_history(asset="BTC")
 
         assert result == expected
-        assert len(result) == 1
-        assert result[0]["asset"] == "BTC"
 
     def test_returns_empty_list_when_not_margin_mode(self, spot_provider):
         """Should return empty list when not in margin mode."""

--- a/tests/unit/test_binance_provider_interest.py
+++ b/tests/unit/test_binance_provider_interest.py
@@ -89,15 +89,14 @@ class TestGetMarginInterestHistory:
 
             assert result == []
 
-    def test_returns_empty_list_on_api_error(self, margin_provider):
-        """Should return empty list and log warning on API error."""
+    def test_propagates_api_error(self, margin_provider):
+        """Should propagate API errors so callers can retry."""
         margin_provider._client.get_margin_interest_history.side_effect = Exception(
             "API timeout"
         )
 
-        result = margin_provider.get_margin_interest_history(asset="BTC")
-
-        assert result == []
+        with pytest.raises(Exception, match="API timeout"):
+            margin_provider.get_margin_interest_history(asset="BTC")
 
     def test_passes_correct_params_all_specified(self, margin_provider):
         """Should pass asset, startTime, endTime to client when all provided."""

--- a/tests/unit/test_binance_provider_interest.py
+++ b/tests/unit/test_binance_provider_interest.py
@@ -1,0 +1,143 @@
+"""Tests for BinanceProvider.get_margin_interest_history() method."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def margin_provider():
+    """Create a BinanceProvider instance in margin mode with a mocked client."""
+    with patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True):
+        from src.data_providers.binance_provider import BinanceProvider
+
+        provider = BinanceProvider.__new__(BinanceProvider)
+        provider._use_margin = True
+        provider._client = MagicMock()
+        yield provider
+
+
+@pytest.fixture
+def spot_provider():
+    """Create a BinanceProvider instance NOT in margin mode."""
+    with patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True):
+        from src.data_providers.binance_provider import BinanceProvider
+
+        provider = BinanceProvider.__new__(BinanceProvider)
+        provider._use_margin = False
+        provider._client = MagicMock()
+        yield provider
+
+
+class TestGetMarginInterestHistory:
+    """Tests for get_margin_interest_history method."""
+
+    def test_returns_data_in_margin_mode(self, margin_provider):
+        """Should return interest history when in margin mode."""
+        expected = [
+            {
+                "txId": 1,
+                "interestAccuredTime": 1672531200000,
+                "asset": "BTC",
+                "interest": "0.00012345",
+                "interestRate": "0.0001",
+                "principal": "1.5",
+                "type": "ON_BORROW",
+            }
+        ]
+        margin_provider._client.get_margin_interest_history.return_value = expected
+
+        result = margin_provider.get_margin_interest_history(asset="BTC")
+
+        assert result == expected
+        assert len(result) == 1
+        assert result[0]["asset"] == "BTC"
+
+    def test_returns_empty_list_when_not_margin_mode(self, spot_provider):
+        """Should return empty list when not in margin mode."""
+        result = spot_provider.get_margin_interest_history(asset="BTC")
+
+        assert result == []
+        spot_provider._client.get_margin_interest_history.assert_not_called()
+
+    def test_returns_empty_list_when_binance_unavailable(self):
+        """Should return empty list when BINANCE_AVAILABLE is False."""
+        with patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", False):
+            from src.data_providers.binance_provider import BinanceProvider
+
+            provider = BinanceProvider.__new__(BinanceProvider)
+            provider._use_margin = True
+            provider._client = MagicMock()
+
+            result = provider.get_margin_interest_history(asset="BTC")
+
+            assert result == []
+
+    def test_returns_empty_list_when_no_client(self):
+        """Should return empty list when client is None."""
+        with patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True):
+            from src.data_providers.binance_provider import BinanceProvider
+
+            provider = BinanceProvider.__new__(BinanceProvider)
+            provider._use_margin = True
+            provider._client = None
+
+            result = provider.get_margin_interest_history(asset="BTC")
+
+            assert result == []
+
+    def test_returns_empty_list_on_api_error(self, margin_provider):
+        """Should return empty list and log warning on API error."""
+        margin_provider._client.get_margin_interest_history.side_effect = Exception(
+            "API timeout"
+        )
+
+        result = margin_provider.get_margin_interest_history(asset="BTC")
+
+        assert result == []
+
+    def test_passes_correct_params_all_specified(self, margin_provider):
+        """Should pass asset, startTime, endTime to client when all provided."""
+        margin_provider._client.get_margin_interest_history.return_value = []
+
+        margin_provider.get_margin_interest_history(
+            asset="ETH", start_time=1000, end_time=2000
+        )
+
+        margin_provider._client.get_margin_interest_history.assert_called_once_with(
+            asset="ETH", startTime=1000, endTime=2000
+        )
+
+    def test_filters_none_params(self, margin_provider):
+        """Should not pass startTime/endTime when they are None."""
+        margin_provider._client.get_margin_interest_history.return_value = []
+
+        margin_provider.get_margin_interest_history(asset="BTC")
+
+        margin_provider._client.get_margin_interest_history.assert_called_once_with(
+            asset="BTC"
+        )
+
+    def test_filters_only_end_time_none(self, margin_provider):
+        """Should pass startTime but not endTime when only end_time is None."""
+        margin_provider._client.get_margin_interest_history.return_value = []
+
+        margin_provider.get_margin_interest_history(asset="BTC", start_time=5000)
+
+        margin_provider._client.get_margin_interest_history.assert_called_once_with(
+            asset="BTC", startTime=5000
+        )
+
+
+class TestOfflineClientStub:
+    """Test that the offline client stub returns empty list."""
+
+    def test_offline_stub_returns_empty_list(self):
+        """Offline client stub for get_margin_interest_history should return []."""
+        with patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", False):
+            from src.data_providers.binance_provider import BinanceProvider
+
+            provider = BinanceProvider.__new__(BinanceProvider)
+            offline_client = provider._create_offline_client()
+            result = offline_client.get_margin_interest_history(asset="BTC")
+            assert result == []

--- a/tests/unit/test_margin_interest_close_flow.py
+++ b/tests/unit/test_margin_interest_close_flow.py
@@ -74,8 +74,8 @@ class TestMarginInterestDeduction:
         exchange = Mock()
         exchange.is_margin_mode = True
         exchange.get_margin_interest_history.return_value = [
-            {"interest": "1.50"},
-            {"interest": "0.75"},
+            {"interest": "0.010"},
+            {"interest": "0.005"},
         ]
 
         engine = _make_engine(exchange_interface=exchange)
@@ -99,10 +99,11 @@ class TestMarginInterestDeduction:
             skip_live_close=True,
         )
 
-        # Interest cost = 1.50 + 0.75 = 2.25
+        # Interest in base asset = 0.010 + 0.005 = 0.015
+        # Interest in USDT = 0.015 * 90.0 (exit_price) = 1.35
         # Gross PnL for short: (100 - 90) / 100 * 0.25 * 1000 = 25.0
-        # Net PnL = 25.0 - 2.25 = 22.75
-        expected_balance = initial_balance + 25.0 - 2.25
+        # Net PnL = 25.0 - 1.35 = 23.65
+        expected_balance = initial_balance + 25.0 - 1.35
         assert engine.current_balance == pytest.approx(expected_balance, abs=0.01)
 
         # Verify performance_tracker.record_trade is called (interest tracked separately)
@@ -193,7 +194,7 @@ class TestMarginInterestLogTrade:
         exchange = Mock()
         exchange.is_margin_mode = True
         exchange.get_margin_interest_history.return_value = [
-            {"interest": "3.00"},
+            {"interest": "0.030"},
         ]
 
         engine = _make_engine(exchange_interface=exchange)
@@ -214,10 +215,11 @@ class TestMarginInterestLogTrade:
         )
 
         # Check that log_trade was called with margin_interest_cost
+        # Interest = 0.030 base asset * 90.0 exit_price = 2.70 USDT
         logged_trade = engine.db_manager._trades
         assert len(logged_trade) == 1
         trade_data = list(logged_trade.values())[0]
-        assert trade_data.get("margin_interest_cost") == pytest.approx(3.0)
+        assert trade_data.get("margin_interest_cost") == pytest.approx(2.70, abs=0.01)
 
     def test_zero_interest_cost_for_non_margin(self):
         """Verify margin_interest_cost=0.0 is passed for non-margin trades."""

--- a/tests/unit/test_margin_interest_close_flow.py
+++ b/tests/unit/test_margin_interest_close_flow.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+pytestmark = pytest.mark.fast
+
 from src.engines.live.trading_engine import LiveTradingEngine, Position, PositionSide
 from src.strategies.components import (
     FixedFractionSizer,

--- a/tests/unit/test_margin_interest_close_flow.py
+++ b/tests/unit/test_margin_interest_close_flow.py
@@ -105,11 +105,11 @@ class TestMarginInterestDeduction:
         expected_balance = initial_balance + 25.0 - 2.25
         assert engine.current_balance == pytest.approx(expected_balance, abs=0.01)
 
-        # Verify performance_tracker.record_trade includes interest in fee
+        # Verify performance_tracker.record_trade is called (interest tracked separately)
         assert engine.performance_tracker.record_trade.call_count == 1
         call_kwargs = engine.performance_tracker.record_trade.call_args[1]
-        # With fee_rate=0.0, entry_fee=0 and exit_fee=0, so fee should equal interest_cost
-        assert call_kwargs["fee"] == pytest.approx(2.25, abs=0.01)
+        # Interest is NOT included in fee — it's tracked via margin_interest_cost column
+        assert call_kwargs["fee"] == pytest.approx(0.0, abs=0.01)
 
     def test_no_interest_deduction_for_long_in_margin_mode(self):
         """Long positions should NOT have interest deducted even in margin mode."""

--- a/tests/unit/test_margin_interest_close_flow.py
+++ b/tests/unit/test_margin_interest_close_flow.py
@@ -106,11 +106,11 @@ class TestMarginInterestDeduction:
         expected_balance = initial_balance + 25.0 - 1.35
         assert engine.current_balance == pytest.approx(expected_balance, abs=0.01)
 
-        # Verify performance_tracker.record_trade is called (interest tracked separately)
+        # Verify performance_tracker.record_trade includes interest in fee
+        # so reported PnL, win rate, and net metrics account for financing
         assert engine.performance_tracker.record_trade.call_count == 1
         call_kwargs = engine.performance_tracker.record_trade.call_args[1]
-        # Interest is NOT included in fee — it's tracked via margin_interest_cost column
-        assert call_kwargs["fee"] == pytest.approx(0.0, abs=0.01)
+        assert call_kwargs["fee"] == pytest.approx(1.35, abs=0.01)
 
     def test_no_interest_deduction_for_long_in_margin_mode(self):
         """Long positions should NOT have interest deducted even in margin mode."""

--- a/tests/unit/test_margin_interest_close_flow.py
+++ b/tests/unit/test_margin_interest_close_flow.py
@@ -1,0 +1,319 @@
+"""Tests for margin interest deduction during position close flow."""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.engines.live.trading_engine import LiveTradingEngine, Position, PositionSide
+from src.strategies.components import (
+    FixedFractionSizer,
+    FixedRiskManager,
+    HoldSignalGenerator,
+    Strategy,
+    StrategyRuntime,
+)
+from tests.mocks import MockDatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def mock_database_manager(monkeypatch):
+    """Mock the DatabaseManager for all tests in this module."""
+    original_init = MockDatabaseManager.__init__
+
+    def patched_init(self, database_url=None):
+        original_init(self, database_url)
+        self._fallback_balance = 1_000.0
+
+    monkeypatch.setattr(MockDatabaseManager, "__init__", patched_init)
+    monkeypatch.setattr("src.engines.live.trading_engine.DatabaseManager", MockDatabaseManager)
+
+
+def _make_engine(exchange_interface=None):
+    """Create a LiveTradingEngine with zero fees for clean PnL testing."""
+    strategy = Mock()
+    strategy.get_risk_overrides.return_value = None
+    data_provider = Mock()
+    data_provider.get_current_price.return_value = 100.0
+
+    engine = LiveTradingEngine(
+        strategy=strategy,
+        data_provider=data_provider,
+        initial_balance=1_000.0,
+        enable_live_trading=False,
+        log_trades=False,
+        fee_rate=0.0,
+        slippage_rate=0.0,
+    )
+    if exchange_interface is not None:
+        engine.exchange_interface = exchange_interface
+    return engine
+
+
+def _make_position(side=PositionSide.SHORT, symbol="ETHUSDT", entry_price=100.0, size=0.25):
+    """Create a test position."""
+    return Position(
+        symbol=symbol,
+        side=side,
+        size=size,
+        entry_price=entry_price,
+        entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        order_id="order-1",
+        original_size=size,
+        current_size=size,
+    )
+
+
+class TestMarginInterestDeduction:
+    """Tests for margin interest being deducted from realized PnL on close."""
+
+    def test_interest_deducted_from_pnl_for_short_in_margin_mode(self):
+        """Short positions in margin mode should have interest deducted from PnL."""
+        exchange = Mock()
+        exchange.is_margin_mode = True
+        exchange.get_margin_interest_history.return_value = [
+            {"interest": "1.50"},
+            {"interest": "0.75"},
+        ]
+
+        engine = _make_engine(exchange_interface=exchange)
+        position = _make_position(side=PositionSide.SHORT, entry_price=100.0)
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        initial_balance = engine.current_balance
+        exit_price = 90.0  # Profitable short: entry 100 -> exit 90
+
+        engine._execute_exit(
+            position=position,
+            reason="test-close",
+            limit_price=None,
+            current_price=exit_price,
+            candle_high=None,
+            candle_low=None,
+            candle=None,
+            skip_live_close=True,
+        )
+
+        # Interest cost = 1.50 + 0.75 = 2.25
+        # Gross PnL for short: (100 - 90) / 100 * 0.25 * 1000 = 25.0
+        # Net PnL = 25.0 - 2.25 = 22.75
+        expected_balance = initial_balance + 25.0 - 2.25
+        assert engine.current_balance == pytest.approx(expected_balance, abs=0.01)
+
+    def test_no_interest_deduction_for_long_in_margin_mode(self):
+        """Long positions should NOT have interest deducted even in margin mode."""
+        exchange = Mock()
+        exchange.is_margin_mode = True
+
+        engine = _make_engine(exchange_interface=exchange)
+        position = _make_position(side=PositionSide.LONG, entry_price=100.0)
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        exit_price = 110.0
+
+        engine._execute_exit(
+            position=position,
+            reason="test-close",
+            limit_price=None,
+            current_price=exit_price,
+            candle_high=None,
+            candle_low=None,
+            candle=None,
+            skip_live_close=True,
+        )
+
+        # No interest query should be made for long positions
+        exchange.get_margin_interest_history.assert_not_called()
+
+    def test_no_interest_deduction_when_not_margin_mode(self):
+        """When not in margin mode, no interest should be deducted."""
+        exchange = Mock()
+        exchange.is_margin_mode = False
+
+        engine = _make_engine(exchange_interface=exchange)
+        position = _make_position(side=PositionSide.SHORT, entry_price=100.0)
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        exit_price = 90.0
+
+        engine._execute_exit(
+            position=position,
+            reason="test-close",
+            limit_price=None,
+            current_price=exit_price,
+            candle_high=None,
+            candle_low=None,
+            candle=None,
+            skip_live_close=True,
+        )
+
+        exchange.get_margin_interest_history.assert_not_called()
+
+    def test_no_interest_deduction_when_no_exchange_interface(self):
+        """When exchange_interface is None (paper trading), no interest deduction."""
+        engine = _make_engine(exchange_interface=None)
+        position = _make_position(side=PositionSide.SHORT, entry_price=100.0)
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        initial_balance = engine.current_balance
+        exit_price = 90.0
+
+        engine._execute_exit(
+            position=position,
+            reason="test-close",
+            limit_price=None,
+            current_price=exit_price,
+            candle_high=None,
+            candle_low=None,
+            candle=None,
+            skip_live_close=True,
+        )
+
+        # Gross PnL only, no interest deduction
+        expected_balance = initial_balance + 25.0  # (100-90)/100 * 0.25 * 1000
+        assert engine.current_balance == pytest.approx(expected_balance, abs=0.01)
+
+
+class TestMarginInterestLogTrade:
+    """Tests that margin_interest_cost is passed to log_trade."""
+
+    def test_interest_cost_passed_to_log_trade(self):
+        """Verify margin_interest_cost is passed to db_manager.log_trade()."""
+        exchange = Mock()
+        exchange.is_margin_mode = True
+        exchange.get_margin_interest_history.return_value = [
+            {"interest": "3.00"},
+        ]
+
+        engine = _make_engine(exchange_interface=exchange)
+        # Set up a trading session so log_trade is called
+        engine.trading_session_id = 1
+        position = _make_position(side=PositionSide.SHORT, entry_price=100.0)
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        engine._execute_exit(
+            position=position,
+            reason="test-close",
+            limit_price=None,
+            current_price=90.0,
+            candle_high=None,
+            candle_low=None,
+            candle=None,
+            skip_live_close=True,
+        )
+
+        # Check that log_trade was called with margin_interest_cost
+        logged_trade = engine.db_manager._trades
+        assert len(logged_trade) == 1
+        trade_data = list(logged_trade.values())[0]
+        assert trade_data.get("margin_interest_cost") == pytest.approx(3.0)
+
+    def test_zero_interest_cost_for_non_margin(self):
+        """Verify margin_interest_cost=0.0 is passed for non-margin trades."""
+        engine = _make_engine(exchange_interface=None)
+        engine.trading_session_id = 1
+        position = _make_position(side=PositionSide.LONG, entry_price=100.0)
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        engine._execute_exit(
+            position=position,
+            reason="test-close",
+            limit_price=None,
+            current_price=110.0,
+            candle_high=None,
+            candle_low=None,
+            candle=None,
+            skip_live_close=True,
+        )
+
+        logged_trade = engine.db_manager._trades
+        assert len(logged_trade) == 1
+        trade_data = list(logged_trade.values())[0]
+        assert trade_data.get("margin_interest_cost") == pytest.approx(0.0)
+
+
+class TestLogTradePersistence:
+    """Tests that DatabaseManager.log_trade persists margin_interest_cost."""
+
+    def test_log_trade_accepts_margin_interest_cost_param(self):
+        """Verify log_trade() accepts margin_interest_cost and passes it to Trade."""
+        from src.database.manager import DatabaseManager
+
+        # Capture kwargs passed to Trade constructor
+        captured_kwargs = {}
+
+        with patch.object(DatabaseManager, "__init__", lambda self, *a, **kw: None):
+            manager = DatabaseManager.__new__(DatabaseManager)
+            manager._current_session_id = None
+
+        mock_session = Mock()
+        mock_trade = Mock()
+        mock_trade.id = 1
+        mock_trade.symbol = "ETHUSDT"
+        mock_trade.side = Mock(value="SHORT")
+        mock_trade.pnl = 25.0
+        mock_trade.pnl_percent = 10.0
+
+        with patch("src.database.manager.Trade") as MockTrade, \
+             patch.object(DatabaseManager, "get_session_with_timeout") as mock_ctx, \
+             patch.object(DatabaseManager, "_update_performance_metrics"):
+            MockTrade.return_value = mock_trade
+            mock_ctx.return_value.__enter__ = Mock(return_value=mock_session)
+            mock_ctx.return_value.__exit__ = Mock(return_value=False)
+
+            manager.log_trade(
+                symbol="ETHUSDT",
+                side="SHORT",
+                entry_price=100.0,
+                exit_price=90.0,
+                size=0.25,
+                entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+                exit_time=datetime(2025, 1, 2, tzinfo=UTC),
+                pnl=25.0,
+                exit_reason="test",
+                strategy_name="test_strategy",
+                margin_interest_cost=3.0,
+            )
+
+            _, call_kwargs = MockTrade.call_args
+            assert call_kwargs["margin_interest_cost"] == 3.0
+
+    def test_log_trade_defaults_margin_interest_cost_to_zero(self):
+        """Verify log_trade() defaults margin_interest_cost to 0.0 when None."""
+        from src.database.manager import DatabaseManager
+
+        with patch.object(DatabaseManager, "__init__", lambda self, *a, **kw: None):
+            manager = DatabaseManager.__new__(DatabaseManager)
+            manager._current_session_id = None
+
+        mock_session = Mock()
+        mock_trade = Mock()
+        mock_trade.id = 1
+        mock_trade.symbol = "ETHUSDT"
+        mock_trade.side = Mock(value="SHORT")
+        mock_trade.pnl = 25.0
+        mock_trade.pnl_percent = 10.0
+
+        with patch("src.database.manager.Trade") as MockTrade, \
+             patch.object(DatabaseManager, "get_session_with_timeout") as mock_ctx, \
+             patch.object(DatabaseManager, "_update_performance_metrics"):
+            MockTrade.return_value = mock_trade
+            mock_ctx.return_value.__enter__ = Mock(return_value=mock_session)
+            mock_ctx.return_value.__exit__ = Mock(return_value=False)
+
+            manager.log_trade(
+                symbol="ETHUSDT",
+                side="SHORT",
+                entry_price=100.0,
+                exit_price=90.0,
+                size=0.25,
+                entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+                exit_time=datetime(2025, 1, 2, tzinfo=UTC),
+                pnl=25.0,
+                exit_reason="test",
+                strategy_name="test_strategy",
+                # No margin_interest_cost passed - should default to 0.0
+            )
+
+            _, call_kwargs = MockTrade.call_args
+            assert call_kwargs["margin_interest_cost"] == 0.0

--- a/tests/unit/test_margin_interest_close_flow.py
+++ b/tests/unit/test_margin_interest_close_flow.py
@@ -83,6 +83,9 @@ class TestMarginInterestDeduction:
         initial_balance = engine.current_balance
         exit_price = 90.0  # Profitable short: entry 100 -> exit 90
 
+        # Mock record_trade to capture call args
+        engine.performance_tracker.record_trade = Mock()
+
         engine._execute_exit(
             position=position,
             reason="test-close",
@@ -99,6 +102,12 @@ class TestMarginInterestDeduction:
         # Net PnL = 25.0 - 2.25 = 22.75
         expected_balance = initial_balance + 25.0 - 2.25
         assert engine.current_balance == pytest.approx(expected_balance, abs=0.01)
+
+        # Verify performance_tracker.record_trade includes interest in fee
+        assert engine.performance_tracker.record_trade.call_count == 1
+        call_kwargs = engine.performance_tracker.record_trade.call_args[1]
+        # With fee_rate=0.0, entry_fee=0 and exit_fee=0, so fee should equal interest_cost
+        assert call_kwargs["fee"] == pytest.approx(2.25, abs=0.01)
 
     def test_no_interest_deduction_for_long_in_margin_mode(self):
         """Long positions should NOT have interest deducted even in margin mode."""

--- a/tests/unit/test_margin_interest_tracker.py
+++ b/tests/unit/test_margin_interest_tracker.py
@@ -1,0 +1,144 @@
+"""Tests for MarginInterestTracker service."""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.engines.live.margin_interest_tracker import MarginInterestTracker
+
+
+@pytest.fixture
+def mock_exchange() -> MagicMock:
+    """Create a mock exchange with get_margin_interest_history method."""
+    return MagicMock()
+
+
+@pytest.fixture
+def tracker(mock_exchange: MagicMock) -> MarginInterestTracker:
+    """Create a MarginInterestTracker with mocked exchange."""
+    return MarginInterestTracker(exchange=mock_exchange)
+
+
+class TestGetPositionInterestCost:
+    """Tests for get_position_interest_cost method."""
+
+    def test_returns_summed_interest_from_records(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Sum interest field (as string) from all returned records."""
+        mock_exchange.get_margin_interest_history.return_value = [
+            {"interest": "0.00012345", "asset": "BTC"},
+            {"interest": "0.00034567", "asset": "BTC"},
+        ]
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert math.isclose(result, 0.00046912, rel_tol=1e-9)
+
+    def test_returns_zero_when_no_records(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Return 0.0 when exchange returns empty list."""
+        mock_exchange.get_margin_interest_history.return_value = []
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert result == 0.0
+
+    def test_returns_zero_on_exchange_error(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Return 0.0 when exchange raises an exception."""
+        mock_exchange.get_margin_interest_history.side_effect = Exception(
+            "API error"
+        )
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert result == 0.0
+
+    def test_skips_non_finite_interest_values(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Skip records with non-finite interest (inf, nan)."""
+        mock_exchange.get_margin_interest_history.return_value = [
+            {"interest": "0.001", "asset": "BTC"},
+            {"interest": "inf", "asset": "BTC"},
+            {"interest": "nan", "asset": "BTC"},
+            {"interest": "0.002", "asset": "BTC"},
+        ]
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert math.isclose(result, 0.003, rel_tol=1e-9)
+
+    def test_converts_entry_time_to_milliseconds(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Pass entry_time as milliseconds timestamp to exchange API."""
+        mock_exchange.get_margin_interest_history.return_value = []
+        # 2025-01-15T10:00:00Z = 1736935200 seconds = 1736935200000 ms
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        tracker.get_position_interest_cost("BTC", entry_time)
+
+        mock_exchange.get_margin_interest_history.assert_called_once_with(
+            asset="BTC", start_time=1736935200000
+        )
+
+    def test_returns_zero_when_exchange_returns_none(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Return 0.0 when exchange returns None instead of a list."""
+        mock_exchange.get_margin_interest_history.return_value = None
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert result == 0.0
+
+    def test_skips_records_with_invalid_interest_string(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Skip records where interest cannot be converted to float."""
+        mock_exchange.get_margin_interest_history.return_value = [
+            {"interest": "0.001", "asset": "BTC"},
+            {"interest": "not_a_number", "asset": "BTC"},
+            {"interest": "0.002", "asset": "BTC"},
+        ]
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert math.isclose(result, 0.003, rel_tol=1e-9)
+
+
+class TestIsMarginPosition:
+    """Tests for is_margin_position method."""
+
+    def test_short_is_margin_position(
+        self, tracker: MarginInterestTracker
+    ) -> None:
+        """SHORT positions borrow and incur interest."""
+        assert tracker.is_margin_position("SHORT") is True
+
+    def test_long_is_not_margin_position(
+        self, tracker: MarginInterestTracker
+    ) -> None:
+        """LONG positions do not borrow."""
+        assert tracker.is_margin_position("LONG") is False
+
+    def test_other_side_is_not_margin_position(
+        self, tracker: MarginInterestTracker
+    ) -> None:
+        """Arbitrary strings are not margin positions."""
+        assert tracker.is_margin_position("BUY") is False
+        assert tracker.is_margin_position("") is False

--- a/tests/unit/test_margin_interest_tracker.py
+++ b/tests/unit/test_margin_interest_tracker.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+pytestmark = pytest.mark.fast
+
 from src.engines.live.margin_interest_tracker import MarginInterestTracker
 
 
@@ -119,26 +121,3 @@ class TestGetPositionInterestCost:
         result = tracker.get_position_interest_cost("BTC", entry_time)
 
         assert math.isclose(result, 0.003, rel_tol=1e-9)
-
-
-class TestIsMarginPosition:
-    """Tests for is_margin_position method."""
-
-    def test_short_is_margin_position(
-        self, tracker: MarginInterestTracker
-    ) -> None:
-        """SHORT positions borrow and incur interest."""
-        assert tracker.is_margin_position("SHORT") is True
-
-    def test_long_is_not_margin_position(
-        self, tracker: MarginInterestTracker
-    ) -> None:
-        """LONG positions do not borrow."""
-        assert tracker.is_margin_position("LONG") is False
-
-    def test_other_side_is_not_margin_position(
-        self, tracker: MarginInterestTracker
-    ) -> None:
-        """Arbitrary strings are not margin positions."""
-        assert tracker.is_margin_position("BUY") is False
-        assert tracker.is_margin_position("") is False

--- a/tests/unit/test_margin_interest_tracker.py
+++ b/tests/unit/test_margin_interest_tracker.py
@@ -137,3 +137,49 @@ class TestGetPositionInterestCost:
         result = tracker.get_position_interest_cost("BTC", entry_time)
 
         assert math.isclose(result, 0.003, rel_tol=1e-9)
+
+    def test_skips_non_dict_records(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Non-dict elements (None, strings, lists) are skipped without crashing."""
+        mock_exchange.get_margin_interest_history.return_value = [
+            {"interest": "0.001", "asset": "BTC"},
+            None,
+            "bad_string",
+            [1, 2, 3],
+            {"interest": "0.002", "asset": "BTC"},
+        ]
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert math.isclose(result, 0.003, rel_tol=1e-9)
+
+    def test_retries_on_api_failure(
+        self, mock_exchange: MagicMock
+    ) -> None:
+        """Retry once on API failure before returning results."""
+        mock_exchange.get_margin_interest_history.side_effect = [
+            Exception("Transient error"),
+            [{"interest": "0.005", "asset": "BTC"}],
+        ]
+        tracker = MarginInterestTracker(exchange=mock_exchange)
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time, retries=1)
+
+        assert math.isclose(result, 0.005, rel_tol=1e-9)
+        assert mock_exchange.get_margin_interest_history.call_count == 2
+
+    def test_returns_zero_after_exhausted_retries(
+        self, mock_exchange: MagicMock
+    ) -> None:
+        """Return 0.0 after all retry attempts fail."""
+        mock_exchange.get_margin_interest_history.side_effect = Exception("Persistent error")
+        tracker = MarginInterestTracker(exchange=mock_exchange)
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time, retries=1)
+
+        assert result == 0.0
+        assert mock_exchange.get_margin_interest_history.call_count == 2

--- a/tests/unit/test_margin_interest_tracker.py
+++ b/tests/unit/test_margin_interest_tracker.py
@@ -109,7 +109,7 @@ class TestGetPositionInterestCost:
         tracker.get_position_interest_cost("BTC", entry_time)
 
         mock_exchange.get_margin_interest_history.assert_called_once_with(
-            asset="BTC", start_time=1736935200000
+            asset="BTC", start_time=1736935200000, page=1
         )
 
     def test_returns_zero_when_exchange_returns_none(

--- a/tests/unit/test_margin_interest_tracker.py
+++ b/tests/unit/test_margin_interest_tracker.py
@@ -82,6 +82,22 @@ class TestGetPositionInterestCost:
 
         assert math.isclose(result, 0.003, rel_tol=1e-9)
 
+    def test_skips_negative_and_zero_interest_values(
+        self, tracker: MarginInterestTracker, mock_exchange: MagicMock
+    ) -> None:
+        """Skip records with negative or zero interest values."""
+        mock_exchange.get_margin_interest_history.return_value = [
+            {"interest": "0.001", "asset": "BTC"},
+            {"interest": "-0.005", "asset": "BTC"},
+            {"interest": "0", "asset": "BTC"},
+            {"interest": "0.002", "asset": "BTC"},
+        ]
+        entry_time = datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
+
+        result = tracker.get_position_interest_cost("BTC", entry_time)
+
+        assert math.isclose(result, 0.003, rel_tol=1e-9)
+
     def test_converts_entry_time_to_milliseconds(
         self, tracker: MarginInterestTracker, mock_exchange: MagicMock
     ) -> None:

--- a/tests/unit/test_reconciliation_interest.py
+++ b/tests/unit/test_reconciliation_interest.py
@@ -127,7 +127,7 @@ class TestReconciliationInterestLogging:
             )
             assert any(
                 "Margin interest accrued for ETHUSDT" in msg
-                and "$0.0523" in msg
+                and "0.05230000 ETH" in msg
                 for msg in caplog.messages
             )
 

--- a/tests/unit/test_reconciliation_interest.py
+++ b/tests/unit/test_reconciliation_interest.py
@@ -243,19 +243,21 @@ class TestRealizePnlOnCloseInterestDeduction:
             "src.engines.live.reconciliation.MarginInterestTracker"
         ) as MockMIT:
             instance = MockMIT.return_value
-            instance.get_position_interest_cost.return_value = 5.0
+            instance.get_position_interest_cost.return_value = 0.002
 
             with caplog.at_level(logging.INFO):
                 reconciler._realize_pnl_on_close(pos, exit_price=1900.0, reason="test")
 
-            # PnL = (2000 - 1900) * 0.1 = 10.0, minus 5.0 interest = 5.0
+            # PnL = (2000 - 1900) * 0.1 = 10.0
+            # Interest = 0.002 base * 1900.0 exit = 3.80 USDT
+            # Net PnL = 10.0 - 3.80 = 6.20
             mock_db.update_balance.assert_called_once()
             call_args = mock_db.update_balance.call_args
             new_balance = call_args[0][0]
-            assert new_balance == pytest.approx(1000.0 + 5.0)
+            assert new_balance == pytest.approx(1000.0 + 6.20)
 
             assert any(
-                "Deducted margin interest $5.00" in msg
+                "Deducted margin interest $3.80" in msg
                 for msg in caplog.messages
             )
 

--- a/tests/unit/test_reconciliation_interest.py
+++ b/tests/unit/test_reconciliation_interest.py
@@ -1,7 +1,9 @@
-"""Unit tests for margin interest logging during reconciliation.
+"""Unit tests for margin interest during reconciliation.
 
 Verifies that the periodic reconciler logs accumulated margin interest
-for open short positions (informational only — no corrections).
+for open short positions (informational only — no corrections), and
+that _realize_pnl_on_close deducts margin interest from realized PnL
+for short positions.
 """
 
 from __future__ import annotations
@@ -13,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.engines.live.reconciliation import PeriodicReconciler
+from src.engines.live.reconciliation import PeriodicReconciler, PositionReconciler
 
 pytestmark = pytest.mark.fast
 
@@ -205,5 +207,146 @@ class TestReconciliationInterestLogging:
 
             assert any(
                 "interest" in msg.lower() and "ETHUSDT" in msg
+                for msg in caplog.messages
+            )
+
+
+def _make_position_reconciler(exchange, tracker, db, *, use_margin: bool = True):
+    return PositionReconciler(
+        exchange_interface=exchange,
+        position_tracker=tracker,
+        db_manager=db,
+        session_id=1,
+        use_margin=use_margin,
+    )
+
+
+class TestRealizePnlOnCloseInterestDeduction:
+    """Margin interest deducted from PnL when reconciliation closes a short."""
+
+    def test_interest_deducted_from_short_pnl(
+        self, mock_exchange, mock_tracker, mock_db, caplog
+    ):
+        """Short position PnL is reduced by margin interest cost."""
+        pos = _MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            entry_price=2000.0,
+            quantity=0.1,
+            current_size=0.1,
+            original_size=0.1,
+            entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        reconciler = _make_position_reconciler(mock_exchange, mock_tracker, mock_db)
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            instance = MockMIT.return_value
+            instance.get_position_interest_cost.return_value = 5.0
+
+            with caplog.at_level(logging.INFO):
+                reconciler._realize_pnl_on_close(pos, exit_price=1900.0, reason="test")
+
+            # PnL = (2000 - 1900) * 0.1 = 10.0, minus 5.0 interest = 5.0
+            mock_db.update_balance.assert_called_once()
+            call_args = mock_db.update_balance.call_args
+            new_balance = call_args[0][0]
+            assert new_balance == pytest.approx(1000.0 + 5.0)
+
+            assert any(
+                "Deducted margin interest $5.00" in msg
+                for msg in caplog.messages
+            )
+
+    def test_no_interest_deduction_for_long(
+        self, mock_exchange, mock_tracker, mock_db
+    ):
+        """Long positions do not have interest deducted."""
+        pos = _MockPosition(
+            symbol="ETHUSDT",
+            side="long",
+            entry_price=1900.0,
+            quantity=0.1,
+            current_size=0.1,
+            original_size=0.1,
+            entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        reconciler = _make_position_reconciler(mock_exchange, mock_tracker, mock_db)
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            reconciler._realize_pnl_on_close(pos, exit_price=2000.0, reason="test")
+
+            # Should not even instantiate the tracker for a long position
+            MockMIT.assert_not_called()
+
+            # PnL = (2000 - 1900) * 0.1 = 10.0
+            mock_db.update_balance.assert_called_once()
+            new_balance = mock_db.update_balance.call_args[0][0]
+            assert new_balance == pytest.approx(1000.0 + 10.0)
+
+    def test_no_interest_deduction_when_not_margin_mode(
+        self, mock_exchange, mock_tracker, mock_db
+    ):
+        """Interest is not deducted when use_margin is False."""
+        pos = _MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            entry_price=2000.0,
+            quantity=0.1,
+            current_size=0.1,
+            original_size=0.1,
+            entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        reconciler = _make_position_reconciler(
+            mock_exchange, mock_tracker, mock_db, use_margin=False
+        )
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            reconciler._realize_pnl_on_close(pos, exit_price=1900.0, reason="test")
+
+            MockMIT.assert_not_called()
+
+            # PnL = (2000 - 1900) * 0.1 = 10.0, no interest deduction
+            mock_db.update_balance.assert_called_once()
+            new_balance = mock_db.update_balance.call_args[0][0]
+            assert new_balance == pytest.approx(1000.0 + 10.0)
+
+    def test_interest_error_does_not_block_balance_update(
+        self, mock_exchange, mock_tracker, mock_db, caplog
+    ):
+        """Interest query failure still allows balance update to proceed."""
+        pos = _MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            entry_price=2000.0,
+            quantity=0.1,
+            current_size=0.1,
+            original_size=0.1,
+            entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        reconciler = _make_position_reconciler(mock_exchange, mock_tracker, mock_db)
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            instance = MockMIT.return_value
+            instance.get_position_interest_cost.side_effect = RuntimeError("API down")
+
+            with caplog.at_level(logging.WARNING):
+                reconciler._realize_pnl_on_close(pos, exit_price=1900.0, reason="test")
+
+            # Balance update must still happen with raw PnL (no interest deduction)
+            # PnL = (2000 - 1900) * 0.1 = 10.0
+            mock_db.update_balance.assert_called_once()
+            new_balance = mock_db.update_balance.call_args[0][0]
+            assert new_balance == pytest.approx(1000.0 + 10.0)
+
+            assert any(
+                "Failed to query margin interest" in msg
                 for msg in caplog.messages
             )

--- a/tests/unit/test_reconciliation_interest.py
+++ b/tests/unit/test_reconciliation_interest.py
@@ -1,0 +1,209 @@
+"""Unit tests for margin interest logging during reconciliation.
+
+Verifies that the periodic reconciler logs accumulated margin interest
+for open short positions (informational only — no corrections).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.engines.live.reconciliation import PeriodicReconciler
+
+pytestmark = pytest.mark.fast
+
+
+# ---------- Fixtures ----------
+
+
+@dataclass
+class _MockBalance:
+    asset: str = "USDT"
+    total: float = 1000.0
+    free: float = 1000.0
+    locked: float = 0.0
+
+
+@dataclass
+class _MockPosition:
+    symbol: str = "ETHUSDT"
+    side: str = "short"
+    entry_price: float = 2000.0
+    order_id: str = "o1"
+    exchange_order_id: str | None = "o1"
+    client_order_id: str | None = "atb_ETHUSDT_short_1_abcd"
+    db_position_id: int | None = 1
+    stop_loss: float | None = None
+    stop_loss_order_id: str | None = None
+    current_size: float | None = 0.1
+    size: float = 0.1
+    quantity: float | None = 0.1
+    partial_exits_taken: int = 0
+    last_partial_exit_price: float | None = None
+    original_size: float | None = 0.1
+    entry_balance: float | None = None
+    entry_time: datetime | None = None
+
+
+@pytest.fixture
+def mock_exchange():
+    exchange = MagicMock()
+    exchange.get_order.return_value = MagicMock(
+        status=MagicMock(__eq__=lambda s, o: True)
+    )
+    exchange.get_order_by_client_id.return_value = None
+    exchange.get_all_orders.return_value = []
+    exchange.get_my_trades.return_value = []
+    exchange.get_open_orders.return_value = []
+    exchange.get_balance.return_value = _MockBalance()
+    exchange.get_margin_borrowed.return_value = 0.1
+    return exchange
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.get_unresolved_orders.return_value = []
+    db.get_current_balance.return_value = 1000.0
+    db.log_audit_event.return_value = 1
+    db.update_order_journal.return_value = True
+    return db
+
+
+@pytest.fixture
+def mock_tracker():
+    return MagicMock()
+
+
+def _make_reconciler(exchange, tracker, db, *, use_margin: bool = True):
+    return PeriodicReconciler(
+        exchange_interface=exchange,
+        position_tracker=tracker,
+        db_manager=db,
+        session_id=1,
+        interval=60,
+        use_margin=use_margin,
+    )
+
+
+# ---------- Tests ----------
+
+
+class TestReconciliationInterestLogging:
+    """Margin interest logging during reconcile cycle."""
+
+    def test_interest_logged_for_short_positions(
+        self, mock_exchange, mock_tracker, mock_db, caplog
+    ):
+        """Interest accrued on open shorts is logged at INFO level."""
+        pos = _MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        mock_tracker.positions = {"o1": pos}
+
+        reconciler = _make_reconciler(mock_exchange, mock_tracker, mock_db)
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            instance = MockMIT.return_value
+            instance.get_position_interest_cost.return_value = 0.0523
+
+            with caplog.at_level(logging.INFO):
+                reconciler._reconcile_cycle()
+
+            MockMIT.assert_called_once_with(mock_exchange)
+            instance.get_position_interest_cost.assert_called_once_with(
+                "ETH", pos.entry_time
+            )
+            assert any(
+                "Margin interest accrued for ETHUSDT" in msg
+                and "$0.0523" in msg
+                for msg in caplog.messages
+            )
+
+    def test_interest_not_logged_for_long_positions(
+        self, mock_exchange, mock_tracker, mock_db, caplog
+    ):
+        """Long positions are skipped — no interest query."""
+        pos = _MockPosition(symbol="BTCUSDT", side="long")
+        mock_tracker.positions = {"o1": pos}
+
+        # Long in margin mode: balance check path, not interest
+        mock_exchange.get_balance.return_value = _MockBalance(
+            asset="BTC", total=0.1
+        )
+
+        reconciler = _make_reconciler(mock_exchange, mock_tracker, mock_db)
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            with caplog.at_level(logging.INFO):
+                reconciler._reconcile_cycle()
+
+            MockMIT.return_value.get_position_interest_cost.assert_not_called()
+
+    def test_interest_not_logged_when_not_margin_mode(
+        self, mock_exchange, mock_tracker, mock_db, caplog
+    ):
+        """Interest logging is skipped entirely outside margin mode."""
+        pos = _MockPosition(symbol="ETHUSDT", side="short")
+        mock_tracker.positions = {"o1": pos}
+
+        # Need balance for spot mode asset check
+        mock_exchange.get_balance.return_value = _MockBalance(
+            asset="ETH", total=0.0
+        )
+
+        reconciler = _make_reconciler(
+            mock_exchange, mock_tracker, mock_db, use_margin=False
+        )
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            with caplog.at_level(logging.INFO):
+                reconciler._reconcile_cycle()
+
+            MockMIT.assert_not_called()
+            assert not any(
+                "Margin interest accrued" in msg for msg in caplog.messages
+            )
+
+    def test_interest_error_does_not_crash_reconciliation(
+        self, mock_exchange, mock_tracker, mock_db, caplog
+    ):
+        """Errors during interest query are caught — reconciliation continues."""
+        pos = _MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        mock_tracker.positions = {"o1": pos}
+
+        reconciler = _make_reconciler(mock_exchange, mock_tracker, mock_db)
+
+        with patch(
+            "src.engines.live.reconciliation.MarginInterestTracker"
+        ) as MockMIT:
+            instance = MockMIT.return_value
+            instance.get_position_interest_cost.side_effect = RuntimeError(
+                "API timeout"
+            )
+
+            with caplog.at_level(logging.WARNING):
+                # Should NOT raise
+                reconciler._reconcile_cycle()
+
+            assert any(
+                "interest" in msg.lower() and "ETHUSDT" in msg
+                for msg in caplog.messages
+            )


### PR DESCRIPTION
## Summary
- Track margin borrow interest charges from Binance and deduct from realized PnL when closing short positions
- New `MarginInterestTracker` service queries `/sapi/v1/margin/interestHistory` with automatic pagination for long-held positions (500-record limit per page)
- Interest deducted in both normal close flow (`_execute_exit`) and reconciliation close flow (`_realize_pnl_on_close`)
- `margin_interest_cost` column added to trades table for transparent audit trail, separate from exchange fees

## New Files
- `src/engines/live/margin_interest_tracker.py` — Protocol-based service with pagination, financial validation (isfinite, positive-only), and fault tolerance
- `migrations/versions/0010_add_margin_interest_cost.py` — Alembic migration for `margin_interest_cost` column

## Modified Files
- `src/data_providers/binance_provider.py` — `get_margin_interest_history()` method + offline stub
- `src/engines/live/trading_engine.py` — interest deduction in `_execute_exit()`, isolated with try/except
- `src/engines/live/reconciliation.py` — interest logging for open shorts + deduction on reconciliation close
- `src/database/models.py` — `margin_interest_cost` column on Trade model
- `src/database/manager.py` — `log_trade()` accepts `margin_interest_cost` parameter
- `src/engines/live/account_sync.py` — Updated TODO comment referencing new implementation

## Test Plan
- [x] 33 new unit tests across 4 test files
- [x] All 3391 existing unit tests pass with zero regressions
- [x] Financial edge cases: negative values, NaN, Inf, zero, pagination truncation
- [x] Error isolation: interest query failure never blocks position close
- [x] Margin/spot mode gating verified
- [ ] Integration test on staging with live Binance margin account

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)