### PR TITLE
fix: add ban-aware retry to Binance client startup

### DIFF
--- a/.claude/plans/websocket-streams.md
+++ b/.claude/plans/websocket-streams.md
@@ -1,0 +1,784 @@
+# Plan: Migrate from REST Polling to WebSocket Streams
+
+## Context
+
+The bot repeatedly gets IP-banned by Binance (-1003 "Way too much request weight used") because it polls REST APIs across 4 parallel cycles: main trading loop (60s), order tracker (10s), periodic reconciler (120s), and account sync. Each deploy triggers startup API calls that stack with ongoing polling, causing bans that prevent the bot from trading.
+
+Binance recommends WebSocket streams for live updates. The python-binance library (v1.0.19) includes `ThreadedWebsocketManager` with full support for kline streams, user data streams (order fills, balance changes), and margin-specific streams. Railway supports long-lived WebSocket connections with no special config.
+
+**Goal:** Replace REST polling with WebSocket event streams, eliminating ~73% of API weight usage initially (kline + order streams), with further reductions to ~97% in follow-up PRs (balance cache, reconciler interval). Sub-100ms event latency for order fills instead of 10s polling delay. Keep REST as a fallback.
+
+## Architecture Overview
+
+### Cache-First Design
+
+WebSocket streams update an **in-memory state cache**. The existing trading engine **heartbeat loop continues** on a short cadence, polling the local cache instead of hitting the exchange REST API. This preserves all current trading semantics (PnL updates, trailing stops, partial exits, account snapshots, hot-swap checks) while eliminating network REST calls.
+
+```
+WebSocket Streams:                        Engine (unchanged heartbeat):
+
+Kline Stream ──push──► KlineCache         Trading Loop ──60s──► read KlineCache
+User Stream  ──push──► OrderEventRouter   │ update PnL, trailing stops, partials
+  ├─ executionReport ──► OrderTracker     │ account snapshots, model hot-swap
+  ├─ outboundAccountPosition ──► (future: BalanceCache)  │ check positions
+  └─ margin events ──► OrderTracker       └─ strategy.process_candle(cached_df)
+
+REST Reconciler ─2min─► Unchanged initially  OrderTracker ──event-fed──► fill/cancel callbacks
+```
+
+**Key principle:** WebSockets are a data source, not a scheduler. The engine heartbeat remains the sole scheduler for trading decisions.
+
+### Connection State Machine
+
+Each provider instance has its own `WebSocketState`. Possible states:
+
+```
+DISCONNECTED ──(start_stream)──► PRIMARY
+PRIMARY ──(stale/disconnect/error)──► RESYNCING
+RESYNCING ──(reconnect success → start_stream sets PRIMARY)──► PRIMARY
+RESYNCING ──(reconnect failure)──► REST_DEGRADED
+REST_DEGRADED ──(reconnect success → start_stream sets PRIMARY)──► PRIMARY
+PRIMARY/RESYNCING ──(API ban -1003)──► SUSPENDED ──(ban expired)──► RESYNCING
+```
+
+- **WS_PRIMARY:** Normal operation. WebSocket streams update caches. REST used only for validation.
+- **RESYNCING:** Gap detected. Behavior depends on mode:
+  - **Live mode:** Full trading freeze — no new entries, no strategy evaluation, no exit monitoring from stale cache. Exchange-side stop-loss orders and the reconciler provide position safety during the brief resync window (typically seconds). Full REST reconciliation runs before resuming WS.
+  - **Paper mode:** Immediate REST fallback — since there are no exchange-side SL orders or reconciler in paper mode, a trading freeze would leave positions unmonitored. Instead, paper mode skips the freeze and falls back to REST polling immediately (the data is simulated anyway, so gap risk is minimal).
+  The engine checks `kline_provider.ws_state == RESYNCING` and branches on `self.enable_live_trading`.
+- **REST_DEGRADED:** WebSocket unavailable for this stream. Falls back to current polling behavior for that stream's data. Note: kline and user streams degrade independently — kline WS can remain PRIMARY while user stream falls back to REST polling (or vice versa). "Only one mode owns state mutation" applies per-stream, not globally.
+
+### Dual Processing Architecture
+
+User-data events (fills, cancels, balance changes) are processed on a **dedicated thread** separate from kline/trading signals, preventing head-of-line blocking:
+
+```python
+# Thread 1: User-data event processor (high priority)
+class UserDataProcessor(threading.Thread):
+    """Processes executionReport and balance events with minimal latency."""
+    def run(self):
+        while running:
+            event = user_data_queue.get(timeout=5)
+            if event.type == "execution":
+                order_tracker.process_execution_event(event.data)
+            # Balance events logged for future BalanceCache integration
+            elif event.type == "balance":
+                logger.debug("Balance event received: %s", event.data.get("a", ""))
+
+# Thread 2: Trading engine heartbeat (existing loop, unchanged cadence)
+# See Phase 4 for detailed pseudocode. High-level flow:
+while running:
+    # 1. Check WS state — live mode freezes during resync, paper falls back to REST
+    # 2. Get data from cache (WS active) or REST (fallback)
+    # 3. Process strategy, check positions, update snapshots (all unchanged)
+    # 4. Sleep with interrupt
+```
+
+### Idempotency & Deduplication
+
+All fill/cancel processing is idempotent, keyed on `(orderId, executionType, I)` where `I` is Binance's execution ID field (NOT `t` which is -1 for non-trade events like cancels/rejects/expires):
+
+```python
+class EventDeduplicator:
+    """Thread-safe tracker for processed events to prevent duplicate state mutations."""
+    def __init__(self, max_size: int = 10000):
+        self._max_size = max_size
+        self._lock = threading.Lock()
+        self._seen: OrderedDict[tuple[str, str, str], datetime] = OrderedDict()
+
+    def is_duplicate(self, order_id: str, exec_type: str, exec_id: str) -> bool:
+        key = (order_id, exec_type, exec_id)
+        with self._lock:
+            if key in self._seen:
+                return True
+            self._seen[key] = datetime.now(UTC)
+            # Evict oldest entries when capacity exceeded
+            while len(self._seen) > self._max_size:
+                self._seen.popitem(last=False)
+            return False
+```
+
+**Dedup key rationale:** Binance `executionReport` events include:
+- `i` = orderId
+- `x` = executionType (NEW, TRADE, CANCELED, REPLACED, REJECTED, EXPIRED)
+- `I` = execution ID (unique per execution event; `t` is -1 for non-trade events)
+
+Using `(i, x, I)` correctly deduplicates both trade fills and lifecycle events.
+
+## Implementation Phases
+
+### Phase 1: WebSocket Manager Layer (binance_provider.py)
+
+Add WebSocket lifecycle to `BinanceProvider` as two independent streams (kline + user data), reusing the existing client configuration path (tld, testnet, margin settings). Kline stream works for both paper and live mode. User data stream requires credentials and is live-only. Both streams handle WS error events and track per-stream timestamps:
+
+```python
+class BinanceProvider:
+    def _ensure_twm(self):
+        """Lazily create the ThreadedWebsocketManager from existing config."""
+        if self._twm is not None:
+            return
+        twm_kwargs = {"api_key": self.api_key, "api_secret": self.api_secret}
+        if self.testnet:
+            twm_kwargs["testnet"] = True
+        api_endpoint = get_binance_api_endpoint()
+        if api_endpoint == "binanceus":
+            twm_kwargs["tld"] = "us"
+        self._twm = ThreadedWebsocketManager(**twm_kwargs)
+        self._twm.start()
+
+    def start_kline_stream(self, symbol: str, timeframe: str, on_kline) -> bool:
+        """Start kline stream only. Safe for paper mode (no credentials needed)."""
+        try:
+            self._ensure_twm()
+            self._active_symbol = symbol
+            self._active_timeframe = timeframe
+            self._on_kline_cb = on_kline  # Store for reconnect
+
+            def _kline_callback(msg):
+                # Handle WS error events before routing to buffer
+                if msg.get("e") == "error":
+                    logger.error("Kline WS error: %s", msg.get("m", "unknown"))
+                    self._on_ws_disconnect()
+                    return
+                self._last_kline_event_time = datetime.now(UTC)
+                on_kline(msg)
+
+            self._kline_socket_key = self._twm.start_kline_socket(
+                callback=_kline_callback, symbol=symbol, interval=timeframe
+            )
+            self._ws_state = WebSocketState.PRIMARY
+            self._last_kline_event_time = datetime.now(UTC)
+            return True
+        except Exception as e:
+            logger.error("Failed to start kline stream: %s", e)
+            return False
+
+    def start_user_stream(self, on_user_event) -> bool:
+        """Start user data stream. Requires credentials. Live mode only."""
+        try:
+            self._ensure_twm()
+            self._on_user_event_cb = on_user_event  # Store for reconnect
+
+            def _user_callback(msg):
+                if msg.get("e") == "error":
+                    logger.error("User data WS error: %s", msg.get("m", "unknown"))
+                    self._on_ws_disconnect()
+                    return
+                self._last_user_event_time = datetime.now(UTC)
+                on_user_event(msg)
+
+            if self._use_margin:
+                self._user_socket_key = self._twm.start_margin_socket(callback=_user_callback)
+            else:
+                self._user_socket_key = self._twm.start_user_socket(callback=_user_callback)
+            self._last_user_event_time = datetime.now(UTC)
+            self._ws_state = WebSocketState.PRIMARY  # User stream provider state
+
+            # python-binance TWM handles listen key keepalive internally.
+            return True
+        except Exception as e:
+            logger.error("Failed to start user data stream: %s", e)
+            return False
+
+    def stop_streams(self):
+        """Stop all WebSocket streams. Uses manager-wide stop (recreates on reconnect)."""
+        if self._twm:
+            self._twm.stop()
+            self._twm = None
+            self._kline_socket_key = None
+            self._user_socket_key = None
+            self._ws_state = WebSocketState.DISCONNECTED
+
+    @property
+    def ws_state(self) -> WebSocketState:
+        """Public read access to WebSocket connection state."""
+        return self._ws_state
+
+    @property
+    def ws_healthy(self) -> bool:
+        """Kline stream must be alive. User-data idleness is normal."""
+        if self._ws_state != WebSocketState.PRIMARY:
+            return False
+        kline_age = (datetime.now(UTC) - self._last_kline_event_time).total_seconds()
+        return kline_age < 120
+```
+
+**WebSocketState enum:**
+```python
+class WebSocketState(Enum):
+    DISCONNECTED = "disconnected"
+    PRIMARY = "primary"        # WS active, normal operation
+    RESYNCING = "resyncing"    # Gap detected, running REST reconciliation
+    REST_DEGRADED = "degraded" # WS failed, using REST polling
+    SUSPENDED = "suspended"    # API ban active, waiting for ban expiry
+```
+
+**Files:** `src/data_providers/binance_provider.py`
+
+### Phase 2: Kline Cache (kline_buffer.py)
+
+WebSocket kline events update a local cache. The trading engine reads from this cache instead of calling `get_live_data()`.
+
+```python
+class KlineBuffer:
+    """Thread-safe rolling kline history maintained by WebSocket events."""
+
+    def __init__(self, symbol: str, timeframe: str, provider):
+        self._lock = threading.Lock()
+        # One-time REST fetch at startup (10 weight)
+        self.df = provider.get_live_data(symbol, timeframe, limit=500)
+        self._last_update = datetime.now(UTC)
+
+    def on_kline(self, event: dict) -> None:
+        """Process kline WebSocket event. Thread-safe.
+
+        Handles both open-candle updates and candle-close transitions.
+        On close: replaces the current tail row if timestamps match,
+        then rolls the window only when a genuinely new timestamp appears.
+        """
+        kline = event.get("k", {})
+        if not kline:
+            return
+
+        event_ts = pd.Timestamp(kline["t"], unit="ms", tz="UTC")
+
+        with self._lock:
+            tail_ts = self.df.index[-1] if len(self.df) > 0 else None
+
+            if kline.get("x"):  # Candle closed
+                closed_row = self._parse_kline(kline)
+                if tail_ts is not None and event_ts == tail_ts:
+                    # Replace current tail with final closed values
+                    self.df.iloc[-1] = closed_row.iloc[0]
+                else:
+                    # New candle we haven't seen — roll window
+                    self.df = pd.concat([self.df.iloc[1:], closed_row])
+            else:
+                # Open candle update — update current tail in-place
+                if tail_ts is not None and event_ts == tail_ts:
+                    self._update_current_candle(kline)
+                elif tail_ts is not None and event_ts > tail_ts:
+                    # First tick of a new candle — roll window to maintain fixed size
+                    new_row = self._parse_kline(kline)
+                    self.df = pd.concat([self.df.iloc[1:], new_row])
+                # else: stale event for older candle, ignore
+
+            self._last_update = datetime.now(UTC)
+
+    def get_dataframe(self) -> pd.DataFrame:
+        """Get current kline history. Thread-safe read."""
+        with self._lock:
+            return self.df.copy()
+
+    @property
+    def is_fresh(self) -> bool:
+        """Check if cache has been updated recently."""
+        age = (datetime.now(UTC) - self._last_update).total_seconds()
+        return age < 120  # 2 min threshold
+
+    def resync_from_rest(self, provider, symbol, timeframe):
+        """Full REST resync after reconnection."""
+        with self._lock:
+            self.df = provider.get_live_data(symbol, timeframe, limit=500)
+            self._last_update = datetime.now(UTC)
+```
+
+**Important:** The buffer updates the current (open) candle in-place so that intra-candle high/low values are available for SL/TP detection via `use_high_low_for_stops`. On candle close, it replaces the tail row (same timestamp) rather than blindly appending, preventing duplicate rows that would corrupt indicators.
+
+**Files:** New file `src/engines/live/kline_buffer.py`
+
+### Phase 3: Feed WebSocket Events into Existing OrderTracker (order_tracker.py)
+
+**Do NOT rewrite OrderTracker.** Instead, add a method to accept WebSocket `executionReport` events and translate them into the same status/fill flow the polling path uses. The WS path constructs an `Order` object from WS fields and looks up the `TrackedOrder`, then delegates to the existing `_process_order_status(order_id, tracked, order)` method:
+
+```python
+class OrderTracker:
+    def __init__(self, ..., event_deduplicator: EventDeduplicator | None = None):
+        # ... existing init ...
+        self._dedup = event_deduplicator or EventDeduplicator()
+
+    def process_execution_event(self, event: dict) -> None:
+        """Process an executionReport from WebSocket user data stream.
+
+        Constructs an Order object from WS fields and delegates to the
+        existing _process_order_status() method, preserving all lifecycle
+        logic (partial fills, cancels, retries, invalid data, orphan prevention).
+        """
+        order_id = str(event.get("i", ""))
+        exec_type = str(event.get("x", ""))   # executionType
+        exec_id = str(event.get("I", ""))      # execution ID (NOT "t")
+
+        # Idempotency check using correct Binance fields
+        if self._dedup.is_duplicate(order_id, exec_type, exec_id):
+            logger.debug("Duplicate execution event for order %s, skipping", order_id)
+            return
+
+        # Look up tracked order — skip if we don't know about it
+        with self._lock:
+            tracked = self._pending_orders.get(order_id)
+        if tracked is None:
+            logger.debug("Execution event for untracked order %s, ignoring", order_id)
+            return
+
+        # Validate payload fields
+        cum_filled = float(event.get("z", 0))
+        cum_quote = float(event.get("Z", 0))
+        avg_price = cum_quote / cum_filled if cum_filled > 0 else 0.0
+
+        # Map WS status — skip unknown statuses
+        status = self._map_ws_status(str(event.get("X", "")))
+        if status is None:
+            logger.warning("Unknown WS order status: %s for order %s", event.get("X"), order_id)
+            return
+
+        # Construct full Order object matching what REST get_order() returns.
+        # All 13 required fields must be provided (see exchange_interface.py:76).
+        event_time = datetime.fromtimestamp(event.get("E", 0) / 1000, tz=UTC)
+        order = Order(
+            order_id=order_id,
+            symbol=str(event.get("s", tracked.symbol)),
+            side=OrderSide(str(event.get("S", "BUY"))),
+            order_type=self._map_ws_order_type(str(event.get("o", "MARKET"))),
+            quantity=float(event.get("q", 0)),
+            price=float(event.get("p", 0)) or None,
+            status=status,
+            filled_quantity=cum_filled,
+            average_price=avg_price,
+            commission=float(event.get("n", 0)),       # Commission amount
+            commission_asset=str(event.get("N", "")),   # Commission asset
+            create_time=datetime.fromtimestamp(event.get("O", 0) / 1000, tz=UTC),
+            update_time=event_time,
+            stop_price=float(event.get("P", 0)) or None,
+            time_in_force=str(event.get("f", "GTC")),
+            client_order_id=str(event.get("c", "")),
+        )
+
+        # Delegate to existing method — preserves ALL lifecycle logic
+        self._process_order_status(order_id, tracked, order)
+
+    @staticmethod
+    def _map_ws_status(ws_status: str) -> OrderStatus | None:
+        """Map Binance WS order status string to internal OrderStatus.
+
+        Returns None for unknown statuses (caller should log and skip).
+        Note: Binance "NEW" maps to our PENDING; Binance "CANCELED" (one L)
+        maps to our CANCELLED (two Ls).
+        """
+        mapping = {
+            "NEW": OrderStatus.PENDING,
+            "PARTIALLY_FILLED": OrderStatus.PARTIALLY_FILLED,
+            "FILLED": OrderStatus.FILLED,
+            "CANCELED": OrderStatus.CANCELLED,
+            "REJECTED": OrderStatus.REJECTED,
+            "EXPIRED": OrderStatus.EXPIRED,
+        }
+        return mapping.get(ws_status)
+
+    @staticmethod
+    def _map_ws_order_type(ws_type: str) -> OrderType:
+        """Map Binance WS order type to internal OrderType.
+
+        Binance sends types like STOP_LOSS_LIMIT that don't exist in our enum.
+        Extends the existing _convert_order_type() mapping with WS-specific types.
+        """
+        mapping = {
+            "MARKET": OrderType.MARKET,
+            "LIMIT": OrderType.LIMIT,
+            "STOP_LOSS": OrderType.STOP_LOSS,
+            "STOP_LOSS_LIMIT": OrderType.STOP_LOSS,
+            "TAKE_PROFIT": OrderType.TAKE_PROFIT,
+            "TAKE_PROFIT_LIMIT": OrderType.TAKE_PROFIT,
+        }
+        return mapping.get(ws_type, OrderType.MARKET)
+```
+
+**What's preserved:** All existing lifecycle logic including:
+- Partial fill handling with invalid data detection
+- Cancel callback with orphan prevention
+- Callback retry with max retry escalation
+- `stop_tracking` only after successful callback (FILLED) or unconditionally (CANCELED)
+
+**What changes:** The `_poll_loop` thread becomes optional. When WebSocket is active, polling is disabled via `disable_polling()`. On WebSocket failure, `enable_polling()` resumes REST polling.
+
+**Files:** `src/engines/live/order_tracker.py`
+
+### Phase 4: Trading Engine Integration (trading_engine.py)
+
+Minimal changes to the existing trading loop — replace REST data source with cache reads and add resync gating.
+
+**Important runtime detail:** The engine has TWO BinanceProvider instances:
+1. `self.data_provider` — typically a `CachedDataProvider` wrapping a `BinanceProvider` for market data. The underlying provider is at `self.data_provider.data_provider`.
+2. `self.exchange_interface` — a separate `BinanceProvider` created only when `enable_live_trading=True`, used for orders/account operations.
+
+For **kline streaming** (paper + live): Use the underlying market data provider (`self.data_provider.data_provider` if wrapped, else `self.data_provider`). This works in both paper and live mode.
+
+For **user data streaming** (live only): Use `self.exchange_interface` (the authenticated provider with order/account access).
+
+**Also:** The loop calls `update_live_data()` (a REST `get_klines(limit=1)` call) before `_get_latest_data()`. When WS kline cache is active, `update_live_data()` must also be skipped.
+
+```python
+class LiveTradingEngine:
+    def start(self, symbol, timeframe, ...):
+        # ... existing startup ...
+
+        # Try WebSocket streams
+        self._kline_buffer = None
+        self._user_data_processor = None
+        ws_started = False
+
+        self._ws_kline_active = False  # Initialize flag
+
+        # Resolve the underlying BinanceProvider for kline streaming.
+        # Works in both paper and live mode (CachedDataProvider wraps it).
+        kline_provider = getattr(self.data_provider, 'data_provider', self.data_provider)
+
+        # Kline streaming: paper + live mode (reduces API weight for both)
+        if hasattr(kline_provider, 'start_kline_stream'):
+            self._kline_buffer = KlineBuffer(
+                self._active_symbol, self.timeframe, self.data_provider)
+            kline_started = kline_provider.start_kline_stream(
+                symbol=self._active_symbol, timeframe=self.timeframe,
+                on_kline=self._kline_buffer.on_kline,
+            )
+            if kline_started:
+                self._ws_kline_active = True
+                self._ws_kline_provider = kline_provider  # Store for health checks
+                logger.info("Kline WebSocket stream active — REST data polling disabled")
+
+        # User data streaming: live mode only (requires authenticated exchange_interface)
+        if self.enable_live_trading and self.exchange_interface and \
+           hasattr(self.exchange_interface, 'start_user_stream'):
+            # Dedup lives inside OrderTracker (set during __init__).
+            # UserDataProcessor routes raw events; OrderTracker.process_execution_event()
+            # calls self._dedup.is_duplicate() before processing.
+            self._user_data_processor = UserDataProcessor(
+                order_tracker=self.order_tracker,
+            )
+            user_started = self.exchange_interface.start_user_stream(
+                on_user_event=self._user_data_processor.enqueue,
+            )
+            if user_started:
+                self._user_data_processor.start()
+                if self.order_tracker:
+                    self.order_tracker.disable_polling()
+                logger.info("User data WebSocket stream active — order polling disabled")
+
+        # ... continue with existing _trading_loop() ...
+
+    def _get_latest_data(self, symbol, timeframe):
+        """Fetch latest market data — from cache or REST."""
+        ws_provider = getattr(self, '_ws_kline_provider', None)
+        # During resync in live mode, return None to trigger skip-cycle
+        # Paper mode falls back to REST immediately (handled in loop above)
+        if self.enable_live_trading and ws_provider and \
+           getattr(ws_provider, 'ws_state', None) == WebSocketState.RESYNCING:
+            logger.info("WebSocket resyncing — skipping data fetch")
+            return None
+
+        if self._kline_buffer and self._kline_buffer.is_fresh and \
+           getattr(ws_provider, 'ws_healthy', False):
+            return self._kline_buffer.get_dataframe()
+
+        # Fallback to REST (existing behavior)
+        return self.data_provider.get_live_data(symbol, timeframe, limit=500)
+
+    # ALSO: In the trading loop, gate both REST data calls on WS state:
+    # Before the existing `update_live_data()` call:
+    #   if not self._ws_kline_active:
+    #       self.data_provider.update_live_data(symbol, timeframe)
+    #
+    # On REST_DEGRADED fallback, reset the flag:
+    #   self._ws_kline_active = False
+```
+
+**Resync gating in the trading loop:** During RESYNCING, `_get_latest_data()` returns `None` and the loop skips the cycle entirely. This is a full trading freeze — no entries, no strategy evaluation, no exit monitoring from stale cache. Position safety is ensured by exchange-side stop-loss orders (already placed) and the reconciler's `reconcile_once()` during resync. The resync window is typically seconds (REST calls to refresh state), not minutes.
+
+**What stays the same:**
+- The `_trading_loop` heartbeat cadence and `_sleep_with_interrupt`
+- All position checking, PnL updates, trailing stops, partial exits
+- Account snapshots, strategy hot-swap, dynamic risk management
+- `_is_context_ready()`, all safety checks
+
+**`_is_data_fresh()` change:** The current implementation checks freshness from the last candle timestamp. For higher timeframes (e.g., 1h), the candle timestamp stays the same for up to an hour even while WS updates the open candle's OHLC values. This would cause WS-fed frames to be incorrectly marked stale. When WS kline cache is active, bypass the existing freshness check and use `KlineBuffer.is_fresh` instead (which checks `_last_update` time, not candle timestamp).
+
+**What changes:**
+- `_get_latest_data()` reads from local cache when available
+- Returns `None` during RESYNCING to prevent trading on stale/partial state
+- Order tracker switches between WS-fed and REST-polling modes
+- On WS health failure, automatic fallback to REST with full resync
+
+**Shutdown sequence** — extend existing `stop()` to clean up WS resources:
+```python
+def stop(self):
+    # 1. Stop inbound WS streams FIRST (no new events arrive)
+    # Kline stream lives on kline_provider (unwrapped data_provider)
+    kline_provider = getattr(self, '_ws_kline_provider', None)
+    if kline_provider and hasattr(kline_provider, 'stop_streams'):
+        kline_provider.stop_streams()
+    # User data stream lives on exchange_interface (separate instance)
+    if self.exchange_interface and hasattr(self.exchange_interface, 'stop_streams'):
+        self.exchange_interface.stop_streams()
+    # 2. Stop/drain UserDataProcessor (process remaining queued events)
+    if self._user_data_processor:
+        self._user_data_processor.stop()
+    # 3. Existing cleanup: reconciler → order tracker → positions → threads
+    ...
+```
+Order matters: stop streams before tracker to prevent late WS callbacks racing against teardown.
+
+**Files:** `src/engines/live/trading_engine.py`
+
+### Phase 5: Reconciler Adjustments (reconciliation.py)
+
+**Keep the reconciler running at current interval initially.** Only reduce after WebSocket path proves production parity (measured by: zero missed fills over 7 days, zero balance drift, zero orphaned positions).
+
+Changes:
+- Reconciler validates that WebSocket-reported state matches REST truth
+- Logs discrepancies between WS cache and REST as metrics (for parity monitoring)
+- Startup reconciliation unchanged — always runs via REST
+
+**After parity proven (separate PR):**
+- Increase interval to 300-600s
+- Reconciler becomes validation-only, not primary detection
+
+**Files:** `src/engines/live/reconciliation.py`, `src/config/constants.py`
+
+### Phase 6: Connection Resilience
+
+**Separation of concerns:** Each BinanceProvider instance owns its own `_ws_state`. Since kline and user streams run on different provider instances, their states are independent:
+- **Kline provider** (`_ws_kline_provider`): `_ws_state` reflects kline stream health
+- **Exchange interface** (`self.exchange_interface`): `_ws_state` reflects user-data stream health (live mode only)
+
+Resync orchestration lives in `LiveTradingEngine`, which owns the buffer, tracker, and reconciler.
+
+**BinanceProvider** (socket lifecycle):
+```python
+def _on_ws_disconnect(self):
+    """Handle WebSocket disconnection. Sets state; engine handles resync."""
+    self._ws_state = WebSocketState.RESYNCING
+    logger.warning("WebSocket disconnected — entering RESYNCING state")
+    # Engine's health monitor thread detects RESYNCING and calls
+    # _handle_kline_disconnect() or _handle_user_stream_disconnect()
+
+def reconnect_kline(self) -> bool:
+    """Reconnect kline stream only. Called by engine on kline staleness."""
+    try:
+        # Stop and recreate TWM (manager-wide stop is the only clean option)
+        self.stop_streams()
+        return self.start_kline_stream(
+            self._active_symbol, self._active_timeframe, self._on_kline_cb)
+    except Exception as e:
+        logger.error("Kline reconnect failed: %s", e)
+        return False
+
+def reconnect_user(self) -> bool:
+    """Reconnect user data stream only. Called by engine on user-stream failure."""
+    try:
+        # Only restart user stream (kline may be on a different provider)
+        if self._user_socket_key and self._twm:
+            self._twm.stop_socket(self._user_socket_key)
+        if self._on_user_event_cb:
+            return self.start_user_stream(self._on_user_event_cb)
+        return False
+    except Exception as e:
+        logger.error("User stream reconnect failed: %s", e)
+        return False
+```
+
+**LiveTradingEngine** (two independent reconnect handlers):
+```python
+def _handle_kline_disconnect(self):
+    """Handle kline stream failure. Called by health monitor."""
+    kline_provider = getattr(self, '_ws_kline_provider', None)
+    if not kline_provider:
+        return
+    # Resync kline history from REST
+    if self._kline_buffer:
+        self._kline_buffer.resync_from_rest(
+            self.data_provider, self._active_symbol, self.timeframe)
+    # Attempt kline reconnect
+    if kline_provider.reconnect_kline():
+        self._ws_kline_active = True
+        logger.info("Kline WebSocket reconnected")
+    else:
+        kline_provider._ws_state = WebSocketState.REST_DEGRADED
+        self._ws_kline_active = False
+        logger.warning("Kline reconnect failed — REST polling resumed")
+
+def _handle_user_stream_disconnect(self):
+    """Handle user data stream failure. Called by health monitor (live only)."""
+    if not self.enable_live_trading or not self.exchange_interface:
+        return
+    # Resync order and position state from REST
+    if self.order_tracker:
+        self.order_tracker.poll_once()
+    if self._periodic_reconciler:
+        self._periodic_reconciler.reconcile_once()
+    # Attempt user stream reconnect (manages exchange_interface._ws_state)
+    if hasattr(self.exchange_interface, 'reconnect_user') and \
+       self.exchange_interface.reconnect_user():
+        # reconnect_user() calls start_user_stream() which sets _ws_state = PRIMARY
+        if self.order_tracker:
+            self.order_tracker.disable_polling()
+        logger.info("User data WebSocket reconnected")
+    else:
+        self.exchange_interface._ws_state = WebSocketState.REST_DEGRADED
+        if self.order_tracker:
+            self.order_tracker.enable_polling()
+        logger.warning("User stream reconnect failed — order polling resumed")
+```
+
+**New public methods required:**
+- `OrderTracker.poll_once()` — public wrapper calling `_check_orders()` once
+- `PeriodicReconciler.reconcile_once()` — public wrapper calling `_reconcile_cycle()` once
+
+**Health monitoring:** Daemon thread in `LiveTradingEngine` monitors both streams independently:
+- **Kline stream** (on `kline_provider`): Staleness > 2 min triggers kline resync/reconnect.
+- **User data stream** (on `exchange_interface`, live mode only): Idleness during quiet periods (no open orders) is normal. But if orders ARE being tracked (`order_tracker.get_tracked_count() > 0`) and no user-data events arrive for > 2 min, trigger user-stream reconnect and re-enable order polling as fallback. This prevents fills/cancels from being silently missed while order polling is disabled.
+
+The two streams are monitored and reconnected **independently** since they live on different provider instances. If user-stream reconnect fails, `order_tracker.enable_polling()` is called immediately to resume REST polling for tracked orders.
+
+**Per-stream timestamps** in BinanceProvider:
+```python
+self._last_kline_event_time: datetime   # Updated on every kline callback
+self._last_user_event_time: datetime    # Updated on every user data callback
+
+@property
+def ws_healthy(self) -> bool:
+    """Kline stream must be alive. User-data idleness is normal."""
+    if self._ws_state != WebSocketState.PRIMARY:
+        return False
+    kline_age = (datetime.now(UTC) - self._last_kline_event_time).total_seconds()
+    return kline_age < 120
+```
+
+**24-hour rotation:** Binance terminates WebSocket connections every 24 hours. The health monitor detects kline staleness and triggers the resync/reconnect flow.
+
+**Files:** `src/data_providers/binance_provider.py`
+
+### Phase 7: REST Fallback
+
+The existing polling code stays intact and activates when WebSocket is unhealthy:
+
+```python
+# In _get_latest_data():
+ws_provider = getattr(self, '_ws_kline_provider', None)
+if self._kline_buffer and self._kline_buffer.is_fresh and \
+   getattr(ws_provider, 'ws_healthy', False):
+    return self._kline_buffer.get_dataframe()
+else:
+    # Current REST polling — unchanged
+    return self.data_provider.get_live_data(symbol, timeframe, limit=500)
+
+# In order tracker:
+if ws_active:
+    # Events arrive via process_execution_event()
+    pass
+else:
+    # Resume REST polling (existing _poll_loop)
+    self.enable_polling()
+```
+
+**Mutual exclusion (per-stream):** For each data stream (kline, user data), only one mode (WS or REST) owns state mutation at a time. Kline and user streams can independently be in different modes.
+
+**WS→REST handoff for user data:** Before `enable_polling()`, the `UserDataProcessor` queue must be stopped and drained so no late WS events race with the first REST poll. Sequence: (1) stop UserDataProcessor, (2) drain remaining queue events through `process_execution_event()`, (3) then `enable_polling()`. The `EventDeduplicator` inside `OrderTracker` provides a secondary safety net — both WS and REST paths call `_process_order_status()` through the tracker, and the dedup check runs before any state mutation. However, the drain-then-switch handoff is the primary protection.
+
+**Margin fail-fast preserved:** The existing fail-fast guard that prevents falling back to offline/mock mode when margin trading is enabled remains untouched. WebSocket fallback goes to REST polling, never to offline mode.
+
+**API ban handling:** The existing `@with_rate_limit_retry` decorator is only used on order placement paths, not on `get_live_data()`/`get_order()`. Ban detection for the resync/fallback paths requires explicit handling: when `get_live_data()` or `get_order()` raises a `-1003` BinanceAPIException during resync, the engine catches it, parses the ban expiry timestamp (reusing the same parsing logic from `binance_provider.py:96`), sets `SUSPENDED` on both providers, and schedules retry after the ban window. The `_handle_kline_disconnect()` and `_handle_user_stream_disconnect()` methods wrap their REST calls in try/except for `-1003` and enter SUSPENDED on detection. An IP ban affects all connections from the same IP, so the engine coordinates setting SUSPENDED on both `_ws_kline_provider` and `exchange_interface`.
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/data_providers/binance_provider.py` | Add split WS streams (kline + user), state machine, per-stream health, error event handling, reconnect |
+| `src/data_providers/exchange_interface.py` | No changes needed — WS methods are Binance-specific, detected via `hasattr` on `exchange_interface` |
+| `src/engines/live/trading_engine.py` | Replace `_get_latest_data()` with cache reads, resync orchestration, WS shutdown, health monitor |
+| `src/engines/live/order_tracker.py` | Add `process_execution_event()`, `poll_once()` public method, toggle polling on/off |
+| `src/engines/live/reconciliation.py` | Add `reconcile_once()` public method, WS parity monitoring (interval unchanged initially) |
+| `src/config/constants.py` | Add WebSocket-related constants |
+| `src/engines/live/kline_buffer.py` | **New:** Thread-safe rolling kline cache with correct close/roll logic |
+| `src/engines/live/user_data_processor.py` | **New:** Dedicated thread for user-data event processing |
+| `src/engines/live/event_deduplicator.py` | **New:** Thread-safe idempotent event tracking by (orderId, executionType, I) |
+
+## Exchange Compatibility
+
+**Binance:** Full WebSocket support via `ThreadedWebsocketManager` in python-binance. Kline streams, user data streams (spot + margin), automatic reconnection. This plan targets Binance.
+
+**Coinbase:** Has its own WebSocket feed (`wss://ws-feed.exchange.coinbase.com`) with similar capabilities (ticker, trades, user orders). However, the API is completely different from Binance — separate implementation needed. The `CoinbaseProvider` currently has no WebSocket support and would continue using REST polling.
+
+**Design:** WS stream methods (`start_kline_stream`, `start_user_stream`, `stop_streams`) are added directly to `BinanceProvider`, NOT to the `ExchangeInterface` ABC. The engine detects kline WS capability on the unwrapped market-data provider (`hasattr(kline_provider, 'start_kline_stream')`) and user-stream capability on the exchange interface (`hasattr(self.exchange_interface, 'start_user_stream')`). Providers without these methods (e.g., `CoinbaseProvider`) automatically fall back to REST polling. This means adding Coinbase WebSocket support later is additive, not blocking.
+
+## Security
+
+- **Margin fail-fast preserved:** The existing safety guard that prevents offline/mock fallback during margin trading remains untouched. WebSocket failure falls back to REST, never to offline mode.
+- **No raw payload logging:** User-data events contain balances, symbols, client IDs, and execution details. Log only structured fields (order_id, status, filled_qty) at INFO level; full payloads only at DEBUG.
+- **Payload validation:** All event handlers validate fields before mutation. `Z / z` division guarded by `z > 0`. Malformed or unknown status events are logged and skipped.
+- **Event deduplication:** `(orderId, executionType, I)` keyed dedup prevents duplicate state mutations during WS/REST transitions, correctly handling both trade fills and non-trade lifecycle events (cancels, rejects, expires where `t = -1`).
+
+## Railway Considerations
+
+- **No extra services needed.** WebSocket connections are outbound from the bot — no inbound ports or services required beyond the existing health endpoint.
+- **Railway supports long-lived connections.** No proxy timeouts or idle disconnects.
+- **Healthcheck stays HTTP.** The `/health` endpoint continues working independently of WebSocket streams.
+- **Deploy restart:** On redeploy, the bot reconnects WebSocket streams during startup. One-time REST fetch for kline history costs ~10 weight (vs current ~100+ per restart).
+
+## API Weight Impact
+
+| Component | Current (REST) | WebSocket | Savings |
+|-----------|---------------|-----------|---------|
+| Kline data | ~10 weight/min | 0 (stream) | 100% |
+| Order status | ~12 weight/min per order | 0 (user stream) | 100% |
+| Balance/account | ~3 weight/min | ~3 weight/min (unchanged initially) | 0% initially |
+| Reconciler | ~5 weight/min | ~5 weight/min (unchanged initially) | 0% initially |
+| Startup | ~30 weight | ~10 weight (one-time history) | 67% |
+| **Total** | **~30 weight/min** | **~8 weight/min** | **73%** |
+
+*After parity proven: reconciler interval increased to 300-600s (~1 weight/min), balance/account moved to WS BalanceCache (0 weight). Estimated ~1 weight/min total (~97% savings). BalanceCache and account sync replacement are separate follow-up PRs, not in initial scope.*
+
+## Verification
+
+### Unit Tests
+1. Mock `ThreadedWebsocketManager` — verify stream start/stop lifecycle
+2. KlineBuffer — verify rolling window with correct replace-then-roll on close, intra-candle updates, thread safety, no duplicate timestamps
+3. OrderTracker — verify `process_execution_event()` constructs correct `Order` object and delegates to `_process_order_status()` for all status types:
+   - FILLED (normal, zero-qty guard on avg_price)
+   - PARTIALLY_FILLED (valid and invalid avg_price)
+   - CANCELED, REJECTED, EXPIRED
+   - Callback retry logic preserved
+4. EventDeduplicator — verify dedup with `(orderId, executionType, I)` key, eviction, thread safety, correct handling of `t = -1` events
+5. UserDataProcessor — verify event routing, queue processing
+6. Connection state machine — verify all transitions, including RESYNCING blocks trading
+
+### Failure Mode Tests
+7. Duplicate `executionReport` events — verify idempotent processing
+8. Out-of-order events — verify correct state after reordering
+9. Partial fill then cancel — verify callback sequence and orphan prevention
+10. Callback exception during WS-fed fill — verify retry behavior
+11. Reconnect during open orders — verify no missed fills after resync
+12. 24-hour connection rotation — verify automatic reconnect/resync
+13. Stream termination mid-trade — verify REST fallback activates
+14. RESYNCING state — verify live mode freezes, paper mode falls back to REST immediately
+
+### Integration Tests
+15. Connect to Binance testnet WebSocket — verify kline + execution events
+16. Fallback test: Kill WebSocket — verify REST polling resumes within 2 min
+17. Parity test: Compare WS-fed vs REST-polled state over extended run
+
+### Deployment
+18. Deploy to dev (paper mode): Verify no API bans over 24h, correct strategy execution
+19. Deploy to production: Monitor for missed fills, balance drift, reconnection events
+
+## Migration Strategy
+
+Implement in phases, each independently deployable:
+1. **Phase 1+2** (kline streams + cache) — eliminates main loop REST polling (works in both paper and live mode)
+2. **Phase 3+4** (user data streams + order tracker integration) — eliminates order polling
+3. **Phase 5** (reconciler monitoring) — adds WS/REST parity metrics
+4. **Phase 6+7** (resilience + fallback) — production hardening
+
+Each phase is a separate PR. Phase N+1 only starts after Phase N passes CI and paper-trading validation.
+
+## Branch
+
+`feat/websocket-streams`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Fixed
+- Add ban-aware retry to Binance client startup — parses `-1003` ban expiry and sleeps until lifted instead of crashing (#590)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ description = "AI Trading Bot CLI and tools"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "python-binance>=1.0.19",
+    "python-binance>=1.0.36",
+    "nest_asyncio>=1.6.0",
     "pandas>=2.1.4",
     "python-dotenv>=1.0.0",
     "numpy>=1.26.2",

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,7 +1,8 @@
 # Server requirements - lighter build without heavy libraries for training models
 # Production dependencies with pinned versions for stability
-# Cache bust: pyarrow + statsmodels added 2026-02-28
-python-binance==1.0.19
+# Cache bust: nest_asyncio added 2026-04-02
+python-binance==1.0.36
+nest_asyncio==1.6.0
 pandas==2.1.4
 python-dotenv==1.0.0
 numpy==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Use locally - includes heavy libraries for training models
-python-binance==1.0.19
+python-binance==1.0.36
+nest_asyncio==1.6.0
 pandas==2.2.0
 python-dotenv==1.0.0
 numpy==1.26.4

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -332,6 +332,8 @@ DEFAULT_WS_KLINE_STALENESS_THRESHOLD = 120  # Seconds before kline stream consid
 DEFAULT_WS_USER_STALENESS_THRESHOLD = 120  # Seconds before user stream considered stale (only when orders tracked)
 DEFAULT_WS_HEALTH_CHECK_INTERVAL = 30  # Seconds between health monitor checks
 DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_DEGRADED
+DEFAULT_STARTUP_BAN_MAX_WAIT = 600  # Max seconds to wait for an IP ban to lift during startup
+DEFAULT_STARTUP_BAN_MAX_RETRIES = 3  # Max retry attempts for ban-related startup failures
 
 # TFT (Temporal Fusion Transformer) Model Defaults
 DEFAULT_TFT_N_HEADS = 4  # Number of attention heads in the temporal decoder

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -50,10 +50,17 @@ from .exchange_interface import (
 logger = logging.getLogger(__name__)
 
 try:
+    import nest_asyncio
+
+    nest_asyncio.apply()  # Allow nested run_until_complete for TWM event loop
+
     from binance import ThreadedWebsocketManager
     from binance.client import Client
     from binance.enums import SIDE_BUY, SIDE_SELL
     from binance.exceptions import BinanceAPIException, BinanceOrderException
+
+    # Ensure ws.protocol.State is accessible (not auto-loaded in websockets 13+)
+    import websockets.protocol  # noqa: F401
 
     BINANCE_AVAILABLE = True
 except ImportError:

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -350,7 +350,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
 
     def _initialize_client(self):
         """Initialize Binance client with geo-aware API selection and error handling"""
-        logger.debug(f"_initialize_client called - BINANCE_AVAILABLE: {BINANCE_AVAILABLE}")
+        logger.debug("_initialize_client called - BINANCE_AVAILABLE: %s", BINANCE_AVAILABLE)
 
         if not BINANCE_AVAILABLE:
             if self._use_margin and self._is_live:
@@ -386,8 +386,10 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 if ban_wait is None:
                     break  # Non-ban error or exceeded limits — stop retrying
                 logger.warning(
-                    f"Startup attempt {attempt + 1}/{DEFAULT_STARTUP_BAN_MAX_RETRIES + 1}: "
-                    f"IP banned, waiting {ban_wait:.0f}s for ban to lift..."
+                    "Startup attempt %d/%d: IP banned, waiting %.0fs for ban to lift...",
+                    attempt + 1,
+                    DEFAULT_STARTUP_BAN_MAX_RETRIES + 1,
+                    ban_wait,
                 )
                 time.sleep(ban_wait)
 
@@ -397,12 +399,14 @@ class BinanceProvider(DataProvider, ExchangeInterface):
     def _attempt_client_init(self, api_endpoint: str):
         """Single attempt to create and verify the Binance client."""
         logger.debug(
-            f"Attempting to create {api_endpoint} client - "
-            f"has_credentials: {bool(self.api_key and self.api_secret)}, testnet: {self.testnet}"
+            "Attempting to create %s client - has_credentials: %s, testnet: %s",
+            api_endpoint,
+            bool(self.api_key and self.api_secret),
+            self.testnet,
         )
 
         if self.api_key and self.api_secret:
-            logger.debug(f"Creating authenticated {api_endpoint} client...")
+            logger.debug("Creating authenticated %s client...", api_endpoint)
             if api_endpoint == "binanceus":
                 client = Client(
                     self.api_key, self.api_secret, testnet=self.testnet, tld="us"
@@ -410,21 +414,23 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             else:
                 client = Client(self.api_key, self.api_secret, testnet=self.testnet)
         else:
-            logger.debug(f"Creating public {api_endpoint} client...")
+            logger.debug("Creating public %s client...", api_endpoint)
             if api_endpoint == "binanceus":
                 client = Client(tld="us")
             else:
                 client = Client()
 
+        auth_mode = "with credentials" if self.api_key and self.api_secret else "public mode"
         logger.info(
-            f"{api_endpoint.title()} client initialized successfully "
-            f"({'with credentials' if self.api_key and self.api_secret else 'public mode'}, "
-            f"testnet: {self.testnet})"
+            "%s client initialized successfully (%s, testnet: %s)",
+            api_endpoint.title(),
+            auth_mode,
+            self.testnet,
         )
 
         logger.debug("Testing client with server time request...")
         test_response = client.get_server_time()
-        logger.debug(f"Server time test successful: {test_response}")
+        logger.debug("Server time test successful: %s", test_response)
 
         # Only promote to self._client after all verification passes
         self._client = client
@@ -459,8 +465,9 @@ class BinanceProvider(DataProvider, ExchangeInterface):
 
         if total_wait > max_wait:
             logger.error(
-                f"IP ban wait ({total_wait:.0f}s) exceeds startup max wait "
-                f"of {max_wait}s. Not retrying."
+                "IP ban wait (%.0fs) exceeds startup max wait of %ss. Not retrying.",
+                total_wait,
+                max_wait,
             )
             return None
 
@@ -476,9 +483,14 @@ class BinanceProvider(DataProvider, ExchangeInterface):
 
         if self._use_margin and self._is_live:
             logger.error(
-                f"{api_endpoint.title()} Client initialization failed with {error_type}: {error_msg}. "
-                f"Credentials available: {bool(self.api_key and self.api_secret)}, "
-                f"Testnet mode: {self.testnet}."
+                "%s Client initialization failed with %s: %s. "
+                "Credentials available: %s, Testnet mode: %s.",
+                api_endpoint.title(),
+                error_type,
+                error_msg,
+                bool(self.api_key and self.api_secret),
+                self.testnet,
+                exc_info=True,
             )
             raise RuntimeError(
                 f"FATAL: Cannot initialize Binance client in live margin mode. "
@@ -487,10 +499,14 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             ) from error
 
         logger.error(
-            f"{api_endpoint.title()} Client initialization failed with {error_type}: {error_msg}. "
-            f"Credentials available: {bool(self.api_key and self.api_secret)}, "
-            f"Testnet mode: {self.testnet}. "
-            f"Falling back to offline stub."
+            "%s Client initialization failed with %s: %s. "
+            "Credentials available: %s, Testnet mode: %s. Falling back to offline stub.",
+            api_endpoint.title(),
+            error_type,
+            error_msg,
+            bool(self.api_key and self.api_secret),
+            self.testnet,
+            exc_info=True,
         )
 
         if "recursion" in error_msg.lower() or "maximum recursion" in error_msg.lower():

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -789,6 +789,10 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         except RuntimeError:
             raise
         except Exception as e:
+            # Re-raise rate-limit errors directly so the startup retry loop
+            # in _initialize_client can detect and retry them.
+            if getattr(e, "code", None) in RATE_LIMIT_ERROR_CODES:
+                raise
             if self._is_live:
                 raise RuntimeError(f"Failed to verify margin account capabilities: {e}") from e
             logger.warning("Could not verify margin account (non-live mode): %s", e)

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -369,79 +369,132 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             f"Geo-detection result: {'US location' if is_us else 'Non-US location'} - using {api_endpoint} API"
         )
 
-        try:
-            logger.debug(
-                f"Attempting to create {api_endpoint} client - has_credentials: {bool(self.api_key and self.api_secret)}, testnet: {self.testnet}"
-            )
+        from src.config.constants import (
+            DEFAULT_STARTUP_BAN_MAX_RETRIES,
+            DEFAULT_STARTUP_BAN_MAX_WAIT,
+        )
 
-            # Create client with appropriate API endpoint
-            if self.api_key and self.api_secret:
-                logger.debug(f"Creating authenticated {api_endpoint} client...")
-                if api_endpoint == "binanceus":
-                    # For Binance US, use tld='us' parameter
-                    self._client = Client(
-                        self.api_key, self.api_secret, testnet=self.testnet, tld="us"
-                    )
-                else:
-                    # For global Binance
-                    self._client = Client(self.api_key, self.api_secret, testnet=self.testnet)
-            else:
-                logger.debug(f"Creating public {api_endpoint} client...")
-                if api_endpoint == "binanceus":
-                    # For Binance US public client
-                    self._client = Client(tld="us")
-                else:
-                    # For global Binance public client
-                    self._client = Client()
-
-            logger.info(
-                f"{api_endpoint.title()} client initialized successfully "
-                f"({'with credentials' if self.api_key and self.api_secret else 'public mode'}, "
-                f"testnet: {self.testnet})"
-            )
-
-            # Test the client with a simple operation
-            logger.debug("Testing client with server time request...")
-            test_response = self._client.get_server_time()
-            logger.debug(f"Server time test successful: {test_response}")
-
-            # A3: Verify margin account capabilities at startup
-            if self._use_margin:
-                self._verify_margin_account()
-
-        except RuntimeError:
-            # Let RuntimeErrors from margin verification propagate directly
-            raise
-        except Exception as e:
-            error_type = type(e).__name__
-            error_msg = str(e)
-
-            # Log detailed error information (never log credentials)
-            logger.error(
-                f"{api_endpoint.title()} Client initialization failed with {error_type}: {error_msg}. "
-                f"Credentials available: {bool(self.api_key and self.api_secret)}, "
-                f"Testnet mode: {self.testnet}. "
-                f"Falling back to offline stub."
-            )
-
-            # A2: Fail-fast — refuse to fall back to offline stub in live margin mode.
-            # Placing dummy margin orders on an offline client risks fund loss.
-            if self._use_margin and self._is_live:
-                raise RuntimeError(
-                    f"FATAL: Cannot initialize Binance client in live margin mode. "
-                    f"Refusing to fall back to offline stub — placing dummy margin orders "
-                    f"risks fund loss. Error: {error_type}: {error_msg}"
-                ) from e
-
-            # Log additional context if it's a recursion error
-            if "recursion" in error_msg.lower() or "maximum recursion" in error_msg.lower():
-                logger.error(
-                    "Recursion error detected during Binance client initialization. "
-                    "This may indicate a circular dependency or infinite loop in the initialization process. "
-                    "Check for circular imports or dependencies in the configuration system."
+        last_error = None
+        for attempt in range(DEFAULT_STARTUP_BAN_MAX_RETRIES + 1):
+            try:
+                self._attempt_client_init(api_endpoint)
+                return  # Success
+            except RuntimeError:
+                raise  # Margin verification failures propagate immediately
+            except Exception as e:
+                last_error = e
+                ban_wait = self._handle_startup_ban(
+                    e, attempt, DEFAULT_STARTUP_BAN_MAX_RETRIES, DEFAULT_STARTUP_BAN_MAX_WAIT
                 )
+                if ban_wait is None:
+                    break  # Non-ban error or exceeded limits — stop retrying
+                logger.warning(
+                    f"Startup attempt {attempt + 1}/{DEFAULT_STARTUP_BAN_MAX_RETRIES + 1}: "
+                    f"IP banned, waiting {ban_wait:.0f}s for ban to lift..."
+                )
+                time.sleep(ban_wait)
 
-            self._client = self._create_offline_client()
+        # All retries exhausted or non-retryable error
+        self._handle_init_failure(last_error, api_endpoint)
+
+    def _attempt_client_init(self, api_endpoint: str):
+        """Single attempt to create and verify the Binance client."""
+        logger.debug(
+            f"Attempting to create {api_endpoint} client - "
+            f"has_credentials: {bool(self.api_key and self.api_secret)}, testnet: {self.testnet}"
+        )
+
+        if self.api_key and self.api_secret:
+            logger.debug(f"Creating authenticated {api_endpoint} client...")
+            if api_endpoint == "binanceus":
+                self._client = Client(
+                    self.api_key, self.api_secret, testnet=self.testnet, tld="us"
+                )
+            else:
+                self._client = Client(self.api_key, self.api_secret, testnet=self.testnet)
+        else:
+            logger.debug(f"Creating public {api_endpoint} client...")
+            if api_endpoint == "binanceus":
+                self._client = Client(tld="us")
+            else:
+                self._client = Client()
+
+        logger.info(
+            f"{api_endpoint.title()} client initialized successfully "
+            f"({'with credentials' if self.api_key and self.api_secret else 'public mode'}, "
+            f"testnet: {self.testnet})"
+        )
+
+        logger.debug("Testing client with server time request...")
+        test_response = self._client.get_server_time()
+        logger.debug(f"Server time test successful: {test_response}")
+
+        if self._use_margin:
+            self._verify_margin_account()
+
+    @staticmethod
+    def _handle_startup_ban(
+        error: Exception,
+        attempt: int,
+        max_retries: int,
+        max_wait: float,
+    ) -> float | None:
+        """Check if a startup error is a retryable IP ban.
+
+        Returns seconds to wait, or None if not retryable.
+        """
+        error_code = getattr(error, "code", None)
+        if error_code not in RATE_LIMIT_ERROR_CODES:
+            return None
+
+        if attempt >= max_retries:
+            return None
+
+        ban_wait = _parse_ban_expiry(str(error))
+        if ban_wait is None or ban_wait <= 0:
+            # No parseable expiry — use a short default
+            ban_wait = 30.0
+
+        if ban_wait > max_wait:
+            logger.error(
+                f"IP ban expires in {ban_wait:.0f}s which exceeds startup max wait "
+                f"of {max_wait}s. Not retrying."
+            )
+            return None
+
+        # Add small buffer so we don't land exactly on the expiry edge
+        return ban_wait + 5.0
+
+    def _handle_init_failure(self, error: Exception | None, api_endpoint: str):
+        """Handle final init failure after all retries exhausted."""
+        if error is None:
+            return
+
+        error_type = type(error).__name__
+        error_msg = str(error)
+
+        logger.error(
+            f"{api_endpoint.title()} Client initialization failed with {error_type}: {error_msg}. "
+            f"Credentials available: {bool(self.api_key and self.api_secret)}, "
+            f"Testnet mode: {self.testnet}. "
+            f"Falling back to offline stub."
+        )
+
+        if self._use_margin and self._is_live:
+            raise RuntimeError(
+                f"FATAL: Cannot initialize Binance client in live margin mode. "
+                f"Refusing to fall back to offline stub — placing dummy margin orders "
+                f"risks fund loss. Error: {error_type}: {error_msg}"
+            ) from error
+
+        if "recursion" in error_msg.lower() or "maximum recursion" in error_msg.lower():
+            logger.error(
+                "Recursion error detected during Binance client initialization. "
+                "This may indicate a circular dependency or infinite loop in the initialization process. "
+                "Check for circular imports or dependencies in the configuration system."
+            )
+
+        self._client = self._create_offline_client()
 
     def _create_offline_client(self):
         """Create offline client stub for testing"""

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -372,6 +372,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         )
 
         last_error = None
+        deadline = time.monotonic() + DEFAULT_STARTUP_BAN_MAX_WAIT
         for attempt in range(DEFAULT_STARTUP_BAN_MAX_RETRIES + 1):
             try:
                 self._attempt_client_init(api_endpoint)
@@ -380,8 +381,9 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 raise  # Margin verification failures propagate immediately
             except Exception as e:
                 last_error = e
+                remaining_budget = deadline - time.monotonic()
                 ban_wait = self._handle_startup_ban(
-                    e, attempt, DEFAULT_STARTUP_BAN_MAX_RETRIES, DEFAULT_STARTUP_BAN_MAX_WAIT
+                    e, attempt, DEFAULT_STARTUP_BAN_MAX_RETRIES, remaining_budget
                 )
                 if ban_wait is None:
                     break  # Non-ban error or exceeded limits — stop retrying
@@ -456,9 +458,12 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             return None
 
         ban_wait = _parse_ban_expiry(str(error))
-        if ban_wait is None or ban_wait <= 0:
+        if ban_wait is None:
             # No parseable expiry — use a short default
             ban_wait = 30.0
+        elif ban_wait <= 0:
+            # Ban already expired — retry with minimal buffer
+            ban_wait = 1.0
 
         # Add small buffer so we don't land exactly on the expiry edge
         total_wait = ban_wait + 5.0

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -25,6 +25,8 @@ import pandas as pd
 from src.config import get_config
 from src.config.constants import (
     DEFAULT_DATA_FETCH_TIMEOUT,
+    DEFAULT_STARTUP_BAN_MAX_RETRIES,
+    DEFAULT_STARTUP_BAN_MAX_WAIT,
     DEFAULT_WS_KLINE_STALENESS_THRESHOLD,
     DEFAULT_WS_RECONNECT_MAX_RETRIES,
 )
@@ -369,11 +371,6 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             f"Geo-detection result: {'US location' if is_us else 'Non-US location'} - using {api_endpoint} API"
         )
 
-        from src.config.constants import (
-            DEFAULT_STARTUP_BAN_MAX_RETRIES,
-            DEFAULT_STARTUP_BAN_MAX_WAIT,
-        )
-
         last_error = None
         for attempt in range(DEFAULT_STARTUP_BAN_MAX_RETRIES + 1):
             try:
@@ -407,17 +404,17 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         if self.api_key and self.api_secret:
             logger.debug(f"Creating authenticated {api_endpoint} client...")
             if api_endpoint == "binanceus":
-                self._client = Client(
+                client = Client(
                     self.api_key, self.api_secret, testnet=self.testnet, tld="us"
                 )
             else:
-                self._client = Client(self.api_key, self.api_secret, testnet=self.testnet)
+                client = Client(self.api_key, self.api_secret, testnet=self.testnet)
         else:
             logger.debug(f"Creating public {api_endpoint} client...")
             if api_endpoint == "binanceus":
-                self._client = Client(tld="us")
+                client = Client(tld="us")
             else:
-                self._client = Client()
+                client = Client()
 
         logger.info(
             f"{api_endpoint.title()} client initialized successfully "
@@ -426,9 +423,11 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         )
 
         logger.debug("Testing client with server time request...")
-        test_response = self._client.get_server_time()
+        test_response = client.get_server_time()
         logger.debug(f"Server time test successful: {test_response}")
 
+        # Only promote to self._client after all verification passes
+        self._client = client
         if self._use_margin:
             self._verify_margin_account()
 
@@ -455,15 +454,17 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             # No parseable expiry — use a short default
             ban_wait = 30.0
 
-        if ban_wait > max_wait:
+        # Add small buffer so we don't land exactly on the expiry edge
+        total_wait = ban_wait + 5.0
+
+        if total_wait > max_wait:
             logger.error(
-                f"IP ban expires in {ban_wait:.0f}s which exceeds startup max wait "
+                f"IP ban wait ({total_wait:.0f}s) exceeds startup max wait "
                 f"of {max_wait}s. Not retrying."
             )
             return None
 
-        # Add small buffer so we don't land exactly on the expiry edge
-        return ban_wait + 5.0
+        return total_wait
 
     def _handle_init_failure(self, error: Exception | None, api_endpoint: str):
         """Handle final init failure after all retries exhausted."""
@@ -473,19 +474,24 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         error_type = type(error).__name__
         error_msg = str(error)
 
+        if self._use_margin and self._is_live:
+            logger.error(
+                f"{api_endpoint.title()} Client initialization failed with {error_type}: {error_msg}. "
+                f"Credentials available: {bool(self.api_key and self.api_secret)}, "
+                f"Testnet mode: {self.testnet}."
+            )
+            raise RuntimeError(
+                f"FATAL: Cannot initialize Binance client in live margin mode. "
+                f"Refusing to fall back to offline stub — placing dummy margin orders "
+                f"risks fund loss. Error: {error_type}: {error_msg}"
+            ) from error
+
         logger.error(
             f"{api_endpoint.title()} Client initialization failed with {error_type}: {error_msg}. "
             f"Credentials available: {bool(self.api_key and self.api_secret)}, "
             f"Testnet mode: {self.testnet}. "
             f"Falling back to offline stub."
         )
-
-        if self._use_margin and self._is_live:
-            raise RuntimeError(
-                f"FATAL: Cannot initialize Binance client in live margin mode. "
-                f"Refusing to fall back to offline stub — placing dummy margin orders "
-                f"risks fund loss. Error: {error_type}: {error_msg}"
-            ) from error
 
         if "recursion" in error_msg.lower() or "maximum recursion" in error_msg.lower():
             logger.error(

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -255,6 +255,7 @@ class TestRateLimitRetryDecorator:
 
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
 class TestPlaceStopLossOrder:
     """Tests for the place_stop_loss_order method."""
 
@@ -496,6 +497,7 @@ class TestPlaceStopLossOrder:
 
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
 class TestGetOrderIdRouting:
     """Tests for get_order() routing between orderId and origClientOrderId."""
 

--- a/tests/unit/data_providers/test_startup_ban_retry.py
+++ b/tests/unit/data_providers/test_startup_ban_retry.py
@@ -267,3 +267,38 @@ class TestInitializeClientBanRetry:
         # Should have retried (slept once) and succeeded
         mock_sleep.assert_called_once_with(10.0)  # 5s ban + 5s buffer
         assert provider._client == mock_client_ok
+
+    @patch("src.data_providers.binance_provider.get_binance_api_endpoint", return_value="binance")
+    @patch("src.data_providers.binance_provider.is_us_location", return_value=False)
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_cumulative_deadline_rejects_second_retry(
+        self, mock_config, mock_client_class, _mock_us, _mock_endpoint
+    ):
+        """Total wait across retries must not exceed DEFAULT_STARTUP_BAN_MAX_WAIT."""
+        mock_config_obj = Mock()
+        mock_config_obj.get.side_effect = lambda key, default=None: {
+            "BINANCE_ACCOUNT_TYPE": "margin",
+            "TRADING_MODE": "live",
+        }.get(key, default)
+        mock_config_obj.get_required.side_effect = lambda key: FAKE_KEY if "KEY" in key else FAKE_SECRET
+        mock_config.return_value = mock_config_obj
+
+        ban_exc = _make_ban_exception(-1003, 1_775_000_010_000)
+        mock_client_class.side_effect = ban_exc  # Always fails
+
+        # Simulate time advancing: first retry at t=0, second at t=590
+        # With DEFAULT_STARTUP_BAN_MAX_WAIT=600, the second retry should be
+        # rejected because remaining_budget < total_wait
+        monotonic_values = iter([0, 0, 590, 590])
+
+        with (
+            patch("time.sleep"),
+            patch("time.monotonic", side_effect=monotonic_values),
+            patch(
+                "src.data_providers.binance_provider._parse_ban_expiry",
+                return_value=300.0,
+            ),
+            pytest.raises(RuntimeError, match="FATAL"),
+        ):
+            BinanceProvider(FAKE_KEY, FAKE_SECRET)

--- a/tests/unit/data_providers/test_startup_ban_retry.py
+++ b/tests/unit/data_providers/test_startup_ban_retry.py
@@ -224,3 +224,46 @@ class TestInitializeClientBanRetry:
         mock_sleep.assert_not_called()
         # Should fall back to offline stub in paper/spot mode
         assert provider._client is not None
+
+    @patch("src.data_providers.binance_provider.get_binance_api_endpoint", return_value="binance")
+    @patch("src.data_providers.binance_provider.is_us_location", return_value=False)
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_margin_verify_ban_retries_instead_of_crashing(
+        self, mock_config, mock_client_class, _mock_us, _mock_endpoint
+    ):
+        """Rate-limit error during _verify_margin_account retries instead of raising RuntimeError."""
+        mock_config_obj = Mock()
+        mock_config_obj.get.side_effect = lambda key, default=None: {
+            "BINANCE_ACCOUNT_TYPE": "margin",
+            "TRADING_MODE": "live",
+        }.get(key, default)
+        mock_config_obj.get_required.side_effect = lambda key: FAKE_KEY if "KEY" in key else FAKE_SECRET
+        mock_config.return_value = mock_config_obj
+
+        ban_exc = _make_ban_exception(-1003, 1_775_000_010_000)
+
+        # First client: server time OK, but margin account call triggers ban
+        mock_client_banned = Mock()
+        mock_client_banned.get_server_time.return_value = {"serverTime": 1234}
+        mock_client_banned.get_margin_account.side_effect = ban_exc
+
+        # Second client: everything succeeds
+        mock_client_ok = Mock()
+        mock_client_ok.get_server_time.return_value = {"serverTime": 1234}
+        mock_client_ok.get_margin_account.return_value = {
+            "tradeEnabled": True,
+            "borrowEnabled": True,
+            "userAssets": [{"asset": "USDT", "free": "100", "locked": "0", "netAsset": "100"}],
+        }
+
+        mock_client_class.side_effect = [mock_client_banned, mock_client_ok]
+
+        with patch("time.sleep") as mock_sleep, patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=5.0
+        ):
+            provider = BinanceProvider(FAKE_KEY, FAKE_SECRET)
+
+        # Should have retried (slept once) and succeeded
+        mock_sleep.assert_called_once_with(10.0)  # 5s ban + 5s buffer
+        assert provider._client == mock_client_ok

--- a/tests/unit/data_providers/test_startup_ban_retry.py
+++ b/tests/unit/data_providers/test_startup_ban_retry.py
@@ -136,6 +136,7 @@ class TestHandleStartupBan:
 
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
 class TestInitializeClientBanRetry:
     """Integration tests for the full _initialize_client retry loop."""
 

--- a/tests/unit/data_providers/test_startup_ban_retry.py
+++ b/tests/unit/data_providers/test_startup_ban_retry.py
@@ -1,0 +1,225 @@
+"""Tests for ban-aware startup retry in BinanceProvider._initialize_client()."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Credentials must be >= 20 chars to pass validation
+FAKE_KEY = "A" * 64
+FAKE_SECRET = "B" * 64
+
+try:
+    from src.data_providers.binance_provider import (
+        BinanceProvider,
+        _parse_ban_expiry,
+    )
+
+    BINANCE_AVAILABLE = True
+except ImportError:
+    BINANCE_AVAILABLE = False
+    BinanceProvider = Mock
+    _parse_ban_expiry = None
+
+
+def _make_ban_exception(code: int, ban_until_ms: int) -> Exception:
+    """Create a mock BinanceAPIException with the given code and ban timestamp."""
+    exc = Exception(
+        f"APIError(code={code}): Way too much request weight used; "
+        f"IP banned until {ban_until_ms}. Please use WebSocket Streams."
+    )
+    exc.code = code
+    return exc
+
+
+def _make_generic_exception() -> Exception:
+    """Create a non-ban exception (e.g. network error)."""
+    exc = Exception("Connection refused")
+    # No .code attribute — not a Binance API error
+    return exc
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+class TestHandleStartupBan:
+    """Tests for BinanceProvider._handle_startup_ban static method."""
+
+    def test_returns_wait_time_for_ban_error(self):
+        """IP ban with parseable expiry returns wait time + 5s buffer."""
+        # Ban expires 60s from now
+        now_ms = 1_775_000_000_000
+        ban_until_ms = now_ms + 60_000
+        exc = _make_ban_exception(-1003, ban_until_ms)
+
+        with patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=60.0
+        ):
+            result = BinanceProvider._handle_startup_ban(
+                exc, attempt=0, max_retries=3, max_wait=600
+            )
+
+        assert result == 65.0  # 60s + 5s buffer
+
+    def test_returns_none_for_non_ban_error(self):
+        """Non-ban errors (no .code or wrong code) are not retryable."""
+        exc = _make_generic_exception()
+        result = BinanceProvider._handle_startup_ban(
+            exc, attempt=0, max_retries=3, max_wait=600
+        )
+        assert result is None
+
+    def test_returns_none_when_retries_exhausted(self):
+        """Returns None when attempt >= max_retries."""
+        exc = _make_ban_exception(-1003, 1_775_000_060_000)
+
+        with patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=60.0
+        ):
+            result = BinanceProvider._handle_startup_ban(
+                exc, attempt=3, max_retries=3, max_wait=600
+            )
+
+        assert result is None
+
+    def test_returns_none_when_ban_exceeds_max_wait(self):
+        """Returns None when ban wait exceeds max_wait threshold."""
+        exc = _make_ban_exception(-1003, 1_775_001_000_000)
+
+        with patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=700.0
+        ):
+            result = BinanceProvider._handle_startup_ban(
+                exc, attempt=0, max_retries=3, max_wait=600
+            )
+
+        assert result is None
+
+    def test_uses_default_wait_when_expiry_not_parseable(self):
+        """Falls back to 30s + 5s buffer when ban timestamp can't be parsed."""
+        exc = _make_ban_exception(-1003, 0)
+
+        with patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=None
+        ):
+            result = BinanceProvider._handle_startup_ban(
+                exc, attempt=0, max_retries=3, max_wait=600
+            )
+
+        assert result == 35.0  # 30s default + 5s buffer
+
+    def test_handles_minus_1015_too_many_orders(self):
+        """-1015 (too many orders) is also retryable."""
+        exc = _make_ban_exception(-1015, 1_775_000_060_000)
+
+        with patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=60.0
+        ):
+            result = BinanceProvider._handle_startup_ban(
+                exc, attempt=0, max_retries=3, max_wait=600
+            )
+
+        assert result == 65.0
+
+    def test_handles_zero_remaining_ban_time(self):
+        """When ban already expired (0s remaining), use default wait."""
+        exc = _make_ban_exception(-1003, 1_775_000_000_000)
+
+        with patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=0.0
+        ):
+            result = BinanceProvider._handle_startup_ban(
+                exc, attempt=0, max_retries=3, max_wait=600
+            )
+
+        assert result == 35.0  # 30s default + 5s buffer
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+class TestInitializeClientBanRetry:
+    """Integration tests for the full _initialize_client retry loop."""
+
+    @patch("src.data_providers.binance_provider.get_binance_api_endpoint", return_value="binance")
+    @patch("src.data_providers.binance_provider.is_us_location", return_value=False)
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_succeeds_after_ban_expires(
+        self, mock_config, mock_client_class, _mock_us, _mock_endpoint
+    ):
+        """Client init succeeds on retry after ban lifts."""
+        mock_config_obj = Mock()
+        mock_config_obj.get.side_effect = lambda key, default=None: {
+            "BINANCE_ACCOUNT_TYPE": "margin",
+            "TRADING_MODE": "live",
+        }.get(key, default)
+        mock_config_obj.get_required.side_effect = lambda key: FAKE_KEY if "KEY" in key else FAKE_SECRET
+        mock_config.return_value = mock_config_obj
+
+        ban_exc = _make_ban_exception(-1003, 1_775_000_010_000)
+
+        mock_client = Mock()
+        mock_client.get_server_time.return_value = {"serverTime": 1234}
+        mock_client.get_margin_account.return_value = {
+            "tradeEnabled": True,
+            "borrowEnabled": True,
+            "userAssets": [{"asset": "USDT", "free": "100", "locked": "0", "netAsset": "100"}],
+        }
+
+        # First call raises ban, second succeeds
+        mock_client_class.side_effect = [ban_exc, mock_client]
+
+        with patch("time.sleep") as mock_sleep, patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=5.0
+        ):
+            provider = BinanceProvider(FAKE_KEY, FAKE_SECRET)
+
+        mock_sleep.assert_called_once_with(10.0)  # 5s ban + 5s buffer
+        assert provider._client == mock_client
+
+    @patch("src.data_providers.binance_provider.get_binance_api_endpoint", return_value="binance")
+    @patch("src.data_providers.binance_provider.is_us_location", return_value=False)
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_fails_after_max_retries_in_margin_mode(
+        self, mock_config, mock_client_class, _mock_us, _mock_endpoint
+    ):
+        """Raises RuntimeError after exhausting retries in live margin mode."""
+        mock_config_obj = Mock()
+        mock_config_obj.get.side_effect = lambda key, default=None: {
+            "BINANCE_ACCOUNT_TYPE": "margin",
+            "TRADING_MODE": "live",
+        }.get(key, default)
+        mock_config_obj.get_required.side_effect = lambda key: FAKE_KEY if "KEY" in key else FAKE_SECRET
+        mock_config.return_value = mock_config_obj
+
+        ban_exc = _make_ban_exception(-1003, 1_775_000_010_000)
+        mock_client_class.side_effect = ban_exc  # Always fails
+
+        with patch("time.sleep"), patch(
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=5.0
+        ), pytest.raises(RuntimeError, match="FATAL"):
+            BinanceProvider(FAKE_KEY, FAKE_SECRET)
+
+    @patch("src.data_providers.binance_provider.get_binance_api_endpoint", return_value="binance")
+    @patch("src.data_providers.binance_provider.is_us_location", return_value=False)
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_non_ban_error_does_not_retry(
+        self, mock_config, mock_client_class, _mock_us, _mock_endpoint
+    ):
+        """Non-ban errors fall through immediately without retrying."""
+        mock_config_obj = Mock()
+        mock_config_obj.get.side_effect = lambda key, default=None: {
+            "BINANCE_ACCOUNT_TYPE": "spot",
+            "TRADING_MODE": "paper",
+        }.get(key, default)
+        mock_config_obj.get_required.side_effect = lambda key: FAKE_KEY if "KEY" in key else FAKE_SECRET
+        mock_config.return_value = mock_config_obj
+
+        mock_client_class.side_effect = ConnectionError("Network unreachable")
+
+        with patch("time.sleep") as mock_sleep:
+            provider = BinanceProvider(FAKE_KEY, FAKE_SECRET)
+
+        mock_sleep.assert_not_called()
+        # Should fall back to offline stub in paper/spot mode
+        assert provider._client is not None

--- a/tests/unit/data_providers/test_startup_ban_retry.py
+++ b/tests/unit/data_providers/test_startup_ban_retry.py
@@ -122,7 +122,7 @@ class TestHandleStartupBan:
         assert result == 65.0
 
     def test_handles_zero_remaining_ban_time(self):
-        """When ban already expired (0s remaining), use default wait."""
+        """When ban already expired (0s remaining), retry with minimal buffer."""
         exc = _make_ban_exception(-1003, 1_775_000_000_000)
 
         with patch(
@@ -132,7 +132,7 @@ class TestHandleStartupBan:
                 exc, attempt=0, max_retries=3, max_wait=600
             )
 
-        assert result == 35.0  # 30s default + 5s buffer
+        assert result == 6.0  # 1s minimal + 5s buffer
 
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")

--- a/tests/unit/data_providers/test_startup_ban_retry.py
+++ b/tests/unit/data_providers/test_startup_ban_retry.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 # Credentials must be >= 20 chars to pass validation
 FAKE_KEY = "A" * 64

--- a/tests/unit/data_providers/test_startup_ban_retry.py
+++ b/tests/unit/data_providers/test_startup_ban_retry.py
@@ -82,11 +82,12 @@ class TestHandleStartupBan:
         assert result is None
 
     def test_returns_none_when_ban_exceeds_max_wait(self):
-        """Returns None when ban wait exceeds max_wait threshold."""
+        """Returns None when ban wait + buffer exceeds max_wait threshold."""
         exc = _make_ban_exception(-1003, 1_775_001_000_000)
 
+        # 596s + 5s buffer = 601s > 600s max_wait
         with patch(
-            "src.data_providers.binance_provider._parse_ban_expiry", return_value=700.0
+            "src.data_providers.binance_provider._parse_ban_expiry", return_value=596.0
         ):
             result = BinanceProvider._handle_startup_ban(
                 exc, attempt=0, max_retries=3, max_wait=600

--- a/tests/unit/engines/live/test_margin_side_effect.py
+++ b/tests/unit/engines/live/test_margin_side_effect.py
@@ -414,7 +414,8 @@ def _make_binance_provider(*, use_margin: bool = False):
     """Create a BinanceProvider with mocked client and optional margin mode."""
     from unittest.mock import patch
 
-    with patch("src.data_providers.binance_provider.get_config") as mock_config:
+    with patch("src.data_providers.binance_provider.get_config") as mock_config, \
+         patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True):
         mock_config_obj = MagicMock()
         mock_config_obj.get.return_value = None
         mock_config_obj.get_required.return_value = "fake_key"


### PR DESCRIPTION
## Summary
- Add ban-aware retry loop to `BinanceProvider._initialize_client()` that parses the `-1003` ban expiry timestamp and sleeps until the ban lifts, instead of crashing immediately
- Prevents Railway deployments from exhausting restart retries on temporary Binance IP bans
- Max wait capped at 10 minutes, 3 retry attempts, 5s buffer after ban expiry

## Context
Production deployment crashed because the previous (pre-WebSocket) code accumulated enough REST API weight to trigger a Binance IP ban. The new WebSocket code couldn't even start because the Binance client init itself hits the API and gets rejected. Railway's 3 restart retries all fired within seconds, all hitting the same ban.

## Changes
- `_initialize_client()` → retry loop with ban detection
- `_attempt_client_init()` → extracted single-attempt logic, assigns client to local before promoting to `self._client`
- `_handle_startup_ban()` → static method to check if error is retryable IP ban and compute wait time
- `_handle_init_failure()` → extracted final failure handling with correct log messages per mode
- 2 new constants: `DEFAULT_STARTUP_BAN_MAX_WAIT` (600s), `DEFAULT_STARTUP_BAN_MAX_RETRIES` (3)
- 10 new unit tests covering all retry paths

## Test plan
- [x] 10 new tests pass (`test_startup_ban_retry.py`)
- [x] 49 existing provider tests pass with no regressions
- [x] 3-agent code review (reuse, quality, efficiency) — all findings addressed
- [ ] Deploy to production and verify startup succeeds after ban

🤖 Generated with [Claude Code](https://claude.com/claude-code)