### PR TITLE
fix: address deep-review findings in margin interest tracking

### DIFF
--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -2913,7 +2913,7 @@ class DatabaseManager:
                 recent_trades = sorted(trades, key=lambda t: t.exit_time, reverse=True)
 
                 for trade in recent_trades:
-                    pnl = float(trade.pnl)
+                    pnl = _trade_net_pnl(trade)
                     if pnl > 0:
                         if consecutive_losses == 0:  # Still in winning streak
                             consecutive_wins += 1
@@ -2928,7 +2928,7 @@ class DatabaseManager:
 
                 # Calculate Sharpe ratio (simplified)
                 if len(trades) > 1:
-                    pnls = [float(t.pnl) for t in trades]
+                    pnls = [_trade_net_pnl(t) for t in trades]
                     import numpy as np
 
                     returns_std = np.std(pnls)

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2018,7 +2018,11 @@ class PositionReconciler:
         else:
             pnl = (exit_price - entry_price) * qty
 
-        # Deduct margin interest for short positions closed during reconciliation
+        # Query margin interest for short positions closed during reconciliation.
+        # Keep pnl as GROSS — subtract interest only for the balance update so
+        # the accounting model stays consistent: trade.pnl = gross, and
+        # _trade_net_pnl() computes net from the margin_interest_cost column.
+        interest_cost = 0.0
         if self._use_margin and side_is_short:
             try:
                 interest_tracker = MarginInterestTracker(self.exchange)
@@ -2031,9 +2035,8 @@ class PositionReconciler:
                     # Convert from base asset units to USDT using exit price
                     interest_cost = interest_base * exit_price
                     if interest_cost > 0:
-                        pnl -= interest_cost
                         logger.info(
-                            "Deducted margin interest $%.4f (%.8f %s @ %.2f) from reconciliation PnL for %s",
+                            "Margin interest $%.4f (%.8f %s @ %.2f) for reconciliation close of %s",
                             interest_cost,
                             interest_base,
                             base_asset,
@@ -2056,7 +2059,8 @@ class PositionReconciler:
                 )
                 return
 
-            new_balance = current_balance + pnl
+            # Balance uses net PnL (gross minus interest)
+            new_balance = current_balance + pnl - interest_cost
             self.db_manager.update_balance(
                 new_balance,
                 f"reconciliation_close: {reason}",
@@ -2229,6 +2233,8 @@ class PeriodicReconciler:
         # Per-position mutation locks to serialize reconciler + OrderTracker + exit
         self._position_mutation_locks: dict[str, threading.Lock] = {}
         self._locks_lock = threading.Lock()  # Protects _position_mutation_locks dict
+        # Cache for margin interest queries (5-min TTL per position)
+        self._interest_cache: dict[str, tuple[float, float]] = {}
 
     def start(self) -> None:
         """Start the periodic reconciliation daemon thread."""
@@ -2439,8 +2445,6 @@ class PeriodicReconciler:
             now = time.time()
             interest_tracker = MarginInterestTracker(self.exchange)
             interest_cache_ttl = 300  # seconds
-            if not hasattr(self, "_interest_cache"):
-                self._interest_cache: dict[str, tuple[float, float]] = {}
 
             for _key, position in list(positions_snapshot.items()):
                 try:
@@ -2469,7 +2473,7 @@ class PeriodicReconciler:
 
                     if interest_base > 0:
                         current_price = getattr(position, "current_price", None)
-                        if current_price and float(current_price) > 0:
+                        if current_price is not None and float(current_price) > 0:
                             interest_usdt = interest_base * float(current_price)
                             logger.info(
                                 "Margin interest accrued for %s: $%.4f (%.8f %s)",
@@ -2491,6 +2495,14 @@ class PeriodicReconciler:
                         getattr(position, "symbol", "?"),
                         e,
                     )
+
+            # Evict stale cache entries for positions no longer tracked
+            active_keys = {
+                f"{pos.symbol}_{k}" for k, pos in positions_snapshot.items()
+            }
+            stale = [k for k in self._interest_cache if k not in active_keys]
+            for k in stale:
+                del self._interest_cache[k]
         else:
             for order_key, position in list(positions_snapshot.items()):
                 # Skip short positions — shorts don't hold the base asset on spot

--- a/tests/unit/test_reconciliation_interest.py
+++ b/tests/unit/test_reconciliation_interest.py
@@ -257,7 +257,7 @@ class TestRealizePnlOnCloseInterestDeduction:
             assert new_balance == pytest.approx(1000.0 + 6.20)
 
             assert any(
-                "Deducted margin interest $3.80" in msg
+                "Margin interest $3.80" in msg
                 for msg in caplog.messages
             )
 


### PR DESCRIPTION
## Summary
- [P1] Complete `_trade_net_pnl` migration in `get_dynamic_risk_performance_metrics` — consecutive streak and Sharpe ratio were still using gross `trade.pnl`, producing inconsistent risk metrics that could mislead the dynamic risk manager
- [P1] Fix reconciliation PnL accounting model — `_realize_pnl_on_close` was mutating `pnl` to net (gross - interest), breaking the invariant that `trade.pnl` is always gross. Now keeps pnl gross and subtracts interest separately for the balance update
- [P2] Initialize `_interest_cache` in `__init__` (not lazy `hasattr`), add eviction of stale entries for closed positions
- [P2] Fix falsy-zero CODE.md violation: `if current_price and ...` → `if current_price is not None and ...`

Fixes found by `/deep-review --pr 589`.

## Test plan
- [x] All 36 margin interest tests pass
- [x] Full unit suite: 3402 passed, 0 failures
- [x] Verified balance assertion in `test_interest_deducted_from_short_pnl` still checks correct net value (1000 + 6.20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)