### PR TITLE
fix: restore bb_width and bb_position derived features (#522)

### DIFF
--- a/src/tech/features/schemas.py
+++ b/src/tech/features/schemas.py
@@ -220,6 +220,21 @@ TECHNICAL_FEATURES_SCHEMA = FeatureSchema(
             required=True,
             dependencies=["close"],
         ),
+        FeatureDefinition(
+            name="bb_width",
+            feature_type=FeatureType.DERIVED,
+            description="Bollinger Bands normalized bandwidth: (upper - lower) / middle",
+            min_value=0.0,
+            required=True,
+            dependencies=["bb_upper", "bb_lower", "bb_middle"],
+        ),
+        FeatureDefinition(
+            name="bb_position",
+            feature_type=FeatureType.DERIVED,
+            description="Price position within Bollinger Bands (0 = lower, 1 = upper)",
+            required=True,
+            dependencies=["close", "bb_upper", "bb_lower"],
+        ),
         # MACD
         FeatureDefinition(
             name="macd",

--- a/src/tech/features/technical.py
+++ b/src/tech/features/technical.py
@@ -249,6 +249,17 @@ class TechnicalFeatureExtractor(FeatureExtractor):
         # Calculate ATR as percentage of price - protected against zero close prices
         df["atr_pct"] = df["atr"] / (df["close"] + EPSILON)
 
+        # Bollinger Bands derived features
+        # bb_width: normalized bandwidth measures volatility expansion/contraction
+        df["bb_width"] = (df["bb_upper"] - df["bb_lower"]) / (df["bb_middle"] + EPSILON)
+        # bb_position: where price sits within the bands (0 = lower, 1 = upper)
+        bb_range = df["bb_upper"] - df["bb_lower"]
+        df["bb_position"] = np.where(
+            bb_range > EPSILON,
+            (df["close"] - df["bb_lower"]) / bb_range,
+            0.5,  # Neutral when bands have zero width (flat market)
+        )
+
         # Calculate trend measures (from MlAdaptive) - protected against zero MA values
         # ma_20 and ma_50 are guaranteed to exist (enforced in __init__)
         df["trend_strength"] = (df["close"] - df["ma_50"]) / (df["ma_50"] + EPSILON)
@@ -288,7 +299,15 @@ class TechnicalFeatureExtractor(FeatureExtractor):
 
     def get_derived_features(self) -> list[str]:
         """Get list of derived feature names."""
-        return ["returns", "volatility_20", "volatility_50", "trend_strength", "trend_direction"]
+        return [
+            "returns",
+            "volatility_20",
+            "volatility_50",
+            "bb_width",
+            "bb_position",
+            "trend_strength",
+            "trend_direction",
+        ]
 
     def validate_features(self, data: pd.DataFrame) -> dict[str, bool]:
         """

--- a/tests/unit/predictions/test_features.py
+++ b/tests/unit/predictions/test_features.py
@@ -146,6 +146,20 @@ class TestTechnicalFeatureExtractor:
         if len(volatility_data) > 0:
             assert (volatility_data >= 0).all()
 
+        # Test Bollinger Bands derived features
+        assert "bb_width" in result.columns
+        assert "bb_position" in result.columns
+        bb_width_data = result["bb_width"].dropna()
+        if len(bb_width_data) > 0:
+            # Bandwidth must be non-negative
+            assert (bb_width_data >= 0).all(), "bb_width has negative values"
+            # No infinite values
+            assert np.isfinite(bb_width_data).all(), "bb_width has infinite values"
+        bb_position_data = result["bb_position"].dropna()
+        if len(bb_position_data) > 0:
+            # No infinite values
+            assert np.isfinite(bb_position_data).all(), "bb_position has infinite values"
+
         # Test trend features
         assert "trend_strength" in result.columns
         assert "trend_direction" in result.columns
@@ -153,6 +167,32 @@ class TestTechnicalFeatureExtractor:
         if len(trend_direction_data) > 0:
             # trend_direction can be -1 (down), 0 (neutral/crossover), or 1 (up)
             assert set(trend_direction_data.unique()).issubset({-1, 0, 1})
+
+    def test_bb_derived_features_zero_width(self, extractor):
+        """Test bb_position handles zero-width bands (constant price)."""
+        dates = pd.date_range("2023-01-01", periods=300, freq="1h")
+        # Constant price produces zero-width Bollinger Bands
+        constant_price = 30000.0
+        data = pd.DataFrame(
+            {
+                "open": [constant_price] * 300,
+                "high": [constant_price] * 300,
+                "low": [constant_price] * 300,
+                "close": [constant_price] * 300,
+                "volume": [100.0] * 300,
+            },
+            index=dates,
+        )
+        result = extractor.extract(data)
+
+        bb_position_data = result["bb_position"].dropna()
+        # Zero-width bands should produce 0.5 (neutral), not NaN or inf
+        assert np.isfinite(bb_position_data).all(), "bb_position not finite for flat price"
+        # All values should be 0.5 when bands are flat
+        assert (bb_position_data == 0.5).all(), "bb_position should be 0.5 for flat bands"
+
+        bb_width_data = result["bb_width"].dropna()
+        assert np.isfinite(bb_width_data).all(), "bb_width not finite for flat price"
 
     def test_invalid_input_handling(self, extractor):
         """Test handling of invalid input data."""
@@ -394,6 +434,8 @@ class TestFeatureSchemas:
             "ma_200",
             "bb_upper",
             "bb_lower",
+            "bb_width",
+            "bb_position",
             "macd",
             "returns",
             "volatility_20",


### PR DESCRIPTION
## Summary
- Adds `bb_width` (normalized bandwidth) and `bb_position` (price position within bands) to the technical feature schema and extractor
- Handles zero-width band edge cases (returns 0.5 for bb_position)
- Adds tests for both features including edge cases

Closes #522

## Test plan
- [x] 47 feature tests pass
- [x] Zero-width band edge case produces safe defaults
- [x] Schema test updated to include new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)