### PR TITLE
fix: unify RSI to Wilder's smoothing everywhere (#520)

### DIFF
--- a/src/ml/training_pipeline/features.py
+++ b/src/ml/training_pipeline/features.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import MinMaxScaler
 
+from src.tech.indicators.core import calculate_rsi
+
 logger = logging.getLogger(__name__)
 
 # Sentiment quality assessment constants
@@ -22,9 +24,6 @@ QUALITY_THRESHOLD_MEDIUM = 0.4  # Threshold for hybrid sentiment recommendation
 SMA_WINDOWS = [7, 14, 30]  # Simple moving average window sizes (days)
 RSI_WINDOW = 14  # Relative Strength Index window size (days)
 RSI_MAX = 100  # Maximum RSI value for normalization
-
-# Division protection constants
-EPSILON_RSI_DIVISION = 1e-10  # Prevents division by zero in RSI calculation (avg_losses ~ 0)
 
 
 def normalize_timezone(ts1: pd.Timestamp, ts2: pd.Timestamp) -> tuple[pd.Timestamp, pd.Timestamp]:
@@ -151,12 +150,10 @@ def merge_price_sentiment_data(
 
 def _calculate_rsi_fast(close_prices: np.ndarray, window: int = 14) -> np.ndarray:
     """
-    Calculate RSI using optimized numpy operations with Wilder's smoothing.
+    Calculate RSI by delegating to the canonical Wilder's smoothing implementation.
 
-    TODO: Unify RSI implementations - this uses Wilder's smoothing (EMA-style) while
-    src/tech/indicators/core.py uses simple rolling mean. Different algorithms produce
-    different RSI values, risking train/inference mismatch. Consolidate to single
-    implementation with smoothing_method parameter.
+    Wraps ``calculate_rsi`` from ``src.tech.indicators.core`` so that training
+    and inference use the exact same algorithm, preventing train/inference mismatch.
 
     Args:
         close_prices: 1D array of close prices
@@ -168,40 +165,17 @@ def _calculate_rsi_fast(close_prices: np.ndarray, window: int = 14) -> np.ndarra
     Raises:
         ValueError: If window is not positive
     """
-    # Validate window parameter before using as divisor
     if window <= 0:
         raise ValueError(f"RSI window must be positive, got {window}")
 
-    # Calculate price changes
-    deltas = np.diff(close_prices, prepend=close_prices[0])
-
-    # Separate gains and losses
-    gains = np.where(deltas > 0, deltas, 0.0)
-    losses = np.where(deltas < 0, -deltas, 0.0)
-
     # Check if we have enough data for RSI calculation
     if len(close_prices) <= window:
-        # Return all NaNs if insufficient data
         return np.full(len(close_prices), np.nan, dtype=np.float32)
 
-    # Calculate rolling averages using numpy (faster than pandas for this)
-    avg_gains = np.full(len(gains), np.nan, dtype=np.float32)
-    avg_losses = np.full(len(losses), np.nan, dtype=np.float32)
-
-    # Calculate initial averages
-    avg_gains[window] = np.mean(gains[1 : window + 1])
-    avg_losses[window] = np.mean(losses[1 : window + 1])
-
-    # Calculate subsequent averages using EMA-style smoothing
-    for i in range(window + 1, len(gains)):
-        avg_gains[i] = (avg_gains[i - 1] * (window - 1) + gains[i]) / window
-        avg_losses[i] = (avg_losses[i - 1] * (window - 1) + losses[i]) / window
-
-    # Calculate RS and RSI (only for valid indices)
-    rs = avg_gains / (avg_losses + EPSILON_RSI_DIVISION)
-    rsi = 100.0 - (100.0 / (1.0 + rs))
-
-    return rsi.astype(np.float32)
+    # Delegate to canonical implementation (Wilder's smoothing)
+    series = pd.Series(close_prices)
+    rsi_series = calculate_rsi(series, period=window, smoothing_method="wilder")
+    return rsi_series.to_numpy(dtype=np.float32)
 
 
 def _add_price_features(

--- a/src/tech/indicators/core.py
+++ b/src/tech/indicators/core.py
@@ -137,27 +137,41 @@ def calculate_moving_averages(df: pd.DataFrame, periods: list[int]) -> pd.DataFr
     return df
 
 
-def calculate_rsi(data: pd.DataFrame | pd.Series, period: int = 14) -> pd.Series:
+def calculate_rsi(
+    data: pd.DataFrame | pd.Series,
+    period: int = 14,
+    smoothing_method: str = "wilder",
+) -> pd.Series:
     """
-    Calculate Relative Strength Index using simple rolling mean.
+    Calculate Relative Strength Index using Wilder's smoothing (industry standard).
 
-    TODO: Unify RSI implementations - this uses simple rolling mean while
-    src/ml/training_pipeline/features.py uses Wilder's smoothing (EMA-style).
-    Different algorithms produce different RSI values, risking train/inference mismatch.
-    Consolidate to single implementation with smoothing_method parameter.
+    Wilder's smoothing uses an EMA-style recursive formula where each new average
+    is weighted: ``(prev_avg * (period - 1) + current_value) / period``. This is
+    the canonical RSI algorithm used by TradingView, MetaTrader, and most charting
+    platforms. It is also used in the ML training pipeline, ensuring train/inference
+    parity.
 
     Args:
         data: DataFrame with 'close' column or Series of closing prices
         period: RSI period (must be positive, default: 14)
+        smoothing_method: Averaging method for gain/loss. "wilder" (default) uses
+            Wilder's smoothing (EMA-style). "sma" uses simple rolling mean.
 
     Returns:
         Series of RSI values ranging from 0 to 100
 
     Raises:
-        ValueError: If period is not positive or required columns are missing
+        ValueError: If period is not positive, required columns are missing,
+            or smoothing_method is invalid
     """
     if period <= 0:
         raise ValueError(f"RSI period must be positive, got {period}")
+
+    valid_methods = ("wilder", "sma")
+    if smoothing_method not in valid_methods:
+        raise ValueError(
+            f"smoothing_method must be one of {valid_methods}, got '{smoothing_method}'"
+        )
 
     if isinstance(data, pd.DataFrame):
         if "close" not in data.columns:
@@ -167,12 +181,36 @@ def calculate_rsi(data: pd.DataFrame | pd.Series, period: int = 14) -> pd.Series
         close = pd.Series(data)
 
     delta = close.diff()
-    gain = (delta.where(delta > 0, 0)).rolling(window=period).mean()
-    loss = (-delta.where(delta < 0, 0)).rolling(window=period).mean()
+    gains = delta.where(delta > 0, 0.0)
+    losses = -delta.where(delta < 0, 0.0)
+
+    if smoothing_method == "sma":
+        avg_gain = gains.rolling(window=period).mean()
+        avg_loss = losses.rolling(window=period).mean()
+    else:
+        # Wilder's smoothing: seed with SMA, then apply recursive EMA-style formula
+        avg_gain = pd.Series(np.nan, index=close.index, dtype=np.float64)
+        avg_loss = pd.Series(np.nan, index=close.index, dtype=np.float64)
+
+        # Seed values: simple mean of the first `period` deltas (index `period`
+        # because diff() produces NaN at index 0, so gains[1:period+1] has
+        # exactly `period` values).
+        if len(close) > period:
+            avg_gain.iloc[period] = gains.iloc[1 : period + 1].mean()
+            avg_loss.iloc[period] = losses.iloc[1 : period + 1].mean()
+
+            # Recursive Wilder's smoothing for remaining values
+            for i in range(period + 1, len(close)):
+                avg_gain.iloc[i] = (
+                    avg_gain.iloc[i - 1] * (period - 1) + gains.iloc[i]
+                ) / period
+                avg_loss.iloc[i] = (
+                    avg_loss.iloc[i - 1] * (period - 1) + losses.iloc[i]
+                ) / period
 
     # Prevent division by zero by adding epsilon to loss
     # When loss is 0, RS approaches infinity and RSI approaches 100
-    rs = gain / (loss + EPSILON)
+    rs = avg_gain / (avg_loss + EPSILON)
     rsi = 100 - (100 / (1 + rs))
     return rsi
 

--- a/tests/unit/indicators/test_indicators.py
+++ b/tests/unit/indicators/test_indicators.py
@@ -85,12 +85,18 @@ class TestMovingAverages:
 
 class TestRSI:
     def test_rsi_calculation(self):
-        data = pd.Series([44, 44.34, 44.09, 44.15, 43.61, 44.33, 44.23, 44.57, 44.15, 43.42])
+        # Use enough data points (> period + 1) so Wilder's smoothing produces values
+        data = pd.Series(
+            [44, 44.34, 44.09, 44.15, 43.61, 44.33, 44.23, 44.57, 44.15, 43.42, 44.8, 45.1]
+        )
         rsi = calculate_rsi(data, period=10)
-        assert rsi.min() >= 0
-        assert rsi.max() <= 100
+        valid_rsi = rsi.dropna()
+        assert len(valid_rsi) > 0
+        assert valid_rsi.min() >= 0
+        assert valid_rsi.max() <= 100
         assert len(rsi) == len(data)
-        assert rsi.iloc[:9].isna().all()
+        # Wilder's smoothing: first valid value is at index `period` (0-based)
+        assert rsi.iloc[:10].isna().all()
 
     def test_rsi_extreme_values(self):
         increasing_data = pd.Series([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
@@ -115,6 +121,49 @@ class TestRSI:
         # Test DataFrame missing close column
         with pytest.raises(ValueError, match="must contain 'close' column"):
             calculate_rsi(pd.DataFrame({"high": [1, 2, 3]}), period=5)
+
+        # Test invalid smoothing method
+        with pytest.raises(ValueError, match="smoothing_method must be one of"):
+            calculate_rsi(data, period=3, smoothing_method="invalid")
+
+    def test_rsi_wilder_vs_sma_differ(self):
+        """Wilder's smoothing and SMA produce different RSI values."""
+        np.random.seed(42)
+        prices = pd.Series(np.cumsum(np.random.randn(50)) + 100)
+        rsi_wilder = calculate_rsi(prices, period=14, smoothing_method="wilder")
+        rsi_sma = calculate_rsi(prices, period=14, smoothing_method="sma")
+        # Both should be valid RSI
+        valid_wilder = rsi_wilder.dropna()
+        valid_sma = rsi_sma.dropna()
+        assert len(valid_wilder) > 0
+        assert len(valid_sma) > 0
+        # They should differ (different algorithms)
+        common_idx = valid_wilder.index.intersection(valid_sma.index)
+        assert not np.allclose(
+            rsi_wilder.loc[common_idx].values, rsi_sma.loc[common_idx].values
+        )
+
+    def test_rsi_training_inference_parity(self):
+        """Verify calculate_rsi and _calculate_rsi_fast produce identical values."""
+        from src.ml.training_pipeline.features import _calculate_rsi_fast
+
+        np.random.seed(123)
+        prices = np.cumsum(np.random.randn(100)) + 500
+
+        # Inference path (pandas Series)
+        rsi_inference = calculate_rsi(pd.Series(prices), period=14)
+        # Training path (numpy array)
+        rsi_training = _calculate_rsi_fast(prices, window=14)
+
+        # Both should produce identical values where valid
+        valid_mask = ~np.isnan(rsi_training)
+        assert valid_mask.sum() > 0
+        np.testing.assert_allclose(
+            rsi_inference.values[valid_mask],
+            rsi_training[valid_mask],
+            rtol=1e-5,
+            err_msg="Training and inference RSI values diverge - algorithm mismatch",
+        )
 
 
 class TestATR:


### PR DESCRIPTION
## Summary
- Rewrites `calculate_rsi()` in `src/tech/indicators/core.py` to use Wilder's smoothing (industry standard) as default
- Makes training pipeline's `_calculate_rsi_fast()` delegate to the canonical implementation, eliminating the train/inference mismatch
- Adds `smoothing_method` parameter for backward compatibility

Closes #520

## Test plan
- [x] 67 indicator/feature tests pass
- [x] New test verifies training and inference RSI produce identical values
- [x] Wilder's vs SMA confirmed to produce different values (validating the fix matters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)