### PR TITLE
fix: harden weekly training workflow with credential preflight (#599)

### DIFF
--- a/.github/workflows/weekly-training.yml
+++ b/.github/workflows/weekly-training.yml
@@ -23,6 +23,7 @@ on:
 permissions:
   contents: read
   issues: write  # For creating issues on failure
+  actions: read  # For reading job status in failure-notification script
 
 env:
   AWS_REGION: us-east-1
@@ -64,6 +65,26 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
 
+    - name: Verify required secrets are present
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        SAGEMAKER_ROLE_ARN: ${{ secrets.SAGEMAKER_ROLE_ARN }}
+        SAGEMAKER_S3_BUCKET: ${{ secrets.SAGEMAKER_S3_BUCKET }}
+        SAGEMAKER_DOCKER_IMAGE: ${{ secrets.SAGEMAKER_DOCKER_IMAGE }}
+      run: |
+        missing=()
+        for var in AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY SAGEMAKER_ROLE_ARN SAGEMAKER_S3_BUCKET SAGEMAKER_DOCKER_IMAGE; do
+          if [ -z "${!var}" ]; then
+            missing+=("$var")
+          fi
+        done
+        if [ ${#missing[@]} -ne 0 ]; then
+          echo "::error title=Missing required secrets::The following GitHub Actions secrets are not set: ${missing[*]}. Configure them in repo Settings -> Secrets and variables -> Actions."
+          exit 1
+        fi
+        echo "All required secrets are present."
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -75,6 +96,20 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ env.AWS_REGION }}
+
+    - name: Verify AWS credentials (preflight)
+      id: aws_preflight
+      run: |
+        set +e
+        OUTPUT=$(aws sts get-caller-identity 2>&1)
+        STATUS=$?
+        set -e
+        if [ $STATUS -ne 0 ]; then
+          echo "::error title=AWS credential preflight failed::aws sts get-caller-identity failed. The AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY GitHub secrets are likely invalid, expired, or revoked. Rotate them in IAM and update the repo secrets. Raw error: ${OUTPUT}"
+          echo "aws_preflight_failed=true" >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+        echo "AWS identity: $OUTPUT"
 
     - name: Train model on SageMaker
       env:
@@ -112,28 +147,67 @@ jobs:
           const date = new Date().toISOString().split('T')[0];
           const runUrl = `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}`;
 
+          // Pull failed jobs to surface a likely root-cause category in the issue body.
+          let failedJobsSummary = '';
+          let suspectedCause = 'Unknown — inspect logs.';
+          try {
+            const jobs = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+            const failed = jobs.data.jobs.filter(j => j.conclusion === 'failure');
+            failedJobsSummary = failed.map(j => {
+              const failedStep = (j.steps || []).find(s => s.conclusion === 'failure');
+              return `- **${j.name}** — failed step: \`${failedStep ? failedStep.name : 'unknown'}\``;
+            }).join('\n') || '- (no failed jobs reported)';
+
+            const stepNames = failed.flatMap(j => (j.steps || []).filter(s => s.conclusion === 'failure').map(s => s.name.toLowerCase()));
+            if (stepNames.some(n => n.includes('verify aws credentials') || n.includes('configure aws credentials'))) {
+              suspectedCause = 'AWS credentials are invalid or expired. Rotate `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in repo Settings -> Secrets and variables -> Actions.';
+            } else if (stepNames.some(n => n.includes('verify required secrets'))) {
+              suspectedCause = 'One or more required GitHub Actions secrets are missing. See the failed step output for the exact list.';
+            } else if (stepNames.some(n => n.includes('train model on sagemaker'))) {
+              suspectedCause = 'SageMaker training job failed. Check SageMaker console for job status, IAM role permissions, S3 bucket access, and service quotas (e.g. `ml.g4dn.xlarge` spot capacity).';
+            } else if (stepNames.some(n => n.includes('install dependencies'))) {
+              suspectedCause = 'Dependency install failed. Likely a transient PyPI issue or a `pyproject.toml` regression. Re-run; if it persists, investigate.';
+            }
+          } catch (e) {
+            failedJobsSummary = `- (failed to enumerate jobs: ${e.message})`;
+          }
+
+          const body = [
+            '## Weekly Model Training Failed',
+            '',
+            'The automated weekly model training workflow has failed.',
+            '',
+            '**Run Details:**',
+            `- Date: ${date}`,
+            `- Workflow Run: ${runUrl}`,
+            `- Trigger: ${context.eventName === 'schedule' ? 'Scheduled (weekly)' : 'Manual'}`,
+            '',
+            '**Failed Jobs:**',
+            failedJobsSummary,
+            '',
+            '**Suspected Root Cause:**',
+            suspectedCause,
+            '',
+            '**Next Steps:**',
+            `1. Check the [workflow logs](${runUrl}) for full error details`,
+            '2. If credentials-related: rotate AWS access keys in IAM, then update `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` repo secrets',
+            '3. If SageMaker-related: check the SageMaker console, IAM role trust policy, S3 bucket, and service quotas',
+            '4. Re-run the workflow manually via the Actions tab once the underlying issue is fixed',
+            '',
+            '---',
+            '*This issue was created automatically by the weekly training workflow.*',
+          ].join('\n');
+
           await github.rest.issues.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
             title: `[Automated] Weekly model training failed - ${date}`,
-            body: `## Weekly Model Training Failed
-
-            The automated weekly model training workflow has failed.
-
-            **Run Details:**
-            - Date: ${date}
-            - Workflow Run: ${runUrl}
-            - Trigger: ${context.eventName === 'schedule' ? 'Scheduled (weekly)' : 'Manual'}
-
-            **Next Steps:**
-            1. Check the [workflow logs](${runUrl}) for error details
-            2. Verify AWS credentials are valid
-            3. Check SageMaker quotas and limits
-            4. Re-run the workflow manually after fixing issues
-
-            ---
-            *This issue was created automatically by the weekly training workflow.*
-            `,
+            body,
             labels: ['automation', 'training', 'bug']
           });
 

--- a/.github/workflows/weekly-training.yml
+++ b/.github/workflows/weekly-training.yml
@@ -109,7 +109,7 @@ jobs:
           echo "aws_preflight_failed=true" >> "$GITHUB_OUTPUT"
           exit 1
         fi
-        echo "AWS identity: $OUTPUT"
+        echo "AWS credential preflight OK"
 
     - name: Train model on SageMaker
       env:

--- a/.github/workflows/weekly-training.yml
+++ b/.github/workflows/weekly-training.yml
@@ -104,12 +104,38 @@ jobs:
         OUTPUT=$(aws sts get-caller-identity 2>&1)
         STATUS=$?
         set -e
+        # Redact 12-digit AWS account IDs from any output before logging.
+        # Needed because STS errors on AccessDenied embed the caller ARN
+        # (which contains the account ID), and GitHub's secret-masking does
+        # not cover account IDs/ARNs. Word-boundary anchors prevent chewing
+        # off the leading 12 digits of longer numeric runs (e.g. 13-digit
+        # millisecond timestamps) and producing a confusing trailing digit.
+        redact_account() {
+          # Two passes so that adjacent 12-digit runs separated by a single
+          # non-digit (e.g. "123456789012 987654321098") still both redact:
+          # the first pass consumes the trailing boundary as \2, leaving the
+          # next run without a leading boundary — the second pass catches it.
+          printf '%s' "$1" \
+            | sed -E 's/(^|[^0-9])[0-9]{12}([^0-9]|$)/\1<account-id>\2/g' \
+            | sed -E 's/(^|[^0-9])[0-9]{12}([^0-9]|$)/\1<account-id>\2/g'
+        }
         if [ $STATUS -ne 0 ]; then
-          echo "::error title=AWS credential preflight failed::aws sts get-caller-identity failed. The AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY GitHub secrets are likely invalid, expired, or revoked. Rotate them in IAM and update the repo secrets. Raw error: ${OUTPUT}"
+          # Flatten newlines so the entire message stays attached to the
+          # ::error:: workflow annotation (annotations are line-delimited).
+          SANITIZED=$(redact_account "$OUTPUT" | tr '\r\n' '  ')
+          echo "::error title=AWS credential preflight failed::aws sts get-caller-identity failed. The AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY GitHub secrets are likely invalid, expired, or revoked. Rotate them in IAM and update the repo secrets. Sanitized error: ${SANITIZED}"
           echo "aws_preflight_failed=true" >> "$GITHUB_OUTPUT"
           exit 1
         fi
-        echo "AWS credential preflight OK"
+        # Log only the IAM principal short name (e.g. "user/sagemaker-ci"
+        # or "role/weekly-training"), not the full ARN or account ID.
+        # This lets operators catch wrong-account credentials (dev keys in
+        # prod repo) without leaking account metadata into public CI logs.
+        # `// ""` keeps jq rc=0 when OUTPUT is not valid JSON / lacks .Arn;
+        # `|| true` is belt-and-braces against any other jq failure so the
+        # step does not abort under GitHub's default `bash -eo pipefail`.
+        PRINCIPAL=$(printf '%s' "$OUTPUT" | jq -r '(.Arn // "") | split(":")[5] // ""' 2>/dev/null || true)
+        echo "AWS credential preflight OK (principal: ${PRINCIPAL:-unknown})"
 
     - name: Train model on SageMaker
       env:


### PR DESCRIPTION
## Summary

Fixes #599. The 2026-04-12 weekly model training run ([failed run](https://github.com/bumpy-croc/ai-trading-bot/actions/runs/24297258802)) errored at the `Configure AWS credentials` step with:

> ##[error]The security token included in the request is invalid.

### Root cause

The static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` GitHub Actions secrets used by `.github/workflows/weekly-training.yml` are invalid, expired, or revoked. AWS rejected the credentials with `InvalidClientTokenId` before any SageMaker call was made. **This is an external/operational issue: only a repo admin can rotate the IAM access keys and update the secrets** — it is not a code regression.

The previous workflow surfaced this only as a generic failure and the auto-filed issue offered no actionable signal, which is why #599 reads as a generic "training failed" with no root cause.

### Fix

Workflow-only hardening so the next failure of this kind is immediately diagnosable:

- **Preflight: required secrets present.** New step fails fast (before installing ~500MB of deps) with an explicit list of any missing secrets.
- **Preflight: AWS credentials valid.** Runs `aws sts get-caller-identity` immediately after `configure-aws-credentials` and emits a `::error` annotation that names the likely cause and remediation if it fails.
- **Smarter auto-issue.** The `notify-on-failure` job now enumerates failed jobs/steps via the Actions API and writes a categorised "Suspected Root Cause" section into the issue body (credentials / missing secret / SageMaker / deps).
- **Permissions.** Adds `actions: read` so the github-script step can call `listJobsForWorkflowRun`.

### What the user still needs to do

1. Rotate the IAM access keys behind `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in IAM.
2. Update both repo secrets under Settings -> Secrets and variables -> Actions.
3. Re-run the workflow manually from the Actions tab to confirm.

After this PR lands, any future credential expiry will fail the new preflight step with a clear message and the auto-issue will identify the cause directly.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/weekly-training.yml'))"` parses cleanly
- [ ] CI green on this PR
- [ ] Manual `workflow_dispatch` of weekly training after secret rotation (out of scope of this PR — requires repo admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)