### PR TITLE
perf: cache PerformanceTracker metrics (#468)

### DIFF
--- a/src/performance/tracker.py
+++ b/src/performance/tracker.py
@@ -41,9 +41,16 @@ MIN_VAR_BALANCE_POINTS = 30
 MIN_VAR_RETURNS = 20
 
 
-@dataclass
+@dataclass(frozen=True)
 class PerformanceMetrics:
     """Comprehensive performance metrics container.
+
+    Immutable: instances are returned by reference from
+    ``PerformanceTracker.get_metrics()`` and may be shared across callers via
+    the metrics cache. Mutation would corrupt the cached snapshot seen by
+    every subsequent reader; frozen=True enforces this contract at the type
+    system level.
+
 
     Attributes:
         # Trade statistics
@@ -261,6 +268,11 @@ class PerformanceTracker:
         exit_time = self._normalize_timestamp(exit_time_raw) if exit_time_raw is not None else None
 
         with self._lock:
+            # Invalidate cache up-front: if any statement below raises after
+            # partial state mutation, a clean cache over dirty state would
+            # silently serve stale metrics for the rest of the process.
+            self._metrics_dirty = True
+
             # Update trade counts (explicitly handle zero-PnL case)
             if pnl > 0:
                 self._winning_trades += 1
@@ -322,9 +334,6 @@ class PerformanceTracker:
             if len(self._trades) > self._max_trade_history:
                 self._trades = self._trades[-self._max_trade_history :]
 
-            # Invalidate metrics cache after state mutation
-            self._metrics_dirty = True
-
     def update_balance(
         self,
         balance: float,
@@ -345,6 +354,9 @@ class PerformanceTracker:
             raise ValueError(f"balance must be non-negative, got {balance}")
 
         with self._lock:
+            # Invalidate cache up-front; see ``record_trade`` for rationale.
+            self._metrics_dirty = True
+
             self.current_balance = balance
 
             # Update peak balance
@@ -364,9 +376,6 @@ class PerformanceTracker:
             # Limit memory usage (same cap as trade history)
             if len(self._balance_history) > self._max_trade_history:
                 self._balance_history = self._balance_history[-self._max_trade_history :]
-
-            # Invalidate metrics cache after state mutation
-            self._metrics_dirty = True
 
     def get_metrics(self) -> PerformanceMetrics:
         """Get current performance metrics.
@@ -612,6 +621,14 @@ class PerformanceTracker:
                 if not math.isfinite(initial_balance):
                     raise ValueError(f"initial_balance must be finite, got {initial_balance}")
                 self.initial_balance = initial_balance
+
+            # Invalidate cache up-front; see ``record_trade`` for rationale.
+            # Both fields are cleared here (rather than only the dirty flag)
+            # because reset represents a full state discontinuity — release
+            # the stale reference for GC as well.
+            self._cached_metrics = None
+            self._metrics_dirty = True
+
             self.current_balance = self.initial_balance
             self.peak_balance = self.initial_balance
             self.max_drawdown = 0.0
@@ -631,10 +648,6 @@ class PerformanceTracker:
             self._max_win_streak = 0
             self._max_loss_streak = 0
             self._balance_history = [(datetime.now(UTC), self.initial_balance)]
-
-            # Invalidate metrics cache after state mutation
-            self._cached_metrics = None
-            self._metrics_dirty = True
 
 
 __all__ = [

--- a/src/performance/tracker.py
+++ b/src/performance/tracker.py
@@ -216,6 +216,11 @@ class PerformanceTracker:
         # Thread safety lock for mutable state (reentrant to allow nested calls)
         self._lock = threading.RLock()
 
+        # Metrics cache: avoid recomputing get_metrics() on every call in
+        # high-frequency live trading. Invalidated by any state-mutating method.
+        self._cached_metrics: PerformanceMetrics | None = None
+        self._metrics_dirty = True
+
     def record_trade(
         self,
         trade: TradeProtocol,
@@ -317,6 +322,9 @@ class PerformanceTracker:
             if len(self._trades) > self._max_trade_history:
                 self._trades = self._trades[-self._max_trade_history :]
 
+            # Invalidate metrics cache after state mutation
+            self._metrics_dirty = True
+
     def update_balance(
         self,
         balance: float,
@@ -357,6 +365,9 @@ class PerformanceTracker:
             if len(self._balance_history) > self._max_trade_history:
                 self._balance_history = self._balance_history[-self._max_trade_history :]
 
+            # Invalidate metrics cache after state mutation
+            self._metrics_dirty = True
+
     def get_metrics(self) -> PerformanceMetrics:
         """Get current performance metrics.
 
@@ -367,6 +378,12 @@ class PerformanceTracker:
             PerformanceMetrics with calculated values.
         """
         with self._lock:
+            # Return cached metrics if no state has changed since last computation.
+            # Significantly reduces CPU usage in high-frequency live trading where
+            # get_metrics() is called repeatedly between state mutations.
+            if not self._metrics_dirty and self._cached_metrics is not None:
+                return self._cached_metrics
+
             # Include zero-PnL trades in total count for consistency
             total_trades = self._winning_trades + self._losing_trades + self._zero_pnl_trades
 
@@ -460,7 +477,7 @@ class PerformanceTracker:
                 if len(returns) >= MIN_VAR_RETURNS:
                     var_95 = perf_metrics.value_at_risk(returns, confidence=0.95)
 
-            return PerformanceMetrics(
+            metrics = PerformanceMetrics(
                 # Trade statistics
                 total_trades=total_trades,
                 winning_trades=self._winning_trades,
@@ -496,6 +513,11 @@ class PerformanceTracker:
                 current_balance=self.current_balance,
                 peak_balance=self.peak_balance,
             )
+
+            # Store in cache; cleared by any state-mutating method
+            self._cached_metrics = metrics
+            self._metrics_dirty = False
+            return metrics
 
     def get_trade_history(self) -> list[dict]:
         """Get list of recorded trades.
@@ -609,6 +631,10 @@ class PerformanceTracker:
             self._max_win_streak = 0
             self._max_loss_streak = 0
             self._balance_history = [(datetime.now(UTC), self.initial_balance)]
+
+            # Invalidate metrics cache after state mutation
+            self._cached_metrics = None
+            self._metrics_dirty = True
 
 
 __all__ = [

--- a/tests/unit/performance/test_tracker.py
+++ b/tests/unit/performance/test_tracker.py
@@ -704,3 +704,107 @@ class TestPerformanceTrackerEdgeCases:
         # Should have recorded all trades without errors
         metrics = tracker.get_metrics()
         assert metrics.total_trades == 250  # 50 trades * 5 threads
+
+
+def _make_trade(pnl: float, symbol: str = "BTCUSDT", side: str = "long") -> Mock:
+    """Build a mock trade matching TradeProtocol attributes."""
+    trade = Mock()
+    trade.pnl = pnl
+    trade.entry_time = datetime.now(UTC) - timedelta(hours=1)
+    trade.exit_time = datetime.now(UTC)
+    trade.symbol = symbol
+    trade.side = side
+    return trade
+
+
+class TestPerformanceTrackerMetricsCache:
+    """Tests for get_metrics() caching with dirty-flag invalidation."""
+
+    def test_cache_hit_returns_same_object(self):
+        """Repeated get_metrics() calls without state changes return the cached instance."""
+        tracker = PerformanceTracker(initial_balance=10000)
+        tracker.record_trade(_make_trade(50.0), fee=0.1)
+
+        first = tracker.get_metrics()
+        second = tracker.get_metrics()
+
+        # Same identity proves cache was used (not recomputed)
+        assert first is second
+
+    def test_cache_invalidated_after_record_trade(self):
+        """record_trade() invalidates the cache so the next read recomputes."""
+        tracker = PerformanceTracker(initial_balance=10000)
+        tracker.record_trade(_make_trade(50.0), fee=0.1)
+        cached = tracker.get_metrics()
+        assert cached.total_trades == 1
+
+        tracker.record_trade(_make_trade(25.0), fee=0.1)
+        refreshed = tracker.get_metrics()
+
+        assert refreshed is not cached
+        assert refreshed.total_trades == 2
+        assert refreshed.total_pnl == 75.0
+
+    def test_cache_invalidated_after_update_balance(self):
+        """update_balance() invalidates the cache."""
+        tracker = PerformanceTracker(initial_balance=10000)
+        cached = tracker.get_metrics()
+        assert cached.current_balance == 10000
+
+        tracker.update_balance(11000.0)
+        refreshed = tracker.get_metrics()
+
+        assert refreshed is not cached
+        assert refreshed.current_balance == 11000.0
+
+    def test_cache_invalidated_after_reset(self):
+        """reset() clears the cache."""
+        tracker = PerformanceTracker(initial_balance=10000)
+        tracker.record_trade(_make_trade(50.0), fee=0.1)
+        cached = tracker.get_metrics()
+        assert cached.total_trades == 1
+
+        tracker.reset()
+        refreshed = tracker.get_metrics()
+
+        assert refreshed is not cached
+        assert refreshed.total_trades == 0
+
+    def test_cache_thread_safety_concurrent_reads_writes(self):
+        """Concurrent record_trade and get_metrics do not corrupt state."""
+        import threading
+
+        tracker = PerformanceTracker(initial_balance=10000)
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def writer() -> None:
+            try:
+                for _ in range(100):
+                    tracker.record_trade(_make_trade(1.0), fee=0.0)
+                    tracker.update_balance(tracker.current_balance + 1.0)
+            except BaseException as exc:  # pragma: no cover - surfaced via assert
+                errors.append(exc)
+            finally:
+                stop.set()
+
+        def reader() -> None:
+            try:
+                while not stop.is_set():
+                    metrics = tracker.get_metrics()
+                    # Invariant: counts must be internally consistent
+                    assert metrics.total_trades >= metrics.winning_trades + metrics.losing_trades
+            except BaseException as exc:  # pragma: no cover - surfaced via assert
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer)]
+        threads.extend(threading.Thread(target=reader) for _ in range(3))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        final = tracker.get_metrics()
+        assert final.total_trades == 100
+        assert final.winning_trades == 100

--- a/tests/unit/performance/test_tracker.py
+++ b/tests/unit/performance/test_tracker.py
@@ -1,5 +1,6 @@
 """Unit tests for src.performance.tracker module."""
 
+import dataclasses
 from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
@@ -771,6 +772,38 @@ class TestPerformanceTrackerMetricsCache:
         assert refreshed is not cached
         assert refreshed.total_trades == 0
 
+    def test_cached_value_equals_fresh_recompute(self):
+        """Cache-hit values match what an uncached recompute would produce.
+
+        Guards against a future refactor that adds a field to the recompute
+        path but forgets the cache (or vice-versa): identity-only tests would
+        miss this, but a value-level comparison catches any drift.
+        """
+        tracker = PerformanceTracker(initial_balance=10000)
+        tracker.record_trade(_make_trade(50.0), fee=0.1)
+        tracker.record_trade(_make_trade(-20.0), fee=0.1)
+        tracker.update_balance(10030.0)
+
+        cached = tracker.get_metrics()
+
+        # Force a recompute without changing any observable state: flip the
+        # dirty flag directly. The next call takes the recompute branch.
+        tracker._metrics_dirty = True
+        recomputed = tracker.get_metrics()
+
+        # Value-level equality across every field proves the two paths agree.
+        assert cached is not recomputed
+        assert cached.to_dict() == recomputed.to_dict()
+
+    def test_cached_metrics_are_immutable(self):
+        """PerformanceMetrics is frozen so callers cannot corrupt the cache."""
+        tracker = PerformanceTracker(initial_balance=10000)
+        tracker.record_trade(_make_trade(50.0), fee=0.1)
+        metrics = tracker.get_metrics()
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            metrics.total_trades = 999  # type: ignore[misc]
+
     def test_cache_thread_safety_concurrent_reads_writes(self):
         """Concurrent record_trade and get_metrics do not corrupt state."""
         import threading
@@ -793,8 +826,18 @@ class TestPerformanceTrackerMetricsCache:
             try:
                 while not stop.is_set():
                     metrics = tracker.get_metrics()
-                    # Invariant: counts must be internally consistent
-                    assert metrics.total_trades >= metrics.winning_trades + metrics.losing_trades
+                    # Writer only produces winning trades (pnl=1.0) so zero-pnl
+                    # and losing counters must stay at zero. Any cache
+                    # staleness that let winning_trades advance while
+                    # total_trades lagged would fail this equality.
+                    assert metrics.total_trades == (
+                        metrics.winning_trades + metrics.losing_trades
+                    ), (
+                        "inconsistent cached snapshot: "
+                        f"total_trades={metrics.total_trades} "
+                        f"winning_trades={metrics.winning_trades} "
+                        f"losing_trades={metrics.losing_trades}"
+                    )
             except BaseException as exc:  # pragma: no cover - surfaced via assert
                 errors.append(exc)
 

--- a/tests/unit/performance/test_tracker.py
+++ b/tests/unit/performance/test_tracker.py
@@ -717,6 +717,7 @@ def _make_trade(pnl: float, symbol: str = "BTCUSDT", side: str = "long") -> Mock
     return trade
 
 
+@pytest.mark.fast
 class TestPerformanceTrackerMetricsCache:
     """Tests for get_metrics() caching with dirty-flag invalidation."""
 


### PR DESCRIPTION
## Summary

- Cache `PerformanceTracker.get_metrics()` output in `_cached_metrics` and only recompute when `_metrics_dirty` is set.
- Flip the dirty flag inside the existing `_lock` from every state-mutating method: `record_trade`, `update_balance`, and `reset`.
- API and behavior unchanged; identical `PerformanceMetrics` values are returned, just without redoing the pandas resample / iteration over the trade list when nothing has changed.

Closes #468.

## Tests added

`tests/unit/performance/test_tracker.py::TestPerformanceTrackerMetricsCache`:
- `test_cache_hit_returns_same_object` — repeated reads return the cached instance.
- `test_cache_invalidated_after_record_trade` — recording a trade forces recomputation.
- `test_cache_invalidated_after_update_balance` — balance updates force recomputation.
- `test_cache_invalidated_after_reset` — reset clears the cache.
- `test_cache_thread_safety_concurrent_reads_writes` — 1 writer + 3 readers (200 mutations) produce no errors and consistent final counts.

## Test plan

- [x] `pytest tests/unit/performance/test_tracker.py` (46 passed locally)
- [x] `ruff check src/performance/tracker.py`
- [x] `black src/performance/tracker.py tests/unit/performance/test_tracker.py`
- [ ] CI green on develop base