### PR TITLE
feat(experiments): close seven gaps surfaced by hyper-growth sweep

### DIFF
--- a/cli/commands/experiment.py
+++ b/cli/commands/experiment.py
@@ -165,6 +165,67 @@ def _handle_show(ns: argparse.Namespace) -> int:
         return 1
 
 
+def _handle_diagnose(ns: argparse.Namespace) -> int:
+    try:
+        from src.experiments.diagnostics import SignalDiagnostic
+
+        start = datetime.fromisoformat(ns.start.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(ns.end.replace("Z", "+00:00"))
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=UTC)
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=UTC)
+
+        factory_kwargs: dict[str, object] = {}
+        for kv in ns.factory_kwarg or []:
+            if "=" not in kv:
+                raise ValueError(f"--factory-kwarg must be KEY=VALUE, got {kv!r}")
+            key, raw = kv.split("=", 1)
+            factory_kwargs[key.strip()] = _coerce_cli_scalar(raw)
+
+        diag = SignalDiagnostic()
+        report = diag.run(
+            strategy_name=ns.strategy,
+            symbol=ns.symbol,
+            timeframe=ns.timeframe,
+            start=start,
+            end=end,
+            provider=ns.provider,
+            use_cache=not ns.no_cache,
+            random_seed=ns.random_seed,
+            factory_kwargs=factory_kwargs or None,
+        )
+        if ns.format == "json":
+            print(json.dumps(report.to_dict(), indent=2))
+        else:
+            print(report.render_text())
+        return 0 if report.constant_signal_warning is None else 2
+    except Exception as exc:
+        if getattr(ns, "debug", False):
+            raise
+        logging.exception("Experiment diagnose failed")
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+def _coerce_cli_scalar(raw: str) -> object:
+    """Best-effort coercion of CLI string values to int/float/bool/None/str."""
+    stripped = raw.strip()
+    if stripped.lower() in {"true", "false"}:
+        return stripped.lower() == "true"
+    if stripped.lower() in {"none", "null", ""}:
+        return None
+    try:
+        return int(stripped)
+    except ValueError:
+        pass
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+    return stripped
+
+
 def _handle_promote(ns: argparse.Namespace) -> int:
     try:
         from src.experiments.ledger import Ledger
@@ -237,3 +298,37 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         help="Promote even when the verdict is not PROMOTE.",
     )
     promote_p.set_defaults(func=_handle_promote)
+
+    diag_p = subs.add_parser(
+        "diagnose",
+        help=(
+            "Walk the strategy's signal generator bar-by-bar and report "
+            "decision mix, predicted-return distribution, confidence "
+            "distribution, and direction-conditional hit rate. Useful for "
+            "catching broken signals that nonetheless produce non-zero P&L."
+        ),
+    )
+    diag_p.add_argument("--strategy", required=True, help="Strategy name (e.g. ml_basic).")
+    diag_p.add_argument("--symbol", default="BTCUSDT")
+    diag_p.add_argument("--timeframe", default="1h")
+    diag_p.add_argument("--start", required=True, help="ISO-8601 start (e.g. 2024-01-01).")
+    diag_p.add_argument("--end", required=True, help="ISO-8601 end (e.g. 2024-12-31).")
+    diag_p.add_argument(
+        "--provider",
+        choices=["binance", "coinbase", "mock", "fixture"],
+        default="fixture",
+    )
+    diag_p.add_argument("--no-cache", action="store_true")
+    diag_p.add_argument("--random-seed", type=int, default=None)
+    diag_p.add_argument(
+        "--factory-kwarg",
+        action="append",
+        metavar="KEY=VALUE",
+        help=(
+            "Keyword argument to pass to the strategy factory at "
+            "construction time. Repeatable. Use for knobs like "
+            "model_type=basic or max_leverage=2.0."
+        ),
+    )
+    diag_p.add_argument("--format", choices=["text", "json"], default="text")
+    diag_p.set_defaults(func=_handle_diagnose)

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -1460,6 +1460,16 @@ class Backtester:
             "total_fees": perf_metrics.total_fees_paid,
             "total_slippage_cost": perf_metrics.total_slippage_cost,
             "execution_settings": self.execution_engine.get_execution_settings(),
+            # Per-trade P&L sequence (in the order trades closed). The
+            # experimentation reporter uses this to distinguish variants
+            # whose aggregate metrics tie the baseline but took different
+            # trade paths from variants whose dead-code overrides produced
+            # literally the same trade sequence. Only populated with trades
+            # whose ``pnl_percent`` was recorded (filters out positions
+            # still open at backtest end, which have None).
+            "trade_pnl_pcts": [
+                float(t.pnl_percent) for t in self.trades if t.pnl_percent is not None
+            ],
         }
 
         # Add regime switching results

--- a/src/experiments/diagnostics.py
+++ b/src/experiments/diagnostics.py
@@ -1,0 +1,399 @@
+"""Signal-quality diagnostic — measure the raw predictive signal of a strategy.
+
+The ExperimentRunner ranks variants by backtest P&L. That is the right metric
+for picking a winner, but it has a critical blind spot: a degenerate signal
+(e.g. constant SELL because the model was fed the wrong feature tensor) can
+still produce non-zero P&L from stop-loss and trailing-stop mechanics, and
+every variant on top of that signal looks bitwise-identical in the reporter.
+See ``.claude/reports/hyper_growth_experiment_sweep_2026-04-17.md`` for the
+incident that motivated this tool.
+
+The diagnostic walks the strategy's ``SignalGenerator`` bar-by-bar over a
+range of history and reports four distributions that, together, tell you
+whether the model has any directional edge at all:
+
+* **Decision mix** — counts of BUY / SELL / HOLD. If it's 100% any-one-side
+  or 100% HOLD the signal is dead regardless of how good the P&L looks.
+* **Predicted return** — ``(prediction - current_price) / current_price``
+  from the generator's metadata. A healthy model has a real distribution;
+  a broken pipeline returns constants like ``-1.0`` (prediction = 0.0).
+* **Confidence** — the generator's per-bar confidence score. A useful
+  signal varies between high- and low-conviction bars.
+* **Direction-conditional hit rate** — ``P(forward return > 0 | BUY)`` and
+  ``P(forward return < 0 | SELL)`` at 1h / 4h / 12h / 24h horizons. These
+  are the quantities any confidence-weighted sizer is trying to exploit.
+
+Run via ``atb experiment diagnose --strategy <name> ...`` or programmatically
+through :class:`SignalDiagnostic`. The module has no dependencies beyond the
+framework that `src/experiments/runner.py` already pulls in.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from src.experiments.runner import ExperimentRunner
+from src.experiments.schemas import ExperimentConfig
+from src.strategies.components.signal_generator import Signal, SignalDirection
+
+# Horizons (in bars) at which to compute direction-conditional hit rate.
+# 1h/4h/12h/24h matches the horizons a typical ML signal generator is
+# trained to predict, and matches the horizons the incident report used.
+DEFAULT_HORIZONS: tuple[int, ...] = (1, 4, 12, 24)
+
+
+@dataclass
+class DistributionStats:
+    """Summary statistics for a numeric series."""
+
+    n: int
+    mean: float
+    std: float
+    min: float
+    max: float
+    positive_fraction: float
+
+    @classmethod
+    def from_series(cls, values: list[float]) -> DistributionStats:
+        if not values:
+            return cls(n=0, mean=0.0, std=0.0, min=0.0, max=0.0, positive_fraction=0.0)
+        n = len(values)
+        mean = sum(values) / n
+        # Guard n=1 (std is 0 by definition). Use sample std for n≥2.
+        if n == 1:
+            std = 0.0
+        else:
+            var = sum((v - mean) ** 2 for v in values) / (n - 1)
+            std = math.sqrt(var)
+        pos = sum(1 for v in values if v > 0) / n
+        return cls(
+            n=n,
+            mean=float(mean),
+            std=float(std),
+            min=float(min(values)),
+            max=float(max(values)),
+            positive_fraction=float(pos),
+        )
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "n": self.n,
+            "mean": self.mean,
+            "std": self.std,
+            "min": self.min,
+            "max": self.max,
+            "positive_fraction": self.positive_fraction,
+        }
+
+
+@dataclass
+class HitRate:
+    """Direction-conditional accuracy at a specific forward horizon."""
+
+    horizon: int
+    buy_samples: int
+    buy_accuracy: float
+    sell_samples: int
+    sell_accuracy: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "horizon": self.horizon,
+            "buy_samples": self.buy_samples,
+            "buy_accuracy": self.buy_accuracy,
+            "sell_samples": self.sell_samples,
+            "sell_accuracy": self.sell_accuracy,
+        }
+
+
+@dataclass
+class DiagnosticReport:
+    """Full signal-quality report for a single strategy run."""
+
+    strategy_name: str
+    symbol: str
+    timeframe: str
+    bars_evaluated: int
+    buy_count: int
+    sell_count: int
+    hold_count: int
+    predicted_return: DistributionStats
+    confidence: DistributionStats
+    hit_rates: list[HitRate] = field(default_factory=list)
+    # Set when predicted_return is literally constant (n>0 and std≈0) —
+    # the single strongest signal that the feature pipeline feeds the
+    # model a shape it can't consume and the model is returning a
+    # fallback-path sentinel value.
+    constant_signal_warning: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "strategy": self.strategy_name,
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "bars_evaluated": self.bars_evaluated,
+            "decisions": {
+                "buy": self.buy_count,
+                "sell": self.sell_count,
+                "hold": self.hold_count,
+            },
+            "predicted_return": self.predicted_return.to_dict(),
+            "confidence": self.confidence.to_dict(),
+            "hit_rates": [hr.to_dict() for hr in self.hit_rates],
+            "constant_signal_warning": self.constant_signal_warning,
+        }
+
+    def render_text(self) -> str:
+        lines = [
+            f"Signal-quality diagnostic: {self.strategy_name} " f"{self.symbol} {self.timeframe}",
+            f"  bars evaluated: {self.bars_evaluated}",
+            "",
+            "Decision mix",
+            f"  BUY : {self.buy_count:>6}  ({_pct(self.buy_count, self.bars_evaluated)}%)",
+            f"  SELL: {self.sell_count:>6}  ({_pct(self.sell_count, self.bars_evaluated)}%)",
+            f"  HOLD: {self.hold_count:>6}  ({_pct(self.hold_count, self.bars_evaluated)}%)",
+            "",
+            "Predicted return",
+            f"  n={self.predicted_return.n}  "
+            f"mean={self.predicted_return.mean:+.6f}  "
+            f"std={self.predicted_return.std:.6f}  "
+            f"min={self.predicted_return.min:+.6f}  "
+            f"max={self.predicted_return.max:+.6f}  "
+            f"pos_frac={self.predicted_return.positive_fraction:.2%}",
+            "",
+            "Confidence",
+            f"  n={self.confidence.n}  "
+            f"mean={self.confidence.mean:.4f}  "
+            f"std={self.confidence.std:.4f}",
+            "",
+            "Direction-conditional hit rate",
+        ]
+        for hr in self.hit_rates:
+            lines.append(
+                f"  h={hr.horizon:>3}: "
+                f"BUY  acc={hr.buy_accuracy * 100:5.2f}%  n={hr.buy_samples:>5}  "
+                f"SELL acc={hr.sell_accuracy * 100:5.2f}%  n={hr.sell_samples:>5}"
+            )
+        if self.constant_signal_warning:
+            lines.append("")
+            lines.append(f"WARNING: {self.constant_signal_warning}")
+        return "\n".join(lines)
+
+
+def _pct(n: int, total: int) -> str:
+    if total <= 0:
+        return "  —  "
+    return f"{100.0 * n / total:5.2f}"
+
+
+class SignalDiagnostic:
+    """Walk a strategy's signal generator bar-by-bar and report on it.
+
+    Does NOT run a full backtest — the risk manager, position sizer, and
+    trade execution are bypassed. This is deliberately signal-only so the
+    report answers "is there a real predictive signal here?" without
+    confusing that question with "is the risk/sizing/exit logic lucky?".
+
+    The instance reuses :class:`ExperimentRunner` for strategy loading and
+    data-provider wiring so factory kwargs, providers, and symbols are
+    configured identically to a backtest suite.
+    """
+
+    def __init__(self, runner: ExperimentRunner | None = None):
+        self.runner = runner or ExperimentRunner()
+
+    def run(
+        self,
+        strategy_name: str,
+        *,
+        symbol: str,
+        timeframe: str,
+        start: datetime,
+        end: datetime,
+        provider: str = "binance",
+        use_cache: bool = True,
+        random_seed: int | None = None,
+        horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+        factory_kwargs: dict[str, Any] | None = None,
+    ) -> DiagnosticReport:
+        """Evaluate the strategy's signal generator over [start, end]."""
+        cfg = ExperimentConfig(
+            strategy_name=strategy_name,
+            symbol=symbol,
+            timeframe=timeframe,
+            start=start,
+            end=end,
+            initial_balance=1000.0,
+            provider=provider,
+            use_cache=use_cache,
+            random_seed=random_seed,
+            factory_kwargs=dict(factory_kwargs or {}),
+        )
+
+        strategy = self.runner._load_strategy(
+            cfg.strategy_name,
+            factory_kwargs=cfg.factory_kwargs or None,
+        )
+        signal_generator = getattr(strategy, "signal_generator", None)
+        if signal_generator is None:
+            raise ValueError(
+                f"Strategy {strategy_name!r} has no signal_generator; diagnostic unavailable."
+            )
+
+        provider_obj = self.runner._load_provider(
+            cfg.provider,
+            cfg.use_cache,
+            start=cfg.start,
+            end=cfg.end,
+            timeframe=cfg.timeframe,
+            seed=cfg.random_seed,
+        )
+        df = provider_obj.get_historical_data(
+            symbol=cfg.symbol,
+            timeframe=cfg.timeframe,
+            start=cfg.start,
+            end=cfg.end,
+        )
+
+        return self._walk_bars(
+            df,
+            signal_generator=signal_generator,
+            strategy_name=strategy_name,
+            symbol=symbol,
+            timeframe=timeframe,
+            horizons=horizons,
+        )
+
+    def _walk_bars(
+        self,
+        df: Any,
+        *,
+        signal_generator: Any,
+        strategy_name: str,
+        symbol: str,
+        timeframe: str,
+        horizons: tuple[int, ...],
+    ) -> DiagnosticReport:
+        if df is None or len(df) == 0:
+            raise ValueError(
+                f"No historical data returned for diagnostic of {strategy_name!r} "
+                f"on {symbol} {timeframe}; cannot walk bars."
+            )
+
+        seq_len = int(getattr(signal_generator, "sequence_length", 1) or 1)
+        start_idx = max(seq_len, 1)
+        # Allocate per-direction forward-return lists used by hit-rate math.
+        buy_forward: dict[int, list[float]] = {h: [] for h in horizons}
+        sell_forward: dict[int, list[float]] = {h: [] for h in horizons}
+
+        predicted_returns: list[float] = []
+        confidences: list[float] = []
+        buy_count = sell_count = hold_count = 0
+
+        # ``close`` column is the reference price for forward-return math.
+        closes = df["close"].to_numpy() if hasattr(df, "to_numpy") else None
+        if closes is None:
+            # FixtureProvider / live providers return DataFrames; bail with
+            # a clear message rather than crashing deep in the walk.
+            raise ValueError(
+                "Diagnostic requires a DataFrame with a 'close' column; "
+                f"got {type(df).__name__}."
+            )
+
+        n_bars = len(df)
+        for i in range(start_idx, n_bars):
+            try:
+                sig: Signal = signal_generator.generate_signal(df, i)
+            except Exception as exc:  # pragma: no cover — defensive
+                raise RuntimeError(
+                    f"Signal generator raised at bar {i} of {n_bars}: {exc}"
+                ) from exc
+
+            meta = sig.metadata if isinstance(sig.metadata, dict) else {}
+            pr = meta.get("predicted_return")
+            if isinstance(pr, int | float) and not isinstance(pr, bool) and math.isfinite(pr):
+                predicted_returns.append(float(pr))
+            conf = float(sig.confidence)
+            if math.isfinite(conf):
+                confidences.append(conf)
+
+            current_price = float(closes[i])
+            if sig.direction == SignalDirection.BUY:
+                buy_count += 1
+                for h in horizons:
+                    j = i + h
+                    if j < n_bars and current_price > 0:
+                        buy_forward[h].append((float(closes[j]) - current_price) / current_price)
+            elif sig.direction == SignalDirection.SELL:
+                sell_count += 1
+                for h in horizons:
+                    j = i + h
+                    if j < n_bars and current_price > 0:
+                        sell_forward[h].append((float(closes[j]) - current_price) / current_price)
+            else:
+                hold_count += 1
+
+        pr_stats = DistributionStats.from_series(predicted_returns)
+        conf_stats = DistributionStats.from_series(confidences)
+
+        hit_rates: list[HitRate] = []
+        for h in horizons:
+            b = buy_forward[h]
+            s = sell_forward[h]
+            hit_rates.append(
+                HitRate(
+                    horizon=h,
+                    buy_samples=len(b),
+                    buy_accuracy=(sum(1 for x in b if x > 0) / len(b)) if b else 0.0,
+                    sell_samples=len(s),
+                    # SELL "hits" when forward return is NEGATIVE (price drops
+                    # after a sell signal), so count x < 0.
+                    sell_accuracy=(sum(1 for x in s if x < 0) / len(s)) if s else 0.0,
+                )
+            )
+
+        warning: str | None = None
+        bars_evaluated = buy_count + sell_count + hold_count
+        # A truly constant predicted_return (std ~0 across many bars) is
+        # the fingerprint of a broken feature pipeline. Only warn when we
+        # actually sampled enough bars to say something meaningful.
+        if pr_stats.n >= 50 and pr_stats.std < 1e-9:
+            warning = (
+                f"predicted_return is effectively constant (n={pr_stats.n}, "
+                f"std={pr_stats.std:.2e}, value≈{pr_stats.mean:+.6f}). This is "
+                "the fingerprint of a feature-pipeline/model-shape mismatch — "
+                "the model is likely returning its fallback value on every "
+                "bar. Inspect the signal generator's feature pipeline."
+            )
+        elif pr_stats.n == 0 and bars_evaluated > 0:
+            warning = (
+                f"signal generator emitted {bars_evaluated} decisions but no "
+                "'predicted_return' metadata. The generator may not be an "
+                "ML-prediction generator, or its metadata schema changed."
+            )
+
+        return DiagnosticReport(
+            strategy_name=strategy_name,
+            symbol=symbol,
+            timeframe=timeframe,
+            bars_evaluated=bars_evaluated,
+            buy_count=buy_count,
+            sell_count=sell_count,
+            hold_count=hold_count,
+            predicted_return=pr_stats,
+            confidence=conf_stats,
+            hit_rates=hit_rates,
+            constant_signal_warning=warning,
+        )
+
+
+__all__ = [
+    "DEFAULT_HORIZONS",
+    "DiagnosticReport",
+    "DistributionStats",
+    "HitRate",
+    "SignalDiagnostic",
+]

--- a/src/experiments/diagnostics/__init__.py
+++ b/src/experiments/diagnostics/__init__.py
@@ -1,0 +1,45 @@
+"""Signal-quality diagnostic — measure the raw predictive signal of a strategy.
+
+The ExperimentRunner ranks variants by backtest P&L. That is the right metric
+for picking a winner, but it has a critical blind spot: a degenerate signal
+(e.g. constant SELL because the model was fed the wrong feature tensor) can
+still produce non-zero P&L from stop-loss and trailing-stop mechanics, and
+every variant on top of that signal looks bitwise-identical in the reporter.
+See ``.claude/reports/hyper_growth_experiment_sweep_2026-04-17.md`` for the
+incident that motivated this tool.
+
+The diagnostic walks the strategy's ``SignalGenerator`` bar-by-bar over a
+range of history and reports four distributions that, together, tell you
+whether the model has any directional edge at all:
+
+* **Decision mix** — counts of BUY / SELL / HOLD. If it's 100% any-one-side
+  or 100% HOLD the signal is dead regardless of how good the P&L looks.
+* **Predicted return** — ``(prediction - current_price) / current_price``
+  from the generator's metadata. A healthy model has a real distribution;
+  a broken pipeline returns constants like ``-1.0`` (prediction = 0.0).
+* **Confidence** — the generator's per-bar confidence score. A useful
+  signal varies between high- and low-conviction bars.
+* **Direction-conditional hit rate** — ``P(forward return > 0 | BUY)`` and
+  ``P(forward return < 0 | SELL)`` at 1h / 4h / 12h / 24h horizons. These
+  are the quantities any confidence-weighted sizer is trying to exploit.
+
+Run via ``atb experiment diagnose --strategy <name> ...`` or programmatically
+through :class:`SignalDiagnostic`. This package is split across one file per
+class per CODE.md; re-exports below preserve the historical flat import path
+``from src.experiments.diagnostics import SignalDiagnostic, ...``.
+"""
+
+from __future__ import annotations
+
+from src.experiments.diagnostics.hit_rate import HitRate
+from src.experiments.diagnostics.report import DiagnosticReport
+from src.experiments.diagnostics.runner import DEFAULT_HORIZONS, SignalDiagnostic
+from src.experiments.diagnostics.stats import DistributionStats
+
+__all__ = [
+    "DEFAULT_HORIZONS",
+    "DiagnosticReport",
+    "DistributionStats",
+    "HitRate",
+    "SignalDiagnostic",
+]

--- a/src/experiments/diagnostics/hit_rate.py
+++ b/src/experiments/diagnostics/hit_rate.py
@@ -1,0 +1,35 @@
+"""Direction-conditional accuracy record for a single forward horizon."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class HitRate:
+    """Direction-conditional accuracy at a specific forward horizon.
+
+    ``buy_accuracy`` is ``P(forward_return > 0 | BUY)`` over ``buy_samples``
+    bars; ``sell_accuracy`` is ``P(forward_return < 0 | SELL)``. Both are
+    floats in [0, 1]; both are zero when their sample count is zero.
+    """
+
+    horizon: int
+    buy_samples: int
+    buy_accuracy: float
+    sell_samples: int
+    sell_accuracy: float
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain-dict serialization suitable for JSON output."""
+        return {
+            "horizon": self.horizon,
+            "buy_samples": self.buy_samples,
+            "buy_accuracy": self.buy_accuracy,
+            "sell_samples": self.sell_samples,
+            "sell_accuracy": self.sell_accuracy,
+        }
+
+
+__all__ = ["HitRate"]

--- a/src/experiments/diagnostics/report.py
+++ b/src/experiments/diagnostics/report.py
@@ -1,0 +1,104 @@
+"""Full signal-quality report aggregating stats + hit-rates for a single run."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.experiments.diagnostics.hit_rate import HitRate
+from src.experiments.diagnostics.stats import DistributionStats
+
+
+@dataclass
+class DiagnosticReport:
+    """Full signal-quality report for a single strategy run.
+
+    Produced by :meth:`SignalDiagnostic.run`. The ``constant_signal_warning``
+    field is populated when ``predicted_return`` is effectively constant
+    across the sampled window (n>=50, std<1e-9) — the fingerprint of a
+    feature-pipeline / model-shape mismatch that returns a sentinel value
+    on every bar. Explicitly separated from the decision-mix counts so the
+    incident can surface in JSON/text output without the caller having to
+    infer it.
+    """
+
+    strategy_name: str
+    symbol: str
+    timeframe: str
+    bars_evaluated: int
+    buy_count: int
+    sell_count: int
+    hold_count: int
+    predicted_return: DistributionStats
+    confidence: DistributionStats
+    hit_rates: list[HitRate] = field(default_factory=list)
+    # Set when predicted_return is literally constant (n>0 and std≈0) —
+    # the single strongest signal that the feature pipeline feeds the
+    # model a shape it can't consume and the model is returning a
+    # fallback-path sentinel value.
+    constant_signal_warning: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain-dict serialization suitable for JSON output."""
+        return {
+            "strategy": self.strategy_name,
+            "symbol": self.symbol,
+            "timeframe": self.timeframe,
+            "bars_evaluated": self.bars_evaluated,
+            "decisions": {
+                "buy": self.buy_count,
+                "sell": self.sell_count,
+                "hold": self.hold_count,
+            },
+            "predicted_return": self.predicted_return.to_dict(),
+            "confidence": self.confidence.to_dict(),
+            "hit_rates": [hr.to_dict() for hr in self.hit_rates],
+            "constant_signal_warning": self.constant_signal_warning,
+        }
+
+    def render_text(self) -> str:
+        """Return a human-readable text rendering of the report."""
+        lines = [
+            f"Signal-quality diagnostic: {self.strategy_name} " f"{self.symbol} {self.timeframe}",
+            f"  bars evaluated: {self.bars_evaluated}",
+            "",
+            "Decision mix",
+            f"  BUY : {self.buy_count:>6}  ({_pct(self.buy_count, self.bars_evaluated)}%)",
+            f"  SELL: {self.sell_count:>6}  ({_pct(self.sell_count, self.bars_evaluated)}%)",
+            f"  HOLD: {self.hold_count:>6}  ({_pct(self.hold_count, self.bars_evaluated)}%)",
+            "",
+            "Predicted return",
+            f"  n={self.predicted_return.n}  "
+            f"mean={self.predicted_return.mean:+.6f}  "
+            f"std={self.predicted_return.std:.6f}  "
+            f"min={self.predicted_return.min:+.6f}  "
+            f"max={self.predicted_return.max:+.6f}  "
+            f"pos_frac={self.predicted_return.positive_fraction:.2%}",
+            "",
+            "Confidence",
+            f"  n={self.confidence.n}  "
+            f"mean={self.confidence.mean:.4f}  "
+            f"std={self.confidence.std:.4f}",
+            "",
+            "Direction-conditional hit rate",
+        ]
+        for hr in self.hit_rates:
+            lines.append(
+                f"  h={hr.horizon:>3}: "
+                f"BUY  acc={hr.buy_accuracy * 100:5.2f}%  n={hr.buy_samples:>5}  "
+                f"SELL acc={hr.sell_accuracy * 100:5.2f}%  n={hr.sell_samples:>5}"
+            )
+        if self.constant_signal_warning:
+            lines.append("")
+            lines.append(f"WARNING: {self.constant_signal_warning}")
+        return "\n".join(lines)
+
+
+def _pct(n: int, total: int) -> str:
+    """Format ``n/total`` as a fixed-width percentage or '  —  ' when total is zero."""
+    if total <= 0:
+        return "  —  "
+    return f"{100.0 * n / total:5.2f}"
+
+
+__all__ = ["DiagnosticReport"]

--- a/src/experiments/diagnostics/runner.py
+++ b/src/experiments/diagnostics/runner.py
@@ -1,40 +1,14 @@
-"""Signal-quality diagnostic — measure the raw predictive signal of a strategy.
-
-The ExperimentRunner ranks variants by backtest P&L. That is the right metric
-for picking a winner, but it has a critical blind spot: a degenerate signal
-(e.g. constant SELL because the model was fed the wrong feature tensor) can
-still produce non-zero P&L from stop-loss and trailing-stop mechanics, and
-every variant on top of that signal looks bitwise-identical in the reporter.
-See ``.claude/reports/hyper_growth_experiment_sweep_2026-04-17.md`` for the
-incident that motivated this tool.
-
-The diagnostic walks the strategy's ``SignalGenerator`` bar-by-bar over a
-range of history and reports four distributions that, together, tell you
-whether the model has any directional edge at all:
-
-* **Decision mix** — counts of BUY / SELL / HOLD. If it's 100% any-one-side
-  or 100% HOLD the signal is dead regardless of how good the P&L looks.
-* **Predicted return** — ``(prediction - current_price) / current_price``
-  from the generator's metadata. A healthy model has a real distribution;
-  a broken pipeline returns constants like ``-1.0`` (prediction = 0.0).
-* **Confidence** — the generator's per-bar confidence score. A useful
-  signal varies between high- and low-conviction bars.
-* **Direction-conditional hit rate** — ``P(forward return > 0 | BUY)`` and
-  ``P(forward return < 0 | SELL)`` at 1h / 4h / 12h / 24h horizons. These
-  are the quantities any confidence-weighted sizer is trying to exploit.
-
-Run via ``atb experiment diagnose --strategy <name> ...`` or programmatically
-through :class:`SignalDiagnostic`. The module has no dependencies beyond the
-framework that `src/experiments/runner.py` already pulls in.
-"""
+"""SignalDiagnostic — walks a strategy's signal generator bar-by-bar."""
 
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from src.experiments.diagnostics.hit_rate import HitRate
+from src.experiments.diagnostics.report import DiagnosticReport
+from src.experiments.diagnostics.stats import DistributionStats
 from src.experiments.runner import ExperimentRunner
 from src.experiments.schemas import ExperimentConfig
 from src.strategies.components.signal_generator import Signal, SignalDirection
@@ -43,150 +17,6 @@ from src.strategies.components.signal_generator import Signal, SignalDirection
 # 1h/4h/12h/24h matches the horizons a typical ML signal generator is
 # trained to predict, and matches the horizons the incident report used.
 DEFAULT_HORIZONS: tuple[int, ...] = (1, 4, 12, 24)
-
-
-@dataclass
-class DistributionStats:
-    """Summary statistics for a numeric series."""
-
-    n: int
-    mean: float
-    std: float
-    min: float
-    max: float
-    positive_fraction: float
-
-    @classmethod
-    def from_series(cls, values: list[float]) -> DistributionStats:
-        if not values:
-            return cls(n=0, mean=0.0, std=0.0, min=0.0, max=0.0, positive_fraction=0.0)
-        n = len(values)
-        mean = sum(values) / n
-        # Guard n=1 (std is 0 by definition). Use sample std for n≥2.
-        if n == 1:
-            std = 0.0
-        else:
-            var = sum((v - mean) ** 2 for v in values) / (n - 1)
-            std = math.sqrt(var)
-        pos = sum(1 for v in values if v > 0) / n
-        return cls(
-            n=n,
-            mean=float(mean),
-            std=float(std),
-            min=float(min(values)),
-            max=float(max(values)),
-            positive_fraction=float(pos),
-        )
-
-    def to_dict(self) -> dict[str, float | int]:
-        return {
-            "n": self.n,
-            "mean": self.mean,
-            "std": self.std,
-            "min": self.min,
-            "max": self.max,
-            "positive_fraction": self.positive_fraction,
-        }
-
-
-@dataclass
-class HitRate:
-    """Direction-conditional accuracy at a specific forward horizon."""
-
-    horizon: int
-    buy_samples: int
-    buy_accuracy: float
-    sell_samples: int
-    sell_accuracy: float
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "horizon": self.horizon,
-            "buy_samples": self.buy_samples,
-            "buy_accuracy": self.buy_accuracy,
-            "sell_samples": self.sell_samples,
-            "sell_accuracy": self.sell_accuracy,
-        }
-
-
-@dataclass
-class DiagnosticReport:
-    """Full signal-quality report for a single strategy run."""
-
-    strategy_name: str
-    symbol: str
-    timeframe: str
-    bars_evaluated: int
-    buy_count: int
-    sell_count: int
-    hold_count: int
-    predicted_return: DistributionStats
-    confidence: DistributionStats
-    hit_rates: list[HitRate] = field(default_factory=list)
-    # Set when predicted_return is literally constant (n>0 and std≈0) —
-    # the single strongest signal that the feature pipeline feeds the
-    # model a shape it can't consume and the model is returning a
-    # fallback-path sentinel value.
-    constant_signal_warning: str | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "strategy": self.strategy_name,
-            "symbol": self.symbol,
-            "timeframe": self.timeframe,
-            "bars_evaluated": self.bars_evaluated,
-            "decisions": {
-                "buy": self.buy_count,
-                "sell": self.sell_count,
-                "hold": self.hold_count,
-            },
-            "predicted_return": self.predicted_return.to_dict(),
-            "confidence": self.confidence.to_dict(),
-            "hit_rates": [hr.to_dict() for hr in self.hit_rates],
-            "constant_signal_warning": self.constant_signal_warning,
-        }
-
-    def render_text(self) -> str:
-        lines = [
-            f"Signal-quality diagnostic: {self.strategy_name} " f"{self.symbol} {self.timeframe}",
-            f"  bars evaluated: {self.bars_evaluated}",
-            "",
-            "Decision mix",
-            f"  BUY : {self.buy_count:>6}  ({_pct(self.buy_count, self.bars_evaluated)}%)",
-            f"  SELL: {self.sell_count:>6}  ({_pct(self.sell_count, self.bars_evaluated)}%)",
-            f"  HOLD: {self.hold_count:>6}  ({_pct(self.hold_count, self.bars_evaluated)}%)",
-            "",
-            "Predicted return",
-            f"  n={self.predicted_return.n}  "
-            f"mean={self.predicted_return.mean:+.6f}  "
-            f"std={self.predicted_return.std:.6f}  "
-            f"min={self.predicted_return.min:+.6f}  "
-            f"max={self.predicted_return.max:+.6f}  "
-            f"pos_frac={self.predicted_return.positive_fraction:.2%}",
-            "",
-            "Confidence",
-            f"  n={self.confidence.n}  "
-            f"mean={self.confidence.mean:.4f}  "
-            f"std={self.confidence.std:.4f}",
-            "",
-            "Direction-conditional hit rate",
-        ]
-        for hr in self.hit_rates:
-            lines.append(
-                f"  h={hr.horizon:>3}: "
-                f"BUY  acc={hr.buy_accuracy * 100:5.2f}%  n={hr.buy_samples:>5}  "
-                f"SELL acc={hr.sell_accuracy * 100:5.2f}%  n={hr.sell_samples:>5}"
-            )
-        if self.constant_signal_warning:
-            lines.append("")
-            lines.append(f"WARNING: {self.constant_signal_warning}")
-        return "\n".join(lines)
-
-
-def _pct(n: int, total: int) -> str:
-    if total <= 0:
-        return "  —  "
-    return f"{100.0 * n / total:5.2f}"
 
 
 class SignalDiagnostic:
@@ -277,10 +107,20 @@ class SignalDiagnostic:
         timeframe: str,
         horizons: tuple[int, ...],
     ) -> DiagnosticReport:
+        """Iterate over ``df`` bars and build the diagnostic report."""
         if df is None or len(df) == 0:
             raise ValueError(
                 f"No historical data returned for diagnostic of {strategy_name!r} "
                 f"on {symbol} {timeframe}; cannot walk bars."
+            )
+
+        # Validate the DataFrame shape BEFORE accessing ``df["close"]`` —
+        # a missing 'close' column would otherwise raise a bare KeyError
+        # deep in the indexer, bypassing the helpful error below.
+        if not hasattr(df, "columns") or "close" not in getattr(df, "columns", []):
+            raise ValueError(
+                "Diagnostic requires a DataFrame with a 'close' column; "
+                f"got {type(df).__name__}."
             )
 
         seq_len = int(getattr(signal_generator, "sequence_length", 1) or 1)
@@ -294,14 +134,7 @@ class SignalDiagnostic:
         buy_count = sell_count = hold_count = 0
 
         # ``close`` column is the reference price for forward-return math.
-        closes = df["close"].to_numpy() if hasattr(df, "to_numpy") else None
-        if closes is None:
-            # FixtureProvider / live providers return DataFrames; bail with
-            # a clear message rather than crashing deep in the walk.
-            raise ValueError(
-                "Diagnostic requires a DataFrame with a 'close' column; "
-                f"got {type(df).__name__}."
-            )
+        closes = df["close"].to_numpy()
 
         n_bars = len(df)
         for i in range(start_idx, n_bars):
@@ -390,10 +223,4 @@ class SignalDiagnostic:
         )
 
 
-__all__ = [
-    "DEFAULT_HORIZONS",
-    "DiagnosticReport",
-    "DistributionStats",
-    "HitRate",
-    "SignalDiagnostic",
-]
+__all__ = ["DEFAULT_HORIZONS", "SignalDiagnostic"]

--- a/src/experiments/diagnostics/stats.py
+++ b/src/experiments/diagnostics/stats.py
@@ -1,0 +1,63 @@
+"""Summary statistics dataclass for a numeric series."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass
+class DistributionStats:
+    """Summary statistics for a numeric series.
+
+    Produced by :meth:`from_series` over the ``predicted_return`` /
+    ``confidence`` streams gathered during a signal-quality diagnostic walk.
+    The ``positive_fraction`` field is especially useful for catching a
+    model that always returns a fallback sentinel — a healthy ML model's
+    predicted-return distribution straddles zero (fraction roughly 0.5);
+    a broken one is 0.0 or 1.0.
+    """
+
+    n: int
+    mean: float
+    std: float
+    min: float
+    max: float
+    positive_fraction: float
+
+    @classmethod
+    def from_series(cls, values: list[float]) -> DistributionStats:
+        """Summarize ``values`` as count / mean / sample-std / min / max / pos-frac."""
+        if not values:
+            return cls(n=0, mean=0.0, std=0.0, min=0.0, max=0.0, positive_fraction=0.0)
+        n = len(values)
+        mean = sum(values) / n
+        # Guard n=1 (std is 0 by definition). Use sample std for n≥2.
+        if n == 1:
+            std = 0.0
+        else:
+            var = sum((v - mean) ** 2 for v in values) / (n - 1)
+            std = math.sqrt(var)
+        pos = sum(1 for v in values if v > 0) / n
+        return cls(
+            n=n,
+            mean=float(mean),
+            std=float(std),
+            min=float(min(values)),
+            max=float(max(values)),
+            positive_fraction=float(pos),
+        )
+
+    def to_dict(self) -> dict[str, float | int]:
+        """Return a plain-dict serialization suitable for JSON output."""
+        return {
+            "n": self.n,
+            "mean": self.mean,
+            "std": self.std,
+            "min": self.min,
+            "max": self.max,
+            "positive_fraction": self.positive_fraction,
+        }
+
+
+__all__ = ["DistributionStats"]

--- a/src/experiments/reporter.py
+++ b/src/experiments/reporter.py
@@ -52,6 +52,12 @@ class VariantReport:
     ranking_confidence: float | None
     verdict: Verdict
     is_baseline: bool = False
+    # Human-readable diagnostic warnings surfaced by the reporter. The most
+    # important case (gap report G6/G7): a variant whose every headline
+    # metric and per-trade P&L sequence ties the baseline — almost
+    # certainly a dead-code override that didn't actually mutate the
+    # strategy. Rendered in the text/CSV/JSON report.
+    warnings: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -259,6 +265,116 @@ def _classify(
     return Verdict.HOLD
 
 
+# Tolerance for "bitwise-identical" comparisons. Floating-point math in the
+# backtest engine is deterministic given identical inputs, so two runs with
+# effective-noop overrides are typically equal to ULP precision — but we
+# allow a tiny slack to survive pandas/numpy version drift.
+_IDENTICAL_TOL = 1e-9
+
+# Metrics compared when deciding whether a variant is "identical to
+# baseline" for G6/G7 warning purposes. The set deliberately omits
+# ``max_drawdown`` derivatives and non-P&L headline numbers — the point
+# of the warning is that the VARIANT'S P&L profile is
+# indistinguishable from baseline, i.e. the override was a no-op.
+_IDENTICAL_METRIC_FIELDS: tuple[str, ...] = (
+    "total_return",
+    "annualized_return",
+    "sharpe_ratio",
+    "max_drawdown",
+    "win_rate",
+    "total_trades",
+    "final_balance",
+)
+
+
+def _is_identical_to_baseline(
+    baseline: ExperimentResult,
+    variant: ExperimentResult,
+) -> bool:
+    """True when every headline metric matches baseline within ``_IDENTICAL_TOL``.
+
+    Used as a trigger for the dead-code-override warning (G6). Integer
+    metrics (``total_trades``) require strict equality; floats use the
+    tolerance so pandas/numpy FP noise doesn't produce false negatives.
+    """
+    for field_name in _IDENTICAL_METRIC_FIELDS:
+        b = getattr(baseline, field_name)
+        v = getattr(variant, field_name)
+        if isinstance(b, int) and isinstance(v, int):
+            if b != v:
+                return False
+            continue
+        bv = float(b)
+        vv = float(v)
+        if math.isnan(bv) or math.isnan(vv):
+            # NaN inputs are rejected upstream by `_metric`; if one slips
+            # through here, treat as non-identical rather than masking it.
+            return False
+        if abs(bv - vv) > _IDENTICAL_TOL:
+            return False
+    return True
+
+
+def _pnl_sequence_identical(
+    baseline_trades: list[float],
+    variant_trades: list[float],
+) -> bool:
+    """True when two per-trade P&L sequences match element-wise.
+
+    Empty baseline AND empty variant sequences count as identical (no
+    trades is trivially "the same" trades). A single-sequence-empty case
+    is treated as different — the tie on aggregate metrics is spurious.
+    """
+    if len(baseline_trades) != len(variant_trades):
+        return False
+    for a, b in zip(baseline_trades, variant_trades, strict=True):
+        if math.isnan(a) or math.isnan(b):
+            # NaN per-trade PnL is invalid upstream; fail the identity
+            # check rather than return True for two NaN-filled lists.
+            return False
+        if abs(float(a) - float(b)) > _IDENTICAL_TOL:
+            return False
+    return True
+
+
+def _detect_identical_to_baseline(
+    baseline: ExperimentResult,
+    variant: ExperimentResult,
+    variant_name: str,
+) -> list[str]:
+    """Return warnings describing baseline-identical variants (G6/G7).
+
+    Emits at most one warning. When the aggregate metrics match, the
+    per-trade P&L sequence decides between:
+      * "literally the same trades" — the override almost certainly did
+        nothing (wrong attribute name, silently dropped, dead-code
+        component target)
+      * "different trades, same aggregate" — rare but interesting: the
+        variant took a different path that happened to tie the baseline
+        on every headline metric, worth surfacing so the operator can
+        decide whether to dig in or trust the tie.
+    """
+    if variant_name == "baseline" or variant is baseline:
+        return []
+    if not _is_identical_to_baseline(baseline, variant):
+        return []
+    if _pnl_sequence_identical(baseline.trade_pnl_pcts, variant.trade_pnl_pcts):
+        return [
+            "Every headline metric AND the per-trade P&L sequence match "
+            "baseline bitwise. The override almost certainly did not take "
+            "effect — verify the attribute name routes to a live component "
+            "and the override isn't a no-op on this strategy's risk "
+            "manager / sizer."
+        ]
+    return [
+        "Headline metrics match baseline exactly but the per-trade P&L "
+        "sequence differs — the variant took different trades that "
+        "happened to tie on aggregates. This is rare and may indicate a "
+        "degenerate signal path; inspect the diagnostic "
+        "(atb experiment diagnose ...) to confirm signal quality."
+    ]
+
+
 class ExperimentReporter:
     """Build a :class:`SuiteReport` from a :class:`SuiteResult`."""
 
@@ -311,6 +427,7 @@ class ExperimentReporter:
             )
             confidence = _ranking_confidence(baseline, result, settings.target_metric)
             verdict = _classify(baseline, result, settings, confidence)
+            warnings = _detect_identical_to_baseline(baseline, result, spec.name)
             rows.append(
                 VariantReport(
                     name=spec.name,
@@ -324,6 +441,7 @@ class ExperimentReporter:
                     delta_vs_baseline=delta,
                     ranking_confidence=confidence,
                     verdict=verdict,
+                    warnings=warnings,
                 )
             )
 
@@ -386,6 +504,13 @@ class ExperimentReporter:
                 f"{row.win_rate:>6.2f} {row.total_trades:>5d} "
                 f"{delta_str} {conf_txt:>6} {tag:>18}"
             )
+        rows_with_warnings = [row for row in report.rows if row.warnings]
+        if rows_with_warnings:
+            lines.append("")
+            lines.append(f"Variant warnings ({len(rows_with_warnings)}):")
+            for row in rows_with_warnings:
+                for msg in row.warnings:
+                    lines.append(f"  - {row.name}: {msg}")
         if report.errors:
             lines.append("")
             lines.append(f"Variant errors ({len(report.errors)}):")
@@ -410,6 +535,7 @@ class ExperimentReporter:
                 "ranking_confidence",
                 "verdict",
                 "is_baseline",
+                "warnings",
             ]
         )
         for row in report.rows:
@@ -427,6 +553,9 @@ class ExperimentReporter:
                     "" if row.ranking_confidence is None else row.ranking_confidence,
                     row.verdict.value,
                     row.is_baseline,
+                    # Join multi-line warnings with " | " so the CSV cell
+                    # stays a single line readable in spreadsheets.
+                    " | ".join(row.warnings),
                 ]
             )
         return buf.getvalue()

--- a/src/experiments/runner.py
+++ b/src/experiments/runner.py
@@ -55,7 +55,20 @@ class ExperimentRunner:
             return CachedDataProvider(provider, cache_ttl_hours=cache_ttl_hours)
         return provider
 
-    def _load_strategy(self, strategy_name: str) -> Strategy:
+    def _load_strategy(
+        self,
+        strategy_name: str,
+        factory_kwargs: dict[str, object] | None = None,
+    ) -> Strategy:
+        """Construct a strategy, optionally passing kwargs to the factory.
+
+        ``factory_kwargs`` carries construction-time settings that cannot be
+        changed by setattr afterwards — e.g. ``model_type`` on hyper_growth
+        (which wires a different signal generator class), ``max_leverage``
+        (which is baked into the LeverageManager at construction), and
+        ``min_regime_bars``. For post-construction knobs like
+        ``long_entry_threshold`` use ``parameters`` overrides instead.
+        """
         strategies = {
             "ml_basic": create_ml_basic_strategy,
             "ml_adaptive": create_ml_adaptive_strategy,
@@ -63,9 +76,21 @@ class ExperimentRunner:
             "hyper_growth": create_hyper_growth_strategy,
         }
         builder = strategies.get(strategy_name)
-        if builder is not None:
+        if builder is None:
+            raise ValueError(f"Unknown strategy: {strategy_name}")
+        kwargs = dict(factory_kwargs or {})
+        if not kwargs:
             return builder()
-        raise ValueError(f"Unknown strategy: {strategy_name}")
+        try:
+            return builder(**kwargs)
+        except TypeError as exc:
+            # Surface the factory name so the user can diff their YAML against
+            # the builder signature rather than squinting at a bare
+            # "unexpected keyword argument" trace.
+            raise ValueError(
+                f"factory_kwargs rejected by {builder.__name__}: {exc}. "
+                f"Check that every key matches the factory signature."
+            ) from exc
 
     def _apply_parameter_overrides(self, strategy: Strategy, config: ExperimentConfig) -> None:
         if not (config.parameters and config.parameters.values):
@@ -88,10 +113,50 @@ class ExperimentRunner:
                 )
 
             if not self._apply_strategy_attribute(strategy, attr, value):
+                # Try to emit a more precise error than "no component accepts
+                # it" — a common failure mode is copying a regime-aware
+                # threshold key onto a regime-agnostic strategy like
+                # ``ml_basic`` / ``hyper_growth``. The gap report (G4)
+                # specifically called out the confusing blanket error on
+                # MLBasicSignalGenerator.
+                if attr in self._ATTR_REQUIRES_REGIME_AWARE:
+                    sg = getattr(strategy, "signal_generator", None)
+                    sg_class = type(sg).__name__ if sg is not None else "None"
+                    raise ValueError(
+                        f"Override {attr!r} requires a regime-aware signal "
+                        f"generator (MLSignalGenerator, used by ml_adaptive / "
+                        f"ml_sentiment). Strategy {config.strategy_name!r} "
+                        f"uses {sg_class} which is regime-agnostic and does "
+                        f"not expose regime-specific short thresholds. Use "
+                        "'short_entry_threshold' to tune the flat short gate."
+                    )
                 raise ValueError(
                     f"Unknown override attribute {attr!r} for strategy "
                     f"{config.strategy_name!r}; no component accepts it."
                 )
+
+    # Maps override attr name → (attr_candidates). When a wrapping sizer like
+    # ``LeveragedPositionSizer`` doesn't own the canonical attribute, the
+    # runner walks ``target.base_sizer`` chains trying each candidate in
+    # order. ``base_fraction`` is the YAML-facing canonical name;
+    # ``FixedFractionSizer`` stores the same quantity under ``fraction``.
+    _SIZER_ATTR_ALIASES: dict[str, tuple[str, ...]] = {
+        "base_fraction": ("base_fraction", "fraction"),
+    }
+
+    # Per-attribute "supported by these classes" hints used to build a
+    # crisp error when the override targets a component that lacks the
+    # attribute (instead of the generic "Unknown override attribute").
+    _ATTR_REQUIRES_REGIME_AWARE: frozenset[str] = frozenset(
+        {
+            "short_threshold_trend_up",
+            "short_threshold_trend_down",
+            "short_threshold_range",
+            "short_threshold_high_vol",
+            "short_threshold_low_vol",
+            "short_threshold_confidence_multiplier",
+        }
+    )
 
     def _apply_strategy_attribute(self, strategy: Strategy, attr: str, value: object) -> bool:
         """Apply overrides to the correct component on a component-based strategy."""
@@ -137,7 +202,28 @@ class ExperimentRunner:
         coerced_value: object = value
 
         for target in targets:
-            if target is None or not hasattr(target, attr):
+            if target is None:
+                continue
+            # Position-sizer overrides may need to unwrap a wrapping sizer
+            # (e.g. LeveragedPositionSizer -> FixedFractionSizer). The
+            # unwrap also resolves canonical-vs-underlying attribute names
+            # (``base_fraction`` -> ``fraction``).
+            if target is position_sizer and attr in self._SIZER_ATTR_ALIASES:
+                resolved = self._resolve_sizer_override_target(target, attr)
+                if resolved is not None:
+                    resolved_target, resolved_attr = resolved
+                    try:
+                        current = getattr(resolved_target, resolved_attr)
+                        coerced_value = self._coerce_value(current, value)
+                        setattr(resolved_target, resolved_attr, coerced_value)
+                        applied = True
+                    except (TypeError, ValueError) as exc:
+                        raise ValueError(
+                            f"Failed to apply override {attr!r}={value!r} to "
+                            f"{type(resolved_target).__name__}.{resolved_attr}: {exc}"
+                        ) from exc
+                    continue
+            if not hasattr(target, attr):
                 continue
             try:
                 current = getattr(target, attr)
@@ -154,37 +240,83 @@ class ExperimentRunner:
                 ) from exc
 
         # Risk-related attributes must land in the strategy's risk-overrides
-        # mapping AND the active risk manager must actually consume it at
-        # trade time. Only CoreRiskAdapter reads ``context["strategy_overrides"]``
-        # (via ``_resolve_overrides``). Other risk managers
-        # (``RegimeAdaptiveRiskManager`` for ml_adaptive,
-        # ``VolatilityRiskManager`` / ``FixedRiskManager``) derive stops
-        # from regime / ATR / constants and would silently ignore the
-        # override — producing meaningless variant rankings.
+        # mapping AND at least one consumer must actually honor it at trade
+        # time. A strategy/manager honors the override via one of three
+        # contracts (any one suffices):
+        #
+        #   (a) The risk manager exposes ``_strategy_overrides`` — CoreRiskAdapter
+        #       reads ``context["strategy_overrides"]`` via ``_resolve_overrides``.
+        #   (b) The risk manager declares the attribute in
+        #       ``_direct_runtime_overrides`` — it reads ``self.<attr>`` directly
+        #       at trade time (e.g. ``FlatRiskManager.stop_loss_pct``).
+        #   (c) The strategy factory already populated
+        #       ``strategy._risk_overrides[attr]`` during construction —
+        #       explicit declaration that the engine-level partial-exit /
+        #       trailing-stop / drawdown logic will consume it. This is the
+        #       ``take_profit_pct`` path on ``hyper_growth``: FlatRiskManager
+        #       ignores TP, but the engine's partial-exit plumbing reads
+        #       ``strategy._risk_overrides["take_profit_pct"]``.
+        #
+        # Managers/strategies that do none of these (``RegimeAdaptiveRiskManager``
+        # on ml_adaptive derives stops from regime context, never honors
+        # ``_risk_overrides``) still raise — silently ignoring the override
+        # would produce meaningless variant rankings.
         if attr in {"stop_loss_pct", "take_profit_pct"}:
             try:
                 numeric_value = float(value)  # type: ignore[arg-type]
             except (TypeError, ValueError) as exc:
                 raise ValueError(f"Override {attr!r} must be numeric, got {value!r}") from exc
-            if risk_manager is not None and not hasattr(risk_manager, "_strategy_overrides"):
+            honors_direct = attr in getattr(risk_manager, "_direct_runtime_overrides", frozenset())
+            honors_via_dict = risk_manager is not None and hasattr(
+                risk_manager, "_strategy_overrides"
+            )
+            existing_overrides = getattr(strategy, "_risk_overrides", None) or {}
+            strategy_wires_attr = attr in existing_overrides
+            if risk_manager is not None and not (
+                honors_direct or honors_via_dict or strategy_wires_attr
+            ):
                 raise ValueError(
                     f"Override {attr!r} is not supported for "
-                    f"{type(risk_manager).__name__}; the risk manager does "
-                    "not consume strategy_overrides at trade time. Only "
-                    "CoreRiskAdapter-backed strategies (ml_basic, "
-                    "ml_sentiment, hyper_growth) honor this knob."
+                    f"{type(risk_manager).__name__}; the risk manager neither "
+                    f"declares {attr!r} in ``_direct_runtime_overrides`` nor "
+                    f"reads ``_strategy_overrides`` at trade time, and the "
+                    f"strategy factory did not wire {attr!r} into "
+                    f"``strategy._risk_overrides``. Only CoreRiskAdapter-backed "
+                    "strategies (ml_basic, ml_sentiment) and strategies that "
+                    "plumb the knob through ``set_risk_overrides`` (hyper_growth) "
+                    "honor this override."
                 )
-            overrides = getattr(strategy, "_risk_overrides", None) or {}
-            overrides[attr] = numeric_value
-            strategy._risk_overrides = overrides
+            existing_overrides[attr] = numeric_value
+            strategy._risk_overrides = existing_overrides
             # Mirror onto the risk manager's internal overrides map so that
             # ``_resolve_overrides`` (merge adapter + context) sees the
             # change even for code paths that don't pass context through.
-            if risk_manager is not None and hasattr(risk_manager, "_strategy_overrides"):
+            if honors_via_dict:
                 risk_manager._strategy_overrides[attr] = numeric_value
             applied = True
 
         return applied
+
+    @classmethod
+    def _resolve_sizer_override_target(cls, sizer: object, attr: str) -> tuple[object, str] | None:
+        """Walk wrapping sizers to find who owns ``attr`` (or an alias).
+
+        Returns ``(target, actual_attr)`` when found, else ``None``. The
+        walk uses the ``base_sizer`` attribute (present on
+        ``LeveragedPositionSizer``) to unwrap, and falls through any alias
+        names listed in :data:`_SIZER_ATTR_ALIASES`.
+        """
+        candidates = cls._SIZER_ATTR_ALIASES.get(attr, (attr,))
+        cursor: object | None = sizer
+        # Guard against pathological cycles: cap the walk at a sane depth.
+        for _ in range(8):
+            if cursor is None:
+                return None
+            for name in candidates:
+                if hasattr(cursor, name):
+                    return cursor, name
+            cursor = getattr(cursor, "base_sizer", None)
+        return None
 
     @staticmethod
     def _coerce_value(current: object, new_value: object) -> object:
@@ -262,7 +394,15 @@ class ExperimentRunner:
 
         position_sizer = getattr(strategy, "position_sizer", None)
         if position_sizer is not None:
-            _check_numeric_bound(position_sizer, "base_fraction", 0.001, 0.5)
+            # For wrapping sizers (``LeveragedPositionSizer``) the
+            # ``base_fraction`` lives on the wrapped sizer under either
+            # ``base_fraction`` or ``fraction``. Locate whoever owns it so
+            # the bound check validates the actual value in use.
+            bf_target = ExperimentRunner._resolve_sizer_override_target(
+                position_sizer, "base_fraction"
+            )
+            if bf_target is not None:
+                _check_numeric_bound(bf_target[0], bf_target[1], 0.001, 0.5)
             _check_numeric_bound(position_sizer, "min_confidence", 0.0, 1.0)
             _check_numeric_bound(position_sizer, "min_confidence_floor", 0.0, 1.0)
             floor = getattr(position_sizer, "min_confidence_floor", None)
@@ -294,7 +434,10 @@ class ExperimentRunner:
                 )
 
     def run(self, config: ExperimentConfig) -> ExperimentResult:
-        strategy = self._load_strategy(config.strategy_name)
+        strategy = self._load_strategy(
+            config.strategy_name,
+            factory_kwargs=config.factory_kwargs or None,
+        )
         # Apply any parameter overrides for strategy-level tuning
         self._apply_parameter_overrides(strategy, config)
         self._validate_post_override_invariants(strategy)
@@ -327,6 +470,9 @@ class ExperimentRunner:
             end=config.end,
         )
 
+        raw_trade_pnls = results.get("trade_pnl_pcts") or []
+        trade_pnl_pcts = [float(x) for x in raw_trade_pnls if isinstance(x, int | float)]
+
         return ExperimentResult(
             config=config,
             total_trades=int(results.get("total_trades", 0)),
@@ -337,6 +483,7 @@ class ExperimentRunner:
             sharpe_ratio=float(results.get("sharpe_ratio", 0.0)),
             final_balance=float(results.get("final_balance", config.initial_balance)),
             session_id=results.get("session_id"),
+            trade_pnl_pcts=trade_pnl_pcts,
         )
 
     def run_sweep(self, configs: list[ExperimentConfig]) -> list[ExperimentResult]:

--- a/src/experiments/schemas.py
+++ b/src/experiments/schemas.py
@@ -31,6 +31,12 @@ class ExperimentConfig:
     use_cache: bool = True
     provider: str = "binance"
     random_seed: int | None = None
+    # Keyword arguments forwarded to the strategy factory at construction time
+    # by :meth:`ExperimentRunner._load_strategy`. Use this for knobs the
+    # strategy only honors in ``__init__`` (e.g. ``model_type`` on
+    # hyper_growth, which swaps the underlying signal generator and cannot be
+    # changed by setattr afterwards).
+    factory_kwargs: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -47,3 +53,9 @@ class ExperimentResult:
     final_balance: float
     session_id: int | None = None
     artifacts_path: str | None = None
+    # Per-trade P&L sequence (as fractional returns in the order trades
+    # closed). The reporter uses this to distinguish "different trades, same
+    # aggregate" from "literally the same trades" when variants tie the
+    # baseline on the headline metrics — a critical tie-breaker for
+    # diagnosing dead-code overrides.
+    trade_pnl_pcts: list[float] = field(default_factory=list)

--- a/src/experiments/suite.py
+++ b/src/experiments/suite.py
@@ -72,6 +72,12 @@ class BacktestSettings:
     random_seed: int | None = None
     start: datetime | None = None
     end: datetime | None = None
+    # Keyword arguments passed to the strategy factory at construction time.
+    # Distinct from ``VariantSpec.overrides`` which mutate attributes post-
+    # construction via setattr. Factory kwargs handle settings the strategy
+    # only honors during ``__init__`` (e.g. ``model_type``, ``max_leverage``,
+    # ``min_regime_bars``, any knob whose value reshapes the component tree).
+    factory_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def resolve_window(self, now: datetime | None = None) -> tuple[datetime, datetime]:
         if self.end is not None and self.start is not None:
@@ -179,6 +185,7 @@ def _build_experiment_config(
         use_cache=suite.backtest.use_cache,
         provider=suite.backtest.provider,
         random_seed=suite.backtest.random_seed,
+        factory_kwargs=dict(suite.backtest.factory_kwargs),
     )
 
 

--- a/src/experiments/suite_loader.py
+++ b/src/experiments/suite_loader.py
@@ -33,6 +33,7 @@ _ALLOWED_BACKTEST = {
     "random_seed",
     "start",
     "end",
+    "factory_kwargs",
 }
 _ALLOWED_VARIANT = {"name", "overrides"}
 _ALLOWED_COMPARISON = {
@@ -135,6 +136,10 @@ def _parse_backtest(data: Any, *, source: str) -> BacktestSettings:
     if start is not None and end is not None and start >= end:
         raise SuiteValidationError(f"{source}: start ({start}) must be earlier than end ({end})")
 
+    factory_kwargs = _parse_factory_kwargs(
+        data.get("factory_kwargs"), source=f"{source}.factory_kwargs"
+    )
+
     return BacktestSettings(
         strategy=_require_str(data, "strategy", source),
         symbol=str(data.get("symbol", "BTCUSDT")),
@@ -146,7 +151,36 @@ def _parse_backtest(data: Any, *, source: str) -> BacktestSettings:
         random_seed=data.get("random_seed"),
         start=start,
         end=end,
+        factory_kwargs=factory_kwargs,
     )
+
+
+def _parse_factory_kwargs(value: Any, *, source: str) -> dict[str, Any]:
+    """Validate and coerce ``factory_kwargs`` from YAML.
+
+    Keys must be non-empty identifiers (no dots — factory kwargs map
+    directly to Python keyword arguments, not dotted override paths). Values
+    must be JSON-safe scalars, matching the same constraint applied to
+    variant overrides. The runner surfaces a clear error if the key is not
+    a valid builder parameter.
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise SuiteValidationError(f"{source}: must be a mapping, got {type(value).__name__}")
+    result: dict[str, Any] = {}
+    for k, v in value.items():
+        if not isinstance(k, str) or not k or not k.isidentifier():
+            raise SuiteValidationError(
+                f"{source}: keys must be valid Python identifiers, got {k!r}"
+            )
+        if not isinstance(v, str | int | float | bool) and v is not None:
+            raise SuiteValidationError(
+                f"{source}[{k!r}]: value must be a scalar "
+                f"(str, int, float, bool, or null), got {type(v).__name__}"
+            )
+        result[k] = v
+    return result
 
 
 def _parse_datetime(value: Any, source: str) -> datetime | None:

--- a/src/strategies/hyper_growth.py
+++ b/src/strategies/hyper_growth.py
@@ -53,6 +53,13 @@ class FlatRiskManager(RiskManager):
     manager control sizing.
     """
 
+    # Experimentation-runner contract: overrides listed here are honored
+    # because this manager reads ``self.<attr>`` directly at trade time.
+    # The runner consults this set to decide whether a setattr-based
+    # override (as opposed to a ``_strategy_overrides`` dict override) is
+    # sufficient for this manager class.
+    _direct_runtime_overrides: frozenset[str] = frozenset({"stop_loss_pct"})
+
     def __init__(
         self,
         risk_fraction: float = 0.10,

--- a/tests/unit/experiments/test_diagnostics.py
+++ b/tests/unit/experiments/test_diagnostics.py
@@ -1,0 +1,372 @@
+"""Unit tests for the signal-quality diagnostic (G5).
+
+The diagnostic walks a strategy's signal generator bar-by-bar and reports
+decision mix, predicted-return distribution, confidence distribution, and
+direction-conditional hit rates. Tests here cover the math
+(``DistributionStats``, hit-rate accounting), the degenerate-signal
+detector, and the dependency-injection wiring so the module can be driven
+without a real data provider.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.experiments.diagnostics import (
+    DEFAULT_HORIZONS,
+    DiagnosticReport,
+    DistributionStats,
+    HitRate,
+    SignalDiagnostic,
+)
+from src.strategies.components.signal_generator import Signal, SignalDirection
+
+pytestmark = pytest.mark.fast
+
+
+# --------------------------------------------------------------------------
+# DistributionStats — summary-statistic math.
+# --------------------------------------------------------------------------
+
+
+class TestDistributionStats:
+    def test_empty_series_returns_zeros(self) -> None:
+        s = DistributionStats.from_series([])
+        assert s.n == 0
+        assert s.mean == 0.0
+        assert s.std == 0.0
+        assert s.positive_fraction == 0.0
+
+    def test_single_value_std_is_zero(self) -> None:
+        s = DistributionStats.from_series([0.42])
+        assert s.n == 1
+        assert s.mean == 0.42
+        assert s.std == 0.0
+
+    def test_mean_and_std_are_sample_not_population(self) -> None:
+        """Sample std divides by n-1, not n — matches numpy ddof=1."""
+        vals = [1.0, 2.0, 3.0, 4.0, 5.0]
+        s = DistributionStats.from_series(vals)
+        assert pytest.approx(s.mean, rel=1e-12) == 3.0
+        # Sample std: sqrt(sum((x - mean)^2) / (n - 1)) = sqrt(10/4) ≈ 1.5811
+        assert pytest.approx(s.std, rel=1e-9) == float(np.std(vals, ddof=1))
+
+    def test_positive_fraction_handles_negatives_and_zero(self) -> None:
+        # Zero is NOT counted as positive.
+        s = DistributionStats.from_series([-1.0, 0.0, 1.0, 2.0])
+        assert pytest.approx(s.positive_fraction, rel=1e-9) == 0.5
+
+    def test_min_and_max_handle_all_negative(self) -> None:
+        s = DistributionStats.from_series([-1.0, -5.0, -0.5])
+        assert s.min == -5.0
+        assert s.max == -0.5
+
+
+# --------------------------------------------------------------------------
+# HitRate — dataclass serialization.
+# --------------------------------------------------------------------------
+
+
+def test_hitrate_to_dict_round_trip() -> None:
+    hr = HitRate(horizon=12, buy_samples=10, buy_accuracy=0.6, sell_samples=8, sell_accuracy=0.4)
+    assert hr.to_dict() == {
+        "horizon": 12,
+        "buy_samples": 10,
+        "buy_accuracy": 0.6,
+        "sell_samples": 8,
+        "sell_accuracy": 0.4,
+    }
+
+
+# --------------------------------------------------------------------------
+# Signal-generator walk — end-to-end with a stub generator + fake data.
+# --------------------------------------------------------------------------
+
+
+class _StubGenerator:
+    """Minimal signal generator that emits a deterministic mix of signals.
+
+    Uses index parity as a proxy for "decision": even → BUY, odd → SELL,
+    multiples of 5 → HOLD. Predicted-return is a simple function of index
+    so the distribution stats exercise real variance.
+    """
+
+    sequence_length = 1
+
+    def __init__(self, name: str = "stub"):
+        self.name = name
+
+    def generate_signal(self, df: pd.DataFrame, index: int) -> Signal:
+        if index % 5 == 0:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={"generator": self.name, "predicted_return": 0.0},
+            )
+        pr = 0.001 if index % 2 == 0 else -0.001
+        return Signal(
+            direction=SignalDirection.BUY if pr > 0 else SignalDirection.SELL,
+            strength=0.5,
+            confidence=0.1,
+            metadata={"generator": self.name, "predicted_return": pr},
+        )
+
+
+def _df_trending_up(n_bars: int = 300, drift_per_bar: float = 0.001) -> pd.DataFrame:
+    """Deterministic upward-drift OHLCV fixture."""
+    ts = pd.date_range(start="2024-01-01", periods=n_bars, freq="1h", tz=UTC)
+    close = 100.0 * (1.0 + drift_per_bar) ** np.arange(n_bars)
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "open": close,
+            "high": close * 1.001,
+            "low": close * 0.999,
+            "close": close,
+            "volume": np.ones(n_bars),
+        }
+    )
+
+
+class _StubStrategy:
+    """Strategy shim the runner returns — only exposes signal_generator."""
+
+    def __init__(self, gen: Any):
+        self.signal_generator = gen
+
+
+class _StubProvider:
+    """Data provider returning a pinned DataFrame regardless of args."""
+
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+
+    def get_historical_data(self, **_kwargs: Any) -> pd.DataFrame:
+        return self._df
+
+
+class _StubRunner:
+    """Minimal ExperimentRunner shim for diagnostic dependency injection."""
+
+    def __init__(self, strategy: _StubStrategy, df: pd.DataFrame):
+        self._strategy = strategy
+        self._df = df
+
+    def _load_strategy(
+        self,
+        strategy_name: str,
+        factory_kwargs: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> _StubStrategy:
+        return self._strategy
+
+    def _load_provider(
+        self,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> _StubProvider:
+        return _StubProvider(self._df)
+
+
+def _run_diag(
+    gen: Any,
+    df: pd.DataFrame,
+    *,
+    horizons: tuple[int, ...] = DEFAULT_HORIZONS,
+) -> DiagnosticReport:
+    diag = SignalDiagnostic(runner=_StubRunner(_StubStrategy(gen), df))
+    end = datetime.now(UTC)
+    start = end - timedelta(days=7)
+    return diag.run(
+        strategy_name="stub",
+        symbol="BTCUSDT",
+        timeframe="1h",
+        start=start,
+        end=end,
+        provider="mock",
+        horizons=horizons,
+    )
+
+
+def test_decision_mix_counts_match_bar_walk() -> None:
+    df = _df_trending_up(n_bars=100)
+    report = _run_diag(_StubGenerator(), df)
+    total = report.buy_count + report.sell_count + report.hold_count
+    assert total == report.bars_evaluated
+    # Multiples of 5 (excluding index 0 since we start at sequence_length=1):
+    # indices 5, 10, 15, ..., 95 → 19 HOLD bars.
+    assert report.hold_count == 19
+    # Remaining 80 bars split BUY/SELL by parity. Even-and-not-multiple-of-5
+    # = 40 BUY; odd-and-not-multiple-of-5 = 40 SELL.
+    assert report.buy_count == 40
+    assert report.sell_count == 40
+
+
+def test_predicted_return_distribution_captured() -> None:
+    df = _df_trending_up(n_bars=100)
+    report = _run_diag(_StubGenerator(), df)
+    # Non-HOLD bars emit ±0.001; HOLD bars emit 0.0 → distribution has
+    # real variance, not a constant.
+    assert report.predicted_return.n == 99  # bars 1..99 (sequence_length=1)
+    assert report.predicted_return.std > 0
+    assert report.predicted_return.min == pytest.approx(-0.001)
+    assert report.predicted_return.max == pytest.approx(0.001)
+
+
+def test_hit_rate_on_monotone_up_trend_favors_buys() -> None:
+    """With deterministic upward drift, BUY signals must be 100% correct
+    at every horizon and SELL signals 0%."""
+    df = _df_trending_up(n_bars=200)
+    report = _run_diag(_StubGenerator(), df)
+    for hr in report.hit_rates:
+        if hr.buy_samples > 0:
+            # Strict monotone: every BUY wins.
+            assert hr.buy_accuracy == pytest.approx(1.0)
+        if hr.sell_samples > 0:
+            assert hr.sell_accuracy == pytest.approx(0.0)
+
+
+def test_hit_rate_horizons_are_respected() -> None:
+    df = _df_trending_up(n_bars=200)
+    report = _run_diag(_StubGenerator(), df, horizons=(1, 24))
+    horizons = [hr.horizon for hr in report.hit_rates]
+    assert horizons == [1, 24]
+
+
+# --------------------------------------------------------------------------
+# Constant-signal detection — the key G5 contract.
+# --------------------------------------------------------------------------
+
+
+class _ConstantSellGenerator:
+    """Reproduces the broken-sentiment-model fingerprint: predicted_return
+    is exactly ``-1.0`` on every bar (``prediction = 0``)."""
+
+    sequence_length = 1
+    name = "constant_sell"
+
+    def generate_signal(self, df: pd.DataFrame, index: int) -> Signal:  # noqa: ARG002
+        return Signal(
+            direction=SignalDirection.SELL,
+            strength=1.0,
+            confidence=1.0,
+            metadata={"generator": self.name, "predicted_return": -1.0},
+        )
+
+
+def test_constant_predicted_return_triggers_warning() -> None:
+    """A constant predicted_return is the fingerprint of a feature-
+    pipeline / model-shape mismatch. Diagnostic must call it out by name."""
+    df = _df_trending_up(n_bars=200)
+    report = _run_diag(_ConstantSellGenerator(), df)
+    assert report.constant_signal_warning is not None
+    assert "constant" in report.constant_signal_warning.lower()
+    # Decision mix is 100% SELL — another fingerprint, reflected correctly.
+    assert report.buy_count == 0
+    assert report.hold_count == 0
+    assert report.sell_count > 0
+
+
+def test_real_signal_no_warning() -> None:
+    df = _df_trending_up(n_bars=200)
+    report = _run_diag(_StubGenerator(), df)
+    assert report.constant_signal_warning is None
+
+
+def test_small_sample_doesnt_trigger_constant_warning_prematurely() -> None:
+    """With n<50, we don't have enough bars to call std≈0 a fingerprint —
+    a short backtest mustn't trigger the warning on every run."""
+    df = _df_trending_up(n_bars=30)
+    report = _run_diag(_ConstantSellGenerator(), df)
+    # Either the warning is None (we aborted early) or it fires on actual
+    # constant — the contract is "n >= 50 required". With 30 bars we
+    # evaluate ~29 and skip the warning.
+    if report.predicted_return.n < 50:
+        assert report.constant_signal_warning is None
+
+
+# --------------------------------------------------------------------------
+# Error/guard paths.
+# --------------------------------------------------------------------------
+
+
+def test_empty_dataframe_raises() -> None:
+    diag = SignalDiagnostic(runner=_StubRunner(_StubStrategy(_StubGenerator()), pd.DataFrame()))
+    end = datetime.now(UTC)
+    start = end - timedelta(days=1)
+    with pytest.raises(ValueError, match="No historical data"):
+        diag.run(
+            strategy_name="stub",
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start=start,
+            end=end,
+            provider="mock",
+        )
+
+
+def test_strategy_without_signal_generator_raises() -> None:
+    class _NoGenStrategy:
+        pass
+
+    class _NoGenRunner:
+        def _load_strategy(
+            self, _name: str, factory_kwargs: dict[str, Any] | None = None  # noqa: ARG002
+        ) -> _NoGenStrategy:
+            return _NoGenStrategy()
+
+        def _load_provider(self, *_args: Any, **_kwargs: Any) -> _StubProvider:
+            return _StubProvider(_df_trending_up())
+
+    diag = SignalDiagnostic(runner=_NoGenRunner())  # type: ignore[arg-type]
+    end = datetime.now(UTC)
+    start = end - timedelta(days=1)
+    with pytest.raises(ValueError, match="no signal_generator"):
+        diag.run(
+            strategy_name="broken",
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start=start,
+            end=end,
+            provider="mock",
+        )
+
+
+# --------------------------------------------------------------------------
+# Render paths — json + text.
+# --------------------------------------------------------------------------
+
+
+def test_to_dict_round_trips_all_fields() -> None:
+    df = _df_trending_up(n_bars=100)
+    report = _run_diag(_StubGenerator(), df)
+    d = report.to_dict()
+    assert d["strategy"] == "stub"
+    assert d["symbol"] == "BTCUSDT"
+    assert d["decisions"]["buy"] == report.buy_count
+    assert d["decisions"]["sell"] == report.sell_count
+    assert d["decisions"]["hold"] == report.hold_count
+    assert "predicted_return" in d and d["predicted_return"]["n"] == report.predicted_return.n
+    assert len(d["hit_rates"]) == len(DEFAULT_HORIZONS)
+
+
+def test_render_text_includes_decision_mix_and_hit_rates() -> None:
+    df = _df_trending_up(n_bars=100)
+    report = _run_diag(_StubGenerator(), df)
+    text = report.render_text()
+    assert "Decision mix" in text
+    assert "Predicted return" in text
+    assert "Direction-conditional hit rate" in text
+    assert "BUY" in text and "SELL" in text and "HOLD" in text
+
+
+def test_render_text_includes_warning_when_present() -> None:
+    df = _df_trending_up(n_bars=200)
+    report = _run_diag(_ConstantSellGenerator(), df)
+    text = report.render_text()
+    assert "WARNING" in text

--- a/tests/unit/experiments/test_diagnostics.py
+++ b/tests/unit/experiments/test_diagnostics.py
@@ -351,7 +351,8 @@ def test_to_dict_round_trips_all_fields() -> None:
     assert d["decisions"]["buy"] == report.buy_count
     assert d["decisions"]["sell"] == report.sell_count
     assert d["decisions"]["hold"] == report.hold_count
-    assert "predicted_return" in d and d["predicted_return"]["n"] == report.predicted_return.n
+    assert "predicted_return" in d
+    assert d["predicted_return"]["n"] == report.predicted_return.n
     assert len(d["hit_rates"]) == len(DEFAULT_HORIZONS)
 
 
@@ -362,7 +363,9 @@ def test_render_text_includes_decision_mix_and_hit_rates() -> None:
     assert "Decision mix" in text
     assert "Predicted return" in text
     assert "Direction-conditional hit rate" in text
-    assert "BUY" in text and "SELL" in text and "HOLD" in text
+    assert "BUY" in text
+    assert "SELL" in text
+    assert "HOLD" in text
 
 
 def test_render_text_includes_warning_when_present() -> None:

--- a/tests/unit/experiments/test_final_review.py
+++ b/tests/unit/experiments/test_final_review.py
@@ -43,7 +43,7 @@ def test_ml_adaptive_stop_loss_override_raises() -> None:
             values={"ml_adaptive.stop_loss_pct": 0.015},
         ),
     )
-    with pytest.raises(ValueError, match="does not consume strategy_overrides"):
+    with pytest.raises(ValueError, match="is not supported for RegimeAdaptiveRiskManager"):
         runner._apply_parameter_overrides(strategy, cfg)
 
 
@@ -62,7 +62,7 @@ def test_ml_adaptive_take_profit_override_raises() -> None:
             values={"ml_adaptive.take_profit_pct": 0.08},
         ),
     )
-    with pytest.raises(ValueError, match="does not consume strategy_overrides"):
+    with pytest.raises(ValueError, match="is not supported for RegimeAdaptiveRiskManager"):
         runner._apply_parameter_overrides(strategy, cfg)
 
 

--- a/tests/unit/experiments/test_overrides.py
+++ b/tests/unit/experiments/test_overrides.py
@@ -202,6 +202,186 @@ def test_stop_loss_override_must_be_numeric(runner: ExperimentRunner) -> None:
         runner._apply_parameter_overrides(strategy, cfg)
 
 
+# --------------------------------------------------------------------------
+# G1: factory_kwargs plumbing — kwargs the strategy factory accepts at
+# construction time (e.g. ``model_type``, ``max_leverage``) must reach
+# ``builder(**kwargs)`` instead of being silently dropped.
+# --------------------------------------------------------------------------
+
+
+def test_factory_kwargs_passed_to_hyper_growth_builder(runner: ExperimentRunner) -> None:
+    """``max_leverage`` / ``stop_loss_pct`` are construction-only on hyper_growth."""
+    strategy = runner._load_strategy(
+        "hyper_growth",
+        factory_kwargs={"max_leverage": 2.5, "stop_loss_pct": 0.07},
+    )
+    # The factory wires max_leverage into the LeverageManager and
+    # stop_loss_pct into the FlatRiskManager's instance attribute.
+    assert pytest.approx(strategy.leverage_manager.max_leverage, rel=1e-9) == 2.5
+    assert pytest.approx(strategy.risk_manager.stop_loss_pct, rel=1e-9) == 0.07
+
+
+def test_factory_kwargs_empty_dict_is_noop(runner: ExperimentRunner) -> None:
+    """Empty / missing factory_kwargs must behave exactly like no kwargs."""
+    default = runner._load_strategy("hyper_growth")
+    with_empty = runner._load_strategy("hyper_growth", factory_kwargs={})
+    with_none = runner._load_strategy("hyper_growth", factory_kwargs=None)
+    assert default.risk_manager.stop_loss_pct == with_empty.risk_manager.stop_loss_pct
+    assert default.risk_manager.stop_loss_pct == with_none.risk_manager.stop_loss_pct
+
+
+def test_factory_kwargs_unknown_kwarg_surfaces_factory_name(runner: ExperimentRunner) -> None:
+    """Typos must fail loudly with the factory name attached to the error."""
+    with pytest.raises(ValueError, match="factory_kwargs rejected by create_hyper_growth_strategy"):
+        runner._load_strategy(
+            "hyper_growth",
+            factory_kwargs={"definitely_not_a_kwarg": 1.0},
+        )
+
+
+def test_factory_kwargs_flow_end_to_end_via_run(runner: ExperimentRunner) -> None:
+    """``ExperimentConfig.factory_kwargs`` must reach ``_load_strategy``.
+
+    Uses a mock provider so we don't hit the network, and only runs long
+    enough to confirm the strategy was built with the requested kwargs —
+    we inspect the runner's resolved strategy via ``_load_strategy``
+    directly (``run`` rebuilds every time so the same contract holds).
+    """
+    from src.experiments.schemas import ExperimentConfig
+
+    end = datetime.now(UTC)
+    start = end - timedelta(days=1)
+    cfg = ExperimentConfig(
+        strategy_name="hyper_growth",
+        symbol="BTCUSDT",
+        timeframe="1h",
+        start=start,
+        end=end,
+        initial_balance=1000.0,
+        provider="mock",
+        random_seed=42,
+        factory_kwargs={"max_leverage": 1.75},
+    )
+    built = runner._load_strategy(cfg.strategy_name, factory_kwargs=cfg.factory_kwargs)
+    assert pytest.approx(built.leverage_manager.max_leverage, rel=1e-9) == 1.75
+
+
+# --------------------------------------------------------------------------
+# G2: FlatRiskManager (hyper_growth) honors stop_loss_pct directly via its
+# instance attribute, not via ``_strategy_overrides``. The runner must
+# accept the override instead of rejecting it with "does not consume
+# strategy_overrides".
+# --------------------------------------------------------------------------
+
+
+def test_hyper_growth_stop_loss_override_lands_on_flat_risk_manager(
+    runner: ExperimentRunner,
+) -> None:
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.stop_loss_pct": 0.07})
+    runner._apply_parameter_overrides(strategy, cfg)
+
+    # FlatRiskManager reads self.stop_loss_pct at trade time (via
+    # get_stop_loss / should_exit) — the override must mutate the
+    # instance attribute, not just the strategy's risk_overrides dict.
+    assert pytest.approx(strategy.risk_manager.stop_loss_pct, rel=1e-9) == 0.07
+    overrides = getattr(strategy, "_risk_overrides", {}) or {}
+    assert pytest.approx(overrides["stop_loss_pct"], rel=1e-9) == 0.07
+
+
+def test_hyper_growth_take_profit_override_does_not_require_strategy_overrides_dict(
+    runner: ExperimentRunner,
+) -> None:
+    """FlatRiskManager doesn't consume TP directly, but the engine-level
+    _risk_overrides dict on the strategy does. The override must reach it
+    rather than being rejected upfront on the risk-manager gate."""
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.take_profit_pct": 0.35})
+    runner._apply_parameter_overrides(strategy, cfg)
+
+    overrides = getattr(strategy, "_risk_overrides", {}) or {}
+    assert pytest.approx(overrides["take_profit_pct"], rel=1e-9) == 0.35
+
+
+def test_flat_risk_manager_declares_direct_runtime_override_contract() -> None:
+    """The runner gate checks this class attribute — it must include
+    ``stop_loss_pct`` so FlatRiskManager-backed strategies are honored."""
+    from src.strategies.hyper_growth import FlatRiskManager
+
+    assert "stop_loss_pct" in FlatRiskManager._direct_runtime_overrides
+
+
+# --------------------------------------------------------------------------
+# G3: ``base_fraction`` routing must walk ``LeveragedPositionSizer ->
+# base_sizer``, and alias to the underlying ``FixedFractionSizer.fraction``
+# attribute. Before this fix, the override silently bounced.
+# --------------------------------------------------------------------------
+
+
+def test_hyper_growth_base_fraction_override_reaches_wrapped_sizer(
+    runner: ExperimentRunner,
+) -> None:
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.base_fraction": 0.12})
+    runner._apply_parameter_overrides(strategy, cfg)
+
+    # hyper_growth's outer sizer is LeveragedPositionSizer which wraps a
+    # FixedFractionSizer under .base_sizer. The fraction attribute is
+    # 'fraction' (not 'base_fraction') on FixedFractionSizer.
+    assert pytest.approx(strategy.position_sizer.base_sizer.fraction, rel=1e-9) == 0.12
+
+
+def test_hyper_growth_base_fraction_post_override_invariant_enforced(
+    runner: ExperimentRunner,
+) -> None:
+    """The bounds check must walk through the wrapping sizer too —
+    otherwise an invalid 0.9 override would pass validation."""
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.base_fraction": 0.9})
+    runner._apply_parameter_overrides(strategy, cfg)
+    with pytest.raises(ValueError, match="base_fraction|fraction"):
+        runner._validate_post_override_invariants(strategy)
+
+
+def test_ml_basic_base_fraction_still_works_on_unwrapped_sizer(
+    runner: ExperimentRunner,
+) -> None:
+    """Sanity guard — the unwrap logic must not break the already-working
+    ConfidenceWeightedSizer path on ml_basic."""
+    strategy = runner._load_strategy("ml_basic")
+    cfg = _cfg("ml_basic", {"ml_basic.base_fraction": 0.15})
+    runner._apply_parameter_overrides(strategy, cfg)
+    assert pytest.approx(strategy.position_sizer.base_fraction, rel=1e-9) == 0.15
+
+
+# --------------------------------------------------------------------------
+# G4: regime-specific ``short_threshold_*`` overrides only exist on
+# regime-aware generators. Attempting them on a regime-agnostic strategy
+# must fail with a clear error that points at the class mismatch — not
+# the generic "no component accepts it".
+# --------------------------------------------------------------------------
+
+
+def test_regime_short_threshold_on_ml_basic_raises_specific_error(
+    runner: ExperimentRunner,
+) -> None:
+    strategy = runner._load_strategy("ml_basic")
+    cfg = _cfg("ml_basic", {"ml_basic.short_threshold_trend_up": -0.0002})
+    with pytest.raises(ValueError, match="regime-aware signal generator"):
+        runner._apply_parameter_overrides(strategy, cfg)
+
+
+def test_regime_short_threshold_error_names_actual_generator_class(
+    runner: ExperimentRunner,
+) -> None:
+    """The error message must name the concrete signal generator class the
+    strategy is using so the operator can fix the YAML without grep."""
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.short_threshold_range": -0.0004})
+    with pytest.raises(ValueError, match="MLBasicSignalGenerator"):
+        runner._apply_parameter_overrides(strategy, cfg)
+
+
 def test_min_confidence_floor_invariant_enforced_after_override(
     runner: ExperimentRunner,
 ) -> None:

--- a/tests/unit/experiments/test_reporter_edges.py
+++ b/tests/unit/experiments/test_reporter_edges.py
@@ -216,3 +216,167 @@ def test_calmar_baseline_infinite_variant_finite_rejects_when_worse() -> None:
 
     row = next(r for r in report.rows if r.name == "finite_var")
     assert row.verdict == Verdict.REJECT
+
+
+# --------------------------------------------------------------------------
+# G6 / G7: Dead-code-override warnings.
+#
+# When a variant's headline metrics tie baseline within floating-point
+# tolerance, the reporter emits a warning pointing at the most common
+# cause — an override that didn't take effect. The per-trade P&L sequence
+# decides between "literally the same trades" (strong signal of a no-op
+# override) and "different trades, same aggregate" (rare; worth inspection).
+# --------------------------------------------------------------------------
+
+
+def _result_with_trades(
+    trades: list[float],
+    *,
+    total_return: float,
+    sharpe: float = 1.0,
+    annualized: float | None = None,
+    max_drawdown: float = 5.0,
+) -> ExperimentResult:
+    r = _result(
+        total_return=total_return,
+        sharpe=sharpe,
+        trades=len(trades),
+        annualized=annualized,
+        max_drawdown=max_drawdown,
+    )
+    r.trade_pnl_pcts = list(trades)
+    return r
+
+
+def test_identical_variant_emits_dead_code_warning() -> None:
+    """Variant matches every headline metric AND every per-trade P&L →
+    near-certain dead-code override. Reporter must emit G6 warning."""
+    suite = _suite([VariantSpec(name="noop_var")])
+    trades = [0.01, -0.005, 0.02]
+    baseline = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    variants = [_result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)]
+    report = ExperimentReporter().render(_suite_result(suite, baseline, variants))
+    row = next(r for r in report.rows if r.name == "noop_var")
+    assert row.warnings, "expected identical-variant warning"
+    assert any("did not take effect" in w for w in row.warnings)
+
+
+def test_identical_aggregate_different_trades_emits_distinct_warning() -> None:
+    """Aggregate metrics tie baseline, but per-trade sequence differs —
+    the G7 "different trades, same aggregate" message, not G6."""
+    suite = _suite([VariantSpec(name="path_var")])
+    b_trades = [0.01, 0.01, -0.015]
+    v_trades = [0.005, -0.005, 0.015]
+    baseline = _result_with_trades(b_trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    variant = _result_with_trades(v_trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
+    row = next(r for r in report.rows if r.name == "path_var")
+    assert row.warnings, "expected sequence-tiebreak warning"
+    assert any("different trades" in w.lower() for w in row.warnings)
+    assert not any("did not take effect" in w for w in row.warnings)
+
+
+def test_differing_variant_emits_no_warning() -> None:
+    """Any headline metric difference above tolerance → no G6 warning."""
+    suite = _suite([VariantSpec(name="real_var")])
+    baseline = _result_with_trades([0.01, 0.02], total_return=2.5, sharpe=1.2)
+    variant = _result_with_trades([0.015, 0.02], total_return=3.5, sharpe=1.5)
+    report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
+    row = next(r for r in report.rows if r.name == "real_var")
+    assert row.warnings == []
+
+
+def test_baseline_row_never_gets_identical_warning() -> None:
+    """The baseline is trivially identical to itself; warning is nonsense."""
+    suite = _suite([VariantSpec(name="noop_var")])
+    trades = [0.01, -0.005]
+    baseline = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    variant = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
+    baseline_row = next(r for r in report.rows if r.is_baseline)
+    assert baseline_row.warnings == []
+
+
+def test_warning_rendered_in_text_report() -> None:
+    """The text renderer must surface warnings so operators see them."""
+    suite = _suite([VariantSpec(name="noop_var")])
+    trades = [0.01, -0.005]
+    baseline = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    variant = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
+    text = ExperimentReporter().render_text(report)
+    assert "Variant warnings" in text
+    assert "noop_var" in text
+
+
+def test_warning_serialized_in_csv_report() -> None:
+    suite = _suite([VariantSpec(name="noop_var")])
+    trades = [0.01]
+    baseline = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    variant = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
+    csv_text = ExperimentReporter().render_csv(report)
+    # Header includes the new column
+    assert ",warnings\r\n" in csv_text or ",warnings\n" in csv_text
+    # Warning cell contains the key diagnostic phrase
+    assert "did not take effect" in csv_text
+
+
+def test_tolerance_floors_tiny_fp_noise_still_triggers_warning() -> None:
+    """FP noise below the identical-tolerance must still trigger the
+    warning so a 1-ULP difference doesn't hide a dead-code override."""
+    suite = _suite([VariantSpec(name="noop_var")])
+    trades = [0.01, -0.005]
+    baseline = _result_with_trades(trades, total_return=2.5, sharpe=1.2, annualized=3.0)
+    # 1e-11 < 1e-9 tolerance
+    variant = _result_with_trades(trades, total_return=2.5 + 1e-11, sharpe=1.2, annualized=3.0)
+    report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
+    row = next(r for r in report.rows if r.name == "noop_var")
+    assert row.warnings, "FP noise below tolerance must not suppress warning"
+
+
+def test_identical_metrics_zero_trades_both_sides_still_warns() -> None:
+    """A variant that produced zero trades and matches an empty-trade
+    baseline is still likely a dead-code override — warn the same way."""
+    suite = _suite([VariantSpec(name="dead_var")])
+    baseline = _result_with_trades([], total_return=0.0, sharpe=0.0, annualized=0.0)
+    variant = _result_with_trades([], total_return=0.0, sharpe=0.0, annualized=0.0)
+    report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
+    row = next(r for r in report.rows if r.name == "dead_var")
+    assert row.warnings, "empty-trade tie should still warn"
+
+
+def test_csv_warnings_column_escapes_multiline_to_single_cell() -> None:
+    """Multi-warning cells must use a delimiter that CSV spreadsheets can
+    read as a single cell — ensuring report.csv stays row-per-variant."""
+    from src.experiments.reporter import VariantReport
+
+    row = VariantReport(
+        name="v",
+        total_return=0.0,
+        annualized_return=0.0,
+        sharpe_ratio=0.0,
+        max_drawdown=0.0,
+        win_rate=0.0,
+        total_trades=0,
+        final_balance=0.0,
+        delta_vs_baseline=0.0,
+        ranking_confidence=None,
+        verdict=Verdict.HOLD,
+        warnings=["first warning", "second warning"],
+    )
+    from src.experiments.reporter import SuiteReport
+
+    report = SuiteReport(
+        suite_id="x",
+        description="",
+        target_metric="sharpe_ratio",
+        significance_level=0.05,
+        min_trades=0,
+        baseline_name="baseline",
+        winner=None,
+        rows=[row],
+    )
+    csv_text = ExperimentReporter().render_csv(report)
+    # Both warnings in the same cell, separated by " | "
+    assert "first warning | second warning" in csv_text

--- a/tests/unit/experiments/test_reporter_edges.py
+++ b/tests/unit/experiments/test_reporter_edges.py
@@ -317,7 +317,7 @@ def test_warning_serialized_in_csv_report() -> None:
     report = ExperimentReporter().render(_suite_result(suite, baseline, [variant]))
     csv_text = ExperimentReporter().render_csv(report)
     # Header includes the new column
-    assert ",warnings\r\n" in csv_text or ",warnings\n" in csv_text
+    assert ",warnings" in csv_text.replace("\r\n", "\n")
     # Warning cell contains the key diagnostic phrase
     assert "did not take effect" in csv_text
 

--- a/tests/unit/experiments/test_suite_loader.py
+++ b/tests/unit/experiments/test_suite_loader.py
@@ -131,3 +131,76 @@ def test_negative_initial_balance_rejected() -> None:
 def test_missing_file() -> None:
     with pytest.raises(FileNotFoundError):
         load_suite("/tmp/does_not_exist_xyz123.yaml")
+
+
+# --------------------------------------------------------------------------
+# G1 — factory_kwargs YAML schema. The runner forwards these to the
+# strategy factory at construction time (distinct from ``overrides`` which
+# setattr post-construction).
+# --------------------------------------------------------------------------
+
+
+def test_factory_kwargs_parsed_as_dict_under_backtest() -> None:
+    cfg = parse_suite(
+        {
+            "id": "fk",
+            "backtest": {
+                "strategy": "hyper_growth",
+                "factory_kwargs": {"max_leverage": 2.0, "min_regime_bars": 5},
+            },
+            "baseline": {"name": "b", "overrides": {}},
+        }
+    )
+    assert cfg.backtest.factory_kwargs == {"max_leverage": 2.0, "min_regime_bars": 5}
+
+
+def test_factory_kwargs_default_is_empty_dict() -> None:
+    cfg = parse_suite(
+        {
+            "id": "nofk",
+            "backtest": {"strategy": "ml_basic"},
+            "baseline": {"name": "b", "overrides": {}},
+        }
+    )
+    assert cfg.backtest.factory_kwargs == {}
+
+
+def test_factory_kwargs_non_mapping_rejected() -> None:
+    with pytest.raises(SuiteValidationError, match="must be a mapping"):
+        parse_suite(
+            {
+                "id": "bad",
+                "backtest": {"strategy": "ml_basic", "factory_kwargs": ["not", "a", "map"]},
+                "baseline": {"name": "b", "overrides": {}},
+            }
+        )
+
+
+def test_factory_kwargs_non_identifier_key_rejected() -> None:
+    """Factory kwargs map to Python keyword arguments; keys must be valid
+    identifiers (no dots, no spaces)."""
+    with pytest.raises(SuiteValidationError, match="valid Python identifiers"):
+        parse_suite(
+            {
+                "id": "bad",
+                "backtest": {
+                    "strategy": "ml_basic",
+                    "factory_kwargs": {"max.leverage": 2.0},
+                },
+                "baseline": {"name": "b", "overrides": {}},
+            }
+        )
+
+
+def test_factory_kwargs_non_scalar_value_rejected() -> None:
+    with pytest.raises(SuiteValidationError, match="must be a scalar"):
+        parse_suite(
+            {
+                "id": "bad",
+                "backtest": {
+                    "strategy": "ml_basic",
+                    "factory_kwargs": {"something": {"nested": 1}},
+                },
+                "baseline": {"name": "b", "overrides": {}},
+            }
+        )

--- a/tests/unit/experiments/test_suite_runner.py
+++ b/tests/unit/experiments/test_suite_runner.py
@@ -122,3 +122,54 @@ def test_baseline_with_no_overrides_yields_no_parameters(suite: SuiteConfig) -> 
     sut = ExperimentSuiteRunner(runner=MagicMock())
     configs = sut.build_configs(suite, now=datetime(2026, 4, 1, tzinfo=UTC))
     assert configs[0].parameters is None
+
+
+# --------------------------------------------------------------------------
+# G1: factory_kwargs on BacktestSettings must be propagated into every
+# generated ExperimentConfig so the runner can forward them to the
+# strategy builder at construction time.
+# --------------------------------------------------------------------------
+
+
+def test_factory_kwargs_propagate_from_backtest_to_every_config() -> None:
+    fk = {"max_leverage": 2.0, "min_regime_bars": 5}
+    suite = SuiteConfig(
+        id="fk_propagation",
+        description="",
+        backtest=BacktestSettings(
+            strategy="hyper_growth",
+            provider="mock",
+            factory_kwargs=fk,
+        ),
+        baseline=VariantSpec(name="baseline"),
+        variants=[VariantSpec(name="v1", overrides={"hyper_growth.stop_loss_pct": 0.1})],
+    )
+    sut = ExperimentSuiteRunner(runner=MagicMock())
+    configs = sut.build_configs(suite, now=datetime(2026, 4, 1, tzinfo=UTC))
+    assert len(configs) == 2
+    for c in configs:
+        assert c.factory_kwargs == fk
+
+
+def test_factory_kwargs_are_copied_not_shared_between_configs() -> None:
+    """Mutating one config's factory_kwargs must not bleed into others —
+    ExperimentRunner.run mutates via ``dict(...)`` but the safer boundary
+    is at suite-build time."""
+    suite = SuiteConfig(
+        id="fk_isolation",
+        description="",
+        backtest=BacktestSettings(
+            strategy="hyper_growth",
+            provider="mock",
+            factory_kwargs={"max_leverage": 2.0},
+        ),
+        baseline=VariantSpec(name="baseline"),
+        variants=[VariantSpec(name="v1")],
+    )
+    sut = ExperimentSuiteRunner(runner=MagicMock())
+    configs = sut.build_configs(suite, now=datetime(2026, 4, 1, tzinfo=UTC))
+    configs[0].factory_kwargs["max_leverage"] = 9.9
+    assert configs[1].factory_kwargs["max_leverage"] == 2.0
+    # The suite's template is also untouched so re-running produces the
+    # same configs.
+    assert suite.backtest.factory_kwargs["max_leverage"] == 2.0

--- a/tests/unit/experiments/test_suite_runner.py
+++ b/tests/unit/experiments/test_suite_runner.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
+from src.experiments.runner import ExperimentRunner
 from src.experiments.schemas import ExperimentConfig, ExperimentResult
 from src.experiments.suite import (
     BacktestSettings,
@@ -15,6 +16,18 @@ from src.experiments.suite import (
     SuiteConfig,
     VariantSpec,
 )
+
+
+def _mock_runner() -> MagicMock:
+    """Build an ExperimentRunner mock with a strict spec.
+
+    ``create_autospec(..., instance=True)`` verifies both the attribute
+    names and method signatures, so a future rename/resignature of
+    ``ExperimentRunner.run`` breaks these tests loudly instead of
+    silently passing through a permissive ``MagicMock()``.
+    """
+    return create_autospec(ExperimentRunner, instance=True)
+
 
 pytestmark = pytest.mark.fast
 
@@ -64,7 +77,7 @@ def suite() -> SuiteConfig:
 
 def test_build_configs_emits_baseline_then_variants(suite: SuiteConfig) -> None:
     now = datetime(2026, 4, 1, tzinfo=UTC)
-    sut = ExperimentSuiteRunner(runner=MagicMock())
+    sut = ExperimentSuiteRunner(runner=_mock_runner())
     configs = sut.build_configs(suite, now=now)
 
     assert [c.parameters.name if c.parameters is not None else None for c in configs] == [
@@ -80,7 +93,7 @@ def test_build_configs_emits_baseline_then_variants(suite: SuiteConfig) -> None:
 
 
 def test_run_calls_runner_once_per_variant(suite: SuiteConfig) -> None:
-    mock_runner = MagicMock()
+    mock_runner = _mock_runner()
     mock_runner.run.side_effect = [
         _fake_result(MagicMock(spec=ExperimentConfig), total_return=1.0),
         _fake_result(MagicMock(spec=ExperimentConfig), total_return=2.0),
@@ -119,7 +132,7 @@ def test_comparison_validates_significance_level() -> None:
 
 
 def test_baseline_with_no_overrides_yields_no_parameters(suite: SuiteConfig) -> None:
-    sut = ExperimentSuiteRunner(runner=MagicMock())
+    sut = ExperimentSuiteRunner(runner=_mock_runner())
     configs = sut.build_configs(suite, now=datetime(2026, 4, 1, tzinfo=UTC))
     assert configs[0].parameters is None
 
@@ -144,7 +157,7 @@ def test_factory_kwargs_propagate_from_backtest_to_every_config() -> None:
         baseline=VariantSpec(name="baseline"),
         variants=[VariantSpec(name="v1", overrides={"hyper_growth.stop_loss_pct": 0.1})],
     )
-    sut = ExperimentSuiteRunner(runner=MagicMock())
+    sut = ExperimentSuiteRunner(runner=_mock_runner())
     configs = sut.build_configs(suite, now=datetime(2026, 4, 1, tzinfo=UTC))
     assert len(configs) == 2
     for c in configs:
@@ -166,7 +179,7 @@ def test_factory_kwargs_are_copied_not_shared_between_configs() -> None:
         baseline=VariantSpec(name="baseline"),
         variants=[VariantSpec(name="v1")],
     )
-    sut = ExperimentSuiteRunner(runner=MagicMock())
+    sut = ExperimentSuiteRunner(runner=_mock_runner())
     configs = sut.build_configs(suite, now=datetime(2026, 4, 1, tzinfo=UTC))
     configs[0].factory_kwargs["max_leverage"] = 9.9
     assert configs[1].factory_kwargs["max_leverage"] == 2.0


### PR DESCRIPTION
## Summary

Follow-up to #602. A sweep of `hyper_growth` through the new experimentation framework produced bitwise-identical metrics on every variant (documented in #603 + `.claude/reports/hyper_growth_experiment_sweep_2026-04-17.md`), which surfaced seven places where the framework silently dropped or misrouted overrides instead of applying or rejecting them clearly. This PR fixes all seven.

### G1 — factory_kwargs plumbing

`ExperimentRunner._load_strategy` called `builder()` with no arguments, so construction-time kwargs like `model_type`, `max_leverage`, and `min_regime_bars` were unreachable via YAML.

- New `BacktestSettings.factory_kwargs: dict[str, Any]` mirrored on `ExperimentConfig`
- YAML loader parses `backtest.factory_kwargs` (keys must be Python identifiers, values JSON-safe scalars)
- Runner forwards them to `builder(**kwargs)` and wraps `TypeError` in a message that names the factory so typos fail readably

### G2 — FlatRiskManager honors `stop_loss_pct` / `take_profit_pct`

The runner hard-coded *"Only CoreRiskAdapter-backed strategies honor this knob"* even though FlatRiskManager reads `self.stop_loss_pct` directly at trade time.

The gate now accepts any one of three contracts:
1. Risk manager declares the attr in `_direct_runtime_overrides` (new class attribute on FlatRiskManager — declares "I read self.attr at trade time")
2. Risk manager has `_strategy_overrides` (existing CoreRiskAdapter path)
3. Strategy factory already wired the key into `strategy._risk_overrides` (explicit declaration that the engine-level partial-exit / trailing-stop / drawdown logic consumes it — hyper_growth's `take_profit_pct` path)

`ml_adaptive`'s `RegimeAdaptiveRiskManager` satisfies none, so its existing rejection test still passes.

### G3 — `base_fraction` routing through wrapping sizers

`LeveragedPositionSizer` wraps a `FixedFractionSizer`, which stores the quantity as `fraction` (not `base_fraction`). The runner's `setattr(position_sizer, "base_fraction", …)` silently did nothing.

- New `_resolve_sizer_override_target` walks `position_sizer.base_sizer` chains and resolves a small alias table (`base_fraction → fraction`). Cap the walk at depth 8 to guard against cycles.
- Post-override invariant validator uses the same walk so bounds checks hit the actual target.

### G4 — Clearer error for regime-only attrs on regime-agnostic generators

`MLBasicSignalGenerator` doesn't expose `short_threshold_trend_up`, etc. Before, you got a generic `"Unknown override attribute"`. Now the runner emits a specific error that names the actual signal generator class and suggests the flat `short_entry_threshold` alternative.

### G5 — Signal-quality diagnostic (`src/experiments/diagnostics.py`)

The P&L-based reporter can't tell "signal is a constant sentinel" apart from "overrides have no measurable effect on already-good trades". That blind spot is what let hyper_growth's broken feature pipeline hide behind ~14% annual return.

- `SignalDiagnostic` walks a strategy's signal generator bar-by-bar (NOT a backtest) and emits a `DiagnosticReport` with decision-mix, `predicted_return` distribution, confidence distribution, and direction-conditional hit rate at 1h/4h/12h/24h horizons.
- Detects constant `predicted_return` (n≥50, std<1e-9) and warns — the fingerprint of a feature-pipeline / model-shape mismatch.
- Wired as `atb experiment diagnose --strategy <name> --start … --end … [--factory-kwarg KEY=VALUE]` with text/json output.

### G6 — Dead-code-override warning in reporter

When every headline metric (total_return, sharpe, max_drawdown, win_rate, total_trades, final_balance, annualized_return) ties baseline within 1e-9, the reporter now emits a `VariantReport.warnings` entry. Rendered in text, JSON, and CSV so overnight runs surface the most likely cause: the override didn't take effect.

### G7 — Per-trade P&L sequence tie-breaking

When aggregate metrics tie, the reporter compares per-trade P&L sequences:

- **Identical sequences** → "almost certainly a dead-code override"
- **Different sequences** → "different trades, same aggregate — rare and worth inspecting with `atb experiment diagnose`"

Backtester exposes `trade_pnl_pcts: list[float]` in its results dict; `ExperimentResult` carries it into the reporter.

## Tests added

Organized by the module each gap touches:

| File | Gap(s) | Tests |
|------|--------|-------|
| `test_overrides.py` | G1, G2, G3, G4 | factory_kwargs routing, FlatRiskManager direct-override contract, LeveragedPositionSizer unwrap, regime-attr clear error |
| `test_suite_loader.py` | G1 | YAML schema validation for `factory_kwargs` |
| `test_suite_runner.py` | G1 | Suite → config propagation and isolation |
| `test_reporter_edges.py` | G6, G7 | Identical-variant warning, sequence tie-break, CSV/text/JSON rendering |
| `test_diagnostics.py` (new) | G5 | DistributionStats math, hit-rate accounting, constant-signal detection, dependency-injection wiring |

One pre-existing assertion in `test_final_review.py` was updated for the new G2 error wording (`"does not consume strategy_overrides"` → `"is not supported for RegimeAdaptiveRiskManager"`).

## Test plan

- [x] 193 experiment unit tests pass (147 → 193, +46 new)
- [x] 847 strategy unit tests pass
- [x] 331 engine unit tests pass
- [x] 3455 fast unit tests pass (`pytest -m "not slow and not integration"`)
- [x] `ruff check` clean on all changed files
- [x] `black --check` clean on all changed files
- [x] `atb experiment` CLI registers cleanly with the new `diagnose` subcommand
- [ ] Integration test with a real suite YAML that uses `factory_kwargs` (manual after merge)

Note: the slow `test_very_large_dataset_10000_candles` hits its 300s pytest timeout on this CI environment regardless of these changes — a pre-existing flakiness issue in the 10k-candle ml_basic backtest, unrelated to the O(n) post-run list comprehension added here.

Reference: `.claude/reports/hyper_growth_experiment_sweep_2026-04-17.md` (merged via #603).

https://claude.ai/code/session_01GgcC34eVaBdZwDQ9EAHbG3