### PR TITLE
fix(engines): close 12 backtest-live parity gaps

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"af3bbd9c-cc46-4b0d-a249-8e67b5261be8","pid":52159,"acquiredAt":1773832341780}

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -131,6 +131,16 @@ print(f"Consecutive Wins: {results['consecutive_wins']}")
 
 All core metrics calculated in backtesting use identical calculation logic as the live trading engine, ensuring accurate validation of backtest results against live performance. The shared `PerformanceTracker` guarantees metric consistency across both engines.
 
+#### Known parity caveats
+
+The shared modules under `src/engines/shared/` keep the bulk of the financial math identical between engines, but a small number of behaviors remain intentionally divergent. Treat backtest results as a strong predictor, not a perfect simulator, in these areas:
+
+- **Tick-size / step-size rounding.** The live engine rounds asset quantities down to the exchange's `step_size` (`src/engines/live/execution/execution_engine.py:_normalize_quantity`). Backtest uses raw float quantities. For strategies sizing 1%+ of balance on liquid pairs the gap is sub-cent, but micro-cap strategies or very small accounts may see a small fill-size drift; treat backtest fill precision as an upper bound.
+- **Margin / borrow interest.** Live deducts realized margin interest via `MarginInterestTracker`. Backtest models interest only when `Backtester(..., annual_margin_interest_rate=0.05)` is set; the default `0.0` preserves spot-mode behaviour. A margin-mode strategy backtested without setting the rate will silently overstate returns by the carry cost — set the parameter to your venue's effective borrow APR.
+- **Concurrent positions.** The backtest engine is single-position by design — its `PositionTracker` holds at most one `ActiveTrade`. The live engine tracks N positions keyed by `order_id` and respects `risk_manager.get_max_concurrent_positions()`. A multi-symbol strategy will only model the first symbol that signals in backtest; validate live behaviour separately rather than inferring it from backtest.
+
+The `Backtester` class docstring (`src/engines/backtest/engine.py`) carries the canonical version of this list — keep the two in sync when adjusting parity guidance.
+
 ## CLI usage
 
 The `atb backtest` command (`cli/commands/backtest.py`) is the fastest way to run a simulation:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Backtest-live engine parity: closed nine silent divergences. Backtest now
+  propagates `TimeExitPolicy`-specific exit reasons (`"Max holding period"`,
+  `"Weekend flat"`, etc.) instead of hardcoding `"Time limit"`; gained an
+  optional `annual_margin_interest_rate` parameter on `Backtester` mirroring
+  live's `MarginInterestTracker` (default `0.0` preserves spot-mode
+  behaviour); now sums `entry_fee + exit_fee + margin_interest_cost` into
+  `PerformanceTracker.record_trade` matching live's total-fee semantics;
+  persists `margin_interest_cost` to the `trades` DB column via
+  `EventLogger.log_completed_trade`. Live now wires `CorrelationHandler`
+  into `LiveEntryHandler` and threads the full `symbol/timeframe/df/index`
+  context through `_check_entry_conditions` so correlation-driven sizing
+  reduction actually fires; backfills historical sentiment over the full
+  buffer before overlaying the live snapshot so ML strategies get
+  equivalent inputs; sweeps the position tracker after reconciliation to
+  register reconciler-created positions with the risk manager (using
+  `current_size` to preserve partial-exit accounting); passes the live
+  positions list to the direct `ComponentStrategy.process_candle` path.
+  Documented tick-size rounding, margin interest, and single-vs-multi-position
+  as known parity caveats on the `Backtester` docstring.
+
 ### Added
 - Experimentation framework (`src/experiments/`) with declarative YAML suites,
   `atb experiment run|list|show|promote` CLI, ranked reporter with statistical

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -127,6 +127,20 @@ class Backtester:
     - ExecutionEngine: Handles fees, slippage, next-bar execution
     - PositionTracker: Manages active trade state and MFE/MAE
     - EntryHandler: Processes entry signals and execution
+
+    Known parity caveats vs the live engine
+    ---------------------------------------
+    - **Exchange tick-size / step-size rounding.** The live engine rounds
+      asset quantities to the exchange's ``step_size`` (see
+      :py:meth:`src.engines.live.execution.execution_engine.ExecutionEngine._normalize_quantity`)
+      while the backtest engine uses raw float quantities. For strategies
+      sizing 1%+ of balance on liquid pairs the difference is sub-cent, but
+      micro-cap strategies or very small accounts may see a small fill-size
+      drift. Treat backtest results as an upper bound on the achievable fill
+      precision; live execution will round down to step_size.
+    - **Margin/borrow interest.** Modeled in backtest only when
+      ``annual_margin_interest_rate`` is set (default 0.0 = spot). See that
+      parameter's docstring for parity guidance.
     - ExitHandler: Processes exit signals and execution
     - CorrelationHandler: Applies correlation-based sizing
     - RegimeHandler: Manages regime-based strategy switching
@@ -160,6 +174,7 @@ class Backtester:
         use_next_bar_execution: bool = False,
         use_high_low_for_stops: bool = True,
         max_position_size: float | None = None,
+        annual_margin_interest_rate: float = 0.0,
         _regime_switcher_class: type | None = None,
         _strategy_manager: Any | None = None,
     ) -> None:
@@ -191,11 +206,26 @@ class Backtester:
             use_next_bar_execution: Execute entries on next bar's open.
             use_high_low_for_stops: Use high/low for SL/TP detection.
             max_position_size: Maximum position size as fraction of balance (backward compatibility).
+            annual_margin_interest_rate: Annual borrow/funding rate for margin
+                positions, as a decimal (e.g. ``0.05`` for 5% APR). Defaults
+                to ``0.0`` (spot trading, no carry cost). When > 0, interest
+                accrues on each position's notional for the holding period and
+                is deducted from realized PnL on close — mirroring the live
+                engine's ``MarginInterestTracker``. Leaving this at 0 while
+                running a margin-mode strategy will silently overstate
+                returns; set it to your venue's effective borrow rate to
+                preserve backtest-live parity.
             _regime_switcher_class: Optional regime switcher class for testing (internal).
             _strategy_manager: Optional strategy manager class or instance for testing (internal).
         """
         if initial_balance <= 0:
             raise ValueError("Initial balance must be positive")
+        if annual_margin_interest_rate < 0 or not math.isfinite(annual_margin_interest_rate):
+            raise ValueError(
+                f"annual_margin_interest_rate must be non-negative and finite, "
+                f"got {annual_margin_interest_rate}"
+            )
+        self.annual_margin_interest_rate = float(annual_margin_interest_rate)
 
         # Validate max_position_size if provided
         if max_position_size is not None:
@@ -390,6 +420,7 @@ class Backtester:
             partial_manager=partial_ops_manager,
             enable_engine_risk_exits=enable_engine_risk_exits,
             use_high_low_for_stops=use_high_low_for_stops,
+            annual_margin_interest_rate=annual_margin_interest_rate,
         )
 
         # For backward compatibility - expose current_trade through position_tracker

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -141,6 +141,15 @@ class Backtester:
     - **Margin/borrow interest.** Modeled in backtest only when
       ``annual_margin_interest_rate`` is set (default 0.0 = spot). See that
       parameter's docstring for parity guidance.
+    - **Concurrent positions.** The backtest engine is single-position by
+      design — its ``PositionTracker`` holds at most one ``ActiveTrade`` at a
+      time (``current_trade``). The live engine's ``LivePositionTracker``
+      holds a dict keyed by ``order_id`` and respects
+      ``risk_manager.get_max_concurrent_positions()`` for multi-symbol
+      portfolios. A backtest of a multi-symbol strategy will only model the
+      first symbol that signals; live can hold N. If your strategy depends
+      on simultaneous positions, validate live behaviour separately rather
+      than inferring it from backtest.
     - ExitHandler: Processes exit signals and execution
     - CorrelationHandler: Applies correlation-based sizing
     - RegimeHandler: Manages regime-based strategy switching
@@ -1243,9 +1252,20 @@ class Backtester:
             self.balance += net_pnl
             self.trades.append(completed_trade)
 
+            # Sum entry + exit fees / slippage for record_trade so the
+            # PerformanceTracker total_fees_paid metric matches live's
+            # `record_trade(fee=total_fee + interest_cost, ...)` semantics
+            # (src/engines/live/trading_engine.py:3361-3390). Previously
+            # backtest passed only the exit-side fee, so total_fees_paid
+            # silently undercounted the entry leg by ~50%.
+            entry_meta = getattr(completed_trade, "metadata", None) or {}
+            entry_fee_logged = float(entry_meta.get("entry_fee", 0.0) or 0.0)
+            entry_slippage_logged = float(entry_meta.get("entry_slippage_cost", 0.0) or 0.0)
+            total_fee = entry_fee_logged + float(exit_fee)
+            total_slippage = entry_slippage_logged + float(slippage)
             # Update performance tracking
             self.performance_tracker.record_trade(
-                trade=completed_trade, fee=exit_fee, slippage=slippage
+                trade=completed_trade, fee=total_fee, slippage=total_slippage
             )
             self.performance_tracker.update_balance(self.balance, timestamp=current_time)
 

--- a/src/engines/backtest/execution/execution_engine.py
+++ b/src/engines/backtest/execution/execution_engine.py
@@ -175,7 +175,10 @@ class ExecutionEngine:
             side=pending["side"],
         )
 
-        # Create trade
+        # Create trade. Stash entry fee/slippage on metadata so the exit
+        # path can pass total fees (entry + exit) to PerformanceTracker.record_trade,
+        # matching live's `position.metadata["entry_fee"]` pattern in
+        # src/engines/live/trading_engine.py:2825-2826.
         trade = ActiveTrade(
             symbol=symbol,
             side=pending["side"],
@@ -186,6 +189,8 @@ class ExecutionEngine:
             take_profit=take_profit,
             entry_balance=balance - entry_fee if balance > entry_fee else balance,
         )
+        trade.metadata["entry_fee"] = float(entry_fee)
+        trade.metadata["entry_slippage_cost"] = float(slippage_cost)
         # Note: component_notional removed - computed on-demand as current_size * balance
 
         # Clear pending entry now that execution succeeded
@@ -248,7 +253,10 @@ class ExecutionEngine:
         entry_fee = cost_result.fee
         slippage_cost = cost_result.slippage_cost
 
-        # Create trade
+        # Create trade. Stash entry fee/slippage on metadata so the exit
+        # path can pass total fees (entry + exit) to PerformanceTracker.record_trade,
+        # matching live's `position.metadata["entry_fee"]` pattern in
+        # src/engines/live/trading_engine.py:2825-2826.
         trade = ActiveTrade(
             symbol=symbol,
             side=side,
@@ -259,6 +267,8 @@ class ExecutionEngine:
             take_profit=take_profit,
             entry_balance=balance - entry_fee if balance > entry_fee else balance,
         )
+        trade.metadata["entry_fee"] = float(entry_fee)
+        trade.metadata["entry_slippage_cost"] = float(slippage_cost)
         # Note: component_notional removed - computed on-demand as current_size * balance
 
         logger.info(

--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -114,6 +114,7 @@ class ExitHandler:
         partial_manager: PartialOperationsManager | None = None,
         enable_engine_risk_exits: bool = True,
         use_high_low_for_stops: bool = True,
+        annual_margin_interest_rate: float = 0.0,
     ) -> None:
         """Initialize exit handler.
 
@@ -127,7 +128,20 @@ class ExitHandler:
             partial_manager: Unified partial operations manager.
             enable_engine_risk_exits: Enable SL/TP checks.
             use_high_low_for_stops: Use high/low for SL/TP detection.
+            annual_margin_interest_rate: Annual borrow/funding rate as a
+                decimal (e.g. ``0.05`` for 5% APR). Defaults to 0.0 (spot
+                trading, no carry cost). When > 0, interest is accrued on
+                the position notional for the holding period and deducted
+                from realized PnL on close — mirroring the live engine's
+                ``MarginInterestTracker`` behavior so margin-mode backtests
+                do not silently overstate returns.
         """
+        if annual_margin_interest_rate < 0 or not math.isfinite(annual_margin_interest_rate):
+            raise ValueError(
+                f"annual_margin_interest_rate must be non-negative and finite, "
+                f"got {annual_margin_interest_rate}"
+            )
+
         self.execution_engine = execution_engine
         self.position_tracker = position_tracker
         self.risk_manager = risk_manager
@@ -137,9 +151,38 @@ class ExitHandler:
         self.partial_manager = partial_manager
         self.enable_engine_risk_exits = enable_engine_risk_exits
         self.use_high_low_for_stops = use_high_low_for_stops
+        self.annual_margin_interest_rate = float(annual_margin_interest_rate)
         # Use shared managers for consistent logic across engines
         self._trailing_stop_manager = TrailingStopManager(trailing_stop_policy)
         self._strategy_exit_checker = StrategyExitChecker()
+
+    def _calculate_margin_interest(
+        self,
+        position_notional: float,
+        entry_time: datetime,
+        exit_time: datetime,
+    ) -> float:
+        """Compute margin interest cost for the holding period.
+
+        Mirrors live's ``MarginInterestTracker`` semantics: interest accrues
+        on the position notional from entry to exit at the configured annual
+        rate. Returns 0.0 when the rate is disabled or inputs are invalid,
+        so spot-mode backtests are unaffected.
+        """
+        if self.annual_margin_interest_rate <= 0:
+            return 0.0
+        if position_notional <= 0 or not math.isfinite(position_notional):
+            return 0.0
+        try:
+            seconds_held = (exit_time - entry_time).total_seconds()
+        except (TypeError, ValueError):
+            return 0.0
+        if seconds_held <= 0:
+            return 0.0
+        seconds_per_year = 365.0 * 24.0 * 3600.0
+        return (
+            position_notional * self.annual_margin_interest_rate * (seconds_held / seconds_per_year)
+        )
 
     def _build_snapshot(
         self,
@@ -490,8 +533,12 @@ class ExitHandler:
             if hit_take_profit:
                 tp_exit_price = take_profit_val
 
-        # Check time limit
+        # Check time limit. Capture the policy-specific reason (e.g.
+        # "Max holding period", "Weekend flat", "End of day flat") so it
+        # propagates into Trade.exit_reason — matching the live engine,
+        # which already does `time_reason or "Time exit"`.
         hit_time_limit = False
+        time_reason: str | None = None
         if self.time_exit_policy is not None:
             try:
                 current_time = candle.name if hasattr(candle, "name") else datetime.now(UTC)
@@ -499,7 +546,7 @@ class ExitHandler:
                 # to prevent TypeError when comparing with UTC-aware entry_time
                 if hasattr(current_time, "tzinfo") and current_time.tzinfo is None:
                     current_time = current_time.replace(tzinfo=UTC)
-                should_time_exit, _ = self.time_exit_policy.check_time_exit_conditions(
+                should_time_exit, time_reason = self.time_exit_policy.check_time_exit_conditions(
                     trade.entry_time, current_time
                 )
                 hit_time_limit = should_time_exit
@@ -517,7 +564,9 @@ class ExitHandler:
             exit_reason = "Take profit"
             exit_price = tp_exit_price
         elif hit_time_limit:
-            exit_reason = "Time limit"
+            # Use the policy-specific reason for parity with the live engine.
+            # Default fallback string also matches live ("Time exit").
+            exit_reason = time_reason or "Time exit"
             exit_price = current_price
         elif exit_signal:
             exit_reason = runtime_reason
@@ -676,8 +725,26 @@ class ExitHandler:
             basis_balance=basis_balance,
         )
 
-        # Subtract exit fee from PnL
-        net_pnl = close_result.pnl_cash - exit_fee
+        # Margin/borrow interest accrual over the holding period. Folded into
+        # exit_fee so PerformanceTracker.record_trade reports it as a cost,
+        # matching live's `record_trade(fee=total_fee + interest_cost, ...)`.
+        # Trade.pnl stays gross (price movement only) — same convention as live.
+        interest_cost = self._calculate_margin_interest(
+            position_notional=position_notional,
+            entry_time=trade.entry_time,
+            exit_time=current_time,
+        )
+        if interest_cost > 0:
+            logger.debug(
+                "Deducted margin interest %.4f from %s PnL (rate=%.4f, held=%.2fh)",
+                interest_cost,
+                symbol,
+                self.annual_margin_interest_rate,
+                (current_time - trade.entry_time).total_seconds() / 3600.0,
+            )
+
+        # Subtract exit fee and margin interest from PnL
+        net_pnl = close_result.pnl_cash - exit_fee - interest_cost
 
         # Close position in risk manager
         try:
@@ -685,7 +752,7 @@ class ExitHandler:
         except Exception as e:
             logger.warning("Failed to update risk manager on close for %s: %s", symbol, e)
 
-        return close_result.trade, net_pnl, exit_fee, slippage_cost
+        return close_result.trade, net_pnl, exit_fee + interest_cost, slippage_cost
 
     def calculate_current_pnl_pct(self, current_price: float) -> float:
         """Calculate current unrealized PnL percentage.

--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -743,6 +743,17 @@ class ExitHandler:
                 (current_time - trade.entry_time).total_seconds() / 3600.0,
             )
 
+        # Stash interest_cost on the completed trade's metadata so it can be
+        # persisted to the trades.margin_interest_cost DB column via
+        # event_logger.log_completed_trade — parity with live, which passes
+        # margin_interest_cost=interest_cost directly to db_manager.log_trade
+        # (src/engines/live/trading_engine.py:3397-3420).
+        if interest_cost > 0 and close_result.trade is not None:
+            try:
+                close_result.trade.metadata["margin_interest_cost"] = float(interest_cost)
+            except (AttributeError, TypeError, ValueError):
+                logger.debug("Could not stash margin_interest_cost on completed trade metadata")
+
         # Subtract exit fee and margin interest from PnL
         net_pnl = close_result.pnl_cash - exit_fee - interest_cost
 

--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -179,10 +179,18 @@ class ExitHandler:
             return 0.0
         if seconds_held <= 0:
             return 0.0
+        # 365 calendar days, matching live MarginInterestTracker's actual/365
+        # convention. Change here only if the live engine ever switches basis.
         seconds_per_year = 365.0 * 24.0 * 3600.0
-        return (
+        interest = (
             position_notional * self.annual_margin_interest_rate * (seconds_held / seconds_per_year)
         )
+        # Defense-in-depth: extreme rate × notional × duration could overflow
+        # to inf/NaN on degenerate inputs, which would propagate through
+        # net_pnl into balance corruption. Treat non-finite as zero.
+        if not math.isfinite(interest) or interest < 0:
+            return 0.0
+        return interest
 
     def _build_snapshot(
         self,

--- a/src/engines/backtest/execution/position_tracker.py
+++ b/src/engines/backtest/execution/position_tracker.py
@@ -310,7 +310,11 @@ class PositionTracker:
         # Get MFE/MAE metrics before clearing
         metrics = self.mfe_mae_tracker.get_position_metrics(self.POSITION_KEY)
 
-        # Create completed trade record
+        # Create completed trade record. Carry forward entry_fee /
+        # entry_slippage_cost from the ActiveTrade metadata so the exit
+        # path can pass total fees (entry + exit) to PerformanceTracker.record_trade,
+        # parity with live (src/engines/live/trading_engine.py:3359-3390 reads
+        # entry_fee/entry_slippage_cost from position.metadata at exit).
         completed_trade = Trade(
             symbol=trade.symbol,
             side=trade.side,
@@ -331,6 +335,16 @@ class PositionTracker:
             mfe_time=metrics.mfe_time if metrics else None,
             mae_time=metrics.mae_time if metrics else None,
         )
+        try:
+            entry_meta = getattr(trade, "metadata", None) or {}
+            if "entry_fee" in entry_meta:
+                completed_trade.metadata["entry_fee"] = float(entry_meta["entry_fee"])
+            if "entry_slippage_cost" in entry_meta:
+                completed_trade.metadata["entry_slippage_cost"] = float(
+                    entry_meta["entry_slippage_cost"]
+                )
+        except (TypeError, ValueError) as exc:
+            logger.debug("Failed to carry entry-fee metadata onto completed trade: %s", exc)
 
         # Clear tracker
         self.mfe_mae_tracker.clear(self.POSITION_KEY)

--- a/src/engines/backtest/logging/event_logger.py
+++ b/src/engines/backtest/logging/event_logger.py
@@ -202,6 +202,21 @@ class EventLogger:
         if not self.enabled:
             return
 
+        # Persist margin interest cost when the backtest is configured with
+        # ``annual_margin_interest_rate > 0``. Without this, margin-mode
+        # backtest trades would silently drop the carry cost from the DB
+        # audit trail while live trades persist it (parity with
+        # src/engines/live/trading_engine.py:3397-3420 which passes
+        # ``margin_interest_cost=interest_cost``). Stashed on the trade
+        # metadata at exit time and read back here.
+        margin_interest_cost = None
+        try:
+            meta = getattr(trade, "metadata", None) or {}
+            if "margin_interest_cost" in meta:
+                margin_interest_cost = float(meta["margin_interest_cost"])
+        except (TypeError, ValueError):
+            margin_interest_cost = None
+
         try:
             self.db_manager.log_trade(
                 symbol=symbol,
@@ -224,6 +239,7 @@ class EventLogger:
                 mae_price=trade.mae_price,
                 mfe_time=trade.mfe_time,
                 mae_time=trade.mae_time,
+                margin_interest_cost=margin_interest_cost,
             )
         except Exception as e:
             if not self._logging_error_warned:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2130,27 +2130,64 @@ class LiveTradingEngine:
             return None
 
     def _add_sentiment_data(self, df: pd.DataFrame, symbol: str) -> pd.DataFrame:
-        """Add sentiment data to price data"""
+        """Add sentiment data to price data.
+
+        Backfills the entire buffer with historical sentiment first
+        (parity with backtest's full-history merge at
+        src/engines/backtest/engine.py:957-964), then layers the live
+        snapshot on top of recent candles. Without the historical pass,
+        bars older than 4 hours in the live buffer carried 0.0 sentiment
+        while backtest had populated values — so ML strategies that
+        consume a sequence_length window saw materially different inputs
+        between the two engines.
+        """
         try:
+            # Step 1: backfill historical sentiment over the buffer if the
+            # provider supports it. Mirrors backtest's `_merge_sentiment_data`
+            # join + ffill so older candles carry real sentiment values.
+            if hasattr(self.sentiment_provider, "get_historical_sentiment") and not df.empty:
+                try:
+                    start = df.index.min().to_pydatetime()
+                    end = df.index.max().to_pydatetime()
+                    sentiment_df = self.sentiment_provider.get_historical_sentiment(
+                        symbol, start, end
+                    )
+                    if sentiment_df is not None and not sentiment_df.empty:
+                        if (
+                            hasattr(self.sentiment_provider, "aggregate_sentiment")
+                            and self.timeframe
+                        ):
+                            sentiment_df = self.sentiment_provider.aggregate_sentiment(
+                                sentiment_df, window=self.timeframe
+                            )
+                        df = df.join(sentiment_df, how="left")
+                        if "sentiment_score" in df.columns:
+                            df["sentiment_score"] = df["sentiment_score"].ffill().fillna(0)
+                except Exception as e:
+                    logger.warning(
+                        "Historical sentiment backfill failed for %s: %s — "
+                        "continuing with live-only sentiment which may differ from backtest",
+                        symbol,
+                        e,
+                    )
+
+            # Step 2: overlay the latest real-time sentiment snapshot on
+            # the most recent 4 hours of candles. The historical backfill
+            # has already populated older rows with the right values.
             if hasattr(self.sentiment_provider, "get_live_sentiment"):
-                # Get live sentiment for recent data
                 live_sentiment = self.sentiment_provider.get_live_sentiment()
-
-                # Apply to recent candles (last 4 hours)
-                recent_mask = df.index >= (df.index.max() - pd.Timedelta(hours=4))
-                for feature, value in live_sentiment.items():
-                    if feature not in df.columns:
-                        df[feature] = 0.0
-                    df.loc[recent_mask, feature] = value
-
-                # Mark sentiment freshness
-                df["sentiment_freshness"] = 0
-                df.loc[recent_mask, "sentiment_freshness"] = 1
-
-                logger.debug("Applied live sentiment to %s recent candles", recent_mask.sum())
+                if live_sentiment and not df.empty:
+                    recent_mask = df.index >= (df.index.max() - pd.Timedelta(hours=4))
+                    for feature, value in live_sentiment.items():
+                        if feature not in df.columns:
+                            df[feature] = 0.0
+                        df.loc[recent_mask, feature] = value
+                    if "sentiment_freshness" not in df.columns:
+                        df["sentiment_freshness"] = 0
+                    df.loc[recent_mask, "sentiment_freshness"] = 1
+                    logger.debug("Applied live sentiment to %s recent candles", recent_mask.sum())
             else:
-                # Fallback to historical sentiment
-                logger.debug("Using historical sentiment data")
+                logger.debug("Using historical sentiment data only (no live provider)")
 
         except Exception as e:
             logger.error("Failed to add sentiment data: %s", e, exc_info=True)

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2403,11 +2403,22 @@ class LiveTradingEngine:
 
         if use_runtime:
             perf_metrics = self.performance_tracker.get_metrics()
+            # Pass symbol/timeframe/df/index so LiveEntryHandler can run
+            # correlation control. These are required keyword args of the
+            # handler's correlation guard (see LiveEntryHandler.process_runtime_decision
+            # at src/engines/live/execution/entry_handler.py:208-222) — without
+            # them, correlation_handler.apply_correlation_control is silently
+            # skipped, so the live engine over-concentrates in correlated pairs
+            # that the backtest engine de-risks.
             entry_signal_result = self.live_entry_handler.process_runtime_decision(
                 runtime_decision=runtime_decision,
                 balance=self.current_balance,
                 current_price=float(current_price),
                 current_time=datetime.now(UTC),
+                symbol=symbol,
+                timeframe=self.timeframe,
+                df=df,
+                index=current_index,
                 peak_balance=perf_metrics.peak_balance or self.current_balance,
                 trading_session_id=self.trading_session_id,
             )

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1135,6 +1135,13 @@ class LiveTradingEngine:
         current_price: float,
         current_time: datetime,
     ) -> RuntimeContext:
+        """Build the StrategyRuntime context with current balance and live positions.
+
+        Delegates the position-translation step to ``_build_component_positions``
+        so the runtime path and the direct ``ComponentStrategy.process_candle``
+        path present an identical position view to the strategy — matching the
+        backtest engine's runtime context construction.
+        """
         positions = self._build_component_positions(current_price)
         return RuntimeContext(balance=float(balance), current_positions=positions or None)
 
@@ -2153,13 +2160,23 @@ class LiveTradingEngine:
                         symbol, start, end
                     )
                     if sentiment_df is not None and not sentiment_df.empty:
-                        if (
-                            hasattr(self.sentiment_provider, "aggregate_sentiment")
-                            and self.timeframe
-                        ):
+                        # Aggregate when the provider supports it. Fall back
+                        # to "1h" when self.timeframe is not yet set (e.g.
+                        # warmup paths) so the join shape is well-defined
+                        # rather than producing NaN-padded raw rows that
+                        # silently diverge from backtest.
+                        if hasattr(self.sentiment_provider, "aggregate_sentiment"):
                             sentiment_df = self.sentiment_provider.aggregate_sentiment(
-                                sentiment_df, window=self.timeframe
+                                sentiment_df, window=self.timeframe or "1h"
                             )
+                        # Drop pre-existing sentiment columns before the
+                        # join so we never produce ``sentiment_score_x``/
+                        # ``_y`` collisions when the buffer was already
+                        # enriched on a prior call (e.g. retained
+                        # _kline_buffer).
+                        collision_cols = [c for c in df.columns if c in sentiment_df.columns]
+                        if collision_cols:
+                            df = df.drop(columns=collision_cols)
                         df = df.join(sentiment_df, how="left")
                         if "sentiment_score" in df.columns:
                             df["sentiment_score"] = df["sentiment_score"].ffill().fillna(0)
@@ -2174,9 +2191,13 @@ class LiveTradingEngine:
             # Step 2: overlay the latest real-time sentiment snapshot on
             # the most recent 4 hours of candles. The historical backfill
             # has already populated older rows with the right values.
+            # The 4h window matches the live sentiment provider's
+            # freshness contract — bars older than that rely on the
+            # historical backfill above.
             if hasattr(self.sentiment_provider, "get_live_sentiment"):
                 live_sentiment = self.sentiment_provider.get_live_sentiment()
                 if live_sentiment and not df.empty:
+                    # 4h: live sentiment freshness window (see step-2 comment).
                     recent_mask = df.index >= (df.index.max() - pd.Timedelta(hours=4))
                     for feature, value in live_sentiment.items():
                         if feature not in df.columns:
@@ -2477,9 +2498,18 @@ class LiveTradingEngine:
             # and in backtest. Previously this hardcoded ``None`` and silently
             # diverged from backtest.
             try:
-                current_positions = self._build_component_positions(
-                    float(df["close"].iloc[current_index]) if current_index < len(df) else 0.0
-                )
+                # Fall back to the most recent close (df[-1]) when
+                # current_index is past the end — never to 0.0, which would
+                # produce a -100% pnl_percent in ComponentPosition and could
+                # trigger forced-exit logic in strategies that consult
+                # current_positions.
+                if len(df) == 0:
+                    fallback_price = 0.0
+                elif current_index < len(df):
+                    fallback_price = float(df["close"].iloc[current_index])
+                else:
+                    fallback_price = float(df["close"].iloc[-1])
+                current_positions = self._build_component_positions(fallback_price)
                 decision = self.strategy.process_candle(
                     df,
                     current_index,
@@ -4071,10 +4101,21 @@ class LiveTradingEngine:
 
         for position in positions_snapshot.values():
             try:
+                # Use current_size (post-partial-exit) — passing the original
+                # ``size`` would silently re-inflate risk_manager.daily_risk_used
+                # on every re-registration, undoing the prior
+                # adjust_position_after_partial_exit. CODE.md "Position Fields"
+                # rules: ``current_size`` is the source of truth for capital
+                # currently deployed.
+                effective_size = (
+                    float(position.current_size)
+                    if position.current_size is not None
+                    else float(position.size)
+                )
                 self.risk_manager.update_position(
                     symbol=position.symbol,
                     side=position.side.value,
-                    size=position.size,
+                    size=effective_size,
                     entry_price=position.entry_price,
                 )
             except Exception as e:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2180,22 +2180,30 @@ class LiveTradingEngine:
                         # provider's frame happens to expose a same-named
                         # column like ``volume`` or ``close``; (b) the join
                         # never raises pandas' default-overlap error.
-                        sentiment_namespace = ("sentiment_", "sentiment")
                         sentiment_only_cols = [
-                            c for c in sentiment_df.columns if c.startswith(sentiment_namespace)
+                            c for c in sentiment_df.columns if c.startswith("sentiment_")
                         ]
                         if not sentiment_only_cols:
-                            # Provider returned no sentiment columns at all —
-                            # nothing to merge.
-                            sentiment_df = sentiment_df.iloc[0:0]
+                            # Provider returned no ``sentiment_*`` columns
+                            # at all (e.g. misconfigured aggregator that
+                            # emits only OHLCV-style columns). Skip the
+                            # merge entirely rather than letting the
+                            # provider's residual column names leak into
+                            # ``collision_cols`` and silently strip OHLCV
+                            # from ``df``.
+                            logger.debug(
+                                "Historical sentiment provider returned no "
+                                "sentiment_* columns for %s — skipping merge",
+                                symbol,
+                            )
                         else:
                             sentiment_df = sentiment_df[sentiment_only_cols]
-                        collision_cols = [c for c in df.columns if c in sentiment_df.columns]
-                        if collision_cols:
-                            df = df.drop(columns=collision_cols)
-                        df = df.join(sentiment_df, how="left")
-                        if "sentiment_score" in df.columns:
-                            df["sentiment_score"] = df["sentiment_score"].ffill().fillna(0)
+                            collision_cols = [c for c in df.columns if c in sentiment_df.columns]
+                            if collision_cols:
+                                df = df.drop(columns=collision_cols)
+                            df = df.join(sentiment_df, how="left")
+                            if "sentiment_score" in df.columns:
+                                df["sentiment_score"] = df["sentiment_score"].ffill().fillna(0)
                 except Exception as e:
                     logger.warning(
                         "Historical sentiment backfill failed for %s: %s — "

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2169,11 +2169,27 @@ class LiveTradingEngine:
                             sentiment_df = self.sentiment_provider.aggregate_sentiment(
                                 sentiment_df, window=self.timeframe or "1h"
                             )
-                        # Drop pre-existing sentiment columns before the
-                        # join so we never produce ``sentiment_score_x``/
+                        # Restrict the merge to the sentiment namespace and
+                        # drop any pre-existing sentiment columns from the
+                        # local df so we never produce ``sentiment_score_x``/
                         # ``_y`` collisions when the buffer was already
                         # enriched on a prior call (e.g. retained
-                        # _kline_buffer).
+                        # ``_kline_buffer``). Filtering BOTH sides on the
+                        # ``sentiment*`` prefix means: (a) OHLCV / indicator
+                        # columns on ``df`` survive even if a future
+                        # provider's frame happens to expose a same-named
+                        # column like ``volume`` or ``close``; (b) the join
+                        # never raises pandas' default-overlap error.
+                        sentiment_namespace = ("sentiment_", "sentiment")
+                        sentiment_only_cols = [
+                            c for c in sentiment_df.columns if c.startswith(sentiment_namespace)
+                        ]
+                        if not sentiment_only_cols:
+                            # Provider returned no sentiment columns at all —
+                            # nothing to merge.
+                            sentiment_df = sentiment_df.iloc[0:0]
+                        else:
+                            sentiment_df = sentiment_df[sentiment_only_cols]
                         collision_cols = [c for c in df.columns if c in sentiment_df.columns]
                         if collision_cols:
                             df = df.drop(columns=collision_cols)
@@ -4112,6 +4128,23 @@ class LiveTradingEngine:
                     if position.current_size is not None
                     else float(position.size)
                 )
+                if effective_size <= 0:
+                    # 100% partial-exit drained the position but the close
+                    # ack has not popped it from the tracker yet. Calling
+                    # ``update_position(size=0.0)`` would fail the size>0
+                    # validator and leave ``daily_risk_used`` inflated at
+                    # the original allocation. Drain the slot via
+                    # ``close_position`` so the next entry sees the right
+                    # remaining budget, then skip re-registration.
+                    try:
+                        self.risk_manager.close_position(position.symbol)
+                    except (KeyError, ValueError, AttributeError) as drain_err:
+                        logger.debug(
+                            "Risk manager close_position drain skipped for %s: %s",
+                            position.symbol,
+                            drain_err,
+                        )
+                    continue
                 self.risk_manager.update_position(
                     symbol=position.symbol,
                     side=position.side.value,

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -54,14 +54,15 @@ from src.engines.live.data.market_data_handler import MarketDataHandler
 from src.engines.live.execution.entry_handler import LiveEntryHandler, LiveEntrySignal
 from src.engines.live.execution.execution_engine import LiveExecutionEngine
 from src.engines.live.execution.exit_handler import LiveExitHandler
-from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.execution.position_tracker import (
     LivePosition,
     LivePositionTracker,
 )
 from src.engines.live.health.health_monitor import HealthMonitor
 from src.engines.live.logging.event_logger import LiveEventLogger
+from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.strategy_manager import StrategyManager
+from src.engines.shared.correlation_handler import CorrelationHandler
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
 from src.engines.shared.execution.execution_model import ExecutionModel
 from src.engines.shared.execution.fill_policy import FillPolicy, resolve_fill_policy
@@ -347,6 +348,27 @@ class LiveTradingEngine:
         except Exception:
             self.correlation_engine = None
 
+        # Correlation handler — applies correlation-based size reduction at
+        # entry. Mirrors backtest engine wiring (src/engines/backtest/engine.py:343-350)
+        # so live entries reduce size for correlated exposure the same way
+        # backtest does. Without this, live silently over-concentrates in
+        # correlated pairs that backtest would have de-risked.
+        self.correlation_handler: CorrelationHandler | None = None
+        if self.correlation_engine is not None:
+            try:
+                self.correlation_handler = CorrelationHandler(
+                    correlation_engine=self.correlation_engine,
+                    risk_manager=self.risk_manager,
+                    data_provider=data_provider,
+                    strategy=self.strategy,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to initialize live correlation handler: %s — "
+                    "live entries will run without correlation controls.",
+                    e,
+                )
+
         # Initialize database manager
         try:
             self.db_manager = DatabaseManager(database_url)
@@ -385,9 +407,11 @@ class LiveTradingEngine:
                     provider, config, testnet
                 )
                 if self.exchange_interface:
-                    use_margin = getattr(self.exchange_interface, 'is_margin_mode', False)
+                    use_margin = getattr(self.exchange_interface, "is_margin_mode", False)
                     self.account_synchronizer = AccountSynchronizer(
-                        self.exchange_interface, self.db_manager, self.trading_session_id,
+                        self.exchange_interface,
+                        self.db_manager,
+                        self.trading_session_id,
                         use_margin=use_margin,
                     )
                     # Initialize order tracker for monitoring order fills
@@ -646,7 +670,9 @@ class LiveTradingEngine:
         # Wire db_manager for order journaling (session_id set during start())
         self.live_execution_engine.db_manager = self.db_manager
 
-        # Entry handler
+        # Entry handler. correlation_handler matches backtest engine wiring
+        # so live and backtest both reduce position size for correlated
+        # exposure at entry.
         self.live_entry_handler = entry_handler or LiveEntryHandler(
             execution_engine=self.live_execution_engine,
             execution_model=self.execution_model,
@@ -655,6 +681,7 @@ class LiveTradingEngine:
                 self.strategy if isinstance(self.strategy, ComponentStrategy) else None
             ),
             dynamic_risk_manager=self.dynamic_risk_manager,
+            correlation_handler=self.correlation_handler,
             max_position_size=self.max_position_size,
             default_take_profit_pct=self._resolve_take_profit_pct(),
         )
@@ -1073,12 +1100,18 @@ class LiveTradingEngine:
         self._runtime_warmup = max(0, int(dataset.warmup_period or 0))
         return dataset.data
 
-    def _build_runtime_context(
+    def _build_component_positions(
         self,
-        balance: float,
         current_price: float,
-        current_time: datetime,
-    ) -> RuntimeContext:
+    ) -> list[ComponentPosition]:
+        """Translate live positions into the strategy-side ComponentPosition list.
+
+        Used by both the StrategyRuntime context and the direct
+        ComponentStrategy.process_candle call so a strategy that consults
+        ``current_positions`` (e.g. for anti-pyramiding or correlation-aware
+        sizing) gets the same view in both code paths — and matching the
+        backtest path where positions always flow through.
+        """
         positions: list[ComponentPosition] = []
         for position in self.live_position_tracker.positions.values():
             try:
@@ -1094,7 +1127,15 @@ class LiveTradingEngine:
                 positions.append(component_position)
             except Exception as exc:
                 logger.debug("Failed to translate live position for runtime: %s", exc)
+        return positions
 
+    def _build_runtime_context(
+        self,
+        balance: float,
+        current_price: float,
+        current_time: datetime,
+    ) -> RuntimeContext:
+        positions = self._build_component_positions(current_price)
         return RuntimeContext(balance=float(balance), current_positions=positions or None)
 
     def _compute_component_quantity(
@@ -1272,6 +1313,17 @@ class LiveTradingEngine:
                 # Reconcile positions with exchange (detect offline stop-loss triggers)
                 self._reconcile_positions_with_exchange()
 
+                # Reconciliation paths (e.g. PositionReconciler._reconcile_filled_entry)
+                # may create LivePositions via track_recovered_position without
+                # registering them with risk_manager. The DB-recovery path in
+                # _recover_active_positions does register; the reconciler path
+                # currently does not. Sweep the tracker after reconciliation so
+                # every tracked position is known to the risk manager — this
+                # restores the parity invariant (also enforced on every
+                # backtest entry) that risk_manager has visibility into all
+                # active positions for per-symbol caps and correlation gating.
+                self._ensure_positions_registered_with_risk_manager()
+
             except Exception as e:
                 logger.error("❌ Account synchronization error: %s", e, exc_info=True)
 
@@ -1311,7 +1363,7 @@ class LiveTradingEngine:
             try:
                 from src.engines.live.reconciliation import PeriodicReconciler
 
-                use_margin = getattr(self.exchange_interface, 'is_margin_mode', False)
+                use_margin = getattr(self.exchange_interface, "is_margin_mode", False)
                 self._periodic_reconciler = PeriodicReconciler(
                     exchange_interface=self.exchange_interface,
                     position_tracker=self.live_position_tracker,
@@ -1348,9 +1400,7 @@ class LiveTradingEngine:
         """Enter close-only mode: no new entries, exits/stops/trailing still active."""
         if not self._close_only_mode:
             self._close_only_mode = True
-            logger.critical(
-                "🚨 CLOSE-ONLY MODE ACTIVATED — no new entries until manual review"
-            )
+            logger.critical("🚨 CLOSE-ONLY MODE ACTIVATED — no new entries until manual review")
 
     def resume_trading(self) -> None:
         """Resume normal trading after close-only mode review."""
@@ -1527,9 +1577,7 @@ class LiveTradingEngine:
         #    while the old thread may still be mutating order state
         if not processor_clean:
             self.exchange_interface.mark_user_degraded()
-            logger.critical(
-                "UserDataProcessor did not stop cleanly — staying in REST_DEGRADED"
-            )
+            logger.critical("UserDataProcessor did not stop cleanly — staying in REST_DEGRADED")
             return
         # 6. Attempt user stream reconnect with fresh callback
         reconnected = False
@@ -2059,7 +2107,9 @@ class LiveTradingEngine:
             if self._kline_buffer and self._kline_buffer.needs_resync:
                 logger.info("KlineBuffer gap detected — resyncing from REST")
                 self._kline_buffer.resync_from_rest(
-                    self.data_provider, self._active_symbol or symbol, self.timeframe or timeframe,
+                    self.data_provider,
+                    self._active_symbol or symbol,
+                    self.timeframe or timeframe,
                 )
 
             # Use WS cache if available and healthy
@@ -2372,10 +2422,21 @@ class LiveTradingEngine:
         elif isinstance(self.strategy, ComponentStrategy):
             # Component-based strategy: use process_candle() for decision
             # Note: runtime_decision should already be populated if this is a component strategy
-            # This branch handles direct ComponentStrategy usage without StrategyRuntime wrapper
+            # This branch handles direct ComponentStrategy usage without StrategyRuntime wrapper.
+            # Pass the live positions list so strategies that consult
+            # current_positions (anti-pyramiding, correlation-aware sizing,
+            # etc.) see the same view they would in the StrategyRuntime path
+            # and in backtest. Previously this hardcoded ``None`` and silently
+            # diverged from backtest.
             try:
+                current_positions = self._build_component_positions(
+                    float(df["close"].iloc[current_index]) if current_index < len(df) else 0.0
+                )
                 decision = self.strategy.process_candle(
-                    df, current_index, self.current_balance, None
+                    df,
+                    current_index,
+                    self.current_balance,
+                    current_positions or None,
                 )
                 self._apply_policies_from_decision(decision)
 
@@ -3290,9 +3351,7 @@ class LiveTradingEngine:
                     from src.engines.live.reconciliation import PositionReconciler
 
                     tracker = MarginInterestTracker(self.exchange_interface)
-                    base_asset = PositionReconciler._extract_base_asset(
-                        position.symbol
-                    )
+                    base_asset = PositionReconciler._extract_base_asset(position.symbol)
                     if base_asset == position.symbol:
                         logger.warning(
                             "Could not extract base asset from %s — margin interest may not be queried correctly",
@@ -3934,6 +3993,49 @@ class LiveTradingEngine:
             logger.error("❌ Error recovering session: %s", e, exc_info=True)
             return None
 
+    def _ensure_positions_registered_with_risk_manager(self) -> None:
+        """Register every tracked position with the risk manager.
+
+        Idempotent. Re-registering a known position is a no-op for risk
+        managers that key on (symbol, side); for the few that count entries,
+        registering twice still leaves the position visible — strictly
+        better than the recovered-but-invisible state we are guarding
+        against.
+
+        Parity rationale:
+        - Backtest registers every position at entry
+          (src/engines/backtest/execution/entry_handler.py:407-421).
+        - Live's DB-recovery path registers
+          (src/engines/live/trading_engine.py:_recover_active_positions).
+        - Live's reconciler path (PositionReconciler._reconcile_filled_entry)
+          can also create positions via track_recovered_position but does
+          not register. This sweep closes that gap so per-symbol caps and
+          correlation gating see all active positions, matching the
+          invariant backtest assumes always holds.
+        """
+        if self.risk_manager is None:
+            return
+        try:
+            positions_snapshot = self.live_position_tracker.positions
+        except Exception as e:
+            logger.warning("Failed to snapshot positions for risk-manager sync: %s", e)
+            return
+
+        for position in positions_snapshot.values():
+            try:
+                self.risk_manager.update_position(
+                    symbol=position.symbol,
+                    side=position.side.value,
+                    size=position.size,
+                    entry_price=position.entry_price,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to register recovered position %s with risk manager: %s",
+                    position.symbol,
+                    e,
+                )
+
     def _recover_active_positions(self) -> None:
         """Recover active positions from database"""
         try:
@@ -4001,10 +4103,7 @@ class LiveTradingEngine:
                 # Validate recovered entry_price before tracking. Positions
                 # with invalid entry_price cannot be closed properly and would
                 # become orphaned in the tracker.
-                if (
-                    position.entry_price <= 0
-                    or not math.isfinite(position.entry_price)
-                ):
+                if position.entry_price <= 0 or not math.isfinite(position.entry_price):
                     logger.critical(
                         "SKIPPING recovery of position %s (%s): invalid entry_price %.8f. "
                         "MANUAL RECONCILIATION REQUIRED.",
@@ -4077,7 +4176,7 @@ class LiveTradingEngine:
                     Severity,
                 )
 
-                use_margin = getattr(self.exchange_interface, 'is_margin_mode', False)
+                use_margin = getattr(self.exchange_interface, "is_margin_mode", False)
                 reconciler = PositionReconciler(
                     exchange_interface=self.exchange_interface,
                     position_tracker=self.live_position_tracker,
@@ -4094,9 +4193,7 @@ class LiveTradingEngine:
                     # Process results even with no positions — a filled entry
                     # order may create a position, and critical issues must
                     # still trigger close-only mode.
-                    critical_count = sum(
-                        1 for r in results if r.severity == Severity.CRITICAL
-                    )
+                    critical_count = sum(1 for r in results if r.severity == Severity.CRITICAL)
                     if critical_count > 0:
                         logger.critical(
                             "🚨 %d CRITICAL reconciliation issues — entering close-only mode",
@@ -4128,9 +4225,7 @@ class LiveTradingEngine:
                 results = reconciler.reconcile_startup(positions_snapshot)
 
                 # Check for critical issues
-                critical_count = sum(
-                    1 for r in results if r.severity == Severity.CRITICAL
-                )
+                critical_count = sum(1 for r in results if r.severity == Severity.CRITICAL)
                 if critical_count > 0:
                     logger.critical(
                         "🚨 %d CRITICAL reconciliation issues — entering close-only mode",
@@ -4257,9 +4352,7 @@ class LiveTradingEngine:
                             from src.engines.live.reconciliation import PositionReconciler
 
                             tracker = MarginInterestTracker(self.exchange_interface)
-                            base_asset = PositionReconciler._extract_base_asset(
-                                position.symbol
-                            )
+                            base_asset = PositionReconciler._extract_base_asset(position.symbol)
                             interest_base = tracker.get_position_interest_cost(
                                 base_asset, position.entry_time
                             )

--- a/tests/unit/backtesting/test_exit_handler_parity.py
+++ b/tests/unit/backtesting/test_exit_handler_parity.py
@@ -1,0 +1,275 @@
+"""Parity tests between backtest and live engines for exit semantics.
+
+These tests cover two divergences that previously made backtest results drift
+from live behaviour:
+
+1. Time-exit reason: the backtest engine used to hardcode ``"Time limit"`` and
+   discard the policy-returned reason. Live preserves the policy reason
+   (``"Max holding period"``, ``"Weekend flat"``, etc.) and falls back to
+   ``"Time exit"``. Backtest now matches.
+2. Margin interest accrual: the live engine deducts borrow interest from
+   realised PnL via ``MarginInterestTracker``. Backtest now models the same
+   carry cost via the ``annual_margin_interest_rate`` parameter so margin-mode
+   strategies don't silently overstate returns.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from src.engines.backtest.execution.exit_handler import ExitHandler
+from src.engines.backtest.execution.position_tracker import PositionTracker
+from src.engines.backtest.models import ActiveTrade
+from src.engines.shared.execution.execution_model import ExecutionModel
+from src.engines.shared.execution.fill_policy import default_fill_policy
+from src.engines.shared.models import PositionSide
+from src.position_management.time_exits import TimeExitPolicy
+
+
+def _make_handler(
+    position_tracker: PositionTracker,
+    *,
+    time_exit_policy: TimeExitPolicy | None = None,
+    annual_margin_interest_rate: float = 0.0,
+) -> ExitHandler:
+    return ExitHandler(
+        execution_engine=Mock(),
+        position_tracker=position_tracker,
+        risk_manager=Mock(),
+        execution_model=ExecutionModel(default_fill_policy()),
+        time_exit_policy=time_exit_policy,
+        use_high_low_for_stops=True,
+        annual_margin_interest_rate=annual_margin_interest_rate,
+    )
+
+
+@pytest.mark.fast
+class TestTimeExitReasonParity:
+    """Backtest must surface the same exit_reason strings as live."""
+
+    def test_max_holding_period_reason_propagates(self) -> None:
+        """Backtest preserves ``"Max holding period"`` from the policy."""
+        entry_time = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+        # 4-hour candle 5 hours after entry — past the 4h max-holding window.
+        candle_time = entry_time + timedelta(hours=5)
+
+        tracker = PositionTracker()
+        tracker.open_position(
+            ActiveTrade(
+                symbol="TEST",
+                side=PositionSide.LONG,
+                entry_price=100.0,
+                entry_time=entry_time,
+                size=0.1,
+            )
+        )
+
+        handler = _make_handler(
+            tracker,
+            time_exit_policy=TimeExitPolicy(max_holding_hours=4),
+        )
+
+        candle = pd.Series(
+            {"open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 1000.0},
+            name=candle_time,
+        )
+
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=candle,
+            current_price=100.5,
+            symbol="TEST",
+        )
+
+        assert result.is_time_limit is True
+        assert result.exit_reason == "Max holding period"
+
+    def test_weekend_flat_reason_propagates(self) -> None:
+        """Backtest preserves ``"Weekend flat"`` from the policy."""
+        # 2024-01-06 is a Saturday — weekend_flat triggers.
+        candle_time = datetime(2024, 1, 6, 12, 0, tzinfo=UTC)
+        entry_time = candle_time - timedelta(hours=1)
+
+        tracker = PositionTracker()
+        tracker.open_position(
+            ActiveTrade(
+                symbol="TEST",
+                side=PositionSide.LONG,
+                entry_price=100.0,
+                entry_time=entry_time,
+                size=0.1,
+            )
+        )
+
+        handler = _make_handler(
+            tracker,
+            time_exit_policy=TimeExitPolicy(weekend_flat=True),
+        )
+
+        candle = pd.Series(
+            {"open": 100.0, "high": 101.0, "low": 99.0, "close": 100.0, "volume": 1000.0},
+            name=candle_time,
+        )
+
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=candle,
+            current_price=100.0,
+            symbol="TEST",
+        )
+
+        assert result.is_time_limit is True
+        assert result.exit_reason == "Weekend flat"
+
+    def test_default_fallback_matches_live(self) -> None:
+        """When the policy returns no specific reason, fall back to ``"Time exit"``.
+
+        This matches live's ``time_reason or "Time exit"`` fallback string.
+        Until the policy is extended with reason-less paths this is a forward
+        guard — kept here so the parity convention is locked in by a test.
+        """
+        # Verify the source code uses the parity fallback (not the legacy
+        # "Time limit") so future edits to the time-exit branch can't regress
+        # silently. The behavioural contract is asserted via the live engine's
+        # equivalent test file.
+        from src.engines.backtest.execution import exit_handler as bt_exit
+
+        source = bt_exit.__file__
+        with open(source, encoding="utf-8") as f:
+            text = f.read()
+
+        assert 'time_reason or "Time exit"' in text, (
+            "Backtest exit_handler must fall back to 'Time exit' for parity "
+            "with live engine; legacy 'Time limit' wording would diverge."
+        )
+
+
+@pytest.mark.fast
+class TestMarginInterestParity:
+    """Backtest must charge margin/borrow interest when the rate is set."""
+
+    def _make_position_with_balance(self, entry_time: datetime) -> PositionTracker:
+        """Build a tracker with a position whose entry_balance is populated."""
+        tracker = PositionTracker()
+        trade = ActiveTrade(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            entry_price=100.0,
+            entry_time=entry_time,
+            size=0.5,
+            current_size=0.5,
+            original_size=0.5,
+            entry_balance=10_000.0,
+        )
+        tracker.open_position(trade)
+        return tracker
+
+    def test_zero_rate_default_charges_no_interest(self) -> None:
+        """The default rate (0.0) preserves spot-mode behavior — no carry cost."""
+        entry_time = datetime(2024, 1, 1, tzinfo=UTC)
+        tracker = self._make_position_with_balance(entry_time)
+        handler = _make_handler(tracker, annual_margin_interest_rate=0.0)
+
+        # 24 hours later, no price move — gross PnL is 0, no interest.
+        interest = handler._calculate_margin_interest(
+            position_notional=5_000.0,
+            entry_time=entry_time,
+            exit_time=entry_time + timedelta(hours=24),
+        )
+        assert interest == 0.0
+
+    def test_positive_rate_charges_interest_pro_rata(self) -> None:
+        """Interest scales linearly with holding period and notional."""
+        entry_time = datetime(2024, 1, 1, tzinfo=UTC)
+        tracker = self._make_position_with_balance(entry_time)
+        handler = _make_handler(tracker, annual_margin_interest_rate=0.10)
+
+        # 5,000 notional × 10% APR × (24h / 8760h) = ~1.3699 USDT
+        interest = handler._calculate_margin_interest(
+            position_notional=5_000.0,
+            entry_time=entry_time,
+            exit_time=entry_time + timedelta(hours=24),
+        )
+        expected = 5_000.0 * 0.10 * (24.0 / (365.0 * 24.0))
+        assert interest == pytest.approx(expected, rel=1e-9)
+
+    def test_negative_holding_returns_zero(self) -> None:
+        """Defensive: clock skew or bad inputs must not produce negative interest."""
+        entry_time = datetime(2024, 1, 1, tzinfo=UTC)
+        tracker = self._make_position_with_balance(entry_time)
+        handler = _make_handler(tracker, annual_margin_interest_rate=0.10)
+
+        interest = handler._calculate_margin_interest(
+            position_notional=5_000.0,
+            entry_time=entry_time,
+            exit_time=entry_time - timedelta(hours=1),
+        )
+        assert interest == 0.0
+
+    def test_init_rejects_negative_rate(self) -> None:
+        """Negative or non-finite rates are rejected at construction."""
+        tracker = PositionTracker()
+        with pytest.raises(ValueError, match="non-negative"):
+            _make_handler(tracker, annual_margin_interest_rate=-0.01)
+
+    def test_init_rejects_nan_rate(self) -> None:
+        """NaN rate is rejected at construction (defense against bad config)."""
+        tracker = PositionTracker()
+        with pytest.raises(ValueError, match="non-negative"):
+            _make_handler(tracker, annual_margin_interest_rate=float("nan"))
+
+
+@pytest.mark.fast
+class TestBacktesterMarginRateWiring:
+    """The Backtester must plumb annual_margin_interest_rate to its ExitHandler."""
+
+    def test_backtester_default_rate_is_zero(self) -> None:
+        """Default preserves existing spot-mode behavior — no surprise carry costs."""
+        from src.engines.backtest.engine import Backtester
+
+        strategy = Mock()
+        strategy.name = "test"
+        strategy.get_risk_overrides.return_value = None
+        strategy.calculate_indicators = Mock(return_value=None)
+        data_provider = Mock()
+
+        bt = Backtester(strategy=strategy, data_provider=data_provider, initial_balance=10_000.0)
+        assert bt.annual_margin_interest_rate == 0.0
+        assert bt.exit_handler.annual_margin_interest_rate == 0.0
+
+    def test_backtester_propagates_rate_to_exit_handler(self) -> None:
+        from src.engines.backtest.engine import Backtester
+
+        strategy = Mock()
+        strategy.name = "test"
+        strategy.get_risk_overrides.return_value = None
+        strategy.calculate_indicators = Mock(return_value=None)
+        data_provider = Mock()
+
+        bt = Backtester(
+            strategy=strategy,
+            data_provider=data_provider,
+            initial_balance=10_000.0,
+            annual_margin_interest_rate=0.05,
+        )
+        assert bt.annual_margin_interest_rate == 0.05
+        assert bt.exit_handler.annual_margin_interest_rate == 0.05
+
+    def test_backtester_rejects_invalid_rate(self) -> None:
+        from src.engines.backtest.engine import Backtester
+
+        strategy = Mock()
+        strategy.name = "test"
+        data_provider = Mock()
+
+        with pytest.raises(ValueError, match="non-negative"):
+            Backtester(
+                strategy=strategy,
+                data_provider=data_provider,
+                initial_balance=10_000.0,
+                annual_margin_interest_rate=-0.01,
+            )

--- a/tests/unit/backtesting/test_exit_handler_parity.py
+++ b/tests/unit/backtesting/test_exit_handler_parity.py
@@ -125,27 +125,49 @@ class TestTimeExitReasonParity:
         assert result.is_time_limit is True
         assert result.exit_reason == "Weekend flat"
 
-    def test_default_fallback_matches_live(self) -> None:
-        """When the policy returns no specific reason, fall back to ``"Time exit"``.
+    def test_default_fallback_matches_live(self, monkeypatch) -> None:
+        """When the policy reports a hit but returns no reason, fall back
+        to ``"Time exit"`` — matching live's ``time_reason or "Time exit"``.
 
-        This matches live's ``time_reason or "Time exit"`` fallback string.
-        Until the policy is extended with reason-less paths this is a forward
-        guard — kept here so the parity convention is locked in by a test.
+        Drives the exit handler with a stubbed policy that returns
+        ``(True, None)`` and asserts the resolved exit_reason. This is a
+        behavioural test (not a source-grep) so future edits to the
+        time-exit branch can't regress silently.
         """
-        # Verify the source code uses the parity fallback (not the legacy
-        # "Time limit") so future edits to the time-exit branch can't regress
-        # silently. The behavioural contract is asserted via the live engine's
-        # equivalent test file.
-        from src.engines.backtest.execution import exit_handler as bt_exit
+        entry_time = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+        candle_time = entry_time + timedelta(hours=5)
 
-        source = bt_exit.__file__
-        with open(source, encoding="utf-8") as f:
-            text = f.read()
-
-        assert 'time_reason or "Time exit"' in text, (
-            "Backtest exit_handler must fall back to 'Time exit' for parity "
-            "with live engine; legacy 'Time limit' wording would diverge."
+        tracker = PositionTracker()
+        tracker.open_position(
+            ActiveTrade(
+                symbol="TEST",
+                side=PositionSide.LONG,
+                entry_price=100.0,
+                entry_time=entry_time,
+                size=0.1,
+            )
         )
+
+        policy = TimeExitPolicy(max_holding_hours=4)
+        # Force the policy to report a hit but with no reason — the exact
+        # contract live falls back to ``"Time exit"`` for.
+        monkeypatch.setattr(policy, "check_time_exit_conditions", lambda *_a, **_k: (True, None))
+
+        handler = _make_handler(tracker, time_exit_policy=policy)
+        candle = pd.Series(
+            {"open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 1000.0},
+            name=candle_time,
+        )
+
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=candle,
+            current_price=100.5,
+            symbol="TEST",
+        )
+
+        assert result.is_time_limit is True
+        assert result.exit_reason == "Time exit"
 
 
 @pytest.mark.fast

--- a/tests/unit/backtesting/test_fee_accounting_parity.py
+++ b/tests/unit/backtesting/test_fee_accounting_parity.py
@@ -1,0 +1,244 @@
+"""Parity tests for backtest fee accounting against live's record_trade contract.
+
+Two parity invariants are locked in here:
+
+1. **PerformanceTracker.record_trade(fee=...) sums entry + exit fees.**
+   Backtest used to pass only ``exit_fee`` to ``record_trade``, while live
+   passes ``total_fee = entry_fee + exit_fee`` (plus interest_cost). That
+   silently undercounted ``total_fees_paid`` in backtest reports by ~50%
+   for any strategy with non-zero fee_rate. The fix stashes ``entry_fee``
+   on ``ActiveTrade.metadata`` at entry, copies it onto the completed
+   ``Trade`` at close, and the engine reads it back when calling
+   ``record_trade``. Live already does the same via
+   ``position.metadata["entry_fee"]``.
+
+2. **log_trade persists margin_interest_cost.** Live writes the
+   ``margin_interest_cost`` column to the trades table; backtest used to
+   drop it from the audit trail entirely. The fix stashes the computed
+   interest on the trade metadata and reads it back in
+   ``EventLogger.log_completed_trade``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import pytest
+
+from src.database.models import TradeSource
+from src.engines.backtest.execution.execution_engine import ExecutionEngine
+from src.engines.backtest.execution.exit_handler import ExitHandler
+from src.engines.backtest.execution.position_tracker import PositionTracker
+from src.engines.backtest.logging.event_logger import EventLogger
+from src.engines.backtest.models import ActiveTrade, Trade
+from src.engines.shared.execution.execution_model import ExecutionModel
+from src.engines.shared.execution.fill_policy import default_fill_policy
+from src.engines.shared.models import PositionSide
+
+
+@pytest.mark.fast
+class TestEntryFeeOnMetadata:
+    """ExecutionEngine must stash entry_fee/entry_slippage on the new trade.
+
+    Without this, the exit path can't reconstruct total fees, so the
+    PerformanceTracker.record_trade fee sum stays ~50% short.
+    """
+
+    def test_immediate_entry_records_entry_fee_metadata(self) -> None:
+        engine = ExecutionEngine(fee_rate=0.001, slippage_rate=0.0)
+        result = engine.execute_immediate_entry(
+            symbol="TEST",
+            side="long",
+            size_fraction=0.1,
+            base_price=100.0,
+            current_time=datetime(2024, 1, 1, tzinfo=UTC),
+            balance=10_000.0,
+            stop_loss=95.0,
+            take_profit=110.0,
+        )
+
+        assert result.executed is True
+        assert result.trade is not None
+        assert result.trade.metadata["entry_fee"] == pytest.approx(result.entry_fee)
+        assert "entry_slippage_cost" in result.trade.metadata
+
+    def test_pending_entry_records_entry_fee_metadata(self) -> None:
+        engine = ExecutionEngine(fee_rate=0.001, slippage_rate=0.0005)
+        engine.queue_entry(
+            side="long",
+            size_fraction=0.1,
+            sl_pct=0.05,
+            tp_pct=0.10,
+            signal_price=100.0,
+            signal_time=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        result = engine.execute_pending_entry(
+            symbol="TEST",
+            open_price=100.5,
+            current_time=datetime(2024, 1, 1, 1, tzinfo=UTC),
+            balance=10_000.0,
+        )
+
+        assert result.executed is True
+        assert result.trade is not None
+        assert result.trade.metadata["entry_fee"] == pytest.approx(result.entry_fee)
+        assert result.trade.metadata["entry_slippage_cost"] == pytest.approx(result.slippage_cost)
+
+
+@pytest.mark.fast
+class TestPositionTrackerCarriesEntryMetadata:
+    """``close_position`` must copy entry_fee/entry_slippage onto completed Trade.
+
+    Otherwise the engine has no way to reconstruct total fees at exit.
+    """
+
+    def test_completed_trade_inherits_entry_fee_metadata(self) -> None:
+        tracker = PositionTracker()
+        active = ActiveTrade(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            entry_price=100.0,
+            entry_time=datetime(2024, 1, 1, tzinfo=UTC),
+            size=0.1,
+            entry_balance=10_000.0,
+        )
+        active.metadata["entry_fee"] = 1.0
+        active.metadata["entry_slippage_cost"] = 0.5
+        tracker.open_position(active)
+
+        result = tracker.close_position(
+            exit_price=110.0,
+            exit_time=datetime(2024, 1, 1, 1, tzinfo=UTC),
+            exit_reason="test",
+            basis_balance=10_000.0,
+        )
+
+        assert result.trade.metadata.get("entry_fee") == pytest.approx(1.0)
+        assert result.trade.metadata.get("entry_slippage_cost") == pytest.approx(0.5)
+
+
+@pytest.mark.fast
+class TestExitHandlerStashesMarginInterestCost:
+    """When margin interest accrues, ``execute_exit`` must surface the cost on
+    the completed trade so ``EventLogger`` can persist it to the DB."""
+
+    def _build_handler(self, rate: float) -> tuple[ExitHandler, PositionTracker]:
+        position_tracker = PositionTracker()
+        execution_engine = ExecutionEngine(fee_rate=0.0, slippage_rate=0.0)
+        risk_manager = Mock()
+        risk_manager.close_position = Mock()
+        handler = ExitHandler(
+            execution_engine=execution_engine,
+            position_tracker=position_tracker,
+            risk_manager=risk_manager,
+            execution_model=ExecutionModel(default_fill_policy()),
+            annual_margin_interest_rate=rate,
+        )
+        return handler, position_tracker
+
+    def test_interest_recorded_on_trade_metadata_when_rate_set(self) -> None:
+        handler, tracker = self._build_handler(rate=0.10)
+        entry = datetime(2024, 1, 1, tzinfo=UTC)
+        exit_t = entry + timedelta(hours=24)
+        tracker.open_position(
+            ActiveTrade(
+                symbol="TEST",
+                side=PositionSide.LONG,
+                entry_price=100.0,
+                entry_time=entry,
+                size=0.5,
+                entry_balance=10_000.0,
+            )
+        )
+
+        completed_trade, _net_pnl, _fee, _slip = handler.execute_exit(
+            exit_price=100.0,
+            exit_reason="test",
+            current_time=exit_t,
+            current_price=100.0,
+            balance=10_000.0,
+            symbol="TEST",
+        )
+
+        assert "margin_interest_cost" in completed_trade.metadata
+        assert completed_trade.metadata["margin_interest_cost"] > 0
+
+    def test_no_interest_metadata_when_rate_zero(self) -> None:
+        handler, tracker = self._build_handler(rate=0.0)
+        entry = datetime(2024, 1, 1, tzinfo=UTC)
+        exit_t = entry + timedelta(hours=24)
+        tracker.open_position(
+            ActiveTrade(
+                symbol="TEST",
+                side=PositionSide.LONG,
+                entry_price=100.0,
+                entry_time=entry,
+                size=0.5,
+                entry_balance=10_000.0,
+            )
+        )
+
+        completed_trade, _net_pnl, _fee, _slip = handler.execute_exit(
+            exit_price=100.0,
+            exit_reason="test",
+            current_time=exit_t,
+            current_price=100.0,
+            balance=10_000.0,
+            symbol="TEST",
+        )
+
+        assert "margin_interest_cost" not in completed_trade.metadata
+
+
+@pytest.mark.fast
+class TestEventLoggerPersistsMarginInterest:
+    """``EventLogger.log_completed_trade`` must forward margin_interest_cost
+    to ``db_manager.log_trade`` when present on the trade metadata."""
+
+    def _make_trade(self, with_interest: bool) -> Trade:
+        trade = Trade(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            entry_price=100.0,
+            exit_price=110.0,
+            entry_time=datetime(2024, 1, 1, tzinfo=UTC),
+            exit_time=datetime(2024, 1, 1, 1, tzinfo=UTC),
+            size=0.1,
+            pnl=10.0,
+            pnl_percent=0.01,
+            exit_reason="test",
+        )
+        if with_interest:
+            trade.metadata["margin_interest_cost"] = 1.23
+        return trade
+
+    def test_persists_margin_interest_when_present(self) -> None:
+        db_manager = Mock()
+        db_manager.log_trade = Mock(return_value=1)
+        logger = EventLogger(db_manager=db_manager, log_to_database=True, session_id=42)
+
+        logger.log_completed_trade(
+            trade=self._make_trade(with_interest=True),
+            symbol="TEST",
+            strategy_name="test_strat",
+            source=TradeSource.BACKTEST,
+        )
+
+        kwargs = db_manager.log_trade.call_args.kwargs
+        assert kwargs["margin_interest_cost"] == pytest.approx(1.23)
+
+    def test_passes_none_when_no_interest_recorded(self) -> None:
+        db_manager = Mock()
+        db_manager.log_trade = Mock(return_value=1)
+        logger = EventLogger(db_manager=db_manager, log_to_database=True, session_id=42)
+
+        logger.log_completed_trade(
+            trade=self._make_trade(with_interest=False),
+            symbol="TEST",
+            strategy_name="test_strat",
+            source=TradeSource.BACKTEST,
+        )
+
+        kwargs = db_manager.log_trade.call_args.kwargs
+        assert kwargs["margin_interest_cost"] is None

--- a/tests/unit/live/test_engine_parity_wiring.py
+++ b/tests/unit/live/test_engine_parity_wiring.py
@@ -1,0 +1,244 @@
+"""Parity wiring tests between live and backtest engines.
+
+These tests lock in three structural parity invariants that previously drifted
+silently between the two engines:
+
+1. **Crash recovery → risk_manager registration.** When a position is added to
+   the live tracker via the reconciler path (no DB row, just a fill detected
+   on the exchange), the engine must still register it with the risk manager
+   — same as backtest does on every entry. Without this, per-symbol caps and
+   correlation gates are bypassed for crash-recovered fills.
+
+2. **CorrelationHandler wired into LiveEntryHandler.** Backtest's EntryHandler
+   reduces position size for correlated exposure; live must too. Previously
+   live built a CorrelationEngine but never wrapped it in a CorrelationHandler
+   nor passed it down — so live entries silently over-concentrated in
+   correlated pairs that backtest would have de-risked.
+
+3. **process_candle current_positions parity.** When live invokes a direct
+   ComponentStrategy via process_candle (no StrategyRuntime wrapper), it now
+   passes the live positions list rather than ``None``. Backtest already
+   passes positions via the runtime context. Strategies that consult
+   current_positions (anti-pyramiding, correlation-aware sizing, exposure
+   capping) get the same view in both engines.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from src.engines.live.trading_engine import LiveTradingEngine, Position, PositionSide
+from tests.mocks import MockDatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def mock_database_manager(monkeypatch):
+    """Mock the DatabaseManager so engine init succeeds without a live DB."""
+    original_init = MockDatabaseManager.__init__
+
+    def patched_init(self, database_url=None):
+        original_init(self, database_url)
+        self._fallback_balance = 10_000.0
+
+    monkeypatch.setattr(MockDatabaseManager, "__init__", patched_init)
+    monkeypatch.setattr("src.engines.live.trading_engine.DatabaseManager", MockDatabaseManager)
+
+
+def _make_engine() -> LiveTradingEngine:
+    """Build a paper-mode engine with a mock strategy / data provider."""
+    strategy = Mock()
+    strategy.get_risk_overrides.return_value = None
+    strategy.name = "test"
+    data_provider = Mock()
+    data_provider.get_current_price.return_value = 100.0
+    return LiveTradingEngine(
+        strategy=strategy,
+        data_provider=data_provider,
+        initial_balance=10_000.0,
+        enable_live_trading=False,
+        log_trades=False,
+        fee_rate=0.0,
+        slippage_rate=0.0,
+    )
+
+
+@pytest.mark.fast
+class TestCorrelationHandlerWired:
+    """The live engine must wire CorrelationHandler into LiveEntryHandler.
+
+    Backtest does this at src/engines/backtest/engine.py:343-385. Live must
+    match so live entries reduce size for correlated exposure the same way
+    backtest entries do.
+    """
+
+    def test_correlation_handler_present_when_engine_available(self) -> None:
+        engine = _make_engine()
+        # Engine should have built a CorrelationHandler iff the underlying
+        # CorrelationEngine initialized successfully — same condition as backtest.
+        if engine.correlation_engine is not None:
+            assert engine.correlation_handler is not None
+            assert engine.live_entry_handler.correlation_handler is engine.correlation_handler
+
+    def test_no_correlation_handler_when_engine_missing(self, monkeypatch) -> None:
+        """If correlation engine init fails, handler must be None — never crash."""
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("simulated correlation engine failure")
+
+        monkeypatch.setattr("src.engines.live.trading_engine.CorrelationEngine", boom)
+        engine = _make_engine()
+        assert engine.correlation_engine is None
+        assert engine.correlation_handler is None
+        assert engine.live_entry_handler.correlation_handler is None
+
+
+@pytest.mark.fast
+class TestRiskManagerSweepRegistersRecoveredPositions:
+    """``_ensure_positions_registered_with_risk_manager`` must register every
+    tracked position with the risk manager.
+
+    This closes the gap where ``PositionReconciler._reconcile_filled_entry``
+    creates a position via ``track_recovered_position`` without registering
+    it (reconciliation.py:454-487 has no risk_manager handle), so per-symbol
+    caps and correlation gates would otherwise miss crash-recovered fills.
+    """
+
+    def test_sweep_registers_tracked_position(self) -> None:
+        engine = _make_engine()
+        engine.risk_manager = MagicMock()
+
+        # Simulate the reconciler path: position appears in tracker but
+        # was never passed through a risk_manager.update_position call.
+        position = Position(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            size=0.1,
+            entry_price=100.0,
+            entry_time=datetime.now(UTC),
+            order_id="recovered-123",
+            original_size=0.1,
+            current_size=0.1,
+        )
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        engine._ensure_positions_registered_with_risk_manager()
+
+        engine.risk_manager.update_position.assert_called_once()
+        kwargs = engine.risk_manager.update_position.call_args.kwargs
+        assert kwargs["symbol"] == "TEST"
+        assert kwargs["side"] == "long"
+        assert kwargs["size"] == pytest.approx(0.1)
+        assert kwargs["entry_price"] == pytest.approx(100.0)
+
+    def test_sweep_is_safe_when_no_positions(self) -> None:
+        engine = _make_engine()
+        engine.risk_manager = MagicMock()
+        engine._ensure_positions_registered_with_risk_manager()
+        engine.risk_manager.update_position.assert_not_called()
+
+    def test_sweep_no_op_when_risk_manager_missing(self) -> None:
+        """Defensive: must not raise when risk_manager is None."""
+        engine = _make_engine()
+        engine.risk_manager = None
+        # Should silently no-op, not crash.
+        engine._ensure_positions_registered_with_risk_manager()
+
+    def test_sweep_swallows_per_position_errors(self) -> None:
+        """One bad position must not block registration of the others."""
+        engine = _make_engine()
+        engine.risk_manager = MagicMock()
+        engine.risk_manager.update_position.side_effect = [
+            RuntimeError("boom"),
+            None,
+        ]
+
+        for i, sym in enumerate(("BAD", "GOOD")):
+            position = Position(
+                symbol=sym,
+                side=PositionSide.LONG,
+                size=0.1,
+                entry_price=100.0 + i,
+                entry_time=datetime.now(UTC),
+                order_id=f"order-{sym}",
+                original_size=0.1,
+                current_size=0.1,
+            )
+            engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        engine._ensure_positions_registered_with_risk_manager()
+
+        # Both positions attempted, error on first didn't block second.
+        assert engine.risk_manager.update_position.call_count == 2
+
+
+@pytest.mark.fast
+class TestProcessCandlePositionsParity:
+    """Live's direct ComponentStrategy.process_candle path must pass populated
+    current_positions, not ``None``.
+
+    Backtest passes the positions list via RuntimeContext (engine.py:695-720).
+    Live's direct path previously hardcoded ``None``, so any strategy
+    consulting current_positions saw an empty list in live but populated in
+    backtest.
+    """
+
+    def test_build_component_positions_returns_tracked_positions(self) -> None:
+        engine = _make_engine()
+        # Pre-track a position
+        position = Position(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            size=0.1,
+            entry_price=100.0,
+            entry_time=datetime.now(UTC),
+            order_id="order-1",
+            original_size=0.1,
+            current_size=0.1,
+            entry_balance=10_000.0,
+        )
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        positions = engine._build_component_positions(current_price=110.0)
+
+        assert len(positions) == 1
+        assert positions[0].symbol == "TEST"
+        assert positions[0].side == "long"
+        assert positions[0].entry_price == pytest.approx(100.0)
+        assert positions[0].current_price == pytest.approx(110.0)
+
+    def test_build_component_positions_empty_when_flat(self) -> None:
+        engine = _make_engine()
+        positions = engine._build_component_positions(current_price=100.0)
+        assert positions == []
+
+    def test_runtime_context_uses_same_helper(self) -> None:
+        """RuntimeContext path must surface positions via the shared helper.
+
+        Locks in the refactor that both code paths (StrategyRuntime and
+        direct ComponentStrategy.process_candle) feed off the same builder.
+        """
+        engine = _make_engine()
+        position = Position(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            size=0.1,
+            entry_price=100.0,
+            entry_time=datetime.now(UTC),
+            order_id="order-1",
+            original_size=0.1,
+            current_size=0.1,
+            entry_balance=10_000.0,
+        )
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        ctx = engine._build_runtime_context(
+            balance=10_000.0,
+            current_price=110.0,
+            current_time=datetime.now(UTC),
+        )
+        assert ctx.current_positions is not None
+        assert len(ctx.current_positions) == 1
+        assert ctx.current_positions[0].symbol == "TEST"

--- a/tests/unit/live/test_engine_parity_wiring.py
+++ b/tests/unit/live/test_engine_parity_wiring.py
@@ -94,6 +94,59 @@ class TestCorrelationHandlerWired:
         assert engine.correlation_handler is None
         assert engine.live_entry_handler.correlation_handler is None
 
+    def test_check_entry_passes_correlation_context(self, monkeypatch) -> None:
+        """``_check_entry_conditions`` must pass symbol/timeframe/df/index to the
+        entry handler so the correlation guard can fire.
+
+        Locks in the fix for the silent no-op: previously
+        ``process_runtime_decision`` was called without these args, so the
+        guard at LiveEntryHandler.process_runtime_decision:208-222
+        (``and df is not None and index is not None``) always evaluated False
+        and ``CorrelationHandler.apply_correlation_control`` never ran in live —
+        making the wired CorrelationHandler a no-op. Backtest passes the full
+        context unconditionally (src/engines/backtest/execution/entry_handler.py:209-216).
+        """
+        import pandas as pd
+
+        engine = _make_engine()
+        engine.timeframe = "1h"
+        engine._active_symbol = "TEST"
+        # Force the runtime path so we hit the call site we patched.
+        monkeypatch.setattr(engine, "_is_runtime_strategy", lambda: True)
+
+        # Use a sentinel exception so we observe the call args without
+        # needing to drive the rest of _check_entry_conditions (which logs
+        # regime info that doesn't tolerate a Mock).
+        class _Captured(Exception):
+            def __init__(self, kwargs):
+                self.kwargs = kwargs
+
+        def fake_process(**kwargs):
+            raise _Captured(kwargs)
+
+        monkeypatch.setattr(engine.live_entry_handler, "process_runtime_decision", fake_process)
+
+        df = pd.DataFrame(
+            {"open": [100.0], "high": [101.0], "low": [99.0], "close": [100.5], "volume": [1.0]}
+        )
+        with pytest.raises(_Captured) as exc_info:
+            engine._check_entry_conditions(
+                df=df,
+                current_index=0,
+                symbol="TEST",
+                current_price=100.0,
+                current_time=datetime.now(UTC),
+                runtime_decision=Mock(),
+            )
+
+        captured = exc_info.value.kwargs
+        # All four context fields must reach the handler — these are exactly
+        # the fields the correlation guard requires to be non-None.
+        assert captured.get("symbol") == "TEST"
+        assert captured.get("timeframe") == "1h"
+        assert captured.get("df") is df
+        assert captured.get("index") == 0
+
 
 @pytest.mark.fast
 class TestRiskManagerSweepRegistersRecoveredPositions:

--- a/tests/unit/live/test_engine_parity_wiring.py
+++ b/tests/unit/live/test_engine_parity_wiring.py
@@ -186,6 +186,36 @@ class TestRiskManagerSweepRegistersRecoveredPositions:
         assert kwargs["size"] == pytest.approx(0.1)
         assert kwargs["entry_price"] == pytest.approx(100.0)
 
+    def test_sweep_uses_current_size_after_partial_exit(self) -> None:
+        """After a partial exit shrinks ``current_size``, the next sweep
+        must report the post-exit fraction — passing the original ``size``
+        would silently re-inflate ``risk_manager.daily_risk_used`` by the
+        full original allocation, undoing
+        ``risk_manager.adjust_position_after_partial_exit``.
+        """
+        engine = _make_engine()
+        engine.risk_manager = MagicMock()
+
+        position = Position(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            size=0.10,  # original entry fraction
+            entry_price=100.0,
+            entry_time=datetime.now(UTC),
+            order_id="recovered-123",
+            original_size=0.10,
+            current_size=0.04,  # 60% partial exit already taken
+        )
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        engine._ensure_positions_registered_with_risk_manager()
+
+        kwargs = engine.risk_manager.update_position.call_args.kwargs
+        assert kwargs["size"] == pytest.approx(0.04), (
+            "sweep must use current_size, not the original size — otherwise "
+            "daily_risk_used re-inflates after partial exits"
+        )
+
     def test_sweep_is_safe_when_no_positions(self) -> None:
         engine = _make_engine()
         engine.risk_manager = MagicMock()

--- a/tests/unit/live/test_engine_parity_wiring.py
+++ b/tests/unit/live/test_engine_parity_wiring.py
@@ -186,6 +186,39 @@ class TestRiskManagerSweepRegistersRecoveredPositions:
         assert kwargs["size"] == pytest.approx(0.1)
         assert kwargs["entry_price"] == pytest.approx(100.0)
 
+    def test_sweep_drains_risk_manager_when_current_size_zero(self) -> None:
+        """A position whose ``current_size`` was drained to 0.0 by partial
+        exits but not yet popped from the tracker must NOT raise in the
+        sweep, and must drain the risk-manager slot via ``close_position``.
+
+        Prior to the fix, ``update_position(size=0.0)`` raised the size>0
+        validator and the prior ``daily_risk_used`` allocation stayed
+        inflated until the close ack popped the position.
+        """
+        engine = _make_engine()
+        engine.risk_manager = MagicMock()
+
+        position = Position(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            size=0.10,
+            entry_price=100.0,
+            entry_time=datetime.now(UTC),
+            order_id="drained-1",
+            original_size=0.10,
+            current_size=0.0,  # 100% partial-exit drained, close ack pending
+        )
+        engine.live_position_tracker.track_recovered_position(position, db_id=None)
+
+        engine._ensure_positions_registered_with_risk_manager()
+
+        # Must not call update_position at all — that path raises ValueError
+        # for size=0 and would leave daily_risk_used stale.
+        engine.risk_manager.update_position.assert_not_called()
+        # Must drain the slot via close_position so the next entry sees the
+        # right remaining daily-risk budget.
+        engine.risk_manager.close_position.assert_called_once_with("TEST")
+
     def test_sweep_uses_current_size_after_partial_exit(self) -> None:
         """After a partial exit shrinks ``current_size``, the next sweep
         must report the post-exit fraction — passing the original ``size``

--- a/tests/unit/live/test_sentiment_merge_parity.py
+++ b/tests/unit/live/test_sentiment_merge_parity.py
@@ -1,0 +1,138 @@
+"""Live engine sentiment merge parity test.
+
+Backtest backfills historical sentiment over the full dataframe via
+``SentimentDataProvider.get_historical_sentiment`` + ``aggregate_sentiment`` +
+``ffill().fillna(0)`` (src/engines/backtest/engine.py:957-964). Live used to
+ONLY apply ``get_live_sentiment`` to the most recent 4 hours of the buffer,
+leaving older bars at 0.0. ML strategies that consume a sequence_length
+window (commonly 60-240 hours) saw materially different inputs in live vs
+backtest.
+
+The fix in ``LiveTradingEngine._add_sentiment_data`` adds a historical
+backfill pass before the live overlay, so older bars carry real sentiment
+values just like backtest.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from src.engines.live.trading_engine import LiveTradingEngine
+from tests.mocks import MockDatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def mock_database_manager(monkeypatch):
+    original_init = MockDatabaseManager.__init__
+
+    def patched_init(self, database_url=None):
+        original_init(self, database_url)
+        self._fallback_balance = 10_000.0
+
+    monkeypatch.setattr(MockDatabaseManager, "__init__", patched_init)
+    monkeypatch.setattr("src.engines.live.trading_engine.DatabaseManager", MockDatabaseManager)
+
+
+def _make_buffer_df(periods: int = 24) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=periods, freq="1h", tz=UTC)
+    return pd.DataFrame(
+        {
+            "open": [100.0] * periods,
+            "high": [101.0] * periods,
+            "low": [99.0] * periods,
+            "close": [100.5] * periods,
+            "volume": [1000.0] * periods,
+        },
+        index=idx,
+    )
+
+
+def _make_engine(sentiment_provider) -> LiveTradingEngine:
+    strategy = Mock()
+    strategy.get_risk_overrides.return_value = None
+    strategy.name = "test"
+    data_provider = Mock()
+    data_provider.get_current_price.return_value = 100.0
+    engine = LiveTradingEngine(
+        strategy=strategy,
+        data_provider=data_provider,
+        sentiment_provider=sentiment_provider,
+        initial_balance=10_000.0,
+        enable_live_trading=False,
+        log_trades=False,
+        fee_rate=0.0,
+        slippage_rate=0.0,
+    )
+    engine.timeframe = "1h"
+    return engine
+
+
+@pytest.mark.fast
+class TestLiveSentimentMergeParity:
+    """Live must backfill historical sentiment so older bars match backtest."""
+
+    def test_historical_sentiment_populates_full_buffer(self) -> None:
+        df = _make_buffer_df(periods=24)
+        sentiment_idx = pd.date_range("2024-01-01", periods=24, freq="1h", tz=UTC)
+        historical = pd.DataFrame({"sentiment_score": [0.5] * 24}, index=sentiment_idx)
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = historical
+        provider.aggregate_sentiment.return_value = historical
+        provider.get_live_sentiment.return_value = {"sentiment_score": 0.9}
+
+        engine = _make_engine(provider)
+        out = engine._add_sentiment_data(df, "TEST")
+
+        assert "sentiment_score" in out.columns
+        # Every bar must have a sentiment value (no zero defaults left over
+        # from the old recent-only path).
+        assert (out["sentiment_score"] != 0.0).all()
+        # Recent 4 hours overlay with the live snapshot value.
+        recent_mask = out.index >= (out.index.max() - pd.Timedelta(hours=4))
+        assert (out.loc[recent_mask, "sentiment_score"].sub(0.9).abs() < 1e-9).all()
+        # Older bars keep the historical value.
+        older_mask = ~recent_mask
+        assert (out.loc[older_mask, "sentiment_score"].sub(0.5).abs() < 1e-9).all()
+
+    def test_no_historical_provider_falls_back_to_live_only(self) -> None:
+        """Provider without get_historical_sentiment must not crash; older
+        bars stay zero (legacy behaviour) — the fix is non-destructive."""
+        df = _make_buffer_df(periods=24)
+        provider = Mock(spec=["get_live_sentiment"])
+        provider.get_live_sentiment.return_value = {"sentiment_score": 0.9}
+
+        engine = _make_engine(provider)
+        out = engine._add_sentiment_data(df, "TEST")
+
+        assert "sentiment_score" in out.columns
+        recent_mask = out.index >= (out.index.max() - pd.Timedelta(hours=4))
+        assert (out.loc[recent_mask, "sentiment_score"].sub(0.9).abs() < 1e-9).all()
+
+    def test_historical_failure_does_not_crash_live_path(self) -> None:
+        """If historical fetch raises, live overlay still applies — graceful
+        degradation, no full crash."""
+        df = _make_buffer_df(periods=24)
+        provider = Mock()
+        provider.get_historical_sentiment.side_effect = RuntimeError("upstream down")
+        provider.get_live_sentiment.return_value = {"sentiment_score": 0.9}
+
+        engine = _make_engine(provider)
+        out = engine._add_sentiment_data(df, "TEST")
+
+        assert "sentiment_score" in out.columns
+        recent_mask = out.index >= (out.index.max() - pd.Timedelta(hours=4))
+        assert (out.loc[recent_mask, "sentiment_score"].sub(0.9).abs() < 1e-9).all()
+
+    def test_empty_df_handled_safely(self) -> None:
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = pd.DataFrame()
+        provider.get_live_sentiment.return_value = {"sentiment_score": 0.9}
+
+        engine = _make_engine(provider)
+        out = engine._add_sentiment_data(pd.DataFrame(), "TEST")
+        assert isinstance(out, pd.DataFrame)

--- a/tests/unit/live/test_sentiment_merge_parity.py
+++ b/tests/unit/live/test_sentiment_merge_parity.py
@@ -137,6 +137,41 @@ class TestLiveSentimentMergeParity:
         out = engine._add_sentiment_data(pd.DataFrame(), "TEST")
         assert isinstance(out, pd.DataFrame)
 
+    def test_collision_drop_does_not_strip_non_sentiment_columns(self) -> None:
+        """If a future provider's frame happens to expose a column whose
+        name overlaps an OHLCV/indicator column (``volume`` is the obvious
+        one), the collision-drop must leave the original df column intact.
+        Only ``sentiment*`` columns are eligible for replacement.
+        """
+        df = _make_buffer_df(periods=12)
+        # Mark the original volume so we can detect over-broad drops.
+        df["volume"] = 12345.0
+
+        sentiment_idx = pd.date_range("2024-01-01", periods=12, freq="1h", tz=UTC)
+        # Provider returns a frame with both a sentiment column and a
+        # spurious ``volume`` column — a future-proof check.
+        historical = pd.DataFrame(
+            {"sentiment_score": [0.3] * 12, "volume": [99999.0] * 12},
+            index=sentiment_idx,
+        )
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = historical
+        provider.aggregate_sentiment.return_value = historical
+        provider.get_live_sentiment.return_value = {}
+
+        engine = _make_engine(provider)
+        out = engine._add_sentiment_data(df, "TEST")
+
+        # OHLCV ``volume`` must survive untouched even though the provider
+        # frame also had a ``volume`` column.
+        assert (out["volume"] == 12345.0).all(), (
+            "collision-drop must be scoped to the sentiment namespace; "
+            "non-sentiment columns must never be stripped"
+        )
+        # Sentiment column still merged correctly.
+        assert "sentiment_score" in out.columns
+
     def test_join_drops_existing_sentiment_columns_to_avoid_collision(self) -> None:
         """If the input df already contains a sentiment column (e.g. from a
         retained kline buffer enriched on a prior call), the merge must

--- a/tests/unit/live/test_sentiment_merge_parity.py
+++ b/tests/unit/live/test_sentiment_merge_parity.py
@@ -137,6 +137,39 @@ class TestLiveSentimentMergeParity:
         out = engine._add_sentiment_data(pd.DataFrame(), "TEST")
         assert isinstance(out, pd.DataFrame)
 
+    def test_provider_with_no_sentiment_columns_does_not_strip_ohlcv(self) -> None:
+        """If the provider's frame contains only non-sentiment columns
+        (e.g. a misconfigured aggregator emitting OHLCV only), the merge
+        must skip entirely rather than letting those column names leak
+        into the collision drop and silently strip OHLCV from ``df``.
+        """
+        df = _make_buffer_df(periods=12)
+        df["volume"] = 12345.0  # mark to detect over-broad drop
+
+        sentiment_idx = pd.date_range("2024-01-01", periods=12, freq="1h", tz=UTC)
+        # Provider returns only OHLCV-style columns — no sentiment_*.
+        historical = pd.DataFrame(
+            {"volume": [99999.0] * 12, "close": [101.0] * 12},
+            index=sentiment_idx,
+        )
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = historical
+        provider.aggregate_sentiment.return_value = historical
+        provider.get_live_sentiment.return_value = {}
+
+        engine = _make_engine(provider)
+        out = engine._add_sentiment_data(df, "TEST")
+
+        # OHLCV must survive untouched even though the provider's frame
+        # carried matching column names.
+        assert (out["volume"] == 12345.0).all(), (
+            "merge must skip when provider returns no sentiment_* columns; "
+            "OHLCV must never be silently stripped"
+        )
+        # No spurious sentiment_score either.
+        assert "sentiment_score" not in out.columns
+
     def test_collision_drop_does_not_strip_non_sentiment_columns(self) -> None:
         """If a future provider's frame happens to expose a column whose
         name overlaps an OHLCV/indicator column (``volume`` is the obvious

--- a/tests/unit/live/test_sentiment_merge_parity.py
+++ b/tests/unit/live/test_sentiment_merge_parity.py
@@ -136,3 +136,60 @@ class TestLiveSentimentMergeParity:
         engine = _make_engine(provider)
         out = engine._add_sentiment_data(pd.DataFrame(), "TEST")
         assert isinstance(out, pd.DataFrame)
+
+    def test_join_drops_existing_sentiment_columns_to_avoid_collision(self) -> None:
+        """If the input df already contains a sentiment column (e.g. from a
+        retained kline buffer enriched on a prior call), the merge must
+        drop it before joining so we never produce ``sentiment_score_x``/
+        ``_y`` and silently feed the wrong column to the strategy.
+        """
+        df = _make_buffer_df(periods=24)
+        # Simulate a previously-enriched buffer: every row already carries
+        # a stale sentiment value.
+        df["sentiment_score"] = 0.1
+
+        sentiment_idx = pd.date_range("2024-01-01", periods=24, freq="1h", tz=UTC)
+        historical = pd.DataFrame({"sentiment_score": [0.5] * 24}, index=sentiment_idx)
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = historical
+        provider.aggregate_sentiment.return_value = historical
+        provider.get_live_sentiment.return_value = {"sentiment_score": 0.9}
+
+        engine = _make_engine(provider)
+        out = engine._add_sentiment_data(df, "TEST")
+
+        # No suffixed collision columns. Single canonical column wins.
+        assert "sentiment_score_x" not in out.columns
+        assert "sentiment_score_y" not in out.columns
+        # Older bars carry the historical merge value, not the stale 0.1.
+        recent_mask = out.index >= (out.index.max() - pd.Timedelta(hours=4))
+        older_mask = ~recent_mask
+        assert (out.loc[older_mask, "sentiment_score"].sub(0.5).abs() < 1e-9).all()
+        # Recent bars carry the live overlay.
+        assert (out.loc[recent_mask, "sentiment_score"].sub(0.9).abs() < 1e-9).all()
+
+    def test_no_self_timeframe_falls_back_to_default_aggregation_window(self) -> None:
+        """When ``self.timeframe`` is None (e.g. warmup paths), historical
+        backfill must still aggregate (default ``"1h"``) rather than join
+        raw rows that pad the dataframe with NaNs and silently diverge
+        from backtest.
+        """
+        df = _make_buffer_df(periods=12)
+        sentiment_idx = pd.date_range("2024-01-01", periods=12, freq="1h", tz=UTC)
+        historical = pd.DataFrame({"sentiment_score": [0.4] * 12}, index=sentiment_idx)
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = historical
+        provider.aggregate_sentiment.return_value = historical
+        provider.get_live_sentiment.return_value = {}
+
+        engine = _make_engine(provider)
+        engine.timeframe = None  # simulate pre-start() state
+
+        engine._add_sentiment_data(df, "TEST")
+
+        # aggregate_sentiment must have been called even when self.timeframe is None.
+        assert provider.aggregate_sentiment.called
+        kwargs = provider.aggregate_sentiment.call_args.kwargs
+        assert kwargs.get("window") == "1h"


### PR DESCRIPTION
## Summary

Multi-round parity audit between live and backtest engines. Filters ~50% false positives across seven exploration sweeps, fixes the verified divergences, and closes them out via a 4-iteration deep-review-auto-fix pass.

**12 verified parity gaps closed across 6 commits.** Backtest now accurately predicts live trading for the full set of behaviours covered here.

## Verified parity fixes

### Round 1 — initial sweep (commit `b77f476c`)

1. **Time-exit reason mismatch.** Backtest hardcoded `"Time limit"` and discarded the `TimeExitPolicy`-returned reason; live used `time_reason or "Time exit"`. Backtest now propagates `"Max holding period"`, `"Weekend flat"`, `"End of day flat"`, etc., with matching fallback string.
2. **Margin/borrow interest not modeled in backtest.** Live deducts via `MarginInterestTracker`; backtest had nothing — margin-mode strategies silently overstated returns by 0.5–2% APR. New `annual_margin_interest_rate` parameter on `Backtester` accrues interest pro-rata and folds into returned `exit_fee`. Defaults to `0.0` so existing spot-mode behaviour is unchanged.
3. **Crash-recovered fills bypassed `risk_manager`.** `PositionReconciler._reconcile_filled_entry` creates a `LivePosition` via `track_recovered_position` without `risk_manager.update_position`, while the parallel DB-recovery path and every backtest entry do. New `_ensure_positions_registered_with_risk_manager` sweep runs after reconciliation; idempotent.
4. **`CorrelationHandler` not built or wired in live.** The slot existed on `LiveEntryHandler` but `LiveTradingEngine` never built or passed one. Live now constructs `CorrelationHandler` mirroring backtest's wiring and threads it through, restoring correlation-driven entry sizing.
5. **`ComponentStrategy.process_candle` got `None` for positions in live's direct path.** Backtest always passes positions via `RuntimeContext`. Extracted `_build_component_positions` helper used by both runtime and direct paths.

### Round 2 — correlation context plumbed through (commit `496e6a5f`)

6. **Live correlation control was a no-op despite the wiring.** `LiveEntryHandler.process_runtime_decision` gates correlation on `symbol/timeframe/df/index` non-None ([entry_handler.py:208-222](src/engines/live/execution/entry_handler.py:208)), but the call site in `_check_entry_conditions` did not pass them, so the guard always short-circuited. Now passes the full context; correlation actually fires.

### Round 3 — DB / fee accounting + sentiment merge (commit `68db6b2e`)

7. **`PerformanceTracker.record_trade` fee parity.** Backtest passed only `exit_fee`; live passes `entry_fee + exit_fee + interest_cost`. `total_fees_paid` metric silently undercounted by ~50%. ExecutionEngine now stashes `entry_fee`/`entry_slippage_cost` on `ActiveTrade.metadata`; `PositionTracker.close_position` carries them onto the completed `Trade`; the engine sums entry+exit when calling `record_trade`.
8. **`log_trade` margin_interest_cost persistence.** Backtest dropped the column from the trades audit table while live persisted it. ExitHandler stashes `interest_cost` on the completed trade's metadata; EventLogger reads it back and forwards to `log_trade`.
9. **Live sentiment merge.** Live applied `get_live_sentiment` only to the last 4 hours of the buffer, leaving older bars at 0.0; backtest backfilled historical sentiment over the full dataframe. ML strategies consuming a `sequence_length` window saw materially different inputs in live vs backtest. `_add_sentiment_data` now backfills historical sentiment first, then layers the live snapshot.

### Deep-review iteration 1 (commit `3aaf3bed`)

10. **`_ensure_positions_registered_with_risk_manager` re-inflated `daily_risk_used`.** The sweep passed `position.size` (original) instead of `current_size` (post-partial-exit), so each account-sync cycle silently undid `risk_manager.adjust_position_after_partial_exit`. Now passes `current_size`.
11. Margin-interest finiteness guard against `inf` from extreme rate × notional × duration.
12. Sentiment merge: timeframe fallback to `"1h"` when `self.timeframe` is None (warmup paths); column-collision guard for retained kline buffers.
13. `_check_entry_conditions` falls back to `df["close"].iloc[-1]` for out-of-bounds `current_index` instead of `0.0` (the `0.0` fallback would produce -100% pnl_percent in `ComponentPosition` and trigger forced exits).
14. Restored `_build_runtime_context` docstring; magic-number comments on `seconds_per_year` and the 4h sentiment freshness window.
15. Replaced tautological source-grep test with behavioural test driving a stubbed `TimeExitPolicy`.

### Deep-review iteration 2 (commit `335f6af1`)

16. **Drained-position sweep raised `ValueError`.** When `current_size == 0.0` (100% partial-exit, close ack pending), `update_position(size=0.0)` failed the size>0 validator and left `daily_risk_used` inflated at the original allocation. Sweep now drains the slot via `risk_manager.close_position` and skips re-registration.
17. **Sentiment column-drop too broad.** Restricted both sides of the join to the `sentiment_*` namespace so OHLCV / indicator columns on `df` survive even if a future provider's frame happens to expose a same-named column like `volume`.
18. Added `docs/backtesting.md` "Known parity caveats" subsection mirroring the `Backtester` docstring (tick-size, margin interest, single-vs-multi-position).

### Deep-review iteration 3 (commit `b1bdc97f`)

19. **Empty-sentiment branch could still strip OHLCV.** When the provider returned a frame with no `sentiment_*` columns at all, the empty-`sentiment_df` left provider non-sentiment column names in `collision_cols` and silently dropped OHLCV from `df`. Now skips the merge entirely on that path.

## Documented as known caveats (not parity bugs)

- **Tick-size / step-size rounding** is live-only. Documented on `Backtester` docstring + `docs/backtesting.md`.
- **Single-position vs multi-position.** Backtest holds at most one `ActiveTrade`; live holds N keyed by `order_id`. Multi-symbol strategies must be validated separately.
- **Margin interest constant APR vs live's exchange-reported rate.** Backtest uses simplified actual/365; live reads exchange `MarginInterestTracker`.

## Flagged for separate work (live-engine correctness, no backtest analog)

Spawned as separate tasks rather than bundled here:

- **Live `_execute_scale_in` never places a real exchange order** — only mutates in-memory size, no fee deduction. P1 safety bug; backtest correctly simulates.
- **Phantom-position close skips `log_trade`** — 11 reconciliation paths call `db_manager.close_position` without recording a Trade; realized PnL silently disappears from `PerformanceTracker` and audit trail.
- **Balance correction skips `PerformanceTracker.peak_balance` update** — `account_sync.update_balance` corrects DB balance without notifying tracker; perturbs dynamic-risk decisions.

## Deep-review verdict

After 4 iterations of `/deep-review` (deep-technical-reviewer + business-reviewer + claude-md-compliance-reviewer in parallel), iteration 4 returned clean across all three reviewers:

- **Technical**: correct. 0 P0, 0 P1, 0 P2, 0 P3.
- **Business**: complete. No business-logic gaps in scope.
- **Compliance**: compliant. No CLAUDE.md / CODE.md violations.

## Test plan

- [x] `pytest tests/unit/live/test_engine_parity_wiring.py` — 11 tests (correlation handler wiring, risk-manager sweep idempotency / current_size / drained-position drain, `_build_component_positions` parity)
- [x] `pytest tests/unit/live/test_sentiment_merge_parity.py` — 6 tests (full-buffer backfill, fallback paths, column-collision guard, scoped namespace filter, empty-sentiment skip)
- [x] `pytest tests/unit/backtesting/test_exit_handler_parity.py` — 11 tests (time-exit reason propagation, margin-interest accrual math, Backtester wiring)
- [x] `pytest tests/unit/backtesting/test_fee_accounting_parity.py` — 7 tests (entry-fee metadata, completed-trade carry, EventLogger margin_interest_cost forwarding)
- [x] Full backtesting + live + parity suite — 449 tests pass across both engines
- [x] `ruff check` clean on touched files
- [x] `black` formatted
- [x] `docs/changelog.md` and `docs/backtesting.md` updated

## Commits

- `b77f476c` — fix(engines): close five backtest-live parity gaps
- `496e6a5f` — fix(live): wire correlation context to runtime entry path
- `68db6b2e` — fix(engines): close three more backtest-live parity gaps
- `3aaf3bed` — fix: address deep-review iteration 1 findings
- `335f6af1` — fix: address deep-review iteration 2 findings
- `b1bdc97f` — fix: address deep-review iteration 3 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)