### PR TITLE
fix(engines): close two more backtest-live parity gaps (round 5)

### DIFF
--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -919,7 +919,18 @@ class Backtester:
         start: datetime,
         end: datetime | None,
     ) -> pd.DataFrame:
-        """Merge sentiment data into price DataFrame."""
+        """Merge sentiment data into price DataFrame.
+
+        Also emits the ``sentiment_freshness`` column so feature schemas
+        line up with the live engine, which sets it to 1 for the most
+        recent 4 hours of candles and 0 elsewhere
+        (src/engines/live/trading_engine.py:_add_sentiment_data, and
+        src/tech/adapters/row_extractors.py lists the column as expected).
+        Historical sentiment is by definition stale, so backtest sets the
+        flag to 0 across the entire dataframe — ML features that key off
+        ``sentiment_freshness`` will then see the same column shape in
+        both engines, even if the runtime distribution differs by design.
+        """
         if not self.sentiment_provider:
             return df
 
@@ -931,6 +942,13 @@ class Backtester:
             df = df.join(sentiment_df, how="left")
             if "sentiment_score" in df.columns:
                 df["sentiment_score"] = df["sentiment_score"].ffill().fillna(0)
+
+        # Emit the freshness flag unconditionally so the column is always
+        # present for downstream feature builders. Historical sentiment is
+        # always treated as stale (==0); the live engine flips this to 1
+        # only for the most recent 4-hour window.
+        if "sentiment_freshness" not in df.columns:
+            df["sentiment_freshness"] = 0
 
         return df
 

--- a/src/engines/live/execution/exit_handler.py
+++ b/src/engines/live/execution/exit_handler.py
@@ -827,14 +827,52 @@ class LiveExitHandler:
                 if scale_result.should_scale:
                     add_size_of_original = scale_result.scale_fraction
 
-                    self._execute_scale_in(
-                        order_id=order_id,
-                        position=position,
-                        delta_fraction=add_size_of_original,
-                        price=current_price,
-                        threshold_level=scale_result.target_index,
-                        fraction_of_original=add_size_of_original,
-                    )
+                    # Clamp scale-in size by remaining daily-risk budget so
+                    # the live engine never exceeds the per-day exposure
+                    # cap that backtest already enforces in its scale-in
+                    # path (src/engines/backtest/execution/exit_handler.py:357-361).
+                    # Without this clamp, a strategy with two scale-in
+                    # targets could push total exposure above
+                    # ``risk_manager.params.max_daily_risk`` while
+                    # backtest results would have it capped.
+                    add_effective = add_size_of_original
+                    if self.risk_manager is not None and add_effective > 0:
+                        try:
+                            params = getattr(self.risk_manager, "params", None)
+                            max_daily_risk = (
+                                getattr(params, "max_daily_risk", None) if params else None
+                            )
+                            daily_risk_used = getattr(self.risk_manager, "daily_risk_used", None)
+                            if max_daily_risk is not None and daily_risk_used is not None:
+                                remaining_daily = max(
+                                    0.0,
+                                    float(max_daily_risk) - float(daily_risk_used),
+                                )
+                                add_effective = min(add_effective, remaining_daily)
+                        except (AttributeError, TypeError, ValueError) as e:
+                            logger.debug(
+                                "Daily-risk clamp skipped for %s scale-in: %s",
+                                position.symbol,
+                                e,
+                            )
+
+                    if add_effective <= 0:
+                        logger.info(
+                            "Skipping %s scale-in: daily-risk budget exhausted "
+                            "(requested=%.4f, remaining=%.4f)",
+                            position.symbol,
+                            add_size_of_original,
+                            add_effective,
+                        )
+                    else:
+                        self._execute_scale_in(
+                            order_id=order_id,
+                            position=position,
+                            delta_fraction=add_effective,
+                            price=current_price,
+                            threshold_level=scale_result.target_index,
+                            fraction_of_original=add_effective,
+                        )
 
             except (AttributeError, ValueError, KeyError, ZeroDivisionError) as e:
                 logger.warning("Partial ops evaluation failed for %s: %s", position.symbol, e)

--- a/src/engines/live/execution/exit_handler.py
+++ b/src/engines/live/execution/exit_handler.py
@@ -835,6 +835,17 @@ class LiveExitHandler:
                     # targets could push total exposure above
                     # ``risk_manager.params.max_daily_risk`` while
                     # backtest results would have it capped.
+                    #
+                    # NOTE on units: in the live engine, ``scale_fraction`` is
+                    # applied as a fraction-of-balance delta — ``apply_scale_in``
+                    # adds it straight onto ``position.size`` and
+                    # ``risk_manager.adjust_position_after_scale_in`` adds it
+                    # straight onto ``daily_risk_used`` (same unit as
+                    # ``max_daily_risk``). So we compare against ``remaining_daily``
+                    # directly and must NOT multiply by ``original_size`` here.
+                    # Backtest multiplies by ``original_size`` only because its
+                    # tracker stores size in a different unit; replicating that
+                    # multiplication in live would under-size the scale-in.
                     add_effective = add_size_of_original
                     if self.risk_manager is not None and add_effective > 0:
                         try:

--- a/tests/unit/backtesting/test_sentiment_freshness_parity.py
+++ b/tests/unit/backtesting/test_sentiment_freshness_parity.py
@@ -1,0 +1,141 @@
+"""Backtest must emit ``sentiment_freshness`` for parity with live.
+
+Live's ``_add_sentiment_data`` (src/engines/live/trading_engine.py:2097-2098)
+sets ``sentiment_freshness=0`` across the buffer and flips it to 1 only for
+the most recent 4 hours. Backtest historically never created the column,
+so feature schemas listing it (src/tech/adapters/row_extractors.py:35)
+saw NaN/missing on backtest and a populated 0/1 flag on live.
+
+The fix in ``Backtester._merge_sentiment_data`` always emits the column
+with value 0 (historical sentiment is by definition stale). ML feature
+shapes now line up; the runtime distribution may still differ by design,
+but the column is guaranteed present on both engines.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from src.engines.backtest.engine import Backtester
+
+
+def _make_engine(sentiment_provider) -> Backtester:
+    strategy = Mock()
+    strategy.name = "test"
+    strategy.get_risk_overrides.return_value = None
+    strategy.calculate_indicators = Mock(return_value=None)
+    data_provider = Mock()
+    return Backtester(
+        strategy=strategy,
+        data_provider=data_provider,
+        sentiment_provider=sentiment_provider,
+        initial_balance=10_000.0,
+    )
+
+
+def _make_price_df(periods: int = 24) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=periods, freq="1h", tz=UTC)
+    return pd.DataFrame(
+        {
+            "open": [100.0] * periods,
+            "high": [101.0] * periods,
+            "low": [99.0] * periods,
+            "close": [100.5] * periods,
+            "volume": [1000.0] * periods,
+        },
+        index=idx,
+    )
+
+
+@pytest.mark.fast
+class TestBacktestSentimentFreshnessParity:
+    """Backtest's sentiment merge must emit a sentiment_freshness column."""
+
+    def test_freshness_column_emitted_when_provider_returns_data(self) -> None:
+        df = _make_price_df(periods=12)
+        sentiment_idx = pd.date_range("2024-01-01", periods=12, freq="1h", tz=UTC)
+        historical = pd.DataFrame({"sentiment_score": [0.5] * 12}, index=sentiment_idx)
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = historical
+        provider.aggregate_sentiment.return_value = historical
+
+        engine = _make_engine(provider)
+        out = engine._merge_sentiment_data(
+            df,
+            "TEST",
+            "1h",
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 1, 1, 12, tzinfo=UTC),
+        )
+
+        assert "sentiment_freshness" in out.columns, (
+            "backtest must emit sentiment_freshness so feature schemas line "
+            "up with live (row_extractors.py expects this column)"
+        )
+        # Historical sentiment is always treated as stale.
+        assert (out["sentiment_freshness"] == 0).all()
+
+    def test_freshness_column_emitted_when_provider_returns_empty(self) -> None:
+        """Even when the provider returns no rows, the column must still
+        be present so downstream feature builders never see a missing
+        column on backtest while live populates it."""
+        df = _make_price_df(periods=6)
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = pd.DataFrame()
+
+        engine = _make_engine(provider)
+        out = engine._merge_sentiment_data(
+            df,
+            "TEST",
+            "1h",
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 1, 1, 6, tzinfo=UTC),
+        )
+
+        assert "sentiment_freshness" in out.columns
+        assert (out["sentiment_freshness"] == 0).all()
+
+    def test_freshness_column_not_clobbered_when_already_present(self) -> None:
+        """If a future flow pre-populates the freshness column (e.g. a
+        custom warmup step), the merge must not overwrite it."""
+        df = _make_price_df(periods=6)
+        df["sentiment_freshness"] = 1  # caller-set marker
+
+        provider = Mock()
+        provider.get_historical_sentiment.return_value = pd.DataFrame()
+
+        engine = _make_engine(provider)
+        out = engine._merge_sentiment_data(
+            df,
+            "TEST",
+            "1h",
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 1, 1, 6, tzinfo=UTC),
+        )
+
+        # Pre-existing values preserved.
+        assert (out["sentiment_freshness"] == 1).all()
+
+    def test_no_provider_returns_df_unchanged(self) -> None:
+        """When the engine has no sentiment provider configured, the merge
+        is a no-op and the column is NOT introduced — matching the
+        existing contract that callers control whether sentiment is
+        modeled at all."""
+        df = _make_price_df(periods=6)
+
+        engine = _make_engine(sentiment_provider=None)
+        out = engine._merge_sentiment_data(
+            df,
+            "TEST",
+            "1h",
+            datetime(2024, 1, 1, tzinfo=UTC),
+            datetime(2024, 1, 1, 6, tzinfo=UTC),
+        )
+
+        assert "sentiment_freshness" not in out.columns

--- a/tests/unit/live/test_daily_risk_clamp_parity.py
+++ b/tests/unit/live/test_daily_risk_clamp_parity.py
@@ -1,0 +1,169 @@
+"""Live scale-in must clamp by remaining daily-risk budget for parity.
+
+Backtest's exit_handler clamps scale-in delta_size by
+``risk_manager.params.max_daily_risk - risk_manager.daily_risk_used``
+(src/engines/backtest/execution/exit_handler.py:357-361). Live previously
+sized scale-ins from the strategy's `scale_fraction` directly with no
+budget check, so a strategy with two scale-in targets could push total
+exposure above the configured per-day cap while backtest results would
+have it capped — silently understating the live risk profile a backtest
+predicted.
+
+The fix mirrors backtest: after ``check_scale_in`` returns
+``should_scale=True``, the live engine reads ``max_daily_risk`` and
+``daily_risk_used`` off the risk manager and shrinks the scale-in
+fraction to ``min(requested, remaining_daily)``. When remaining is
+zero or negative, the scale-in is skipped entirely with an info log.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import pandas as pd
+import pytest
+
+from src.engines.live.execution.exit_handler import LiveExitHandler
+from src.engines.live.execution.position_tracker import LivePositionTracker, PositionSide
+from src.engines.shared.execution.execution_model import ExecutionModel
+from src.engines.shared.execution.fill_policy import default_fill_policy
+
+
+def _make_handler(
+    *, max_daily_risk: float, daily_risk_used: float
+) -> tuple[LiveExitHandler, LivePositionTracker, MagicMock, MagicMock]:
+    """Build a LiveExitHandler with a stubbed partial manager whose
+    ``check_scale_in`` reports a positive scale request, and a risk
+    manager configured with the given daily-risk numbers.
+    """
+    position_tracker = LivePositionTracker(db_manager=Mock())
+
+    risk_manager = MagicMock()
+    risk_manager.params = SimpleNamespace(max_daily_risk=max_daily_risk)
+    risk_manager.daily_risk_used = daily_risk_used
+
+    partial_manager = MagicMock()
+    # Always-true partial-exit gate is suppressed; only scale-ins matter
+    # for these tests.
+    partial_manager.check_partial_exit.return_value = SimpleNamespace(
+        should_exit=False, exit_fraction=0.0, target_index=0
+    )
+    partial_manager.check_scale_in.return_value = SimpleNamespace(
+        should_scale=True, scale_fraction=0.20, target_index=0
+    )
+
+    execution_engine = MagicMock()
+    execution_engine.fee_rate = 0.0
+    execution_engine.slippage_rate = 0.0
+
+    handler = LiveExitHandler(
+        execution_engine=execution_engine,
+        position_tracker=position_tracker,
+        risk_manager=risk_manager,
+        execution_model=ExecutionModel(default_fill_policy()),
+        partial_manager=partial_manager,
+    )
+
+    # Spy on the actual scale-in execution.
+    handler._execute_scale_in = MagicMock()
+    return handler, position_tracker, risk_manager, partial_manager
+
+
+def _track_position(tracker: LivePositionTracker) -> str:
+    from src.engines.live.execution.position_tracker import LivePosition
+
+    position = LivePosition(
+        symbol="TEST",
+        side=PositionSide.LONG,
+        entry_price=100.0,
+        entry_time=datetime(2024, 1, 1, tzinfo=UTC),
+        size=0.10,
+        original_size=0.10,
+        current_size=0.10,
+        order_id="order-1",
+    )
+    tracker.track_recovered_position(position, db_id=None)
+    return position.order_id
+
+
+@pytest.mark.fast
+class TestLiveDailyRiskClampParity:
+    """Live's scale-in must respect the same daily-risk budget backtest does."""
+
+    def test_clamps_scale_in_to_remaining_daily(self) -> None:
+        """Strategy requests 20% scale-in but only 5% of daily risk
+        remains — the executed delta must be 5%, not 20%."""
+        handler, tracker, _rm, _pm = _make_handler(max_daily_risk=0.30, daily_risk_used=0.25)
+        _track_position(tracker)
+
+        df = pd.DataFrame({"close": [100.0]}, index=[datetime(2024, 1, 1, tzinfo=UTC)])
+        handler.check_partial_operations(
+            df=df,
+            current_index=0,
+            current_price=100.0,
+            current_balance=10_000.0,
+            candle_time=datetime(2024, 1, 1, 1, tzinfo=UTC),
+        )
+
+        handler._execute_scale_in.assert_called_once()
+        kwargs = handler._execute_scale_in.call_args.kwargs
+        # Requested 0.20, remaining 0.05 → clamp to 0.05.
+        assert kwargs["delta_fraction"] == pytest.approx(0.05)
+        assert kwargs["fraction_of_original"] == pytest.approx(0.05)
+
+    def test_skips_scale_in_when_budget_exhausted(self) -> None:
+        """Daily-risk budget already at the cap — scale-in must NOT execute."""
+        handler, tracker, _rm, _pm = _make_handler(max_daily_risk=0.30, daily_risk_used=0.30)
+        _track_position(tracker)
+
+        df = pd.DataFrame({"close": [100.0]}, index=[datetime(2024, 1, 1, tzinfo=UTC)])
+        handler.check_partial_operations(
+            df=df,
+            current_index=0,
+            current_price=100.0,
+            current_balance=10_000.0,
+            candle_time=datetime(2024, 1, 1, 1, tzinfo=UTC),
+        )
+
+        handler._execute_scale_in.assert_not_called()
+
+    def test_passes_full_request_when_budget_has_room(self) -> None:
+        """Plenty of remaining budget — scale-in executes at the full
+        requested fraction (no clamp)."""
+        handler, tracker, _rm, _pm = _make_handler(max_daily_risk=1.0, daily_risk_used=0.10)
+        _track_position(tracker)
+
+        df = pd.DataFrame({"close": [100.0]}, index=[datetime(2024, 1, 1, tzinfo=UTC)])
+        handler.check_partial_operations(
+            df=df,
+            current_index=0,
+            current_price=100.0,
+            current_balance=10_000.0,
+            candle_time=datetime(2024, 1, 1, 1, tzinfo=UTC),
+        )
+
+        handler._execute_scale_in.assert_called_once()
+        kwargs = handler._execute_scale_in.call_args.kwargs
+        assert kwargs["delta_fraction"] == pytest.approx(0.20)
+
+    def test_no_risk_manager_does_not_crash(self) -> None:
+        """Defensive: if risk_manager is missing, scale-in still runs at
+        the requested fraction (legacy behaviour)."""
+        handler, tracker, _rm, _pm = _make_handler(max_daily_risk=1.0, daily_risk_used=0.0)
+        handler.risk_manager = None  # simulate degraded mode
+        _track_position(tracker)
+
+        df = pd.DataFrame({"close": [100.0]}, index=[datetime(2024, 1, 1, tzinfo=UTC)])
+        handler.check_partial_operations(
+            df=df,
+            current_index=0,
+            current_price=100.0,
+            current_balance=10_000.0,
+            candle_time=datetime(2024, 1, 1, 1, tzinfo=UTC),
+        )
+
+        handler._execute_scale_in.assert_called_once()
+        kwargs = handler._execute_scale_in.call_args.kwargs
+        assert kwargs["delta_fraction"] == pytest.approx(0.20)


### PR DESCRIPTION
## Summary

Round 5 of the backtest-live parity audit. Three independent sweeps found ~10 candidate divergences; 7 turned out to be false positives or already-documented caveats. The 2 verified divergences are fixed in this PR — kept narrow so the diff stays manageable for review.

PR #610 closed the previous 12 parity gaps; this PR is independent and targets `develop`.

## Verified parity fixes

### P2 — Backtest never emitted ``sentiment_freshness``

[src/engines/backtest/engine.py:914-940](src/engines/backtest/engine.py:914): `_merge_sentiment_data` joined historical sentiment but never created the `sentiment_freshness` column. Live's `_add_sentiment_data` sets it to 0 by default and flips to 1 for the most recent 4 hours, and `src/tech/adapters/row_extractors.py:35` lists it as an expected feature. ML feature schemas including this column saw a shape mismatch between the two engines.

**Fix**: backtest now emits `sentiment_freshness=0` across the dataframe (historical sentiment is by definition stale). Only when the engine has a sentiment provider configured — no provider → no merge, preserving the existing "callers control whether sentiment is modeled" contract.

### P2 — Live scale-in did not respect daily-risk budget

[src/engines/live/execution/exit_handler.py:820-883](src/engines/live/execution/exit_handler.py:820): live's scale-in path took the strategy's `scale_fraction` directly with no per-day cap. Backtest's [exit_handler.py:357-361](src/engines/backtest/execution/exit_handler.py:357) clamps the fraction by `max_daily_risk - daily_risk_used`. A strategy with two scale-in targets could push total exposure above the configured per-day cap in live while backtest results would have it capped — silently understating the live risk profile a backtest predicted.

**Fix**: live now reads `max_daily_risk` and `daily_risk_used` off the risk manager and clamps `scale_fraction` to `min(requested, remaining_daily)`. When remaining is non-positive, the scale-in is skipped entirely with an info log. Defensive: tolerates a missing risk_manager / params via try-except, falling back to legacy behaviour.

## Triaged but not in this PR

**False positives:**
- P1 dropna index-shift — both engines do the same OHLCV-only dropna, symmetric.
- P1 quantity rounding loss / min_notional — already documented as known caveat.
- P3 ONNX session reuse, SL tick-size — live-only safety, not parity.

**Symmetric gaps (both engines equally broken — separate work):**
- `RiskManager._calculate_raw_fraction` dispatch missing Kelly / Leveraged / RegimeAdaptive sizers.
- Asymmetric long/short SL/TP overrides not supported by either engine.
- Per-symbol position cap not implemented in either.

**Bigger architectural change (deferred for separate PR):**
- Strategy hot-swap (`strategy_manager._apply_strategy_swap` at strategy_manager.py:333-355) only swaps the reference; no call to `get_risk_overrides()` on the new strategy and no rebinding of policy hydration. Backtest re-fetches per entry. Real gap, but plumbing is invasive — needs its own focused fix with tests.

## Test plan

- [x] `pytest tests/unit/backtesting/test_sentiment_freshness_parity.py` — 4 tests
- [x] `pytest tests/unit/live/test_daily_risk_clamp_parity.py` — 4 tests
- [x] `pytest tests/unit/live/ tests/unit/backtesting/ tests/unit/test_backtest_live_parity.py` — 425 pass, no regressions
- [x] `ruff check` clean on touched files
- [x] `black` formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)