### PR TITLE
fix(live): refresh strategy-dependent state on hot-swap

### DIFF
--- a/src/engines/live/strategy_manager.py
+++ b/src/engines/live/strategy_manager.py
@@ -344,9 +344,31 @@ class StrategyManager:
                 self.current_version = new_version
                 self.version_history[new_version.version_id] = new_version
 
+            # Audit-log the new strategy's risk overrides so operators have a
+            # paper trail of the active SL/TP/trailing/partial config after a
+            # mid-run regime swap. Engine-side rebinding lives in
+            # ``LiveTradingEngine._refresh_strategy_dependencies``.
+            new_overrides: dict[str, Any] | None = None
+            if hasattr(new_strategy, "get_risk_overrides"):
+                try:
+                    fetched = new_strategy.get_risk_overrides()
+                    if isinstance(fetched, dict):
+                        new_overrides = fetched
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    logger.debug("Failed to read get_risk_overrides() on swap: %s", exc)
+            adapter = getattr(new_strategy, "risk_manager", None)
+            adapter_overrides = getattr(adapter, "_strategy_overrides", None)
+            if isinstance(adapter_overrides, dict):
+                merged = dict(adapter_overrides)
+                if new_overrides:
+                    merged.update(new_overrides)
+                new_overrides = merged
+
             logger.info(
-                f"✅ Strategy swapped: {self._display_name(old_strategy)} "
-                f"→ {self._display_name(new_strategy)}"
+                "✅ Strategy swapped: %s → %s | new risk overrides: %s",
+                self._display_name(old_strategy),
+                self._display_name(new_strategy),
+                new_overrides if new_overrides else "<none>",
             )
             return True
 

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -54,13 +54,13 @@ from src.engines.live.data.market_data_handler import MarketDataHandler
 from src.engines.live.execution.entry_handler import LiveEntryHandler, LiveEntrySignal
 from src.engines.live.execution.execution_engine import LiveExecutionEngine
 from src.engines.live.execution.exit_handler import LiveExitHandler
-from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.execution.position_tracker import (
     LivePosition,
     LivePositionTracker,
 )
 from src.engines.live.health.health_monitor import HealthMonitor
 from src.engines.live.logging.event_logger import LiveEventLogger
+from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.strategy_manager import StrategyManager
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
 from src.engines.shared.execution.execution_model import ExecutionModel
@@ -385,9 +385,11 @@ class LiveTradingEngine:
                     provider, config, testnet
                 )
                 if self.exchange_interface:
-                    use_margin = getattr(self.exchange_interface, 'is_margin_mode', False)
+                    use_margin = getattr(self.exchange_interface, "is_margin_mode", False)
                     self.account_synchronizer = AccountSynchronizer(
-                        self.exchange_interface, self.db_manager, self.trading_session_id,
+                        self.exchange_interface,
+                        self.db_manager,
+                        self.trading_session_id,
                         use_margin=use_margin,
                     )
                     # Initialize order tracker for monitoring order fills
@@ -1311,7 +1313,7 @@ class LiveTradingEngine:
             try:
                 from src.engines.live.reconciliation import PeriodicReconciler
 
-                use_margin = getattr(self.exchange_interface, 'is_margin_mode', False)
+                use_margin = getattr(self.exchange_interface, "is_margin_mode", False)
                 self._periodic_reconciler = PeriodicReconciler(
                     exchange_interface=self.exchange_interface,
                     position_tracker=self.live_position_tracker,
@@ -1348,9 +1350,7 @@ class LiveTradingEngine:
         """Enter close-only mode: no new entries, exits/stops/trailing still active."""
         if not self._close_only_mode:
             self._close_only_mode = True
-            logger.critical(
-                "🚨 CLOSE-ONLY MODE ACTIVATED — no new entries until manual review"
-            )
+            logger.critical("🚨 CLOSE-ONLY MODE ACTIVATED — no new entries until manual review")
 
     def resume_trading(self) -> None:
         """Resume normal trading after close-only mode review."""
@@ -1527,9 +1527,7 @@ class LiveTradingEngine:
         #    while the old thread may still be mutating order state
         if not processor_clean:
             self.exchange_interface.mark_user_degraded()
-            logger.critical(
-                "UserDataProcessor did not stop cleanly — staying in REST_DEGRADED"
-            )
+            logger.critical("UserDataProcessor did not stop cleanly — staying in REST_DEGRADED")
             return
         # 6. Attempt user stream reconnect with fresh callback
         reconnected = False
@@ -1695,17 +1693,8 @@ class LiveTradingEngine:
                 try:
                     if self.strategy_manager and self.strategy_manager.has_pending_update():
                         logger.info("🔄 Applying pending strategy/model update...")
-                        success = self.strategy_manager.apply_pending_update()
-                        if success:
-                            self._finalize_runtime()
-                            updated_strategy = self.strategy_manager.current_strategy
-                            self._configure_strategy(updated_strategy)
-                            self._runtime_dataset = None
-                            self._runtime_warmup = 0
-                            logger.info("✅ Strategy/model update applied successfully")
+                        if self._apply_pending_strategy_update():
                             self._send_alert("Strategy/Model updated in live trading")
-                        else:
-                            logger.error("❌ Failed to apply strategy/model update")
                 except Exception as e:
                     logger.error(
                         "❌ Exception during strategy update check/application: %s",
@@ -2059,7 +2048,9 @@ class LiveTradingEngine:
             if self._kline_buffer and self._kline_buffer.needs_resync:
                 logger.info("KlineBuffer gap detected — resyncing from REST")
                 self._kline_buffer.resync_from_rest(
-                    self.data_provider, self._active_symbol or symbol, self.timeframe or timeframe,
+                    self.data_provider,
+                    self._active_symbol or symbol,
+                    self.timeframe or timeframe,
                 )
 
             # Use WS cache if available and healthy
@@ -3290,9 +3281,7 @@ class LiveTradingEngine:
                     from src.engines.live.reconciliation import PositionReconciler
 
                     tracker = MarginInterestTracker(self.exchange_interface)
-                    base_asset = PositionReconciler._extract_base_asset(
-                        position.symbol
-                    )
+                    base_asset = PositionReconciler._extract_base_asset(position.symbol)
                     if base_asset == position.symbol:
                         logger.warning(
                             "Could not extract base asset from %s — margin interest may not be queried correctly",
@@ -4001,10 +3990,7 @@ class LiveTradingEngine:
                 # Validate recovered entry_price before tracking. Positions
                 # with invalid entry_price cannot be closed properly and would
                 # become orphaned in the tracker.
-                if (
-                    position.entry_price <= 0
-                    or not math.isfinite(position.entry_price)
-                ):
+                if position.entry_price <= 0 or not math.isfinite(position.entry_price):
                     logger.critical(
                         "SKIPPING recovery of position %s (%s): invalid entry_price %.8f. "
                         "MANUAL RECONCILIATION REQUIRED.",
@@ -4077,7 +4063,7 @@ class LiveTradingEngine:
                     Severity,
                 )
 
-                use_margin = getattr(self.exchange_interface, 'is_margin_mode', False)
+                use_margin = getattr(self.exchange_interface, "is_margin_mode", False)
                 reconciler = PositionReconciler(
                     exchange_interface=self.exchange_interface,
                     position_tracker=self.live_position_tracker,
@@ -4094,9 +4080,7 @@ class LiveTradingEngine:
                     # Process results even with no positions — a filled entry
                     # order may create a position, and critical issues must
                     # still trigger close-only mode.
-                    critical_count = sum(
-                        1 for r in results if r.severity == Severity.CRITICAL
-                    )
+                    critical_count = sum(1 for r in results if r.severity == Severity.CRITICAL)
                     if critical_count > 0:
                         logger.critical(
                             "🚨 %d CRITICAL reconciliation issues — entering close-only mode",
@@ -4128,9 +4112,7 @@ class LiveTradingEngine:
                 results = reconciler.reconcile_startup(positions_snapshot)
 
                 # Check for critical issues
-                critical_count = sum(
-                    1 for r in results if r.severity == Severity.CRITICAL
-                )
+                critical_count = sum(1 for r in results if r.severity == Severity.CRITICAL)
                 if critical_count > 0:
                     logger.critical(
                         "🚨 %d CRITICAL reconciliation issues — entering close-only mode",
@@ -4257,9 +4239,7 @@ class LiveTradingEngine:
                             from src.engines.live.reconciliation import PositionReconciler
 
                             tracker = MarginInterestTracker(self.exchange_interface)
-                            base_asset = PositionReconciler._extract_base_asset(
-                                position.symbol
-                            )
+                            base_asset = PositionReconciler._extract_base_asset(position.symbol)
                             interest_base = tracker.get_position_interest_cost(
                                 base_asset, position.entry_time
                             )
@@ -4498,3 +4478,242 @@ class LiveTradingEngine:
         Uses shared risk configuration logic for consistency with backtest engine.
         """
         return build_trailing_stop_policy(self.strategy, self.risk_manager)
+
+    def _apply_pending_strategy_update(self) -> bool:
+        """Apply a queued strategy/model update from the StrategyManager.
+
+        Drives the full hot-swap pipeline as observed by the run loop:
+        ``strategy_manager.apply_pending_update()`` then engine-side reconfigure
+        and refresh of all strategy-dependent state. Returns ``True`` on success.
+
+        Extracted as a method so unit tests can drive the same code path the
+        run loop uses.
+        """
+        if not self.strategy_manager:
+            return False
+
+        success = self.strategy_manager.apply_pending_update()
+        if not success:
+            logger.error("❌ Failed to apply strategy/model update")
+            return False
+
+        self._finalize_runtime()
+        updated_strategy = self.strategy_manager.current_strategy
+        self._configure_strategy(updated_strategy)
+        self._runtime_dataset = None
+        self._runtime_warmup = 0
+        # Refresh strategy-dependent state so the new strategy's overrides take
+        # effect on the very next decision (matches backtest _switch_strategy).
+        self._refresh_strategy_dependencies()
+        logger.info("✅ Strategy/model update applied successfully")
+        return True
+
+    def _refresh_strategy_dependencies(self) -> None:
+        """Refresh engine state derived from the active strategy.
+
+        Called after a hot-swap (or model update) to re-bind the new component
+        risk adapter to the engine's portfolio risk manager and rebuild engine-
+        level policies (trailing stop, partial operations, time exits) from the
+        new strategy's risk overrides. Without this, the live engine continues
+        to use the previous strategy's risk plumbing until restart, silently
+        diverging from a backtest-validated strategy.
+
+        Mirrors the backtest equivalent in ``Backtester._switch_strategy``.
+        """
+        component_strategy = getattr(self, "_component_strategy", None)
+        component_risk = (
+            getattr(component_strategy, "risk_manager", None)
+            if component_strategy is not None
+            else None
+        )
+
+        # 1. Re-bind component risk adapter to the engine's portfolio risk
+        #    manager so position-tracking writes hit the canonical instance.
+        if component_risk is not None and hasattr(component_risk, "bind_core_manager"):
+            try:
+                component_risk.bind_core_manager(self.risk_manager)
+            except Exception as exc:
+                logger.warning(
+                    "Hot-swap: failed to re-bind core risk manager to component "
+                    "strategy: %s. Component risk limits may not be enforced.",
+                    exc,
+                    exc_info=True,
+                )
+
+        # 2. Push the new strategy's overrides onto the component risk adapter.
+        #    The factory typically already does this, but engines have
+        #    historically also called it (see __init__ around L250) so the
+        #    adapter is the single source of truth post-swap.
+        new_overrides: dict[str, Any] = {}
+        if component_strategy is not None and hasattr(component_strategy, "get_risk_overrides"):
+            try:
+                fetched = component_strategy.get_risk_overrides()
+            except Exception as exc:
+                logger.debug("Hot-swap: get_risk_overrides() failed: %s", exc)
+                fetched = None
+            if isinstance(fetched, dict):
+                new_overrides = dict(fetched)
+        if component_risk is not None and hasattr(component_risk, "set_strategy_overrides"):
+            adapter_overrides = getattr(component_risk, "_strategy_overrides", None)
+            merged = dict(adapter_overrides) if isinstance(adapter_overrides, dict) else {}
+            merged.update(new_overrides)
+            try:
+                component_risk.set_strategy_overrides(merged)
+            except Exception as exc:
+                logger.warning(
+                    "Hot-swap: failed to propagate strategy overrides to "
+                    "component risk manager: %s",
+                    exc,
+                    exc_info=True,
+                )
+
+        # 3. Rebuild engine-level trailing-stop policy from the new strategy /
+        #    risk-manager and propagate it into the live exit handler so that
+        #    the next trailing-stop tick uses the refreshed configuration.
+        try:
+            self.trailing_stop_policy = self._build_trailing_policy()
+            self._trailing_stop_opt_in = self.trailing_stop_policy is not None
+            exit_handler = getattr(self, "live_exit_handler", None)
+            if exit_handler is not None:
+                exit_handler.trailing_stop_policy = self.trailing_stop_policy
+                trailing_manager = getattr(exit_handler, "_trailing_stop_manager", None)
+                if trailing_manager is not None:
+                    trailing_manager.policy = self.trailing_stop_policy
+        except Exception as exc:
+            logger.warning(
+                "Hot-swap: failed to refresh trailing stop policy: %s",
+                exc,
+                exc_info=True,
+            )
+
+        # 4. Rebuild engine-level partial operations policy from new overrides.
+        try:
+            self._refresh_partial_manager_after_swap(new_overrides)
+        except Exception as exc:
+            logger.warning(
+                "Hot-swap: failed to refresh partial operations manager: %s",
+                exc,
+                exc_info=True,
+            )
+
+        # 5. Rebuild engine-level time exit policy from new overrides.
+        try:
+            self._refresh_time_exit_policy_after_swap(new_overrides)
+        except Exception as exc:
+            logger.warning(
+                "Hot-swap: failed to refresh time exit policy: %s",
+                exc,
+                exc_info=True,
+            )
+
+        # 6. If a correlation handler is wired on the entry handler, refresh
+        #    its strategy reference (mirrors backtest engine.py:817).
+        entry_handler = getattr(self, "live_entry_handler", None)
+        if entry_handler is not None:
+            correlation_handler = getattr(entry_handler, "correlation_handler", None)
+            if correlation_handler is not None and hasattr(correlation_handler, "set_strategy"):
+                try:
+                    correlation_handler.set_strategy(self.strategy)
+                except Exception as exc:
+                    logger.debug("Hot-swap: correlation_handler.set_strategy failed: %s", exc)
+
+        # 7. Defensive invariant guard: ConfidenceWeightedSizer enforces
+        #    min_confidence_floor <= min_confidence at construction time, but
+        #    log a critical signal here if it ever slips through (e.g. via a
+        #    mutated sizer instance) so operators can intervene quickly.
+        position_sizer = getattr(component_strategy, "position_sizer", None)
+        if position_sizer is not None:
+            min_conf = getattr(position_sizer, "min_confidence", None)
+            min_floor = getattr(position_sizer, "min_confidence_floor", None)
+            if min_conf is not None and min_floor is not None and min_floor > min_conf:
+                logger.critical(
+                    "Hot-swap invariant violation: min_confidence_floor (%s) > "
+                    "min_confidence (%s) on new strategy sizer; live engine may "
+                    "over-size low-confidence signals until next swap.",
+                    min_floor,
+                    min_conf,
+                )
+
+    def _refresh_partial_manager_after_swap(
+        self,
+        new_overrides: dict[str, Any],
+    ) -> None:
+        """Rebuild engine-level partial_manager from new strategy overrides.
+
+        Pushes the refreshed policy into the live exit handler's
+        :class:`PartialOperationsManager` so that partial-exit / scale-in
+        decisions on the next bar use the new configuration.
+        """
+        new_policy: PartialExitPolicy | None = None
+        partial_cfg = (
+            new_overrides.get("partial_operations") if isinstance(new_overrides, dict) else None
+        )
+        if isinstance(partial_cfg, dict):
+            new_policy = PartialExitPolicy(
+                exit_targets=partial_cfg.get("exit_targets", []),
+                exit_sizes=partial_cfg.get("exit_sizes", []),
+                scale_in_thresholds=partial_cfg.get("scale_in_thresholds", []),
+                scale_in_sizes=partial_cfg.get("scale_in_sizes", []),
+                max_scale_ins=partial_cfg.get("max_scale_ins", 0),
+            )
+        elif self.enable_partial_operations:
+            rp = self.risk_manager.params if self.risk_manager else RiskParameters()
+            new_policy = PartialExitPolicy(
+                exit_targets=rp.partial_exit_targets or [],
+                exit_sizes=rp.partial_exit_sizes or [],
+                scale_in_thresholds=rp.scale_in_thresholds or [],
+                scale_in_sizes=rp.scale_in_sizes or [],
+                max_scale_ins=rp.max_scale_ins,
+            )
+
+        self.partial_manager = new_policy
+        self._partial_operations_opt_in = bool(
+            self.enable_partial_operations or self.partial_manager is not None
+        )
+
+        exit_handler = getattr(self, "live_exit_handler", None)
+        if exit_handler is None:
+            return
+
+        ops_manager = getattr(exit_handler, "partial_manager", None)
+        if new_policy is None:
+            # Disable partial operations on the exit handler.
+            exit_handler.partial_manager = None
+            return
+
+        if ops_manager is None:
+            exit_handler.partial_manager = PartialOperationsManager(policy=new_policy)
+        elif hasattr(ops_manager, "set_policy"):
+            ops_manager.set_policy(new_policy)
+        else:
+            ops_manager.policy = new_policy
+
+    def _refresh_time_exit_policy_after_swap(
+        self,
+        new_overrides: dict[str, Any],
+    ) -> None:
+        """Rebuild engine-level time_exit_policy from new strategy overrides."""
+        time_cfg = new_overrides.get("time_exits") if isinstance(new_overrides, dict) else None
+        if not time_cfg and self.risk_manager and getattr(self.risk_manager, "params", None):
+            time_cfg = getattr(self.risk_manager.params, "time_exits", None)
+
+        new_policy: TimeExitPolicy | None = None
+        if time_cfg:
+            tr = time_cfg.get("time_restrictions") or DEFAULT_TIME_RESTRICTIONS
+            restrictions = TimeRestrictions(
+                no_overnight=bool(tr.get("no_overnight", False)),
+                no_weekend=bool(tr.get("no_weekend", False)),
+                trading_hours_only=bool(tr.get("trading_hours_only", False)),
+            )
+            new_policy = TimeExitPolicy(
+                max_holding_hours=time_cfg.get("max_holding_hours", DEFAULT_MAX_HOLDING_HOURS),
+                end_of_day_flat=time_cfg.get("end_of_day_flat", DEFAULT_END_OF_DAY_FLAT),
+                weekend_flat=time_cfg.get("weekend_flat", DEFAULT_WEEKEND_FLAT),
+                market_timezone=time_cfg.get("market_timezone", DEFAULT_MARKET_TIMEZONE),
+                time_restrictions=restrictions,
+            )
+
+        self.time_exit_policy = new_policy
+        exit_handler = getattr(self, "live_exit_handler", None)
+        if exit_handler is not None:
+            exit_handler.time_exit_policy = new_policy

--- a/tests/unit/live/test_strategy_hotswap_overrides.py
+++ b/tests/unit/live/test_strategy_hotswap_overrides.py
@@ -1,0 +1,295 @@
+"""Unit tests for live engine hot-swap refresh behaviour.
+
+After a regime/manual hot-swap, the live engine must refresh strategy-dependent
+state so the new strategy's risk overrides take effect on the very next
+decision. Without this, the engine silently diverges from a backtest-validated
+strategy until the next restart (P2 issue documented on this branch).
+
+These tests target the live engine's swap-apply pipeline (the same code path
+the run loop drives every cycle when ``strategy_manager.has_pending_update()``
+is True). The corresponding backtest behaviour lives in ``Backtester._switch_strategy``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.engines.live.trading_engine import LiveTradingEngine
+from src.strategies.ml_basic import create_ml_basic_strategy
+from tests.mocks import MockDatabaseManager
+
+pytestmark = pytest.mark.unit
+
+
+def _build_engine(monkeypatch, *, strategy, **kwargs) -> LiveTradingEngine:
+    """Construct a LiveTradingEngine with mocked DB for unit testing."""
+    monkeypatch.setattr("src.engines.live.trading_engine.DatabaseManager", MockDatabaseManager)
+    kwargs.setdefault("data_provider", object())
+    kwargs.setdefault("enable_live_trading", False)
+    kwargs.setdefault("log_trades", False)
+    kwargs.setdefault("enable_hot_swapping", True)
+    return LiveTradingEngine(strategy=strategy, **kwargs)
+
+
+def _drive_swap(engine: LiveTradingEngine, new_strategy_name: str, new_config: dict) -> bool:
+    """Drive a full hot-swap through the production code path.
+
+    Mirrors what the live engine main loop does when a pending update is
+    detected: prepares the swap via ``hot_swap_strategy``, applies the pending
+    update, and runs the engine-side refresh hook. Returns success bool.
+    """
+    prepared = engine.strategy_manager.hot_swap_strategy(new_strategy_name, new_config=new_config)
+    if not prepared:
+        return False
+    return engine._apply_pending_strategy_update()
+
+
+# ---------------------------------------------------------------------------
+# Component risk binding
+# ---------------------------------------------------------------------------
+
+
+def test_hot_swap_rebinds_component_risk_to_engine_core_manager(monkeypatch):
+    """The new strategy's CoreRiskAdapter must be bound to the engine's
+    PortfolioRiskManager after a swap. Without this, the strategy adapter
+    writes position-tracking state into a stale risk manager that diverges
+    from the engine's, breaking correlation/exposure caps.
+    """
+    initial = create_ml_basic_strategy(fast_mode=True, stop_loss_pct=0.05)
+    engine = _build_engine(monkeypatch, strategy=initial)
+    engine_core = engine.risk_manager
+
+    # Sanity: at startup, the initial strategy's adapter is bound to the engine.
+    assert initial.risk_manager._core_manager is engine_core
+
+    success = _drive_swap(engine, "ml_basic", {"stop_loss_pct": 0.02})
+    assert success, "Hot-swap apply pipeline should succeed"
+
+    new_strategy = engine.strategy
+    assert new_strategy is not initial
+    # New strategy adapter must point at the engine's portfolio risk manager,
+    # not the fresh one its factory created in isolation.
+    assert new_strategy.risk_manager._core_manager is engine_core
+
+
+def test_hot_swap_propagates_new_strategy_overrides_to_component_risk(monkeypatch):
+    """After swap, the new component risk adapter must carry the new
+    strategy's risk overrides (so SL/TP overrides flow into runtime sizing).
+    """
+    initial = create_ml_basic_strategy(fast_mode=True, stop_loss_pct=0.05)
+    engine = _build_engine(monkeypatch, strategy=initial)
+
+    success = _drive_swap(engine, "ml_basic", {"stop_loss_pct": 0.02})
+    assert success
+
+    new_strategy = engine.strategy
+    overrides = new_strategy.risk_manager._strategy_overrides
+    assert overrides["stop_loss_pct"] == pytest.approx(0.02)
+
+
+# ---------------------------------------------------------------------------
+# Entry handler & SL/TP propagation (the headline regression)
+# ---------------------------------------------------------------------------
+
+
+def test_hot_swap_applies_new_overrides_on_next_entry(monkeypatch):
+    """Headline regression: after swap, the live entry handler reads the new
+    strategy's SL override on the very next entry. Backtest already does this
+    via ``_switch_strategy`` rebinding; live must match.
+    """
+    initial = create_ml_basic_strategy(fast_mode=True, stop_loss_pct=0.05)
+    engine = _build_engine(monkeypatch, strategy=initial)
+
+    # Pre-swap sanity
+    assert initial.risk_manager._strategy_overrides["stop_loss_pct"] == pytest.approx(0.05)
+
+    success = _drive_swap(engine, "ml_basic", {"stop_loss_pct": 0.02})
+    assert success
+
+    new_strategy = engine.strategy
+    # Entry handler points at the new strategy.
+    assert engine.live_entry_handler.component_strategy is new_strategy
+    # And the new strategy exposes the new SL via the same path entry_utils uses.
+    assert new_strategy.risk_manager._strategy_overrides["stop_loss_pct"] == pytest.approx(0.02)
+
+
+# ---------------------------------------------------------------------------
+# Engine-level policy refresh
+# ---------------------------------------------------------------------------
+
+
+def _component_strategy_with_trailing_overrides(*, activation: float, distance_pct: float):
+    """Build a component strategy whose ``get_risk_overrides`` returns trailing config."""
+    strategy = create_ml_basic_strategy(fast_mode=True)
+    # ml_basic does not call set_risk_overrides on the Strategy itself, so do it here
+    # to drive the trailing-policy builder through the strategy override branch.
+    strategy.set_risk_overrides(
+        {
+            "stop_loss_pct": 0.02,
+            "trailing_stop": {
+                "activation_threshold": activation,
+                "trailing_distance_pct": distance_pct,
+            },
+        }
+    )
+    return strategy
+
+
+def test_hot_swap_rebuilds_engine_trailing_stop_policy(monkeypatch):
+    """Engine-level ``trailing_stop_policy`` must reflect the new strategy's
+    trailing overrides after a swap (and the live exit handler must see the
+    refreshed reference, not the stale construction-time one).
+    """
+    initial = _component_strategy_with_trailing_overrides(activation=0.01, distance_pct=0.005)
+    engine = _build_engine(monkeypatch, strategy=initial)
+
+    pre_policy = engine.trailing_stop_policy
+    assert pre_policy is not None
+    assert pre_policy.activation_threshold == pytest.approx(0.01)
+    assert engine.live_exit_handler.trailing_stop_policy is pre_policy
+    assert engine.live_exit_handler._trailing_stop_manager.policy is pre_policy
+
+    # Swap to a different ml_basic instance and inject distinct trailing overrides
+    # via the manager's hot-swap path.
+    success = engine.strategy_manager.hot_swap_strategy("ml_basic", new_config={})
+    assert success
+    new_strategy = engine.strategy_manager.pending_update["data"]["new_strategy"]
+    new_strategy.set_risk_overrides(
+        {
+            "trailing_stop": {
+                "activation_threshold": 0.05,
+                "trailing_distance_pct": 0.02,
+            },
+        }
+    )
+    success = engine._apply_pending_strategy_update()
+    assert success
+
+    refreshed = engine.trailing_stop_policy
+    assert refreshed is not None
+    assert refreshed is not pre_policy
+    assert refreshed.activation_threshold == pytest.approx(0.05)
+    # Live exit handler must observe the same refreshed instance.
+    assert engine.live_exit_handler.trailing_stop_policy is refreshed
+    assert engine.live_exit_handler._trailing_stop_manager.policy is refreshed
+
+
+def test_hot_swap_rebuilds_partial_manager(monkeypatch):
+    """Engine-level partial_manager must reflect the new strategy's
+    ``partial_operations`` overrides after a swap, including the wrapped
+    PartialOperationsManager inside the live exit handler.
+    """
+    initial = create_ml_basic_strategy(fast_mode=True)
+    initial.set_risk_overrides(
+        {
+            "partial_operations": {
+                "exit_targets": [0.01],
+                "exit_sizes": [0.5],
+                "scale_in_thresholds": [],
+                "scale_in_sizes": [],
+                "max_scale_ins": 0,
+            },
+        }
+    )
+    engine = _build_engine(
+        monkeypatch,
+        strategy=initial,
+        enable_partial_operations=True,
+    )
+    pre_partial = engine.partial_manager
+    assert pre_partial is not None
+    assert pre_partial.exit_targets == [0.01]
+
+    success = engine.strategy_manager.hot_swap_strategy("ml_basic", new_config={})
+    assert success
+    new_strategy = engine.strategy_manager.pending_update["data"]["new_strategy"]
+    new_strategy.set_risk_overrides(
+        {
+            "partial_operations": {
+                "exit_targets": [0.05, 0.10],
+                "exit_sizes": [0.4, 0.4],
+                "scale_in_thresholds": [],
+                "scale_in_sizes": [],
+                "max_scale_ins": 0,
+            },
+        }
+    )
+    success = engine._apply_pending_strategy_update()
+    assert success
+
+    refreshed = engine.partial_manager
+    assert refreshed is not None
+    assert refreshed is not pre_partial
+    assert refreshed.exit_targets == [0.05, 0.10]
+    # Exit handler's PartialOperationsManager wraps the refreshed policy.
+    assert engine.live_exit_handler.partial_manager is not None
+    assert engine.live_exit_handler.partial_manager.policy is refreshed
+
+
+# ---------------------------------------------------------------------------
+# Correlation handler refresh
+# ---------------------------------------------------------------------------
+
+
+def test_hot_swap_refreshes_correlation_handler_strategy(monkeypatch):
+    """When a correlation_handler is wired on the live entry handler, the
+    swap must refresh its strategy reference (mirrors backtest engine.py:817).
+    """
+    initial = create_ml_basic_strategy(fast_mode=True)
+    engine = _build_engine(monkeypatch, strategy=initial)
+
+    correlation_handler = MagicMock()
+    engine.live_entry_handler.correlation_handler = correlation_handler
+
+    success = _drive_swap(engine, "ml_basic", {"stop_loss_pct": 0.02})
+    assert success
+
+    new_strategy = engine.strategy
+    correlation_handler.set_strategy.assert_called_once_with(new_strategy)
+
+
+# ---------------------------------------------------------------------------
+# Sizer-invariant guard
+# ---------------------------------------------------------------------------
+
+
+def test_hot_swap_rejects_invalid_min_confidence_floor(monkeypatch):
+    """Attempting to swap to a strategy with ``min_confidence_floor > min_confidence``
+    must fail at preparation time and leave the engine on its original strategy.
+
+    The ConfidenceWeightedSizer constructor enforces the invariant; this test
+    confirms the regime-driven hot-swap path surfaces that failure cleanly
+    instead of leaving the engine in an invalid sizer state.
+    """
+    initial = create_ml_basic_strategy(fast_mode=False)
+    engine = _build_engine(monkeypatch, strategy=initial)
+
+    success = engine.strategy_manager.hot_swap_strategy(
+        "ml_basic",
+        new_config={"min_confidence": 0.3, "min_confidence_floor": 0.5},
+    )
+    assert success is False
+    # No pending update was queued.
+    assert engine.strategy_manager.has_pending_update() is False
+    # Engine remains on the original strategy.
+    assert engine.strategy is initial
+
+
+# ---------------------------------------------------------------------------
+# No-correlation-handler defensive path
+# ---------------------------------------------------------------------------
+
+
+def test_hot_swap_succeeds_when_no_correlation_handler_wired(monkeypatch):
+    """The swap path must not fail when no correlation_handler is wired
+    (default for live engine today).
+    """
+    initial = create_ml_basic_strategy(fast_mode=True)
+    engine = _build_engine(monkeypatch, strategy=initial)
+    assert engine.live_entry_handler.correlation_handler is None
+
+    success = _drive_swap(engine, "ml_basic", {"stop_loss_pct": 0.02})
+    assert success
+    assert engine.live_entry_handler.correlation_handler is None

--- a/tests/unit/live/test_strategy_hotswap_overrides.py
+++ b/tests/unit/live/test_strategy_hotswap_overrides.py
@@ -283,11 +283,18 @@ def test_hot_swap_rejects_invalid_min_confidence_floor(monkeypatch):
 
 
 def test_hot_swap_succeeds_when_no_correlation_handler_wired(monkeypatch):
-    """The swap path must not fail when no correlation_handler is wired
-    (default for live engine today).
+    """The swap path must not fail when no correlation_handler is wired.
+
+    The live engine wires a CorrelationHandler by default (see PR #610), but
+    a deployment may run without one. This test explicitly clears the handler
+    to exercise the defensive ``getattr``/``hasattr``-guarded branch in
+    ``_refresh_strategy_dependencies``.
     """
     initial = create_ml_basic_strategy(fast_mode=True)
     engine = _build_engine(monkeypatch, strategy=initial)
+    # Simulate a deployment with no correlation handler wired.
+    engine.correlation_handler = None
+    engine.live_entry_handler.correlation_handler = None
     assert engine.live_entry_handler.correlation_handler is None
 
     success = _drive_swap(engine, "ml_basic", {"stop_loss_pct": 0.02})


### PR DESCRIPTION
## Summary

- Live engine hot-swaps previously only re-pointed `self.strategy` via `_configure_strategy`; engine-level policies (trailing stop, partial operations, time exits), the component risk adapter binding, and any wired correlation handler kept their construction-time configuration. After a regime switch, entries silently used the prior strategy's SL/TP and sizing until the engine restarted, diverging from a backtest-validated strategy. Backtest already handles this in `Backtester._switch_strategy`.
- This change extracts the run-loop swap-apply block into `LiveTradingEngine._apply_pending_strategy_update()` and adds `_refresh_strategy_dependencies()` to:
  - rebind the new component risk adapter to the engine's portfolio `RiskManager` (`bind_core_manager`);
  - propagate the new strategy's risk overrides onto the adapter (`set_strategy_overrides`);
  - rebuild engine-level `trailing_stop_policy` / `partial_manager` / `time_exit_policy` from the new overrides and push the refreshed references into `live_exit_handler` (including its inner `TrailingStopManager` and `PartialOperationsManager`);
  - refresh any wired `correlation_handler.set_strategy(new_strategy)` (mirrors `backtest/engine.py:817`);
  - guard the `min_confidence_floor <= min_confidence` sizer invariant with a CRITICAL log if a mutated sizer ever bypasses the constructor check.
- `StrategyManager._apply_strategy_swap` also now audit-logs the new override dict at INFO so operators have a paper trail of the active SL/TP/trailing/partial config after a mid-run regime swap.

This is the focused follow-up requested separately from PR #611 — the plumbing change is invasive and benefits from its own review.

## Test plan

- [x] New `tests/unit/live/test_strategy_hotswap_overrides.py` (8 tests) — covers core-manager rebind, override propagation, headline next-entry SL refresh, engine + exit-handler trailing-stop / partial refresh, correlation-handler refresh when wired, swap rejection for invalid `min_confidence_floor > min_confidence`, and the no-correlation-handler defensive path.
- [x] No regression in `tests/unit/live/test_strategy_manager_unit.py` (10), `test_component_risk_binding.py` (5), `test_live_policy_hydration.py` (4).
- [x] Full live unit suite (`pytest tests/unit/live -q`) — **329 passed**.
- [x] Wider unit suite (`pytest tests/unit/engines tests/unit/strategies tests/unit/test_trading_engine_ws_health.py -q`) — **1188 passed**.
- [x] `ruff` clean and `black` formatted on changed files.

## Acceptance criteria from issue spec

- [x] Mid-run regime switch in live applies the new strategy's overrides on the very next entry signal, matching backtest semantics — verified by `test_hot_swap_applies_new_overrides_on_next_entry`.
- [x] New tests live in `tests/unit/live/`.
- [x] No regression in `tests/unit/live/test_strategy_manager_unit.py`.

## Out of scope (per spec)

- No changes to how overrides are stored on the strategy class — still `get_risk_overrides()`.
- No changes to backtest's regime-switch flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)