### PR TITLE
fix(logging): match ws_api subscribe-timeout signature in BinanceWSKeepaliveFilter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configured but stale or non-PRIMARY (was previously kline-only, masking a
   permanently-dark user stream). New `user_ws_healthy` property exposes the
   user-stream status directly.
+- `BinanceWSKeepaliveFilter` now also matches the ws_api subscribe-timeout
+  signature (GH #608 follow-up). #609's filter only matched the 1011
+  'keepalive ping timeout' close code, which never fires on prod — the
+  actual ~2-min churn is the margin `userDataStream.subscribe` request
+  timing out after 10s (`BinanceWebsocketUnableToConnect: Request timed
+  out`), which carries no 'keepalive ping timeout' text and so was never
+  suppressed. Replaced the single fingerprint with `KEEPALIVE_MARKER_GROUPS`
+  (match all markers in any group); a `binance/ws/` anchor prevents
+  swallowing connection errors raised by our own code.
 - Add ban-aware retry to Binance client startup — parses `-1003` ban expiry and sleeps until lifted instead of crashing (#590)
 - `hyper_growth`: fix silent-SELL bug caused by feature-shape mismatch
   (#603). The factory wired `MLBasicSignalGenerator(model_type="sentiment")`

--- a/src/infrastructure/logging/binance_ws_filter.py
+++ b/src/infrastructure/logging/binance_ws_filter.py
@@ -1,15 +1,21 @@
 """Rate-limit Binance WebSocket keepalive-timeout exception noise.
 
 `python-binance==1.0.36` multiplexes margin user-data subscriptions over a
-shared `ws_api` connection. That socket is closed periodically by Binance with
-WebSocket close code ``1011 keepalive ping timeout``. The library's
-ThreadedApiManager surfaces the close as an unretrieved asyncio task
-exception (``Task exception was never retrieved``), which the asyncio default
-exception handler logs at WARNING+ level on the ``atb.asyncio`` logger.
+shared `ws_api` connection, and that connection fails recoverably in two
+ways the library surfaces as an unretrieved asyncio task exception
+(``Task exception was never retrieved``) on the ``atb.asyncio`` logger:
+
+  * the socket is closed by Binance with WebSocket close code
+    ``1011 keepalive ping timeout`` (the original #609 target); or
+  * the ws_api ``userDataStream.subscribe`` request times out after 10s and
+    raises ``BinanceWebsocketUnableToConnect('Request timed out')``. This is
+    what actually fires on prod every ~2 minutes (~720/day) — there is NO
+    "keepalive ping timeout" text, so #609's single fingerprint missed it
+    entirely (GH #608 follow-up).
 
 The library's reconnect machinery recovers automatically — a fresh task is
-spawned on the next subscribe attempt — so live trading is unaffected. But
-on prod the message fires every ~2 minutes (~720/day), drowning real signals.
+spawned on the next subscribe attempt — so live trading is unaffected, but
+the noise drowns real signals.
 
 This filter keeps the *first* occurrence per ``WINDOW_SECONDS`` so an
 operator can still see the full traceback once, suppresses the rest, and
@@ -30,10 +36,11 @@ class BinanceWSKeepaliveFilter(logging.Filter):
     """Rate-limit ``Task exception was never retrieved`` keepalive-timeout noise.
 
     Attached to the console handler in ``build_logging_config``. Inspects the
-    record's message text and exception traceback for the
-    python-binance keepalive-timeout fingerprint; passes the first match per
-    window through, drops subsequent matches, and emits a synthetic summary
-    log when the window rolls over so operators retain visibility.
+    record's message text and exception traceback for any of the
+    python-binance recoverable-ws-churn fingerprints
+    (see ``KEEPALIVE_MARKER_GROUPS``); passes the first match per window
+    through, drops subsequent matches, and emits a synthetic summary log
+    when the window rolls over so operators retain visibility.
 
     Thread-safe: a logging filter can be invoked from multiple threads
     (asyncio default handler runs on the loop thread; other handlers run on
@@ -42,11 +49,26 @@ class BinanceWSKeepaliveFilter(logging.Filter):
     Non-matching records pass through unchanged.
     """
 
-    # Markers that must all appear (in message text or exception traceback)
-    # for a record to be classified as keepalive-timeout noise.
-    KEEPALIVE_MARKERS: tuple[str, ...] = (
-        "keepalive_websocket",
-        "keepalive ping timeout",
+    # A record is classified as recoverable python-binance ws churn noise
+    # when *every* marker in *any one* group appears in its message text or
+    # exception traceback. Two distinct signatures exist (GH #608):
+    #
+    #   * 1011 keepalive-ping-timeout close — the original #609 target. Rare
+    #     in practice; kept for completeness.
+    #   * ws_api subscribe timeout — what actually fires on prod every ~2min:
+    #     the margin user-data subscription is multiplexed over the shared
+    #     ws_api socket, whose request times out after 10s and surfaces as an
+    #     unretrieved task exception. There is NO "keepalive ping timeout"
+    #     text in this case, so it must be matched on its own fingerprint.
+    #     The "binance/ws/" anchor keeps this from swallowing a
+    #     BinanceWebsocketUnableToConnect raised by our own code.
+    KEEPALIVE_MARKER_GROUPS: tuple[tuple[str, ...], ...] = (
+        ("keepalive_websocket", "keepalive ping timeout"),
+        (
+            "Task exception was never retrieved",
+            "BinanceWebsocketUnableToConnect",
+            "binance/ws/",
+        ),
     )
 
     # Window length in seconds. One traceback per window is preserved; the
@@ -143,4 +165,7 @@ class BinanceWSKeepaliveFilter(logging.Filter):
                 pass
         elif record.exc_text:
             text = text + "\n" + record.exc_text
-        return all(marker in text for marker in self.KEEPALIVE_MARKERS)
+        return any(
+            all(marker in text for marker in group)
+            for group in self.KEEPALIVE_MARKER_GROUPS
+        )

--- a/tests/unit/infrastructure/test_binance_ws_filter.py
+++ b/tests/unit/infrastructure/test_binance_ws_filter.py
@@ -14,6 +14,7 @@ import time
 from typing import Any
 
 import pytest
+from binance.exceptions import BinanceWebsocketUnableToConnect
 from websockets.exceptions import ConnectionClosedError
 from websockets.frames import Close, CloseCode
 
@@ -67,6 +68,59 @@ def _keepalive_record() -> logging.LogRecord:
         "Task exception was never retrieved (keepalive_websocket.py)",
         exc=_keepalive_exc(),
     )
+
+
+# Faithful reproduction of the record asyncio's default exception handler
+# emits on `atb.asyncio` in production (see GH #608 follow-up). The python-
+# binance ws_api-multiplexed margin subscription times out after 10s and the
+# unretrieved task exception carries this exact text. Unlike the 1011 close,
+# there is NO "keepalive ping timeout" substring anywhere — only a
+# BinanceWebsocketUnableToConnect('Request timed out') raised from the
+# binance ws stack.
+_PROD_WS_API_TIMEOUT_MSG = (
+    "Task exception was never retrieved\n"
+    "future: <Task finished name='Task-8989572' "
+    "coro=<ThreadedApiManager.start_listener() done, defined at "
+    "/usr/local/lib/python3.11/site-packages/binance/ws/threaded_stream.py:72> "
+    "exception=BinanceWebsocketUnableToConnect('Request timed out')>"
+)
+
+
+def _ws_api_timeout_record() -> logging.LogRecord:
+    """Record matching the real prod ws_api margin-subscribe timeout."""
+    return _make_record(
+        _PROD_WS_API_TIMEOUT_MSG,
+        exc=BinanceWebsocketUnableToConnect("Request timed out"),
+    )
+
+
+class TestWsApiSubscribeTimeoutFingerprint:
+    """The real prod signature (GH #608 follow-up) must be rate-limited.
+
+    #609 only matched the 1011 'keepalive ping timeout' close code, which
+    never fires on prod. The actual recurring noise is the ws_api margin
+    subscribe timing out, surfaced as an unretrieved task exception.
+    """
+
+    def test_first_match_passes_then_suppresses(self):
+        f = BinanceWSKeepaliveFilter(window_seconds=60)
+
+        assert f.filter(_ws_api_timeout_record()) is True
+        for _ in range(5):
+            assert f.filter(_ws_api_timeout_record()) is False
+        assert f.suppressed_count == 5
+
+    def test_unrelated_binance_connect_error_not_suppressed(self):
+        """A BinanceWebsocketUnableToConnect from our own code (no binance
+        ws stack, no unretrieved-task message) must still pass through."""
+        f = BinanceWSKeepaliveFilter(window_seconds=60)
+        record = _make_record(
+            "Failed to place order: connection unavailable",
+            exc=BinanceWebsocketUnableToConnect("boom"),
+        )
+
+        assert f.filter(record) is True
+        assert f.suppressed_count == 0
 
 
 class TestKeepaliveFingerprint:


### PR DESCRIPTION
Closes the filter half of #616 (follow-up to #608 / #609).

## Problem

#609's `BinanceWSKeepaliveFilter` required both `keepalive_websocket` **and** `keepalive ping timeout` in the record text. Production never emits `keepalive ping timeout` — the actual ~720/day noise is the python-binance 1.0.36 margin `userDataStream.subscribe` request timing out after 10s over the shared `ws_api` socket (`BinanceWebsocketUnableToConnect: Request timed out`). So `all(...)` was always False and #609 silenced nothing in prod. Verified against live production deploy logs on the merged #609 build.

## Change

- Replace `KEEPALIVE_MARKERS` with `KEEPALIVE_MARKER_GROUPS`: a record matches if **all markers in any one group** are present.
  - Group 1: the original `1011 keepalive ping timeout` close (kept).
  - Group 2: `Task exception was never retrieved` + `BinanceWebsocketUnableToConnect` + `binance/ws/`. The `binance/ws/` anchor prevents the group from swallowing a `BinanceWebsocketUnableToConnect` raised by our own code.
- Docstrings + changelog updated.

## Testing

- TDD: added `TestWsApiSubscribeTimeoutFingerprint` reproducing the exact prod asyncio record; confirmed it failed before the fix (record passed through unfiltered) and passes after.
- Added a guard test that an unrelated `BinanceWebsocketUnableToConnect` from our own code is **not** suppressed.
- Full filter suite: 12 passed. `ruff` + `black` clean; `mypy` clean on the changed module (pre-existing unrelated errors elsewhere untouched).

## Scope / not in this PR

This stops the **log noise** as #609 intended. It does **not** fix the underlying ~2-min margin-stream reconnect loop or the shared-live-key config issue — both tracked as open checkboxes in #616 (they touch live-trading behaviour / secrets and need separate, reviewed changes).

## User-facing impact

Operators get one full traceback per 60s window + a periodic suppression summary, instead of ~720 raw tracebacks/day burying real signals on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)