### PR TITLE
fix(live): ride out transient DB outages; add heartbeat monitor

### DIFF
--- a/.github/workflows/heartbeat-monitor.yml
+++ b/.github/workflows/heartbeat-monitor.yml
@@ -1,0 +1,46 @@
+name: Heartbeat Monitor
+
+# Periodically verifies the live trading bots are still writing account_history
+# snapshots. If a bot's heartbeat goes stale, this job fails and GitHub notifies
+# maintainers — catching a silent outage within ~2.5h (30-min cron + 120-min
+# staleness threshold) instead of the ~12 days it took on 2026-05-19.
+#
+# Requires repository secrets:
+#   RAILWAY_STAGING_DATABASE_URL
+#   RAILWAY_PRODUCTION_DATABASE_URL
+# A target is simply skipped if its secret is absent.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # every 30 minutes
+  workflow_dispatch:
+    inputs:
+      threshold_minutes:
+        description: "Staleness threshold in minutes"
+        required: false
+        default: "120"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: heartbeat-monitor
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install client
+        run: pip install --no-input psycopg2-binary
+      - name: Check live-bot heartbeats
+        env:
+          RAILWAY_STAGING_DATABASE_URL: ${{ secrets.RAILWAY_STAGING_DATABASE_URL }}
+          RAILWAY_PRODUCTION_DATABASE_URL: ${{ secrets.RAILWAY_PRODUCTION_DATABASE_URL }}
+          HEARTBEAT_THRESHOLD_MINUTES: ${{ github.event.inputs.threshold_minutes || '120' }}
+        run: python scripts/check_heartbeat.py

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Live trading engine no longer shuts itself down during transient database
+  outages. Transient DB-connectivity errors (DNS resolution failures, dropped
+  connections, brief Postgres unavailability) are now classified and *ridden
+  out* with a bounded backoff instead of counting toward
+  `max_consecutive_errors`. This was the root cause of the 2026-05-19 incident:
+  a multi-hour Railway internal-DNS outage made `postgres.railway.internal`
+  unresolvable, every loop iteration raised `OperationalError`, the
+  consecutive-error limit tripped, and **both the staging and production bots
+  went offline — silently — for ~12 days**. `pool_pre_ping` reconnects
+  automatically once the database returns. Permanent faults (bad credentials,
+  missing role/database, permission denied) are excluded and still fail fast,
+  and an outage lasting more than 30 minutes drops the engine into close-only
+  mode (new entries suspended; exits and server-side stop-losses continue).
+
+### Added
+- Heartbeat staleness monitor (`scripts/check_heartbeat.py` +
+  `.github/workflows/heartbeat-monitor.yml`): a scheduled, read-only CI job that
+  fails (notifying maintainers) when an active trading session's
+  `account_history` snapshot goes stale beyond a threshold (default 2h) — the
+  canonical liveness signal. Requires the `RAILWAY_STAGING_DATABASE_URL` /
+  `RAILWAY_PRODUCTION_DATABASE_URL` repository secrets.
+
+### Changed
+- `railway.json`: raised the Trading Bot `restartPolicyMaxRetries` from 3 to 10
+  so Railway keeps retrying through longer transient infrastructure failures.
+
 ### Security
 - Hardened a batch of security findings from a repo-wide scan (bandit + manual
   audit):

--- a/railway.json
+++ b/railway.json
@@ -8,6 +8,6 @@
     "healthcheckPath": "/health",
     "healthcheckTimeout": 10,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 3
+    "restartPolicyMaxRetries": 10
   }
 }

--- a/scripts/check_heartbeat.py
+++ b/scripts/check_heartbeat.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Heartbeat staleness monitor for the live trading bots.
+
+Connects (read-only) to one or more environment databases and verifies that the
+bot is still writing ``account_history`` snapshots. Exits non-zero if a
+heartbeat is stale, so a scheduled CI job (``.github/workflows/heartbeat-monitor.yml``)
+fails and notifies maintainers.
+
+Why this exists: on 2026-05-19 both the staging and production bots died
+(Railway internal-DNS outage made Postgres unresolvable) and then stayed
+*silently* down for ~12 days. The ``account_history`` snapshot (written every
+~30 min while running) is the canonical liveness signal.
+
+Liveness is judged from the GLOBAL latest ``account_history`` snapshot rather
+than from session state, on purpose: a crashed bot leaves its session
+``is_active=True`` with a frozen snapshot, while a clean ``stop()`` sets
+``is_active=False`` — in BOTH cases the snapshot simply stops advancing, so the
+global max timestamp is the reliable signal. (Filtering on ``is_active`` would
+either miss clean-stop deaths or false-positive forever on stale crashed-active
+rows.) The active session, if any, is reported only as context.
+
+Read-only: issues only SELECTs against a read-only session. Safe for production.
+
+Configuration (environment variables):
+  RAILWAY_STAGING_DATABASE_URL      staging DB connection string (optional)
+  RAILWAY_PRODUCTION_DATABASE_URL   production DB connection string (optional)
+  HEARTBEAT_THRESHOLD_MINUTES       staleness threshold, default 120
+
+Exit codes: 0 = healthy or nothing to check, 1 = stale heartbeat or check error.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import UTC, datetime
+
+try:
+    import psycopg2
+except ImportError:  # pragma: no cover
+    print("ERROR: psycopg2 is required (pip install psycopg2-binary)", file=sys.stderr)
+    sys.exit(1)
+
+DEFAULT_THRESHOLD_MINUTES = 120
+
+# Environment variable holding the connection string -> friendly label.
+TARGETS = {
+    "RAILWAY_STAGING_DATABASE_URL": "staging",
+    "RAILWAY_PRODUCTION_DATABASE_URL": "production",
+}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _as_aware(ts: datetime | None) -> datetime | None:
+    """Treat naive timestamps as UTC (the bot stores naive UTC datetimes)."""
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
+def check_target(label: str, url: str, threshold_minutes: int) -> list[str]:
+    """Return a list of staleness problems for one environment (empty == healthy)."""
+    problems: list[str] = []
+    conn = psycopg2.connect(url, connect_timeout=15)
+    try:
+        # Enforce read-only at the connection level — defense in depth for prod.
+        conn.set_session(readonly=True, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(timestamp) FROM account_history;")
+            row = cur.fetchone()
+            last_hb = row[0] if row else None
+            cur.execute(
+                "SELECT id, mode, session_name FROM trading_sessions "
+                "WHERE is_active IS TRUE ORDER BY start_time DESC LIMIT 1;"
+            )
+            active = cur.fetchone()
+    finally:
+        conn.close()
+
+    ctx = (
+        f"active session {active[0]} ({active[1]}) '{active[2]}'" if active else "no active session"
+    )
+    last_hb = _as_aware(last_hb)
+    if last_hb is None:
+        # Never run here (fresh/unused DB) — not an outage.
+        print(f"[{label}] no account_history yet — skipping ({ctx})")
+        return problems
+
+    age_h = (_utcnow() - last_hb).total_seconds() / 3600.0
+    if age_h * 60.0 > threshold_minutes:
+        detail = (
+            f"last account_history {age_h:.1f}h ago ({last_hb.isoformat()}), "
+            f"{ctx} (threshold {threshold_minutes}m)"
+        )
+        print(f"[{label}] STALE — {detail}")
+        problems.append(f"{label} heartbeat stale: {detail}")
+    else:
+        print(f"[{label}] OK — last heartbeat {age_h:.1f}h ago, {ctx}")
+    return problems
+
+
+def main() -> int:
+    threshold = int(os.environ.get("HEARTBEAT_THRESHOLD_MINUTES", DEFAULT_THRESHOLD_MINUTES))
+    checked = 0
+    all_problems: list[str] = []
+    errors: list[str] = []
+    for env_var, label in TARGETS.items():
+        url = os.environ.get(env_var)
+        if not url:
+            continue
+        checked += 1
+        try:
+            all_problems.extend(check_target(label, url, threshold))
+        except Exception as e:  # noqa: BLE001 - any failure to verify liveness is alert-worthy
+            errors.append(f"{label}: failed to check ({type(e).__name__}: {e})")
+
+    if checked == 0:
+        # No targets configured (e.g. secrets not set). Don't fail recurring CI;
+        # surface a clear warning and exit cleanly.
+        print(
+            "WARNING: no target database URLs configured "
+            "(set RAILWAY_STAGING_DATABASE_URL / RAILWAY_PRODUCTION_DATABASE_URL). "
+            "Nothing to check.",
+            file=sys.stderr,
+        )
+        return 0
+
+    for err in errors:
+        print(f"ERROR: {err}", file=sys.stderr)
+
+    if all_problems:
+        print("\nHEARTBEAT ALERT — stale live-bot heartbeat(s) detected:", file=sys.stderr)
+        for p in all_problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    # A connection/query failure means we could not confirm liveness — treat as alert.
+    if errors:
+        return 1
+
+    print(f"\nAll heartbeats healthy (threshold {threshold}m).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -62,6 +62,10 @@ DEFAULT_DRAWDOWN_THRESHOLD = 0.15
 # Error Handling Constants
 DEFAULT_ERROR_COOLDOWN = 30  # seconds to wait after consecutive errors
 DEFAULT_MAX_CONSECUTIVE_ERRORS = 10  # Maximum errors before shutdown
+# After the database has been continuously unreachable for this long, the live
+# loop stops opening new positions (close-only) while it keeps retrying, to
+# avoid order churn during a prolonged outage. Exits and server-side stops still run.
+DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS = 1800  # 30 minutes
 
 # Health Monitor Constants (distinct from CPU optimization intervals)
 DEFAULT_HEALTH_BASE_CHECK_INTERVAL = 60  # Base health check interval in seconds

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -13,12 +13,14 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pandas as pd
+from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
 
 from src.config import get_config
 from src.config.constants import (
     DEFAULT_ACCOUNT_SNAPSHOT_INTERVAL,
     DEFAULT_CHECK_INTERVAL,
     DEFAULT_DATA_FRESHNESS_THRESHOLD,
+    DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS,
     DEFAULT_DYNAMIC_RISK_ENABLED,
     DEFAULT_END_OF_DAY_FLAT,
     DEFAULT_ERROR_COOLDOWN,
@@ -54,13 +56,13 @@ from src.engines.live.data.market_data_handler import MarketDataHandler
 from src.engines.live.execution.entry_handler import LiveEntryHandler, LiveEntrySignal
 from src.engines.live.execution.execution_engine import LiveExecutionEngine
 from src.engines.live.execution.exit_handler import LiveExitHandler
-from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.execution.position_tracker import (
     LivePosition,
     LivePositionTracker,
 )
 from src.engines.live.health.health_monitor import HealthMonitor
 from src.engines.live.logging.event_logger import LiveEventLogger
+from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.strategy_manager import StrategyManager
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
 from src.engines.shared.execution.execution_model import ExecutionModel
@@ -477,6 +479,12 @@ class LiveTradingEngine:
         # Error handling
         self.max_consecutive_errors = max_consecutive_errors
         self.consecutive_errors = 0
+        # Monotonic timestamp marking when the database first became unreachable
+        # inside the trading loop (None while reachable). Lets the engine ride
+        # out transient DB outages instead of counting them toward
+        # max_consecutive_errors (incident 2026-05-19: a Railway internal-DNS
+        # outage made Postgres unresolvable and shut the live bot down).
+        self.db_unreachable_since: float | None = None
         self.error_cooldown = DEFAULT_ERROR_COOLDOWN
 
         # Time exit policy (construct from overrides if not provided)
@@ -1957,12 +1965,49 @@ class LiveTradingEngine:
                     self._log_status(symbol, current_price)
                 # Reset error counter on successful iteration
                 self.consecutive_errors = 0
+                self.db_unreachable_since = None
 
                 # Calculate and use adaptive interval for next iteration
                 current_price = df.iloc[-1]["close"] if df is not None and not df.empty else None
                 self.check_interval = self._calculate_adaptive_interval(current_price)
 
             except Exception as e:
+                # Transient database-connectivity errors (a brief Postgres
+                # outage or DNS hiccup) must NOT shut the engine down: ride them
+                # out with a bounded backoff and keep the process alive so it
+                # reconnects when the database returns. Counting them toward
+                # max_consecutive_errors killed the live bot during a multi-hour
+                # Railway internal-DNS outage on 2026-05-19.
+                if self._is_transient_db_error(e):
+                    if self.db_unreachable_since is None:
+                        self.db_unreachable_since = time.monotonic()
+                    unreachable_for = time.monotonic() - self.db_unreachable_since
+                    # Prolonged outage: stop opening new positions (exits and
+                    # server-side stop-losses still run) to avoid order churn
+                    # while DB writes keep failing. Stays close-only until a
+                    # manual resume_trading() after review.
+                    if (
+                        unreachable_for >= DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS
+                        and not self._close_only_mode
+                    ):
+                        logger.critical(
+                            "Database unreachable for %.0fs (>= %ds) — entering "
+                            "close-only mode (new entries suspended).",
+                            unreachable_for,
+                            DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS,
+                        )
+                        self._enter_close_only_mode()
+                    logger.warning(
+                        "Database temporarily unreachable in trading loop (%s); "
+                        "backing off %.0fs and retrying — not counted toward "
+                        "shutdown (unreachable for %.0fs).",
+                        type(e).__name__,
+                        self.error_cooldown,
+                        unreachable_for,
+                    )
+                    self._sleep_with_interrupt(self.error_cooldown)
+                    continue
+
                 self.consecutive_errors += 1
                 logger.error(
                     f"Error in trading loop (#{self.consecutive_errors}): {e}", exc_info=True
@@ -1984,6 +2029,64 @@ class LiveTradingEngine:
 
         logger.info("Trading loop ended")
         self._finalize_runtime()
+
+    @staticmethod
+    def _is_transient_db_error(exc: BaseException) -> bool:
+        """Return True if *exc* is a transient database-connectivity error.
+
+        Brief Postgres unavailability, dropped connections, or DNS hiccups
+        should be ridden out with a backoff rather than counted toward
+        ``max_consecutive_errors``. Otherwise a short infrastructure blip
+        shuts the live engine down — which is exactly what happened on
+        2026-05-19 when Railway's internal DNS failed to resolve
+        ``postgres.railway.internal`` for several hours. ``pool_pre_ping``
+        reconnects automatically once the database returns.
+
+        Permanent faults (bad credentials, missing role/database, permission
+        denied) are deliberately NOT treated as transient: retrying them
+        forever would keep the bot alive but brain-dead, so they fall through
+        to the normal consecutive-error path and fail fast.
+        """
+        # Permanent misconfiguration — never retry. These are psycopg2
+        # OperationalError subclasses too, so they must be matched BEFORE the
+        # broad isinstance() net below.
+        permanent_markers = (
+            "password authentication failed",
+            "authentication failed",
+            "no password supplied",
+            "permission denied",
+            "does not exist",  # role/database missing — will not self-heal
+        )
+        transient_markers = (
+            "could not translate host name",
+            "temporary failure in name resolution",
+            "name or service not known",
+            "could not connect",
+            "connection refused",
+            "server closed the connection",
+            "connection already closed",
+            "ssl connection has been closed",
+            "terminating connection",
+            "the database system is starting up",
+            "connection timed out",
+            "could not receive data from server",
+            "no route to host",
+        )
+        seen: set[int] = set()
+        cur: BaseException | None = exc
+        while cur is not None and id(cur) not in seen:
+            seen.add(id(cur))
+            text = str(cur).lower()
+            if any(marker in text for marker in permanent_markers):
+                return False
+            if any(marker in text for marker in transient_markers):
+                return True
+            if isinstance(cur, OperationalError | InterfaceError):
+                return True
+            if isinstance(cur, DBAPIError) and getattr(cur, "connection_invalidated", False):
+                return True
+            cur = getattr(cur, "orig", None) or cur.__cause__ or cur.__context__
+        return False
 
     def _is_context_ready(self, df: pd.DataFrame) -> tuple[bool, str]:
         """Check if the current frame has enough context for strategy-driven decisions.

--- a/tests/unit/test_db_resilience.py
+++ b/tests/unit/test_db_resilience.py
@@ -1,0 +1,191 @@
+"""Tests for transient-DB-error handling in the live trading engine.
+
+Regression coverage for the 2026-05-19 incident: a multi-hour Railway
+internal-DNS outage made Postgres unresolvable, every trading-loop iteration
+raised ``OperationalError``, the consecutive-error counter hit its limit, and
+the engine shut itself down — staying silently offline for ~12 days.
+
+Covers:
+- ``LiveTradingEngine._is_transient_db_error`` classification (transient vs
+  permanent vs unrelated), including exception-chain unwrapping.
+- Loop behaviour: transient DB errors are ridden out (not counted toward
+  ``max_consecutive_errors``); permanent/unrelated errors still trigger
+  shutdown; a prolonged outage escalates to close-only mode.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy.exc import InterfaceError, OperationalError
+
+from src.data_providers.data_provider import DataProvider
+from src.engines.live.trading_engine import LiveTradingEngine
+
+is_transient = LiveTradingEngine._is_transient_db_error
+
+
+def _op_error(message: str) -> OperationalError:
+    """Build a SQLAlchemy OperationalError(statement, params, orig)."""
+    return OperationalError("SELECT 1", {}, Exception(message))
+
+
+def _make_engine() -> LiveTradingEngine:
+    """A paper-mode engine with the database manager patched out."""
+    from src.strategies.ml_basic import create_ml_basic_strategy
+
+    with patch("src.engines.live.trading_engine.DatabaseManager"):
+        return LiveTradingEngine(
+            strategy=create_ml_basic_strategy(),
+            data_provider=Mock(spec=DataProvider),
+            initial_balance=10000,
+            enable_live_trading=False,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Classifier: transient connectivity errors -> ride out
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "exc",
+    [
+        _op_error('could not translate host name "postgres.railway.internal" to address'),
+        _op_error("server closed the connection unexpectedly"),
+        _op_error("terminating connection due to administrator command"),
+        InterfaceError("SELECT 1", {}, Exception("connection already closed")),
+        Exception(
+            'could not translate host name "postgres.railway.internal" to address: '
+            "Temporary failure in name resolution"
+        ),
+        Exception("connection refused"),
+        Exception("could not connect to server"),
+    ],
+)
+def test_transient_db_errors_detected(exc: BaseException) -> None:
+    assert is_transient(exc) is True
+
+
+# --------------------------------------------------------------------------- #
+# Classifier: permanent faults -> fail fast (NOT transient)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "exc",
+    [
+        _op_error('password authentication failed for user "trading_bot"'),
+        _op_error('role "trading_bot" does not exist'),
+        _op_error('database "ai_trading_bot" does not exist'),
+        _op_error("permission denied for table trades"),
+        Exception("FATAL: password authentication failed"),
+    ],
+)
+def test_permanent_db_errors_not_transient(exc: BaseException) -> None:
+    # Permanent misconfig is a psycopg2 OperationalError too, but must fail fast
+    # rather than retry forever.
+    assert is_transient(exc) is False
+
+
+# --------------------------------------------------------------------------- #
+# Classifier: unrelated errors and chain unwrapping
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("invalid position size"),
+        KeyError("close"),
+        RuntimeError("strategy produced an invalid signal"),
+        Exception("some unrelated application failure"),
+    ],
+)
+def test_non_transient_errors_not_flagged(exc: BaseException) -> None:
+    assert is_transient(exc) is False
+
+
+@pytest.mark.fast
+def test_wrapped_transient_error_is_unwrapped() -> None:
+    inner = _op_error("could not connect to server")
+    outer = RuntimeError("trading loop iteration failed")
+    outer.__cause__ = inner
+    assert is_transient(outer) is True
+
+
+@pytest.mark.fast
+def test_context_chained_transient_error_is_unwrapped() -> None:
+    inner = Exception("temporary failure in name resolution")
+    outer = RuntimeError("wrapper")
+    outer.__context__ = inner
+    assert is_transient(outer) is True
+
+
+@pytest.mark.fast
+def test_cyclic_cause_chain_terminates() -> None:
+    a = Exception("a")
+    b = Exception("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert is_transient(a) is False
+
+
+# --------------------------------------------------------------------------- #
+# Loop behaviour
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+def test_transient_db_error_in_loop_is_ridden_out() -> None:
+    """Transient DB errors each iteration must NOT count toward shutdown."""
+    engine = _make_engine()
+    engine.max_consecutive_errors = 1  # would stop after a single *counted* error
+    engine.is_running = True
+    engine._sleep_with_interrupt = Mock()  # skip the real backoff sleep
+    engine._get_latest_data = Mock(side_effect=_op_error('could not translate host name "db"'))
+
+    engine._trading_loop("BTCUSDT", "1h", max_steps=3)
+
+    # Rode out all three iterations without tripping the shutdown counter.
+    assert engine._get_latest_data.call_count == 3
+    assert engine.consecutive_errors == 0
+    assert engine.db_unreachable_since is not None
+
+
+@pytest.mark.fast
+def test_non_transient_error_in_loop_still_shuts_down() -> None:
+    """A non-transient error must still increment the counter and stop."""
+    engine = _make_engine()
+    engine.max_consecutive_errors = 1
+    engine.is_running = True
+    engine._sleep_with_interrupt = Mock()
+    engine._get_latest_data = Mock(side_effect=ValueError("boom"))
+
+    engine._trading_loop("BTCUSDT", "1h", max_steps=5)
+
+    # Shut down after the first counted error — did not run all five iterations.
+    assert engine._get_latest_data.call_count == 1
+    assert engine.is_running is False
+
+
+@pytest.mark.fast
+def test_prolonged_db_outage_enters_close_only() -> None:
+    """After the close-only threshold, the loop suspends new entries."""
+    import time
+
+    engine = _make_engine()
+    engine.max_consecutive_errors = 100
+    engine.is_running = True
+    engine._sleep_with_interrupt = Mock()
+    engine._get_latest_data = Mock(side_effect=_op_error("connection refused"))
+    # Pretend the outage began well beyond the close-only threshold.
+    engine.db_unreachable_since = time.monotonic() - 10_000
+
+    engine._trading_loop("BTCUSDT", "1h", max_steps=1)
+
+    assert engine._close_only_mode is True


### PR DESCRIPTION
## Summary

Both the **staging** and **production** trading bots were silently offline for ~12 days (since 2026-05-19). A multi-hour Railway internal-DNS outage made `postgres.railway.internal` unresolvable; every trading-loop iteration raised `OperationalError`, which the loop counted toward `max_consecutive_errors` (10) until it called `self.stop()` and shut the engine down. Neither bot recovered, and nothing alerted.

## What changed

**Root-cause fix — `src/engines/live/trading_engine.py`**
- Transient DB-connectivity errors (DNS failures, dropped connections, brief Postgres unavailability) are now classified (`_is_transient_db_error`) and *ridden out* with a bounded backoff instead of counting toward shutdown. `pool_pre_ping` (already configured) reconnects once the DB returns.
- **Permanent** faults (bad credentials, missing role/database, permission denied) are excluded and still fail fast — no infinite retry on a misconfiguration.
- A prolonged outage (>30 min) escalates to **close-only mode**: new entries suspended while exits and server-side stop-losses keep running (no order churn; positions stay protected).

**Detection — `scripts/check_heartbeat.py` + `.github/workflows/heartbeat-monitor.yml`**
- A scheduled (every 30 min), read-only CI job that fails — notifying maintainers — if a bot's `account_history` heartbeat goes stale (>2h). Liveness is judged from the **global latest snapshot**, so it's robust to session `is_active` state (catches both crashes that leave `is_active=true` and clean stops that set it false).
- ⚙️ **Requires repo secrets** to activate: `RAILWAY_STAGING_DATABASE_URL`, `RAILWAY_PRODUCTION_DATABASE_URL`. A target is skipped if its secret is absent; if none are set the job soft-skips (exit 0).

**Backstop — `railway.json`**
- `restartPolicyMaxRetries` 3 → 10.

## Testing
- `tests/unit/test_db_resilience.py` (22 tests): classifier (transient / permanent / unrelated / `__cause__`+`__context__` unwrap / cyclic-chain termination) and loop behaviour (transient ridden out → no shutdown; non-transient still shuts down; prolonged outage → close-only).
- 52 existing live-engine safety tests still pass (no regression).
- `scripts/check_heartbeat.py` smoke-tested against the live DBs: staging **OK**, production correctly flagged **STALE**.
- `ruff` + `black` clean.

## Review
Addresses a two-reviewer audit (architecture + code): **P1** — the original fix converted fail-closed into fail-open with no ceiling (permanent errors would retry forever); now bounded by permanent-error fail-fast + close-only escalation. **P2** — the monitor's liveness query is decoupled from `is_active` so it can't false-negative on a clean stop or false-positive forever on a stale crashed-active row.

## Notes
This PR **does not restart the bots**. Staging was already redeployed and has recovered; **production is intentionally held** pending a manual decision — reconciliation showed its DB and the live Binance account drifted apart during the outage (DB lists 3 open positions incl. a ghost short; the exchange has no shorts, no borrow, no stop orders, ~$85).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
