### PR TITLE
Promote to production: DB-resilience hardening (#623) + security fixes (#620)

### DIFF
--- a/.github/workflows/heartbeat-monitor.yml
+++ b/.github/workflows/heartbeat-monitor.yml
@@ -1,0 +1,46 @@
+name: Heartbeat Monitor
+
+# Periodically verifies the live trading bots are still writing account_history
+# snapshots. If a bot's heartbeat goes stale, this job fails and GitHub notifies
+# maintainers — catching a silent outage within ~2.5h (30-min cron + 120-min
+# staleness threshold) instead of the ~12 days it took on 2026-05-19.
+#
+# Requires repository secrets:
+#   RAILWAY_STAGING_DATABASE_URL
+#   RAILWAY_PRODUCTION_DATABASE_URL
+# A target is simply skipped if its secret is absent.
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # every 30 minutes
+  workflow_dispatch:
+    inputs:
+      threshold_minutes:
+        description: "Staleness threshold in minutes"
+        required: false
+        default: "120"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: heartbeat-monitor
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install client
+        run: pip install --no-input psycopg2-binary
+      - name: Check live-bot heartbeats
+        env:
+          RAILWAY_STAGING_DATABASE_URL: ${{ secrets.RAILWAY_STAGING_DATABASE_URL }}
+          RAILWAY_PRODUCTION_DATABASE_URL: ${{ secrets.RAILWAY_PRODUCTION_DATABASE_URL }}
+          HEARTBEAT_THRESHOLD_MINUTES: ${{ github.event.inputs.threshold_minutes || '120' }}
+        run: python scripts/check_heartbeat.py

--- a/cli/commands/data.py
+++ b/cli/commands/data.py
@@ -19,6 +19,91 @@ if SRC_PATH.exists() and str(SRC_PATH) not in sys.path:
 from src.infrastructure.logging.config import configure_logging
 from src.trading.symbols.factory import SymbolFactory
 
+# Exact ``(module, name)`` allowlist for the restricted cache unpickler.
+#
+# This MUST be an exact allowlist, NOT a ``pandas.*``/``numpy.*`` module-prefix
+# match. Those namespaces export callables that re-enter unrestricted unpickling
+# or execute code — most notably ``pandas.read_pickle`` (performs a fresh,
+# unrestricted ``pickle.load`` on an attacker-controlled path -> full RCE), plus
+# ``numpy.load`` / ``numpy.lib.npyio.load``, ``numpy.DataSource`` and
+# ``numpy.vectorize``. A prefix match would expose those and defeat the control.
+# Every entry below is an inert data class or a pure reconstruction helper that
+# only rebuilds DataFrame/Series/Index/ndarray state; object-dtype contents are
+# themselves re-resolved through this same ``find_class`` and so cannot smuggle
+# in a disallowed target.
+_PICKLE_ALLOWED: frozenset[tuple[str, str]] = frozenset(
+    {
+        # inert stdlib data types referenced during reconstruction
+        ("builtins", "slice"),
+        ("builtins", "complex"),
+        ("datetime", "datetime"),
+        ("datetime", "date"),
+        ("datetime", "time"),
+        ("datetime", "timedelta"),
+        ("datetime", "timezone"),
+        # numpy core reconstruction (1.x and 2.x module paths)
+        ("numpy", "ndarray"),
+        ("numpy", "dtype"),
+        ("numpy.core.multiarray", "_reconstruct"),
+        ("numpy.core.multiarray", "scalar"),
+        ("numpy.core.numeric", "_frombuffer"),
+        ("numpy._core.multiarray", "_reconstruct"),
+        ("numpy._core.multiarray", "scalar"),
+        ("numpy._core.numeric", "_frombuffer"),
+        # pandas frame/series/index/block reconstruction
+        ("pandas.core.frame", "DataFrame"),
+        ("pandas.core.series", "Series"),
+        ("pandas.core.indexes.base", "Index"),
+        ("pandas.core.indexes.base", "_new_Index"),
+        ("pandas.core.indexes.range", "RangeIndex"),
+        ("pandas.core.indexes.datetimes", "DatetimeIndex"),
+        ("pandas.core.indexes.datetimes", "_new_DatetimeIndex"),
+        # legacy numeric index classes (removed in newer pandas; for old caches)
+        ("pandas.core.indexes.numeric", "Int64Index"),
+        ("pandas.core.indexes.numeric", "Float64Index"),
+        ("pandas.core.indexes.numeric", "UInt64Index"),
+        ("pandas.core.internals.managers", "BlockManager"),
+        ("pandas.core.internals.managers", "SingleBlockManager"),
+        ("pandas.core.internals.blocks", "new_block"),
+        ("pandas._libs.internals", "_unpickle_block"),
+        ("pandas._libs.arrays", "__pyx_unpickle_NDArrayBacked"),
+        ("pandas.core.arrays.datetimes", "DatetimeArray"),
+        ("pandas.core.dtypes.dtypes", "DatetimeTZDtype"),
+        # frequency offset classes for the stored timeframes
+        ("pandas._libs.tslibs.offsets", "Minute"),
+        ("pandas._libs.tslibs.offsets", "Hour"),
+        ("pandas._libs.tslibs.offsets", "Day"),
+        ("pandas._libs.tslibs.offsets", "Week"),
+        ("pandas._libs.tslibs.timezones", "maybe_get_tz"),
+    }
+)
+
+
+def _safe_pickle_load(file_obj):
+    """Load a pickle restricted to an exact allowlist of inert pandas/numpy types.
+
+    Legacy ``.pkl`` cache files are inspected by the cache-manager CLI. A crafted
+    pickle can execute arbitrary code on load (``pickle`` is a known RCE sink),
+    so this restricted ``Unpickler`` only resolves the specific reconstruction
+    symbols in ``_PICKLE_ALLOWED`` and rejects everything else.
+
+    See ``_PICKLE_ALLOWED`` for why an exact allowlist (not a ``pandas.*``/
+    ``numpy.*`` prefix) is required: those namespaces contain RCE gadgets such as
+    ``pandas.read_pickle``. If a future pandas/numpy version emits a new
+    reconstruction helper, loading fails safe (clear ``UnpicklingError``) rather
+    than opening a hole. Cache files are written at the highest pickle protocol,
+    which is what this supports.
+    """
+    import pickle
+
+    class _RestrictedUnpickler(pickle.Unpickler):
+        def find_class(self, module, name):
+            if (module, name) in _PICKLE_ALLOWED:
+                return super().find_class(module, name)
+            raise pickle.UnpicklingError(f"Blocked unpickling of disallowed type {module}.{name}")
+
+    return _RestrictedUnpickler(file_obj).load()
+
 
 def _normalize_symbols(raw: list[str]) -> list[str]:
     """Normalize symbol names to exchange format (e.g. BTC-USD -> BTCUSDT)."""
@@ -332,8 +417,6 @@ def _test_offline_access(cache_dir: str, symbol: str = "BTCUSDT", timeframe: str
 
 
 def _cache_manager(ns: argparse.Namespace) -> int:
-    import pickle
-
     from src.config.paths import get_cache_dir
     from src.data_providers.binance_provider import BinanceProvider
     from src.data_providers.cached_data_provider import CachedDataProvider
@@ -380,7 +463,7 @@ def _cache_manager(ns: argparse.Namespace) -> int:
             if ns.detailed:
                 try:
                     with open(info["path"], "rb") as f:
-                        data = pickle.load(f)
+                        data = _safe_pickle_load(f)
                     data_info = ""
                     if hasattr(data, "shape"):
                         data_info = f" - {data.shape[0]} rows"

--- a/cli/commands/db.py
+++ b/cli/commands/db.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import os
+import re
 import subprocess
 import sys
 import traceback
@@ -227,9 +228,16 @@ def _basic_integrity_checks(db_url: str) -> dict[str, Any]:
             results["alembic_version_present"] = "alembic_version" in actual_tables
             for t in expected_tables:
                 if t in actual_tables:
+                    # Table names originate from SQLAlchemy ORM metadata (trusted),
+                    # but validate as a plain identifier and quote it before
+                    # interpolation so this can never become a SQL-injection sink.
+                    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", t):
+                        results["row_counts"][t] = None
+                        continue
                     try:
-                        count_q = text(f"SELECT COUNT(*) FROM {t}")
-                        results["row_counts"][t] = int(conn.execute(count_q).scalar() or 0)
+                        quoted = conn.engine.dialect.identifier_preparer.quote(t)
+                        sql = f"SELECT COUNT(*) FROM {quoted}"  # nosec B608 - identifier validated and quoted
+                        results["row_counts"][t] = int(conn.execute(text(sql)).scalar() or 0)
                     except SQLAlchemyError:
                         results["row_counts"][t] = None
     except Exception as exc:  # noqa: BLE001

--- a/cli/commands/dev.py
+++ b/cli/commands/dev.py
@@ -491,7 +491,10 @@ def _dashboard(ns: argparse.Namespace) -> int:
 
     # Get port from environment or use default
     port = int(os.environ.get("PORT", "8090"))
-    host = os.environ.get("HOST", "0.0.0.0")
+    # Bind all interfaces by default so the dashboard is reachable in container
+    # deployments (e.g. Railway). Sensitive endpoints are protected by the
+    # dashboard's MONITORING_DASHBOARD_TOKEN auth guard.
+    host = os.environ.get("HOST", "0.0.0.0")  # nosec B104 - intentional for container deployment
 
     print(f"Starting monitoring dashboard on {host}:{port}")
 

--- a/cli/commands/tests.py
+++ b/cli/commands/tests.py
@@ -1,7 +1,17 @@
 import argparse
 import sys
-import xml.etree.ElementTree as ET
 from pathlib import Path
+
+# Prefer defusedxml to harden against XXE / entity-expansion ("billion laughs")
+# attacks when parsing JUnit XML. Fall back to the stdlib parser only if the
+# hardened library is unavailable.
+try:
+    import defusedxml.ElementTree as ET
+    from defusedxml.ElementTree import ParseError as _XMLParseError
+except ImportError:  # pragma: no cover - defusedxml is a declared dependency
+    import xml.etree.ElementTree as ET  # nosec B405 - fallback only
+
+    _XMLParseError = ET.ParseError
 
 from cli.commands.test_commands import (
     heartbeat_main,
@@ -26,11 +36,13 @@ def _handle_secrets(ns: argparse.Namespace) -> int:
 def _collect_failures(xml_path: Path) -> list[dict[str, str]]:
     failures: list[dict[str, str]] = []
     try:
-        tree = ET.parse(xml_path)
+        tree = ET.parse(
+            xml_path
+        )  # nosec B314 - ET is defusedxml (hardened); stdlib only as fallback
     except FileNotFoundError:
         print(f"JUnit XML not found: {xml_path}", file=sys.stderr)
         return failures
-    except ET.ParseError as exc:
+    except _XMLParseError as exc:
         print(f"Unable to parse {xml_path}: {exc}", file=sys.stderr)
         return failures
 

--- a/cli/core/codex_workflow.py
+++ b/cli/core/codex_workflow.py
@@ -126,7 +126,9 @@ def _ensure_python_on_path(python_bin: str, env: dict[str, str]) -> TemporaryDir
     shim_dir = TemporaryDirectory(prefix="codex-python-shim-")
     shim_path = Path(shim_dir.name) / "python"
     shim_path.write_text(f'#!/bin/sh\n"{resolved_python}" "$@"\n', encoding="utf-8")
-    os.chmod(shim_path, 0o755)
+    # Only the current user needs to execute this throwaway shim; avoid the
+    # group/other-executable bits flagged by static analysis (B103).
+    os.chmod(shim_path, 0o700)
     env["PATH"] = f"{shim_dir.name}{os.pathsep}{env.get('PATH', '')}"
     return shim_dir
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Live trading engine no longer shuts itself down during transient database
+  outages. Transient DB-connectivity errors (DNS resolution failures, dropped
+  connections, brief Postgres unavailability) are now classified and *ridden
+  out* with a bounded backoff instead of counting toward
+  `max_consecutive_errors`. This was the root cause of the 2026-05-19 incident:
+  a multi-hour Railway internal-DNS outage made `postgres.railway.internal`
+  unresolvable, every loop iteration raised `OperationalError`, the
+  consecutive-error limit tripped, and **both the staging and production bots
+  went offline — silently — for ~12 days**. `pool_pre_ping` reconnects
+  automatically once the database returns. Permanent faults (bad credentials,
+  missing role/database, permission denied) are excluded and still fail fast,
+  and an outage lasting more than 30 minutes drops the engine into close-only
+  mode (new entries suspended; exits and server-side stop-losses continue).
+
+### Added
+- Heartbeat staleness monitor (`scripts/check_heartbeat.py` +
+  `.github/workflows/heartbeat-monitor.yml`): a scheduled, read-only CI job that
+  fails (notifying maintainers) when an active trading session's
+  `account_history` snapshot goes stale beyond a threshold (default 2h) — the
+  canonical liveness signal. Requires the `RAILWAY_STAGING_DATABASE_URL` /
+  `RAILWAY_PRODUCTION_DATABASE_URL` repository secrets.
+
+### Changed
+- `railway.json`: raised the Trading Bot `restartPolicyMaxRetries` from 3 to 10
+  so Railway keeps retrying through longer transient infrastructure failures.
+
+### Security
+- Hardened a batch of security findings from a repo-wide scan (bandit + manual
+  audit):
+  - Monitoring dashboard: added a token auth guard (`MONITORING_DASHBOARD_TOKEN`)
+    on state-changing/data-leaking endpoints (`POST /api/balance`,
+    `POST /api/config`, `POST /api/debug/fix-positions`, `GET /api/debug/positions`).
+    Fails closed in production when no token is set; warns-and-allows only in
+    explicit dev/test envs. Restricted Socket.IO CORS from `"*"` to same-origin
+    (override via `MONITORING_CORS_ALLOWED_ORIGINS`).
+  - SageMaker artifact extraction now validates tar members (rejects path
+    traversal / zip-slip and escaping symlinks). Model-registry sync validates
+    `version_id`/`model_type` from `metadata.json` and asserts the resolved path
+    stays inside the registry before any `rmtree`/`copytree`/`symlink`.
+    S3 artifact download skips object keys that escape the target directory.
+  - `get_secret_key()` now fails closed: an unset `ENV`/`FLASK_ENV` is treated as
+    production instead of silently returning the public dev key.
+  - Admin UI login compares the username in constant time (`hmac.compare_digest`).
+  - `atb data cache-manager --detailed` uses a restricted unpickler (allowlisted
+    pandas/numpy types) instead of raw `pickle.load` on legacy `.pkl` files.
+  - JUnit XML parsing uses `defusedxml` (XXE / billion-laughs hardening).
+  - Tightened temp-shim permissions to `0o700`; quoted/validated table
+    identifiers in the DB integrity check; marked the dashboard's `0.0.0.0`
+    bind intentional.
+
 ### Added
 - Experimentation framework (`src/experiments/`) with declarative YAML suites,
   `atb experiment run|list|show|promote` CLI, ranked reporter with statistical

--- a/railway.json
+++ b/railway.json
@@ -8,6 +8,6 @@
     "healthcheckPath": "/health",
     "healthcheckTimeout": 10,
     "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 3
+    "restartPolicyMaxRetries": 10
   }
 }

--- a/requirements-github.txt
+++ b/requirements-github.txt
@@ -17,6 +17,7 @@ textblob==0.17.1
 nltk==3.9.1
 ccxt==4.4.85
 tqdm==4.66.3
+defusedxml==0.7.1
 matplotlib==3.8.2
 psutil==5.9.6
 pyarrow==20.0.0

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -13,6 +13,7 @@ textblob==0.17.1
 nltk==3.9.1
 ccxt==4.4.85
 tqdm==4.66.3
+defusedxml==0.7.1
 sqlalchemy==2.0.23
 psycopg2-binary==2.9.9
 psutil>=5.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ requests==2.31.0
 nltk==3.9.1
 ccxt==4.4.85
 tqdm==4.66.3
+defusedxml==0.7.1
 tensorflow==2.19.0
 tf2onnx==1.16.1
 sqlalchemy==2.0.23

--- a/scripts/check_heartbeat.py
+++ b/scripts/check_heartbeat.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Heartbeat staleness monitor for the live trading bots.
+
+Connects (read-only) to one or more environment databases and verifies that the
+bot is still writing ``account_history`` snapshots. Exits non-zero if a
+heartbeat is stale, so a scheduled CI job (``.github/workflows/heartbeat-monitor.yml``)
+fails and notifies maintainers.
+
+Why this exists: on 2026-05-19 both the staging and production bots died
+(Railway internal-DNS outage made Postgres unresolvable) and then stayed
+*silently* down for ~12 days. The ``account_history`` snapshot (written every
+~30 min while running) is the canonical liveness signal.
+
+Liveness is judged from the GLOBAL latest ``account_history`` snapshot rather
+than from session state, on purpose: a crashed bot leaves its session
+``is_active=True`` with a frozen snapshot, while a clean ``stop()`` sets
+``is_active=False`` — in BOTH cases the snapshot simply stops advancing, so the
+global max timestamp is the reliable signal. (Filtering on ``is_active`` would
+either miss clean-stop deaths or false-positive forever on stale crashed-active
+rows.) The active session, if any, is reported only as context.
+
+Read-only: issues only SELECTs against a read-only session. Safe for production.
+
+Configuration (environment variables):
+  RAILWAY_STAGING_DATABASE_URL      staging DB connection string (optional)
+  RAILWAY_PRODUCTION_DATABASE_URL   production DB connection string (optional)
+  HEARTBEAT_THRESHOLD_MINUTES       staleness threshold, default 120
+
+Exit codes: 0 = healthy or nothing to check, 1 = stale heartbeat or check error.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import UTC, datetime
+
+try:
+    import psycopg2
+except ImportError:  # pragma: no cover
+    print("ERROR: psycopg2 is required (pip install psycopg2-binary)", file=sys.stderr)
+    sys.exit(1)
+
+DEFAULT_THRESHOLD_MINUTES = 120
+
+# Environment variable holding the connection string -> friendly label.
+TARGETS = {
+    "RAILWAY_STAGING_DATABASE_URL": "staging",
+    "RAILWAY_PRODUCTION_DATABASE_URL": "production",
+}
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _as_aware(ts: datetime | None) -> datetime | None:
+    """Treat naive timestamps as UTC (the bot stores naive UTC datetimes)."""
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
+def check_target(label: str, url: str, threshold_minutes: int) -> list[str]:
+    """Return a list of staleness problems for one environment (empty == healthy)."""
+    problems: list[str] = []
+    conn = psycopg2.connect(url, connect_timeout=15)
+    try:
+        # Enforce read-only at the connection level — defense in depth for prod.
+        conn.set_session(readonly=True, autocommit=True)
+        with conn.cursor() as cur:
+            cur.execute("SELECT max(timestamp) FROM account_history;")
+            row = cur.fetchone()
+            last_hb = row[0] if row else None
+            cur.execute(
+                "SELECT id, mode, session_name FROM trading_sessions "
+                "WHERE is_active IS TRUE ORDER BY start_time DESC LIMIT 1;"
+            )
+            active = cur.fetchone()
+    finally:
+        conn.close()
+
+    ctx = (
+        f"active session {active[0]} ({active[1]}) '{active[2]}'" if active else "no active session"
+    )
+    last_hb = _as_aware(last_hb)
+    if last_hb is None:
+        # Never run here (fresh/unused DB) — not an outage.
+        print(f"[{label}] no account_history yet — skipping ({ctx})")
+        return problems
+
+    age_h = (_utcnow() - last_hb).total_seconds() / 3600.0
+    if age_h * 60.0 > threshold_minutes:
+        detail = (
+            f"last account_history {age_h:.1f}h ago ({last_hb.isoformat()}), "
+            f"{ctx} (threshold {threshold_minutes}m)"
+        )
+        print(f"[{label}] STALE — {detail}")
+        problems.append(f"{label} heartbeat stale: {detail}")
+    else:
+        print(f"[{label}] OK — last heartbeat {age_h:.1f}h ago, {ctx}")
+    return problems
+
+
+def main() -> int:
+    threshold = int(os.environ.get("HEARTBEAT_THRESHOLD_MINUTES", DEFAULT_THRESHOLD_MINUTES))
+    checked = 0
+    all_problems: list[str] = []
+    errors: list[str] = []
+    for env_var, label in TARGETS.items():
+        url = os.environ.get(env_var)
+        if not url:
+            continue
+        checked += 1
+        try:
+            all_problems.extend(check_target(label, url, threshold))
+        except Exception as e:  # noqa: BLE001 - any failure to verify liveness is alert-worthy
+            errors.append(f"{label}: failed to check ({type(e).__name__}: {e})")
+
+    if checked == 0:
+        # No targets configured (e.g. secrets not set). Don't fail recurring CI;
+        # surface a clear warning and exit cleanly.
+        print(
+            "WARNING: no target database URLs configured "
+            "(set RAILWAY_STAGING_DATABASE_URL / RAILWAY_PRODUCTION_DATABASE_URL). "
+            "Nothing to check.",
+            file=sys.stderr,
+        )
+        return 0
+
+    for err in errors:
+        print(f"ERROR: {err}", file=sys.stderr)
+
+    if all_problems:
+        print("\nHEARTBEAT ALERT — stale live-bot heartbeat(s) detected:", file=sys.stderr)
+        for p in all_problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+
+    # A connection/query failure means we could not confirm liveness — treat as alert.
+    if errors:
+        return 1
+
+    print(f"\nAll heartbeats healthy (threshold {threshold}m).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -62,6 +62,10 @@ DEFAULT_DRAWDOWN_THRESHOLD = 0.15
 # Error Handling Constants
 DEFAULT_ERROR_COOLDOWN = 30  # seconds to wait after consecutive errors
 DEFAULT_MAX_CONSECUTIVE_ERRORS = 10  # Maximum errors before shutdown
+# After the database has been continuously unreachable for this long, the live
+# loop stops opening new positions (close-only) while it keeps retrying, to
+# avoid order churn during a prolonged outage. Exits and server-side stops still run.
+DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS = 1800  # 30 minutes
 
 # Health Monitor Constants (distinct from CPU optimization intervals)
 DEFAULT_HEALTH_BASE_CHECK_INTERVAL = 60  # Base health check interval in seconds

--- a/src/dashboards/monitoring/dashboard.py
+++ b/src/dashboards/monitoring/dashboard.py
@@ -31,6 +31,7 @@ else:
 
 # Standard library imports
 import argparse
+import hmac
 import json
 import logging
 import threading
@@ -64,6 +65,69 @@ from src.performance.metrics import sharpe as perf_sharpe
 
 # Configure logging via centralized config (set by entry points)
 logger = logging.getLogger(__name__)
+
+
+def _is_production_env() -> bool:
+    """Return True unless an explicit dev/test marker is set (fail closed)."""
+    env = os.environ.get("ENV", os.environ.get("FLASK_ENV", "production")).lower()
+    return env not in {"dev", "development", "test", "testing"}
+
+
+def _dashboard_auth_required(view):
+    """Protect sensitive (state-changing / data-leaking) dashboard endpoints.
+
+    Authentication is enforced via a shared token in ``MONITORING_DASHBOARD_TOKEN``
+    (sent as ``X-Dashboard-Token`` or ``Authorization: Bearer <token>``):
+
+    * Token set   -> the request must present a matching token (constant-time check).
+    * Token unset + production -> the endpoint is disabled (fail closed), since the
+      dashboard has no login and may be bound to all interfaces.
+    * Token unset + dev/test   -> allowed, with a warning logged.
+    """
+    import functools
+
+    @functools.wraps(view)
+    def wrapper(*args, **kwargs):
+        token = os.environ.get("MONITORING_DASHBOARD_TOKEN", "").strip()
+        if token:
+            provided = request.headers.get("X-Dashboard-Token", "").strip()
+            if not provided:
+                auth_header = request.headers.get("Authorization", "")
+                if auth_header.startswith("Bearer "):
+                    provided = auth_header[len("Bearer ") :].strip()
+            # Compare as bytes: hmac.compare_digest raises TypeError on str
+            # inputs containing codepoints > 127, and the token comes from an
+            # attacker-controlled header (Werkzeug decodes headers as latin-1),
+            # which would otherwise surface as an unhandled 500 instead of 401.
+            if not (
+                provided and hmac.compare_digest(provided.encode("utf-8"), token.encode("utf-8"))
+            ):
+                return jsonify({"success": False, "error": "Unauthorized"}), 401
+            return view(*args, **kwargs)
+        if _is_production_env():
+            logger.error(
+                "Blocked %s: MONITORING_DASHBOARD_TOKEN is not set in a production "
+                "environment; sensitive dashboard endpoints are disabled.",
+                request.path,
+            )
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "error": "Endpoint disabled: set MONITORING_DASHBOARD_TOKEN to enable it.",
+                    }
+                ),
+                403,
+            )
+        logger.warning(
+            "MONITORING_DASHBOARD_TOKEN not set; allowing unauthenticated access to %s "
+            "(non-production environment only).",
+            request.path,
+        )
+        return view(*args, **kwargs)
+
+    return wrapper
+
 
 # after imports define typedicts
 
@@ -125,7 +189,22 @@ class MonitoringDashboard:
         from src.infrastructure.runtime.secrets import get_secret_key
 
         self.app.config["SECRET_KEY"] = get_secret_key()
-        self.socketio = SocketIO(self.app, cors_allowed_origins="*", async_mode=_ASYNC_MODE)
+        # Do not allow arbitrary cross-origin connections by default — a wildcard
+        # would let any website open a Socket.IO connection and read pushed
+        # trading/balance data. Default to same-origin; allow an explicit
+        # comma-separated allowlist via MONITORING_CORS_ALLOWED_ORIGINS.
+        #
+        # NB: pass ``None`` (not ``[]``) for the same-origin default. In
+        # python-engineio an empty list is a sentinel that *disables* CORS
+        # handling entirely (no Access-Control-Allow-Origin header, no origin
+        # check), whereas ``None``/omitted means "only the same origin".
+        _cors_env = os.environ.get("MONITORING_CORS_ALLOWED_ORIGINS", "").strip()
+        cors_allowed_origins: Any = (
+            [o.strip() for o in _cors_env.split(",") if o.strip()] if _cors_env else None
+        )
+        self.socketio = SocketIO(
+            self.app, cors_allowed_origins=cors_allowed_origins, async_mode=_ASYNC_MODE
+        )
 
         # Initialize database manager – avoid passing None to ease mocking in unit tests
         self.db_manager = DatabaseManager() if db_url is None else DatabaseManager(db_url)
@@ -251,6 +330,7 @@ class MonitoringDashboard:
             return jsonify(self.monitoring_config)
 
         @self.app.route("/api/config", methods=["POST"])
+        @_dashboard_auth_required
         def update_config():
             """Update monitoring configuration"""
             new_config = request.json
@@ -367,6 +447,7 @@ class MonitoringDashboard:
             return jsonify(history)
 
         @self.app.route("/api/balance", methods=["POST"])
+        @_dashboard_auth_required
         def update_balance():
             """Manually update balance"""
             data = request.json or {}
@@ -431,6 +512,7 @@ class MonitoringDashboard:
                 return jsonify({"items": [], "error": str(e)}), 200
 
         @self.app.route("/api/debug/positions")
+        @_dashboard_auth_required
         def debug_positions():
             """Debug endpoint showing positions by all statuses for troubleshooting."""
             try:
@@ -470,6 +552,7 @@ class MonitoringDashboard:
                 return jsonify({"error": str(e)}), 500
 
         @self.app.route("/api/debug/fix-positions", methods=["POST"])
+        @_dashboard_auth_required
         def fix_position_inconsistencies():
             """Endpoint to manually trigger position status fixes."""
             try:

--- a/src/database/admin_ui/app.py
+++ b/src/database/admin_ui/app.py
@@ -1,3 +1,4 @@
+import hmac
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -265,8 +266,14 @@ def create_app() -> "Flask":
             username = request.form.get("username")
             password = request.form.get("password")
             # SEC-002 Fix: Use secure password hash comparison (timing-attack resistant)
+            # Compare the username in constant time too, so a non-default username
+            # cannot be recovered character-by-character via timing.
+            # Compare as bytes: hmac.compare_digest raises TypeError on str
+            # inputs containing codepoints > 127, and ``username`` is
+            # attacker-controlled (request.form), which would otherwise 500.
             if (
-                username == ADMIN_USERNAME
+                username is not None
+                and hmac.compare_digest(username.encode("utf-8"), ADMIN_USERNAME.encode("utf-8"))
                 and password is not None
                 and check_password_hash(ADMIN_PASSWORD_HASH, password)
             ):

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -13,12 +13,14 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pandas as pd
+from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
 
 from src.config import get_config
 from src.config.constants import (
     DEFAULT_ACCOUNT_SNAPSHOT_INTERVAL,
     DEFAULT_CHECK_INTERVAL,
     DEFAULT_DATA_FRESHNESS_THRESHOLD,
+    DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS,
     DEFAULT_DYNAMIC_RISK_ENABLED,
     DEFAULT_END_OF_DAY_FLAT,
     DEFAULT_ERROR_COOLDOWN,
@@ -54,13 +56,13 @@ from src.engines.live.data.market_data_handler import MarketDataHandler
 from src.engines.live.execution.entry_handler import LiveEntryHandler, LiveEntrySignal
 from src.engines.live.execution.execution_engine import LiveExecutionEngine
 from src.engines.live.execution.exit_handler import LiveExitHandler
-from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.execution.position_tracker import (
     LivePosition,
     LivePositionTracker,
 )
 from src.engines.live.health.health_monitor import HealthMonitor
 from src.engines.live.logging.event_logger import LiveEventLogger
+from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.live.strategy_manager import StrategyManager
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
 from src.engines.shared.execution.execution_model import ExecutionModel
@@ -477,6 +479,12 @@ class LiveTradingEngine:
         # Error handling
         self.max_consecutive_errors = max_consecutive_errors
         self.consecutive_errors = 0
+        # Monotonic timestamp marking when the database first became unreachable
+        # inside the trading loop (None while reachable). Lets the engine ride
+        # out transient DB outages instead of counting them toward
+        # max_consecutive_errors (incident 2026-05-19: a Railway internal-DNS
+        # outage made Postgres unresolvable and shut the live bot down).
+        self.db_unreachable_since: float | None = None
         self.error_cooldown = DEFAULT_ERROR_COOLDOWN
 
         # Time exit policy (construct from overrides if not provided)
@@ -1957,12 +1965,49 @@ class LiveTradingEngine:
                     self._log_status(symbol, current_price)
                 # Reset error counter on successful iteration
                 self.consecutive_errors = 0
+                self.db_unreachable_since = None
 
                 # Calculate and use adaptive interval for next iteration
                 current_price = df.iloc[-1]["close"] if df is not None and not df.empty else None
                 self.check_interval = self._calculate_adaptive_interval(current_price)
 
             except Exception as e:
+                # Transient database-connectivity errors (a brief Postgres
+                # outage or DNS hiccup) must NOT shut the engine down: ride them
+                # out with a bounded backoff and keep the process alive so it
+                # reconnects when the database returns. Counting them toward
+                # max_consecutive_errors killed the live bot during a multi-hour
+                # Railway internal-DNS outage on 2026-05-19.
+                if self._is_transient_db_error(e):
+                    if self.db_unreachable_since is None:
+                        self.db_unreachable_since = time.monotonic()
+                    unreachable_for = time.monotonic() - self.db_unreachable_since
+                    # Prolonged outage: stop opening new positions (exits and
+                    # server-side stop-losses still run) to avoid order churn
+                    # while DB writes keep failing. Stays close-only until a
+                    # manual resume_trading() after review.
+                    if (
+                        unreachable_for >= DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS
+                        and not self._close_only_mode
+                    ):
+                        logger.critical(
+                            "Database unreachable for %.0fs (>= %ds) — entering "
+                            "close-only mode (new entries suspended).",
+                            unreachable_for,
+                            DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS,
+                        )
+                        self._enter_close_only_mode()
+                    logger.warning(
+                        "Database temporarily unreachable in trading loop (%s); "
+                        "backing off %.0fs and retrying — not counted toward "
+                        "shutdown (unreachable for %.0fs).",
+                        type(e).__name__,
+                        self.error_cooldown,
+                        unreachable_for,
+                    )
+                    self._sleep_with_interrupt(self.error_cooldown)
+                    continue
+
                 self.consecutive_errors += 1
                 logger.error(
                     f"Error in trading loop (#{self.consecutive_errors}): {e}", exc_info=True
@@ -1984,6 +2029,64 @@ class LiveTradingEngine:
 
         logger.info("Trading loop ended")
         self._finalize_runtime()
+
+    @staticmethod
+    def _is_transient_db_error(exc: BaseException) -> bool:
+        """Return True if *exc* is a transient database-connectivity error.
+
+        Brief Postgres unavailability, dropped connections, or DNS hiccups
+        should be ridden out with a backoff rather than counted toward
+        ``max_consecutive_errors``. Otherwise a short infrastructure blip
+        shuts the live engine down — which is exactly what happened on
+        2026-05-19 when Railway's internal DNS failed to resolve
+        ``postgres.railway.internal`` for several hours. ``pool_pre_ping``
+        reconnects automatically once the database returns.
+
+        Permanent faults (bad credentials, missing role/database, permission
+        denied) are deliberately NOT treated as transient: retrying them
+        forever would keep the bot alive but brain-dead, so they fall through
+        to the normal consecutive-error path and fail fast.
+        """
+        # Permanent misconfiguration — never retry. These are psycopg2
+        # OperationalError subclasses too, so they must be matched BEFORE the
+        # broad isinstance() net below.
+        permanent_markers = (
+            "password authentication failed",
+            "authentication failed",
+            "no password supplied",
+            "permission denied",
+            "does not exist",  # role/database missing — will not self-heal
+        )
+        transient_markers = (
+            "could not translate host name",
+            "temporary failure in name resolution",
+            "name or service not known",
+            "could not connect",
+            "connection refused",
+            "server closed the connection",
+            "connection already closed",
+            "ssl connection has been closed",
+            "terminating connection",
+            "the database system is starting up",
+            "connection timed out",
+            "could not receive data from server",
+            "no route to host",
+        )
+        seen: set[int] = set()
+        cur: BaseException | None = exc
+        while cur is not None and id(cur) not in seen:
+            seen.add(id(cur))
+            text = str(cur).lower()
+            if any(marker in text for marker in permanent_markers):
+                return False
+            if any(marker in text for marker in transient_markers):
+                return True
+            if isinstance(cur, OperationalError | InterfaceError):
+                return True
+            if isinstance(cur, DBAPIError) and getattr(cur, "connection_invalidated", False):
+                return True
+            cur = getattr(cur, "orig", None) or cur.__cause__ or cur.__context__
+        return False
 
     def _is_context_ready(self, df: pd.DataFrame) -> tuple[bool, str]:
         """Check if the current frame has enough context for strategy-driven decisions.

--- a/src/infrastructure/runtime/secrets.py
+++ b/src/infrastructure/runtime/secrets.py
@@ -18,7 +18,11 @@ def get_secret_key(env_var: str = "FLASK_SECRET_KEY", *, allow_default_in_dev: b
         RuntimeError: If secret is missing in non-development environments.
     """
     value = os.getenv(env_var)
-    env = os.getenv("ENV", os.getenv("FLASK_ENV", "development")).lower()
+    # Fail closed: when neither ENV nor FLASK_ENV is set we must NOT assume
+    # development, otherwise a misconfigured production deployment would silently
+    # sign sessions with the publicly known dev key (session-forgery risk). Only
+    # an explicit dev/test marker unlocks the default fallback.
+    env = os.getenv("ENV", os.getenv("FLASK_ENV", "production")).lower()
     if value:
         return value
     if allow_default_in_dev and env in {"dev", "development", "test", "testing"}:

--- a/src/ml/cloud/artifacts/s3_manager.py
+++ b/src/ml/cloud/artifacts/s3_manager.py
@@ -158,6 +158,14 @@ class S3ArtifactManager:
                         continue
 
                     local_file = local_dir / relative_path
+                    # S3 object keys may legally contain ".." segments; ensure the
+                    # download target stays within ``local_dir`` (path traversal).
+                    if not local_file.resolve().is_relative_to(local_dir.resolve()):
+                        logger.warning(
+                            "Skipping S3 object with unsafe key outside target dir: %s",
+                            s3_key,
+                        )
+                        continue
                     local_file.parent.mkdir(parents=True, exist_ok=True)
 
                     self._s3_client.download_file(bucket, s3_key, str(local_file))

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -51,6 +51,21 @@ MAX_JOB_SUFFIX_LENGTH = 100
 MAX_METADATA_SEARCH_DEPTH = 100
 
 
+def _validate_registry_component(value: str, field: str) -> str:
+    """Validate a path component used to build local model-registry paths.
+
+    ``version_id``/``model_type`` originate from a downloaded ``metadata.json``
+    (outside this process) and are used to build registry paths that are later
+    targets of rmtree/copytree/symlink. A value containing ``..`` or a path
+    separator would allow writing or deleting files outside the registry, so we
+    only accept simple identifiers.
+    """
+    text = str(value)
+    if text in (".", "..") or not re.match(r"^[\w\-.]+$", text):
+        raise ArtifactSyncError(f"Refusing to use unsafe {field} from metadata: {value!r}")
+    return text
+
+
 class CloudTrainingOrchestrator:
     """Orchestrates cloud training workflow.
 
@@ -411,6 +426,10 @@ class CloudTrainingOrchestrator:
                 version_id = datetime.now(UTC).strftime("%Y-%m-%d_%Hh_v1")
                 model_type = "basic"
 
+            # Validate metadata-supplied path components (see helper docstring).
+            version_id = _validate_registry_component(version_id, "version_id")
+            model_type = _validate_registry_component(model_type, "model_type")
+
             # Sync to local registry
             local_registry = get_project_root() / "src" / "ml" / "models"
             symbol = self.config.training_config.symbol.upper()
@@ -489,6 +508,12 @@ class CloudTrainingOrchestrator:
         """
         # Create expected registry directory path
         version_dir = local_registry / symbol / model_type / version_id
+
+        # Defense in depth: ensure the resolved target never escapes the registry
+        # before any destructive rmtree/copytree/symlink operation runs.
+        registry_root = local_registry.resolve()
+        if not version_dir.resolve().is_relative_to(registry_root):
+            raise ArtifactSyncError(f"Computed model path escapes registry root: {version_dir}")
 
         # If artifact is already in the registry at the correct location, just update the symlink
         if artifact_path.resolve() == version_dir.resolve():

--- a/src/ml/cloud/providers/sagemaker.py
+++ b/src/ml/cloud/providers/sagemaker.py
@@ -32,6 +32,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _safe_extract_tar(tar: tarfile.TarFile, dest: Path) -> None:
+    """Extract ``tar`` into ``dest`` while rejecting unsafe members.
+
+    Protects against path-traversal ("zip-slip") and symlink/hardlink members
+    that could write or point outside ``dest``. Any member whose resolved
+    destination escapes ``dest`` raises :class:`ArtifactSyncError`.
+    """
+    dest_root = dest.resolve()
+    for member in tar.getmembers():
+        # Reject absolute paths and ".." traversal before touching the disk.
+        member_path = (dest_root / member.name).resolve()
+        if not (member_path == dest_root or dest_root in member_path.parents):
+            raise ArtifactSyncError(
+                f"Refusing to extract unsafe tar member outside target dir: {member.name!r}"
+            )
+        # Reject link members that could redirect writes/reads outside dest.
+        if member.islnk() or member.issym():
+            link_target = (member_path.parent / member.linkname).resolve()
+            if not (link_target == dest_root or dest_root in link_target.parents):
+                raise ArtifactSyncError(
+                    f"Refusing to extract unsafe link member in tar: {member.name!r}"
+                )
+    tar.extractall(path=dest)  # nosec B202 - members validated above
+
+
 class SageMakerProvider(CloudTrainingProvider):
     """AWS SageMaker training provider with spot instance support.
 
@@ -245,9 +270,10 @@ class SageMakerProvider(CloudTrainingProvider):
             self._s3_client.download_file(bucket, key, str(tmp_path))
             logger.info(f"Downloaded artifacts from s3://{bucket}/{key}")
 
-            # Extract tarball
+            # Extract tarball safely (guard against path traversal / zip-slip and
+            # symlink members that could write outside ``local_path``).
             with tarfile.open(tmp_path, "r:gz") as tar:
-                tar.extractall(path=local_path)
+                _safe_extract_tar(tar, local_path)
 
             # Clean up temp file
             tmp_path.unlink()

--- a/src/tech/indicators/core.py
+++ b/src/tech/indicators/core.py
@@ -34,7 +34,8 @@ def _make_cache_key(df: pd.DataFrame, func_name: str, *args, **kwargs) -> str | 
     # the last row). All indicator functions depend on prior rows, so a full content hash
     # is required for correctness. pd.util.hash_pandas_object is efficient (vectorized).
     data_hash = hashlib.md5(
-        pd.util.hash_pandas_object(df, index=True).values.tobytes()
+        pd.util.hash_pandas_object(df, index=True).values.tobytes(),
+        usedforsecurity=False,
     ).hexdigest()[:12]
 
     # Include positional arguments in cache key
@@ -44,7 +45,7 @@ def _make_cache_key(df: pd.DataFrame, func_name: str, *args, **kwargs) -> str | 
 
     # Create composite key and hash for shorter keys
     key_str = "|".join([func_name, last_ts, str(num_rows), data_hash, args_str, param_str])
-    return hashlib.md5(key_str.encode()).hexdigest()
+    return hashlib.md5(key_str.encode(), usedforsecurity=False).hexdigest()
 
 
 def cached_indicator(func: Callable) -> Callable:
@@ -201,12 +202,8 @@ def calculate_rsi(
 
             # Recursive Wilder's smoothing for remaining values
             for i in range(period + 1, len(close)):
-                avg_gain.iloc[i] = (
-                    avg_gain.iloc[i - 1] * (period - 1) + gains.iloc[i]
-                ) / period
-                avg_loss.iloc[i] = (
-                    avg_loss.iloc[i - 1] * (period - 1) + losses.iloc[i]
-                ) / period
+                avg_gain.iloc[i] = (avg_gain.iloc[i - 1] * (period - 1) + gains.iloc[i]) / period
+                avg_loss.iloc[i] = (avg_loss.iloc[i - 1] * (period - 1) + losses.iloc[i]) / period
 
     # Prevent division by zero by adding epsilon to loss
     # When loss is 0, RS approaches infinity and RSI approaches 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,13 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
 
+# Tests run in a test environment. Pin ENV early (before any test constructs a
+# Flask app) so get_secret_key() stays deterministic: without an explicit
+# dev/test marker it now fails closed (production behavior), which would make
+# admin-UI and monitoring-dashboard construction raise RuntimeError on CI
+# runners that don't set ENV.
+os.environ.setdefault("ENV", "test")
+
 if sys.version_info < (3, 10):
     try:
         import src.prediction  # noqa: F401  # ensure real package is loaded

--- a/tests/unit/cli/test_data.py
+++ b/tests/unit/cli/test_data.py
@@ -5,7 +5,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pandas as pd
+import pytest
 
 from cli.commands.data import _download, _prefill, _preload_offline
 
@@ -240,3 +242,124 @@ class TestDataPreloadOffline:
 
         # Assert
         assert result == 0
+
+
+class TestSafePickleLoad:
+    """Regression tests for the restricted unpickler used by cache-manager."""
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize("protocol", [4, 5])
+    def test_round_trips_realistic_cached_frames(self, protocol):
+        """Legitimate cached DataFrames/Series must load unchanged.
+
+        Covers a datetime/tz index (the OHLCV cache shape), naive index,
+        RangeIndex, integer index, mixed dtypes, and a Series.
+        """
+        import io
+        import pickle
+
+        from cli.commands.data import _safe_pickle_load
+
+        idx = pd.date_range("2023-01-01", periods=5, freq="1h", tz="UTC")
+        df = pd.DataFrame(
+            {
+                "open": np.arange(5.0),
+                "close": np.arange(5.0),
+                "volume": np.arange(5),
+            },
+            index=idx,
+        )
+        cases = [
+            df,
+            df.tz_localize(None),
+            df.reset_index(drop=True),
+            df["close"],
+            pd.DataFrame({"a": [1, 2, 3]}, index=pd.Index([10, 20, 30])),
+            pd.DataFrame({"a": [1, 2], "b": [1.5, 2.5], "c": ["p", "q"], "d": [True, False]}),
+        ]
+        for obj in cases:
+            loaded = _safe_pickle_load(io.BytesIO(pickle.dumps(obj, protocol=protocol)))
+            if isinstance(obj, pd.Series):
+                pd.testing.assert_series_equal(loaded, obj)
+            else:
+                pd.testing.assert_frame_equal(loaded, obj)
+
+    @pytest.mark.fast
+    def test_blocks_os_system_gadget(self):
+        import io
+        import pickle
+
+        from cli.commands.data import _safe_pickle_load
+
+        class _Evil:
+            def __reduce__(self):
+                import os
+
+                return (os.system, ("echo pwned",))
+
+        with pytest.raises(pickle.UnpicklingError):
+            _safe_pickle_load(io.BytesIO(pickle.dumps(_Evil())))
+
+    @pytest.mark.fast
+    def test_blocks_builtins_eval_gadget(self):
+        import builtins
+        import io
+        import pickle
+
+        from cli.commands.data import _safe_pickle_load
+
+        class _Evil:
+            def __reduce__(self):
+                return (builtins.eval, ("__import__('os').system('id')",))
+
+        with pytest.raises(pickle.UnpicklingError):
+            _safe_pickle_load(io.BytesIO(pickle.dumps(_Evil())))
+
+    @pytest.mark.fast
+    def test_blocks_pandas_read_pickle_reentrancy_gadget(self, tmp_path):
+        """``pandas.read_pickle`` must be blocked.
+
+        A module-prefix allowlist (pandas.*/numpy.*) would resolve
+        ``pandas.read_pickle``, which performs a fresh *unrestricted*
+        ``pickle.load`` on an attacker path — full RCE escaping the restriction.
+        Verify it is rejected and the nested payload never executes.
+        """
+        import io
+        import pickle
+
+        from cli.commands.data import _safe_pickle_load
+
+        marker = tmp_path / "pwned.txt"
+        nested = tmp_path / "nested.pkl"
+
+        class _Inner:
+            def __reduce__(self):
+                import os
+
+                return (os.system, (f"touch {marker}",))
+
+        nested.write_bytes(pickle.dumps(_Inner()))
+
+        class _Outer:
+            def __reduce__(self):
+                return (pd.read_pickle, (str(nested),))
+
+        with pytest.raises(pickle.UnpicklingError):
+            _safe_pickle_load(io.BytesIO(pickle.dumps(_Outer())))
+        assert not marker.exists(), "read_pickle gadget executed — allowlist bypassed"
+
+    @pytest.mark.fast
+    def test_blocks_numpy_load_gadget(self):
+        """``numpy.load`` (a re-entrant/file-reading gadget) must be blocked
+        before it touches the filesystem."""
+        import io
+        import pickle
+
+        from cli.commands.data import _safe_pickle_load
+
+        class _Evil:
+            def __reduce__(self):
+                return (np.load, ("/nonexistent/whatever.npy",))
+
+        with pytest.raises(pickle.UnpicklingError):
+            _safe_pickle_load(io.BytesIO(pickle.dumps(_Evil())))

--- a/tests/unit/cloud/test_orchestrator_security.py
+++ b/tests/unit/cloud/test_orchestrator_security.py
@@ -1,0 +1,79 @@
+"""Security regression tests for cloud orchestrator path handling.
+
+Covers the validation branches that guard destructive rmtree/copytree/symlink
+operations in the local model-registry sync against attacker-controlled
+``metadata.json`` fields and registry-escaping paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.ml.cloud.exceptions import ArtifactSyncError
+from src.ml.cloud.orchestrator import (
+    CloudTrainingOrchestrator,
+    _validate_registry_component,
+)
+
+
+class TestValidateRegistryComponent:
+    @pytest.mark.fast
+    @pytest.mark.parametrize("value", ["2025-10-27_14h_v1", "basic", "sentiment", "v1.2.3"])
+    def test_accepts_simple_identifiers(self, value):
+        assert _validate_registry_component(value, "version_id") == value
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize(
+        "value",
+        ["..", ".", "../../etc", "a/b", "a\\b", "", "x/../y", "/abs"],
+    )
+    def test_rejects_unsafe_values(self, value):
+        with pytest.raises(ArtifactSyncError):
+            _validate_registry_component(value, "model_type")
+
+
+class TestSyncLocalArtifactsContainment:
+    @pytest.mark.fast
+    def test_rejects_path_escaping_registry(self, tmp_path):
+        """A model_type/version that resolves outside the registry must raise
+        before any filesystem mutation."""
+        # Bypass __init__ — the containment check does not use instance state.
+        orch = object.__new__(CloudTrainingOrchestrator)
+        registry = tmp_path / "registry"
+        registry.mkdir()
+        artifact = tmp_path / "artifact"
+        artifact.mkdir()
+
+        with pytest.raises(ArtifactSyncError, match="escapes registry root"):
+            orch._sync_local_artifacts(
+                artifact_path=artifact,
+                local_registry=registry,
+                symbol="BTCUSDT",
+                model_type="../../../../tmp",
+                version_id="evil",
+            )
+
+        # Nothing was created outside the registry.
+        assert not (tmp_path / "tmp").exists()
+
+    @pytest.mark.fast
+    def test_allows_normal_path_into_registry(self, tmp_path):
+        orch = object.__new__(CloudTrainingOrchestrator)
+        registry = tmp_path / "registry"
+        registry.mkdir()
+        artifact = tmp_path / "artifact"
+        artifact.mkdir()
+        (artifact / "model.onnx").write_text("x")
+
+        result = orch._sync_local_artifacts(
+            artifact_path=artifact,
+            local_registry=registry,
+            symbol="BTCUSDT",
+            model_type="basic",
+            version_id="2025-10-27_14h_v1",
+        )
+        expected = registry / "BTCUSDT" / "basic" / "2025-10-27_14h_v1"
+        assert Path(result) == expected
+        assert (expected / "model.onnx").exists()

--- a/tests/unit/cloud/test_s3_manager_security.py
+++ b/tests/unit/cloud/test_s3_manager_security.py
@@ -1,0 +1,51 @@
+"""Security regression test for S3 artifact download path traversal.
+
+S3 object keys may legally contain ``..`` segments; download must skip any key
+whose resolved local path escapes the target directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.ml.cloud.artifacts.s3_manager import S3ArtifactManager
+
+
+def _make_manager(contents, downloaded):
+    """Build an S3ArtifactManager with a mocked S3 client (bypassing __init__)."""
+    mgr = object.__new__(S3ArtifactManager)
+
+    def _download_file(bucket, key, dest):
+        Path(dest).write_text("data")
+        downloaded.append((key, dest))
+
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": contents}]
+    client.get_paginator.return_value = paginator
+    client.download_file.side_effect = _download_file
+    mgr._s3_client = client
+    return mgr
+
+
+@pytest.mark.fast
+def test_skips_keys_escaping_local_dir(tmp_path):
+    local_dir = tmp_path / "out"
+    downloaded: list = []
+    contents = [
+        {"Key": "prefix/sub/model.onnx"},  # normal -> downloaded
+        {"Key": "prefix/../../escape.txt"},  # traversal -> skipped
+    ]
+    mgr = _make_manager(contents, downloaded)
+
+    mgr.download_model_artifacts("s3://bucket/prefix", local_dir)
+
+    # Normal key landed inside local_dir; traversal key was skipped.
+    assert (local_dir / "sub" / "model.onnx").exists()
+    assert not (tmp_path / "escape.txt").exists()
+    downloaded_keys = {k for k, _ in downloaded}
+    assert "prefix/sub/model.onnx" in downloaded_keys
+    assert "prefix/../../escape.txt" not in downloaded_keys

--- a/tests/unit/cloud/test_safe_extract.py
+++ b/tests/unit/cloud/test_safe_extract.py
@@ -1,0 +1,61 @@
+"""Tests for safe tar extraction in the SageMaker provider.
+
+Locks in protection against path-traversal ("zip-slip") and symlink members in
+downloaded model archives (CVE-2007-4559 class).
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from src.ml.cloud.exceptions import ArtifactSyncError
+from src.ml.cloud.providers.sagemaker import _safe_extract_tar
+
+
+def _make_tar(path: Path, members: dict[str, bytes]) -> None:
+    with tarfile.open(path, "w:gz") as tar:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+
+@pytest.mark.fast
+def test_safe_extract_allows_normal_members(tmp_path):
+    archive = tmp_path / "ok.tar.gz"
+    _make_tar(archive, {"model.onnx": b"abc", "sub/metadata.json": b"{}"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with tarfile.open(archive, "r:gz") as tar:
+        _safe_extract_tar(tar, dest)
+    assert (dest / "model.onnx").read_bytes() == b"abc"
+    assert (dest / "sub" / "metadata.json").exists()
+
+
+@pytest.mark.fast
+def test_safe_extract_rejects_path_traversal(tmp_path):
+    archive = tmp_path / "evil.tar.gz"
+    _make_tar(archive, {"../../escape.txt": b"pwned"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with tarfile.open(archive, "r:gz") as tar, pytest.raises(ArtifactSyncError):
+        _safe_extract_tar(tar, dest)
+    assert not (tmp_path / "escape.txt").exists()
+
+
+@pytest.mark.fast
+def test_safe_extract_rejects_escaping_symlink(tmp_path):
+    archive = tmp_path / "evil-link.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        info = tarfile.TarInfo(name="link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "../../../etc/passwd"
+        tar.addfile(info)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with tarfile.open(archive, "r:gz") as tar, pytest.raises(ArtifactSyncError):
+        _safe_extract_tar(tar, dest)

--- a/tests/unit/dashboards/test_monitoring_auth.py
+++ b/tests/unit/dashboards/test_monitoring_auth.py
@@ -1,0 +1,88 @@
+"""Tests for the monitoring dashboard authentication guard.
+
+These lock in the security fix that protects state-changing / data-leaking
+endpoints (balance adjustment, fix-positions, config) on the monitoring
+dashboard, which has no login system and may be bound to all interfaces.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from flask import Flask, jsonify
+
+from src.dashboards.monitoring.dashboard import _dashboard_auth_required, _is_production_env
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+
+    @app.route("/protected", methods=["POST"])
+    @_dashboard_auth_required
+    def protected():
+        return jsonify({"ok": True})
+
+    return app.test_client()
+
+
+@pytest.mark.fast
+def test_production_without_token_is_disabled(client):
+    """Fail closed: in production with no token, the endpoint returns 403."""
+    with patch.dict(os.environ, {"ENV": "production"}, clear=False):
+        os.environ.pop("MONITORING_DASHBOARD_TOKEN", None)
+        resp = client.post("/protected")
+        assert resp.status_code == 403
+        assert resp.get_json()["success"] is False
+
+
+@pytest.mark.fast
+def test_token_required_when_configured(client):
+    """When a token is configured, a missing/wrong token yields 401."""
+    with patch.dict(os.environ, {"MONITORING_DASHBOARD_TOKEN": "s3cret"}, clear=False):
+        assert client.post("/protected").status_code == 401
+        assert client.post("/protected", headers={"X-Dashboard-Token": "wrong"}).status_code == 401
+
+
+@pytest.mark.fast
+def test_non_ascii_token_yields_401_not_500(client):
+    """A non-ASCII token must be rejected cleanly (401), not crash with a 500.
+
+    hmac.compare_digest raises TypeError on str inputs with codepoints > 127;
+    the guard compares bytes so an attacker cannot trigger a 500 via the
+    X-Dashboard-Token header.
+    """
+    with patch.dict(os.environ, {"MONITORING_DASHBOARD_TOKEN": "s3cret"}, clear=False):
+        resp = client.post("/protected", headers={"X-Dashboard-Token": "wröng-Ω"})
+        assert resp.status_code == 401
+
+
+@pytest.mark.fast
+def test_correct_token_allows_access(client):
+    """A correct token (header or bearer) allows the request through."""
+    with patch.dict(os.environ, {"MONITORING_DASHBOARD_TOKEN": "s3cret"}, clear=False):
+        ok_header = client.post("/protected", headers={"X-Dashboard-Token": "s3cret"})
+        assert ok_header.status_code == 200
+        assert ok_header.get_json()["ok"] is True
+
+        ok_bearer = client.post("/protected", headers={"Authorization": "Bearer s3cret"})
+        assert ok_bearer.status_code == 200
+
+
+@pytest.mark.fast
+def test_dev_without_token_allowed(client):
+    """In an explicit dev/test env, no token is required (warn-and-allow)."""
+    with patch.dict(os.environ, {"ENV": "development"}, clear=False):
+        os.environ.pop("MONITORING_DASHBOARD_TOKEN", None)
+        assert client.post("/protected").status_code == 200
+
+
+@pytest.mark.fast
+def test_is_production_env_fails_closed():
+    """Unset ENV/FLASK_ENV must be treated as production."""
+    with patch.dict(os.environ, {}, clear=True):
+        assert _is_production_env() is True
+    with patch.dict(os.environ, {"ENV": "test"}, clear=True):
+        assert _is_production_env() is False

--- a/tests/unit/infrastructure/runtime/test_secrets.py
+++ b/tests/unit/infrastructure/runtime/test_secrets.py
@@ -98,14 +98,19 @@ class TestGetSecretKey:
             result = get_secret_key()
             assert result == "dev-key-change-in-production"
 
-    def test_empty_env_treated_as_development(self):
-        """Test that empty/missing ENV defaults to development."""
+    def test_empty_env_fails_closed_as_production(self):
+        """Test that empty/missing ENV fails closed (treated as production).
+
+        A missing ENV/FLASK_ENV must NOT silently fall back to the publicly
+        known dev key, otherwise a misconfigured production deployment would
+        sign sessions with a known key (session-forgery risk).
+        """
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("FLASK_SECRET_KEY", None)
             os.environ.pop("ENV", None)
             os.environ.pop("FLASK_ENV", None)
-            result = get_secret_key()
-            assert result == "dev-key-change-in-production"
+            with pytest.raises(RuntimeError, match="Missing required secret"):
+                get_secret_key()
 
 
 @pytest.mark.fast

--- a/tests/unit/test_db_resilience.py
+++ b/tests/unit/test_db_resilience.py
@@ -1,0 +1,191 @@
+"""Tests for transient-DB-error handling in the live trading engine.
+
+Regression coverage for the 2026-05-19 incident: a multi-hour Railway
+internal-DNS outage made Postgres unresolvable, every trading-loop iteration
+raised ``OperationalError``, the consecutive-error counter hit its limit, and
+the engine shut itself down — staying silently offline for ~12 days.
+
+Covers:
+- ``LiveTradingEngine._is_transient_db_error`` classification (transient vs
+  permanent vs unrelated), including exception-chain unwrapping.
+- Loop behaviour: transient DB errors are ridden out (not counted toward
+  ``max_consecutive_errors``); permanent/unrelated errors still trigger
+  shutdown; a prolonged outage escalates to close-only mode.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy.exc import InterfaceError, OperationalError
+
+from src.data_providers.data_provider import DataProvider
+from src.engines.live.trading_engine import LiveTradingEngine
+
+is_transient = LiveTradingEngine._is_transient_db_error
+
+
+def _op_error(message: str) -> OperationalError:
+    """Build a SQLAlchemy OperationalError(statement, params, orig)."""
+    return OperationalError("SELECT 1", {}, Exception(message))
+
+
+def _make_engine() -> LiveTradingEngine:
+    """A paper-mode engine with the database manager patched out."""
+    from src.strategies.ml_basic import create_ml_basic_strategy
+
+    with patch("src.engines.live.trading_engine.DatabaseManager"):
+        return LiveTradingEngine(
+            strategy=create_ml_basic_strategy(),
+            data_provider=Mock(spec=DataProvider),
+            initial_balance=10000,
+            enable_live_trading=False,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Classifier: transient connectivity errors -> ride out
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "exc",
+    [
+        _op_error('could not translate host name "postgres.railway.internal" to address'),
+        _op_error("server closed the connection unexpectedly"),
+        _op_error("terminating connection due to administrator command"),
+        InterfaceError("SELECT 1", {}, Exception("connection already closed")),
+        Exception(
+            'could not translate host name "postgres.railway.internal" to address: '
+            "Temporary failure in name resolution"
+        ),
+        Exception("connection refused"),
+        Exception("could not connect to server"),
+    ],
+)
+def test_transient_db_errors_detected(exc: BaseException) -> None:
+    assert is_transient(exc) is True
+
+
+# --------------------------------------------------------------------------- #
+# Classifier: permanent faults -> fail fast (NOT transient)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "exc",
+    [
+        _op_error('password authentication failed for user "trading_bot"'),
+        _op_error('role "trading_bot" does not exist'),
+        _op_error('database "ai_trading_bot" does not exist'),
+        _op_error("permission denied for table trades"),
+        Exception("FATAL: password authentication failed"),
+    ],
+)
+def test_permanent_db_errors_not_transient(exc: BaseException) -> None:
+    # Permanent misconfig is a psycopg2 OperationalError too, but must fail fast
+    # rather than retry forever.
+    assert is_transient(exc) is False
+
+
+# --------------------------------------------------------------------------- #
+# Classifier: unrelated errors and chain unwrapping
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ValueError("invalid position size"),
+        KeyError("close"),
+        RuntimeError("strategy produced an invalid signal"),
+        Exception("some unrelated application failure"),
+    ],
+)
+def test_non_transient_errors_not_flagged(exc: BaseException) -> None:
+    assert is_transient(exc) is False
+
+
+@pytest.mark.fast
+def test_wrapped_transient_error_is_unwrapped() -> None:
+    inner = _op_error("could not connect to server")
+    outer = RuntimeError("trading loop iteration failed")
+    outer.__cause__ = inner
+    assert is_transient(outer) is True
+
+
+@pytest.mark.fast
+def test_context_chained_transient_error_is_unwrapped() -> None:
+    inner = Exception("temporary failure in name resolution")
+    outer = RuntimeError("wrapper")
+    outer.__context__ = inner
+    assert is_transient(outer) is True
+
+
+@pytest.mark.fast
+def test_cyclic_cause_chain_terminates() -> None:
+    a = Exception("a")
+    b = Exception("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert is_transient(a) is False
+
+
+# --------------------------------------------------------------------------- #
+# Loop behaviour
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+def test_transient_db_error_in_loop_is_ridden_out() -> None:
+    """Transient DB errors each iteration must NOT count toward shutdown."""
+    engine = _make_engine()
+    engine.max_consecutive_errors = 1  # would stop after a single *counted* error
+    engine.is_running = True
+    engine._sleep_with_interrupt = Mock()  # skip the real backoff sleep
+    engine._get_latest_data = Mock(side_effect=_op_error('could not translate host name "db"'))
+
+    engine._trading_loop("BTCUSDT", "1h", max_steps=3)
+
+    # Rode out all three iterations without tripping the shutdown counter.
+    assert engine._get_latest_data.call_count == 3
+    assert engine.consecutive_errors == 0
+    assert engine.db_unreachable_since is not None
+
+
+@pytest.mark.fast
+def test_non_transient_error_in_loop_still_shuts_down() -> None:
+    """A non-transient error must still increment the counter and stop."""
+    engine = _make_engine()
+    engine.max_consecutive_errors = 1
+    engine.is_running = True
+    engine._sleep_with_interrupt = Mock()
+    engine._get_latest_data = Mock(side_effect=ValueError("boom"))
+
+    engine._trading_loop("BTCUSDT", "1h", max_steps=5)
+
+    # Shut down after the first counted error — did not run all five iterations.
+    assert engine._get_latest_data.call_count == 1
+    assert engine.is_running is False
+
+
+@pytest.mark.fast
+def test_prolonged_db_outage_enters_close_only() -> None:
+    """After the close-only threshold, the loop suspends new entries."""
+    import time
+
+    engine = _make_engine()
+    engine.max_consecutive_errors = 100
+    engine.is_running = True
+    engine._sleep_with_interrupt = Mock()
+    engine._get_latest_data = Mock(side_effect=_op_error("connection refused"))
+    # Pretend the outage began well beyond the close-only threshold.
+    engine.db_unreachable_since = time.monotonic() - 10_000
+
+    engine._trading_loop("BTCUSDT", "1h", max_steps=1)
+
+    assert engine._close_only_mode is True


### PR DESCRIPTION
Promotes `staging` → `main` (**production**), the final step of rolling out the live-bot resilience fix.

**Included (2 commits):**
- #623 — `fix(live): ride out transient DB outages; add heartbeat monitor` — fixes the root cause of the 2026-05-19 silent outage (the live loop counted transient DB errors toward `max_consecutive_errors` and shut both bots down for ~12 days). Adds permanent-error fail-fast, close-only escalation, a heartbeat CI monitor, and raises Railway restart retries 3→10.
- #620 — `fix(security): harden findings from repo-wide security scan`.

**Deploy safety:** staging + production DBs are already at alembic `0011_drop_optimization_cycles` (verified), so the pre-deploy schema check passes. Verified on staging before merging this.

**Effect:** redeploys the production Trading Bot with the hardening so a future transient DB/DNS blip can't silently kill it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)