### PR TITLE
fix(live): run SHORT inventory guard before journaling to stop order leak (#626)

### DIFF
--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -645,32 +645,10 @@ class LiveExecutionEngine:
             if quantity <= 0:
                 return None, None
 
-            # Generate deterministic client order ID for idempotency
-            # Format: atb_{timestamp_hex}_{uuid8} (~24 chars, within Binance 36-char limit)
-            # Symbol and side are already in the order params, so omitted from the ID
-            timestamp_ms = int(time.time() * 1000)
-            unique_suffix = uuid.uuid4().hex[:8]
-            client_order_id = f"atb_{timestamp_ms:x}_{unique_suffix}"
-
-            # Journal the order BEFORE submission (crash recovery anchor)
-            if self.db_manager and self.session_id:
-                try:
-                    self.db_manager.create_order_journal_entry(
-                        session_id=self.session_id,
-                        client_order_id=client_order_id,
-                        symbol=symbol,
-                        side=side.value,
-                        order_type="ENTRY",
-                        quantity=quantity,
-                        strategy_name=self.strategy_name,
-                    )
-                except Exception as e:
-                    logger.warning("Failed to journal entry order: %s", e)
-                    # Journal failure means no crash-recovery anchor exists.
-                    # Proceeding would risk a phantom position on restart.
-                    return None, None
-
-            # Determine margin side_effect_type based on position side:
+            # Determine margin side_effect_type and run the SHORT inventory guard
+            # BEFORE journaling, so an order rejected here never leaks an orphan
+            # PENDING_SUBMIT journal row (#626). The guard uses only symbol/side/
+            # price — never client_order_id — so it is safe to run first.
             # - Long entry (BUY): None — use existing USDT, no borrow needed
             # - Short entry (SELL): "MARGIN_BUY" — auto-borrow base asset to sell.
             #   NOTE: MARGIN_BUY only borrows when free base inventory is insufficient.
@@ -720,6 +698,32 @@ class LiveExecutionEngine:
                                 base_asset,
                             )
                             return None, None
+
+            # Generate deterministic client order ID for idempotency
+            # Format: atb_{timestamp_hex}_{uuid8} (~24 chars, within Binance 36-char limit)
+            timestamp_ms = int(time.time() * 1000)
+            unique_suffix = uuid.uuid4().hex[:8]
+            client_order_id = f"atb_{timestamp_ms:x}_{unique_suffix}"
+
+            # Journal the order BEFORE submission (crash recovery anchor). Reached
+            # only after the SHORT guard above accepts the order, so a rejected
+            # short never creates an orphan PENDING_SUBMIT journal row (#626).
+            if self.db_manager and self.session_id:
+                try:
+                    self.db_manager.create_order_journal_entry(
+                        session_id=self.session_id,
+                        client_order_id=client_order_id,
+                        symbol=symbol,
+                        side=side.value,
+                        order_type="ENTRY",
+                        quantity=quantity,
+                        strategy_name=self.strategy_name,
+                    )
+                except Exception as e:
+                    logger.warning("Failed to journal entry order: %s", e)
+                    # Journal failure means no crash-recovery anchor exists.
+                    # Proceeding would risk a phantom position on restart.
+                    return None, None
 
             try:
                 order_result = self.exchange_interface.place_order(

--- a/tests/unit/live/test_order_journal_leak.py
+++ b/tests/unit/live/test_order_journal_leak.py
@@ -1,0 +1,66 @@
+"""Regression tests for #626: SHORT-guard rejection must not leak a journal row.
+
+Before the fix, `_execute_live_order` wrote a `PENDING_SUBMIT` journal row BEFORE
+the SHORT inventory guard, so every guard-rejected short leaked an orphan row
+(4,786 accumulated in production and jammed startup reconciliation). The guard
+now runs before journaling.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.engines.live.execution.execution_engine import LiveExecutionEngine
+from src.engines.shared.models import PositionSide
+
+
+def _engine(balance_free: float) -> tuple[LiveExecutionEngine, Mock]:
+    exchange = Mock()
+    exchange.is_margin_mode = True
+    exchange.get_balance.return_value = Mock(free=balance_free)
+    exchange.place_order.return_value = None
+    engine = LiveExecutionEngine(enable_live_trading=True, exchange_interface=exchange)
+    engine.db_manager = Mock()
+    engine.session_id = 1
+    engine.strategy_name = "test"
+    # Bypass exchange LOT_SIZE/notional lookups — not under test here.
+    engine._normalize_quantity = Mock(return_value=0.05)
+    return engine, exchange
+
+
+@pytest.mark.fast
+def test_short_rejected_by_inventory_guard_does_not_journal():
+    """A short blocked by the inventory guard must NOT write a journal row (#626)."""
+    # free base value = 0.05 * 2000 = $100 (> $1 dust threshold) -> guard rejects.
+    engine, exchange = _engine(balance_free=0.05)
+
+    result = engine._execute_live_order(
+        symbol="ETHUSDT", side=PositionSide.SHORT, value=100.0, price=2000.0
+    )
+
+    assert result == (None, None)
+    engine.db_manager.create_order_journal_entry.assert_not_called()  # no leaked row
+    exchange.place_order.assert_not_called()  # order never sent
+
+
+@pytest.mark.fast
+def test_short_accepted_when_no_inventory_is_journaled():
+    """With no significant inventory the guard passes and the order is journaled."""
+    engine, exchange = _engine(balance_free=0.0)  # no inventory -> guard passes
+
+    engine._execute_live_order(symbol="ETHUSDT", side=PositionSide.SHORT, value=100.0, price=2000.0)
+
+    # Journal anchor is still written for an order that is actually sent.
+    engine.db_manager.create_order_journal_entry.assert_called_once()
+    exchange.place_order.assert_called_once()
+
+
+@pytest.mark.fast
+def test_long_entry_is_journaled():
+    """Long entries are unaffected — journaled then placed (no guard)."""
+    engine, exchange = _engine(balance_free=0.0)
+
+    engine._execute_live_order(symbol="ETHUSDT", side=PositionSide.LONG, value=100.0, price=2000.0)
+
+    engine.db_manager.create_order_journal_entry.assert_called_once()
+    exchange.place_order.assert_called_once()


### PR DESCRIPTION
## Summary
Fixes #626. The SHORT-entry inventory guard rejected orders with `return None, None` **after** `create_order_journal_entry` wrote a `PENDING_SUBMIT` row, so every blocked short leaked an orphan journal row — 4,786 accumulated in production and jammed startup reconciliation for ~40 min during the 2026-05-19 recovery.

## Change
In `execution_engine.py::_execute_live_order`, the margin side-effect computation + SHORT inventory guard now run **before** the journal write. The guard reads only `symbol`/`side`/`price` (never `client_order_id`), so a rejected short returns before any row is written. Pure block move; the crash-recovery journal anchor is preserved for orders that are actually sent.

## Tests
`tests/unit/live/test_order_journal_leak.py` — guard-reject writes no journal; guard-pass journals; long entry unaffected. Full `tests/unit/live/` suite (324) passes.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)