### PR TITLE
fix(live): deep /health that reflects trading-loop liveness (#627)

### DIFF
--- a/cli/commands/live_health.py
+++ b/cli/commands/live_health.py
@@ -10,6 +10,38 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from cli.core.forward import forward_to_module_main
 
 
+def _health_payload() -> tuple[int, dict]:
+    """Build the (http_status, body) for /health from trading-loop liveness.
+
+    Returns 503 when the trading loop has gone silent (a zombie: HTTP server up but
+    loop dead) so the process is no longer always reported healthy — the failure
+    mode that hid the 2026-05-19 outage (#627). Returns 200 while the loop is
+    running or still starting up.
+    """
+    body: dict = {
+        "status": "healthy",
+        "timestamp": datetime.now(UTC).isoformat(),
+        "service": "ai-trading-bot",
+    }
+    try:
+        from src.config.constants import DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS
+        from src.infrastructure import liveness
+
+        age = liveness.seconds_since_beat()
+    except Exception:  # pragma: no cover - never fail the healthcheck on an import error
+        return 200, body
+
+    if age is None:
+        body["loop"] = "starting"
+        return 200, body
+    body["loop_heartbeat_age_seconds"] = round(age, 1)
+    if age > DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS:
+        body["status"] = "unhealthy"
+        body["reason"] = f"trading loop stalled: no heartbeat for {age:.0f}s"
+        return 503, body
+    return 200, body
+
+
 class _HealthCheckHandler(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802 (BaseHTTPRequestHandler API)
         if self.path == "/health":
@@ -21,12 +53,8 @@ class _HealthCheckHandler(BaseHTTPRequestHandler):
 
     def _handle_health(self):
         try:
-            response = {
-                "status": "healthy",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "service": "ai-trading-bot",
-            }
-            self.send_response(200)
+            code, response = _health_payload()
+            self.send_response(code)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
             self.wfile.write(json.dumps(response).encode())

--- a/cli/commands/live_health.py
+++ b/cli/commands/live_health.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import threading
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from cli.core.forward import forward_to_module_main
+
+logger = logging.getLogger(__name__)
 
 
 def _health_payload() -> tuple[int, dict]:
@@ -28,7 +31,8 @@ def _health_payload() -> tuple[int, dict]:
         from src.infrastructure import liveness
 
         age = liveness.seconds_since_beat()
-    except Exception:  # pragma: no cover - never fail the healthcheck on an import error
+    except ImportError as e:  # liveness/constants unavailable — don't fail the healthcheck
+        logger.warning("Health liveness probe unavailable, reporting healthy: %s", e)
         return 200, body
 
     if age is None:

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -69,6 +69,10 @@ DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS = 1800  # 30 minutes
 
 # Health Monitor Constants (distinct from CPU optimization intervals)
 DEFAULT_HEALTH_BASE_CHECK_INTERVAL = 60  # Base health check interval in seconds
+# /health reports unhealthy (503) if the trading loop has not iterated within this
+# many seconds, so a zombie (HTTP server up, loop dead) is detectable (#627).
+# Must exceed DEFAULT_MAX_CHECK_INTERVAL (300) with margin.
+DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS = 900  # 15 minutes
 DEFAULT_HEALTH_MIN_CHECK_INTERVAL = 10  # Minimum health check interval (aggressive recovery)
 DEFAULT_HEALTH_MAX_CHECK_INTERVAL = 300  # Maximum health check interval
 

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1659,6 +1659,8 @@ class LiveTradingEngine:
 
     def _trading_loop(self, symbol: str, timeframe: str, max_steps: int | None = None) -> None:
         """Main trading loop"""
+        from src.infrastructure import liveness  # shared loop-liveness for /health (#627)
+
         logger.info("Trading loop started")
         steps = 0
         cfg = get_config()
@@ -1673,6 +1675,7 @@ class LiveTradingEngine:
                 self.stop()
                 break
             steps += 1
+            liveness.beat()  # record loop liveness for the /health endpoint (#627)
             try:
                 # For mock and real providers, update live data if supported.
                 # Skip when WS kline cache is active (no REST needed).

--- a/src/infrastructure/liveness.py
+++ b/src/infrastructure/liveness.py
@@ -32,7 +32,8 @@ def seconds_since_beat() -> float | None:
 
 
 def reset() -> None:
-    """Clear the heartbeat (used by tests and when the loop stops cleanly)."""
+    """Clear the heartbeat (used by tests; the running loop never resets it, so a
+    stopped loop correctly goes stale rather than reporting "starting" forever)."""
     global _last_beat
     with _lock:
         _last_beat = None

--- a/src/infrastructure/liveness.py
+++ b/src/infrastructure/liveness.py
@@ -1,0 +1,38 @@
+"""Process-wide trading-loop liveness heartbeat.
+
+The live engine's trading loop and the embedded ``/health`` HTTP server run in the
+same process but different threads, and the health handler holds no reference to
+the engine. This module is their shared signal: the loop records a heartbeat each
+iteration, and ``/health`` reports unhealthy once it goes stale — so a zombie
+process (HTTP server alive, trading loop dead) is detectable instead of always
+reporting healthy, which masked the 2026-05-19 silent outage (#627).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+_lock = threading.Lock()
+_last_beat: float | None = None  # time.monotonic() of the last loop iteration
+
+
+def beat() -> None:
+    """Record that the trading loop completed an iteration."""
+    global _last_beat
+    with _lock:
+        _last_beat = time.monotonic()
+
+
+def seconds_since_beat() -> float | None:
+    """Seconds since the last loop heartbeat, or None if the loop has not beaten yet."""
+    with _lock:
+        last = _last_beat
+    return None if last is None else time.monotonic() - last
+
+
+def reset() -> None:
+    """Clear the heartbeat (used by tests and when the loop stops cleanly)."""
+    global _last_beat
+    with _lock:
+        _last_beat = None

--- a/tests/unit/test_health_liveness.py
+++ b/tests/unit/test_health_liveness.py
@@ -13,6 +13,14 @@ from cli.commands.live_health import _health_payload
 from src.infrastructure import liveness
 
 
+@pytest.fixture(autouse=True)
+def _reset_liveness():
+    """Isolate each test from the process-global heartbeat (order-independent)."""
+    liveness.reset()
+    yield
+    liveness.reset()
+
+
 @pytest.mark.fast
 def test_liveness_beat_and_reset():
     liveness.reset()

--- a/tests/unit/test_health_liveness.py
+++ b/tests/unit/test_health_liveness.py
@@ -1,0 +1,53 @@
+"""Tests for the deep /health loop-liveness check (#627).
+
+Before this, /health returned a hardcoded "healthy" with no reference to the
+engine, so a zombie process (HTTP server up, trading loop dead) reported healthy
+for 12 days during the 2026-05-19 outage. /health now reflects loop liveness.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from cli.commands.live_health import _health_payload
+from src.infrastructure import liveness
+
+
+@pytest.mark.fast
+def test_liveness_beat_and_reset():
+    liveness.reset()
+    assert liveness.seconds_since_beat() is None
+    liveness.beat()
+    age = liveness.seconds_since_beat()
+    assert age is not None and 0 <= age < 1.0
+    liveness.reset()
+    assert liveness.seconds_since_beat() is None
+
+
+@pytest.mark.fast
+def test_health_starting_when_loop_not_beaten():
+    """Before the loop's first beat, /health is healthy+starting (let the deploy come up)."""
+    liveness.reset()
+    code, body = _health_payload()
+    assert code == 200
+    assert body["status"] == "healthy"
+    assert body["loop"] == "starting"
+
+
+@pytest.mark.fast
+def test_health_ok_when_loop_fresh():
+    liveness.beat()
+    code, body = _health_payload()
+    assert code == 200
+    assert body["status"] == "healthy"
+    assert body["loop_heartbeat_age_seconds"] < 5
+
+
+@pytest.mark.fast
+def test_health_unhealthy_when_loop_stale():
+    """A stalled loop makes /health return 503 so the zombie is detectable."""
+    with patch("src.infrastructure.liveness.seconds_since_beat", return_value=10_000.0):
+        code, body = _health_payload()
+    assert code == 503
+    assert body["status"] == "unhealthy"
+    assert "stalled" in body["reason"]


### PR DESCRIPTION
## Summary
Closes #627. `/health` returned a hardcoded `{"status":"healthy"}` with no engine reference, so during the 2026-05-19 outage a zombie (HTTP server up, trading loop dead) reported healthy for 12 days and Railway's healthcheck passed throughout.

## Change
- `src/infrastructure/liveness.py` — a process-wide loop-liveness heartbeat (the loop and the `/health` server share a process but different threads; the handler has no engine reference).
- `_trading_loop` beats each iteration.
- `_health_payload()` returns **503** when the loop has been silent > `DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS` (900s, > the 300s max check interval), **200** while running or still starting.
- Loop-liveness is **not** DB-write coupled, so `/health` stays healthy during a DB outage the loop rides out (complements the `account_history` heartbeat CI monitor, which conflates loop-dead with DB-unreachable).

## Tests
`tests/unit/test_health_liveness.py` — beat/reset, starting (200), fresh (200), stale (503). Loop-regression (`test_db_resilience.py`) still passes.

## Note
This is the **detection** half. The **action** — exiting the process non-zero on loop death so Railway's `ON_FAILURE` restart fires — is #630.

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)