### PR TITLE
fix(live): WS health watchdog + bounded REST + non-blocking fill handling (#631)

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -279,10 +279,16 @@ DEFAULT_MFE_MAE_LOG_LEVEL = "INFO"
 # - INFERENCE_TIMEOUT_SECONDS
 # - API_REQUEST_TIMEOUT_SECONDS
 # - DATA_FETCH_TIMEOUT_SECONDS
+# - BINANCE_REST_TIMEOUT_SECONDS
 DEFAULT_MODEL_LOAD_TIMEOUT = 60.0  # Timeout for loading ML models (ONNX, Keras)
 DEFAULT_INFERENCE_TIMEOUT = 30.0  # Timeout for model inference
 DEFAULT_API_REQUEST_TIMEOUT = 30.0  # Timeout for external API requests
 DEFAULT_DATA_FETCH_TIMEOUT = 60.0  # Timeout for historical data fetches
+# Socket timeout (seconds) applied to every Binance REST call via the client's
+# requests_params. Bounds disconnect-path resync/reconnect and order polling so
+# a half-open TCP socket can't hang the WS health thread or loop (#631). Kept
+# below the WS health check interval so a stuck call returns before stalling.
+DEFAULT_BINANCE_REST_TIMEOUT = 15.0
 
 # Numeric Precision Constants
 DEFAULT_EPSILON = 1e-9  # Small value for floating point comparisons

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 from src.config import get_config
 from src.config.constants import (
+    DEFAULT_BINANCE_REST_TIMEOUT,
     DEFAULT_DATA_FETCH_TIMEOUT,
     DEFAULT_STARTUP_BAN_MAX_RETRIES,
     DEFAULT_STARTUP_BAN_MAX_WAIT,
@@ -420,18 +421,37 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             self.testnet,
         )
 
+        # Socket timeout on every REST call so a half-open TCP connection can't
+        # hang order polling, reconciliation, or the WS disconnect-recovery path
+        # indefinitely (#631). python-binance forwards requests_params to requests.
+        rest_timeout = get_config().get_float(
+            "BINANCE_REST_TIMEOUT_SECONDS", DEFAULT_BINANCE_REST_TIMEOUT
+        )
+        requests_params = {"timeout": rest_timeout}
+
         if self.api_key and self.api_secret:
             logger.debug("Creating authenticated %s client...", api_endpoint)
             if api_endpoint == "binanceus":
-                client = Client(self.api_key, self.api_secret, testnet=self.testnet, tld="us")
+                client = Client(
+                    self.api_key,
+                    self.api_secret,
+                    testnet=self.testnet,
+                    tld="us",
+                    requests_params=requests_params,
+                )
             else:
-                client = Client(self.api_key, self.api_secret, testnet=self.testnet)
+                client = Client(
+                    self.api_key,
+                    self.api_secret,
+                    testnet=self.testnet,
+                    requests_params=requests_params,
+                )
         else:
             logger.debug("Creating public %s client...", api_endpoint)
             if api_endpoint == "binanceus":
-                client = Client(tld="us")
+                client = Client(tld="us", requests_params=requests_params)
             else:
-                client = Client()
+                client = Client(requests_params=requests_params)
 
         auth_mode = "with credentials" if self.api_key and self.api_secret else "public mode"
         logger.info(

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1465,9 +1465,11 @@ class LiveTradingEngine:
         The monitor is the lone WS-staleness watchdog; if its thread dies, stale
         streams go unnoticed and never reconnect. The main trading loop — itself
         liveness-tracked (#627) and crash-exiting (#630) — supervises it here (#631).
-        Only the loop thread writes ``self._ws_health_thread`` after start(), so no
-        lock is needed. Respawns are naturally spaced (the monitor's grace-period
-        wait) so a thread that re-dies immediately can't busy-respawn.
+        The initial ``self._ws_health_thread`` write happens-before the loop thread
+        is started, and thereafter only the loop thread writes it, so the two
+        writers never overlap and no lock is needed. Respawns are naturally spaced
+        (the monitor's grace-period wait) so a thread that re-dies immediately
+        can't busy-respawn.
         """
         # Only relevant once a stream the monitor watches has been started.
         if not (self._ws_kline_active or self._user_data_processor):
@@ -1488,11 +1490,12 @@ class LiveTradingEngine:
 
         The poll thread enqueues only identifiers (it must stay fast and unblocked);
         the actual close runs here, on the trading loop, where exits already happen.
-        Each item is isolated: a failure is logged and left for the periodic/startup
-        reconcilers (#628/#629) — which detect an open position whose stop-loss has
-        filled on the exchange — rather than aborting the drain or orphaning the
-        order. The stop-loss has already executed on-exchange, so this is purely
-        local bookkeeping and a small latency here is harmless (#631).
+        Each item is isolated so one bad item can't abort the rest of the queue. A
+        close that fails is logged and absorbed by ``_execute_exit`` itself, and the
+        periodic/startup reconcilers (#628/#629) recover an unclosed position (they
+        detect one whose stop-loss has filled on the exchange). The stop-loss has
+        already executed on-exchange, so this is purely local bookkeeping and a
+        small latency here is harmless (#631).
         """
         while True:
             try:
@@ -1518,9 +1521,13 @@ class LiveTradingEngine:
                     skip_live_close=True,
                 )
             except Exception as e:
+                # _execute_exit logs and absorbs its own close failures (reconciliation
+                # then recovers an unclosed position); reaching here means an unexpected
+                # error in the drain itself (e.g. the position lookup). Isolate it so
+                # one bad item can't abort the rest of the queue.
                 logger.critical(
-                    "CRITICAL: deferred stop-loss exit failed for position %s: %s. "
-                    "Left for reconciliation to recover.",
+                    "CRITICAL: unexpected error draining deferred stop-loss exit for "
+                    "position %s: %s. Left for reconciliation to recover.",
                     position_order_id,
                     e,
                     exc_info=True,

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import queue
 import signal
 import sys
 import threading
@@ -470,6 +471,10 @@ class LiveTradingEngine:
         self._ws_kline_active = False
         self._ws_kline_provider = None
         self._ws_health_thread = None
+        # Stop-loss fills are detected on the OrderTracker poll thread but their
+        # bookkeeping exit is deferred to the trading loop so a slow/failing close
+        # can't block order polling or force-remove a filled order (#631).
+        self._pending_fill_exits: queue.SimpleQueue = queue.SimpleQueue()
 
         # Performance tracker (unified with backtest engine)
         from src.performance.tracker import PerformanceTracker
@@ -1454,6 +1459,73 @@ class LiveTradingEngine:
         self._ws_health_thread.start()
         logger.info("WebSocket health monitor started")
 
+    def _ensure_ws_health_monitor_alive(self) -> None:
+        """Watchdog-on-watchdog: restart the WS health monitor if its thread died.
+
+        The monitor is the lone WS-staleness watchdog; if its thread dies, stale
+        streams go unnoticed and never reconnect. The main trading loop — itself
+        liveness-tracked (#627) and crash-exiting (#630) — supervises it here (#631).
+        Only the loop thread writes ``self._ws_health_thread`` after start(), so no
+        lock is needed. Respawns are naturally spaced (the monitor's grace-period
+        wait) so a thread that re-dies immediately can't busy-respawn.
+        """
+        # Only relevant once a stream the monitor watches has been started.
+        if not (self._ws_kline_active or self._user_data_processor):
+            return
+        if not self.is_running or self.stop_event.is_set():
+            return
+        t = self._ws_health_thread
+        if t is not None and t.is_alive():
+            return
+        logger.critical("WS health monitor thread is dead — restarting it (watchdog).")
+        try:
+            self._start_ws_health_monitor()
+        except Exception as e:
+            logger.error("Failed to restart WS health monitor: %s", e)
+
+    def _drain_pending_fill_exits(self) -> None:
+        """Execute stop-loss-fill exits deferred from the OrderTracker poll thread.
+
+        The poll thread enqueues only identifiers (it must stay fast and unblocked);
+        the actual close runs here, on the trading loop, where exits already happen.
+        Each item is isolated: a failure is logged and left for the periodic/startup
+        reconcilers (#628/#629) — which detect an open position whose stop-loss has
+        filled on the exchange — rather than aborting the drain or orphaning the
+        order. The stop-loss has already executed on-exchange, so this is purely
+        local bookkeeping and a small latency here is harmless (#631).
+        """
+        while True:
+            try:
+                position_order_id, fill_price = self._pending_fill_exits.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                position = self.live_position_tracker.get_position(position_order_id)
+                if position is None:
+                    logger.info(
+                        "Deferred stop-loss exit skipped — position %s already closed",
+                        position_order_id,
+                    )
+                    continue
+                self._execute_exit(
+                    position,
+                    reason="stop_loss",
+                    limit_price=fill_price,
+                    current_price=float(fill_price),
+                    candle_high=None,
+                    candle_low=None,
+                    candle=None,
+                    skip_live_close=True,
+                )
+            except Exception as e:
+                logger.critical(
+                    "CRITICAL: deferred stop-loss exit failed for position %s: %s. "
+                    "Left for reconciliation to recover.",
+                    position_order_id,
+                    e,
+                    exc_info=True,
+                )
+
     def _ws_health_loop(self) -> None:
         """Monitor WebSocket streams and trigger reconnection on failure."""
         from src.config.constants import DEFAULT_WS_HEALTH_CHECK_INTERVAL
@@ -1517,11 +1589,18 @@ class LiveTradingEngine:
                 )
             except Exception as e:
                 logger.error("Kline REST resync failed: %s", e)
-        # Attempt reconnect
-        if (
-            hasattr(self._ws_kline_provider, "reconnect_kline")
-            and self._ws_kline_provider.reconnect_kline()
-        ):
+        # Attempt reconnect. The call is bounded by the REST socket timeout
+        # (#631); treat any failure as "stay on REST polling" rather than letting
+        # it abort recovery / propagate into the WS health thread.
+        reconnected = False
+        try:
+            reconnected = bool(
+                hasattr(self._ws_kline_provider, "reconnect_kline")
+                and self._ws_kline_provider.reconnect_kline()
+            )
+        except Exception as e:
+            logger.error("Kline reconnect attempt failed: %s", e)
+        if reconnected:
             self._ws_kline_active = True
             logger.info("Kline WebSocket reconnected")
         else:
@@ -1546,11 +1625,16 @@ class LiveTradingEngine:
         # 3. Enable REST polling as fallback
         if self.order_tracker:
             self.order_tracker.enable_polling()
-        # 4. Resync order and position state from REST
-        if self.order_tracker:
-            self.order_tracker.poll_once()
-        if self._periodic_reconciler:
-            self._periodic_reconciler.reconcile_once()
+        # 4. Resync order and position state from REST. Bounded by the REST
+        #    socket timeout (#631); a failed resync must not abort the rest of
+        #    recovery — REST polling (step 3) keeps orders tracked meanwhile.
+        try:
+            if self.order_tracker:
+                self.order_tracker.poll_once()
+            if self._periodic_reconciler:
+                self._periodic_reconciler.reconcile_once()
+        except Exception as e:
+            logger.error("User-stream REST resync failed: %s", e)
         # 5. If processor didn't stop cleanly, stay degraded — don't reconnect
         #    while the old thread may still be mutating order state
         if not processor_clean:
@@ -1562,24 +1646,34 @@ class LiveTradingEngine:
         # 6. Attempt user stream reconnect with fresh callback
         reconnected = False
         if hasattr(self.exchange_interface, "reconnect_user"):
-            new_processor = UserDataProcessor(
-                order_tracker=self.order_tracker,
-            )
-            if self.exchange_interface.reconnect_user(
-                on_user_event=new_processor.enqueue,
-            ):
-                self._user_data_processor = new_processor
-                self._user_data_processor.start()
-                # Post-reconnect catch-up: reconcile events from the handoff gap
-                # before disabling polling, so nothing is lost
-                if self.order_tracker:
-                    self.order_tracker.poll_once()
-                if self._periodic_reconciler:
-                    self._periodic_reconciler.reconcile_once()
-                if self.order_tracker:
-                    self.order_tracker.disable_polling()
-                logger.info("User data WebSocket reconnected")
-                reconnected = True
+            try:
+                new_processor = UserDataProcessor(
+                    order_tracker=self.order_tracker,
+                )
+                if self.exchange_interface.reconnect_user(
+                    on_user_event=new_processor.enqueue,
+                ):
+                    self._user_data_processor = new_processor
+                    self._user_data_processor.start()
+                    reconnected = True
+                    logger.info("User data WebSocket reconnected")
+                    # Post-reconnect catch-up: reconcile events from the handoff
+                    # gap before disabling polling, so nothing is lost. A catch-up
+                    # failure leaves REST polling on as a safe fallback rather than
+                    # undoing the reconnect.
+                    try:
+                        if self.order_tracker:
+                            self.order_tracker.poll_once()
+                        if self._periodic_reconciler:
+                            self._periodic_reconciler.reconcile_once()
+                        if self.order_tracker:
+                            self.order_tracker.disable_polling()
+                    except Exception as e:
+                        logger.error(
+                            "Post-reconnect catch-up failed (staying on REST polling): %s", e
+                        )
+            except Exception as e:
+                logger.error("User stream reconnect attempt failed: %s", e)
         if not reconnected:
             self.exchange_interface.mark_user_degraded()
             logger.warning("User stream reconnect failed — order polling resumed")
@@ -1739,6 +1833,11 @@ class LiveTradingEngine:
             steps += 1
             liveness.beat()  # record loop liveness for the /health endpoint (#627)
             try:
+                # Supervise the WS health monitor and drain deferred stop-loss
+                # exits first, so both run every iteration even when a data outage
+                # would `continue` below before reaching them (#631).
+                self._ensure_ws_health_monitor_alive()
+                self._drain_pending_fill_exits()
                 # For mock and real providers, update live data if supported.
                 # Skip when WS kline cache is active (no REST needed).
                 if not self._ws_kline_active and hasattr(self.data_provider, "update_live_data"):
@@ -3206,34 +3305,25 @@ class LiveTradingEngine:
             average_price=avg_price,
         )
 
-        # Check if this is a stop-loss order fill - need to close the position.
-        # positions property returns a thread-safe copy. _execute_exit has its
-        # own defensive has_position() check to handle the race where another
-        # thread closes the position between our lookup and the exit call.
-        position_to_close: Position | None = None
+        # If this is a stop-loss order fill, the position must be closed — but the
+        # close (DB writes, P&L bookkeeping) is DEFERRED to the trading loop via a
+        # queue rather than run here on the OrderTracker poll thread. Running it
+        # inline blocked all order polling on a slow close and, on failure, drove
+        # the order toward force-removal (orphaning the position). The stop-loss
+        # has already executed on-exchange, so the loop drains and runs the exit
+        # with skip_live_close=True; a drain failure is backstopped by the
+        # periodic/startup reconcilers (#631). positions returns a thread-safe copy.
         for pos_order_id, position in self.live_position_tracker.positions.items():
             if position.stop_loss_order_id == order_id:
-                position_to_close = position
                 logger.warning(
-                    "Stop-loss order %s filled for position %s at $%.2f - closing position",
+                    "Stop-loss order %s filled for position %s at $%.2f - "
+                    "queuing position close for the trading loop",
                     order_id,
                     pos_order_id,
                     avg_price,
                 )
+                self._pending_fill_exits.put((pos_order_id, float(avg_price)))
                 break
-        if position_to_close:
-            # _execute_exit re-verifies the position still exists under the
-            # tracker lock before proceeding, preventing double-close races.
-            self._execute_exit(
-                position_to_close,
-                reason="stop_loss",
-                limit_price=avg_price,
-                current_price=float(avg_price),
-                candle_high=None,
-                candle_low=None,
-                candle=None,
-                skip_live_close=True,
-            )
 
     def _handle_partial_fill(
         self, order_id: str, symbol: str, new_filled_qty: float, avg_price: float

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -36,6 +36,25 @@ class TestBinanceDataProvider:
 
     @pytest.mark.data_provider
     @patch("src.data_providers.binance_provider.Client")
+    def test_client_constructed_with_rest_timeout(self, mock_client_class):
+        """Every Binance REST call gets a socket timeout via requests_params (#631).
+
+        A timeout-less client lets a half-open TCP socket hang order polling,
+        reconciliation, and the WS disconnect-recovery path indefinitely.
+        """
+        mock_client_class.return_value = Mock()
+        with patch("src.data_providers.binance_provider.get_config") as mock_config:
+            mock_config_obj = Mock()
+            mock_config_obj.get_required.return_value = "fake_key"
+            mock_config_obj.get_float.return_value = 15.0
+            mock_config.return_value = mock_config_obj
+            BinanceProvider()
+
+        assert mock_client_class.called
+        assert mock_client_class.call_args.kwargs.get("requests_params") == {"timeout": 15.0}
+
+    @pytest.mark.data_provider
+    @patch("src.data_providers.binance_provider.Client")
     def test_binance_historical_data_success(self, mock_client_class):
         mock_client = Mock()
         mock_client_class.return_value = mock_client

--- a/tests/unit/live/test_order_execution.py
+++ b/tests/unit/live/test_order_execution.py
@@ -429,20 +429,31 @@ class TestHandleOrderFill:
             assert mock_log.call_args.args[0] == "order_filled"
 
     def test_handle_fill_detects_stop_loss_fill(self, engine_with_exchange, sample_position):
-        """Fill callback detects and handles stop-loss fills."""
+        """A stop-loss fill is queued for the trading loop, which then closes it (#631).
+
+        The OrderTracker poll thread must not run the close inline (it blocked all
+        polling and could force-remove the filled order); it only enqueues, and
+        the loop's drain performs the actual close.
+        """
         sample_position.stop_loss_order_id = "sl_order_456"
         engine_with_exchange.live_position_tracker.track_recovered_position(
             sample_position, db_id=None
         )
 
         with patch.object(engine_with_exchange, "_execute_exit") as mock_close:
+            # Poll-thread callback: enqueue only, no inline close.
             engine_with_exchange._handle_order_fill("sl_order_456", "BTCUSDT", 0.02, 48000.0)
+            mock_close.assert_not_called()
+
+            # Trading-loop drain: perform the deferred close.
+            engine_with_exchange._drain_pending_fill_exits()
 
             mock_close.assert_called_once()
             call_args = mock_close.call_args
             assert call_args.args[0] == sample_position
             assert call_args.kwargs["reason"] == "stop_loss"
             assert call_args.kwargs["limit_price"] == 48000.0
+            assert call_args.kwargs["skip_live_close"] is True
 
     def test_handle_fill_skips_if_position_already_closed(
         self, engine_with_exchange, sample_position

--- a/tests/unit/test_db_resilience.py
+++ b/tests/unit/test_db_resilience.py
@@ -438,5 +438,46 @@ def test_drain_failure_is_isolated_and_logged(caplog) -> None:
         engine._drain_pending_fill_exits()
 
     assert engine._execute_exit.call_count == 2  # did not abort after the first failure
-    assert "deferred stop-loss exit failed" in caplog.text
+    assert "draining deferred stop-loss exit" in caplog.text
     assert engine._pending_fill_exits.empty()
+
+
+# --------------------------------------------------------------------------- #
+# Disconnect handlers stay exception-safe once REST calls can time out (#631)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+def test_kline_disconnect_degrades_when_reconnect_raises() -> None:
+    """A raising kline reconnect (e.g. REST timeout) degrades to polling, not crash."""
+    engine = _make_engine()
+    engine._kline_buffer = None  # skip REST resync
+    provider = Mock()
+    provider.reconnect_kline.side_effect = TimeoutError("rest socket hung")
+    engine._ws_kline_provider = provider
+    engine._ws_kline_active = True
+
+    engine._handle_kline_disconnect()  # must not propagate
+
+    provider.mark_kline_degraded.assert_called_once()
+    assert engine._ws_kline_active is False
+
+
+@pytest.mark.fast
+def test_user_stream_disconnect_survives_resync_timeout() -> None:
+    """A REST resync timeout mid-recovery must not abort the handler (#631)."""
+    engine = _make_engine()
+    engine.enable_live_trading = True
+    exchange = Mock()
+    exchange.reconnect_user.return_value = False  # force the degraded fallback
+    engine.exchange_interface = exchange
+    tracker = Mock()
+    tracker.poll_once.side_effect = TimeoutError("rest socket hung")  # step-4 resync
+    engine.order_tracker = tracker
+    engine._user_data_processor = None
+    engine._periodic_reconciler = None
+
+    with patch("src.engines.live.user_data_processor.UserDataProcessor"):
+        engine._handle_user_stream_disconnect()  # must not propagate
+
+    exchange.mark_user_degraded.assert_called_once()

--- a/tests/unit/test_db_resilience.py
+++ b/tests/unit/test_db_resilience.py
@@ -278,3 +278,165 @@ def test_start_returns_on_loop_crash_when_not_opted_in() -> None:
 
     # Recorded the crash but did not exit the process.
     assert engine._loop_crashed is True
+
+
+# --------------------------------------------------------------------------- #
+# WS health watchdog — the main loop restarts a dead monitor thread (#631)
+# --------------------------------------------------------------------------- #
+
+
+def _dead_thread() -> Mock:
+    t = Mock()
+    t.is_alive.return_value = False
+    return t
+
+
+@pytest.mark.fast
+def test_watchdog_respawns_dead_ws_thread() -> None:
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = True
+    engine._ws_health_thread = _dead_thread()
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_called_once()
+
+
+@pytest.mark.fast
+def test_watchdog_noop_when_thread_alive() -> None:
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = True
+    alive = Mock()
+    alive.is_alive.return_value = True
+    engine._ws_health_thread = alive
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_not_called()
+
+
+@pytest.mark.fast
+def test_watchdog_noop_when_no_stream_configured() -> None:
+    """No WS stream is being watched → nothing to supervise (pure REST mode)."""
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = False
+    engine._user_data_processor = None
+    engine._ws_health_thread = _dead_thread()
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_not_called()
+
+
+@pytest.mark.fast
+def test_watchdog_noop_when_stopping() -> None:
+    """A shutting-down engine must not respawn the monitor."""
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = True
+    engine.stop_event.set()
+    engine._ws_health_thread = _dead_thread()
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Deferred stop-loss fill exits — non-blocking, off the OrderTracker thread (#631)
+# --------------------------------------------------------------------------- #
+
+
+def _seed_sl_position(engine, order_id: str = "pos1", sl_order_id: str = "sl1"):
+    """Give the engine a position whose stop-loss is `sl_order_id`."""
+    pos = Mock()
+    pos.order_id = order_id
+    pos.stop_loss_order_id = sl_order_id
+    engine.live_position_tracker = Mock()
+    engine.live_position_tracker.positions = {order_id: pos}
+    engine.live_position_tracker.get_position = Mock(
+        side_effect=lambda oid: pos if oid == order_id else None
+    )
+    return pos
+
+
+@pytest.mark.fast
+def test_handle_order_fill_enqueues_sl_exit_instead_of_running_it() -> None:
+    """A stop-loss fill is queued for the loop, NOT executed on the poll thread."""
+    engine = _make_engine()
+    _seed_sl_position(engine, order_id="pos1", sl_order_id="sl1")
+    engine._execute_exit = Mock()
+
+    engine._handle_order_fill("sl1", "BTCUSDT", 0.5, 100.0)
+
+    assert engine._pending_fill_exits.get_nowait() == ("pos1", 100.0)
+    engine._execute_exit.assert_not_called()  # deferred, not run inline
+
+
+@pytest.mark.fast
+def test_handle_order_fill_entry_does_not_enqueue() -> None:
+    """A non-stop-loss (entry) fill enqueues nothing."""
+    engine = _make_engine()
+    _seed_sl_position(engine, order_id="pos1", sl_order_id="sl1")
+    engine._execute_exit = Mock()
+
+    engine._handle_order_fill("some-entry-order", "BTCUSDT", 0.5, 100.0)
+
+    assert engine._pending_fill_exits.empty()
+    engine._execute_exit.assert_not_called()
+
+
+@pytest.mark.fast
+def test_drain_executes_pending_exit() -> None:
+    engine = _make_engine()
+    _seed_sl_position(engine, order_id="pos1", sl_order_id="sl1")
+    engine._execute_exit = Mock()
+    engine._pending_fill_exits.put(("pos1", 100.0))
+
+    engine._drain_pending_fill_exits()
+
+    engine._execute_exit.assert_called_once()
+    kwargs = engine._execute_exit.call_args.kwargs
+    assert kwargs["skip_live_close"] is True
+    assert kwargs["reason"] == "stop_loss"
+    assert engine._pending_fill_exits.empty()
+
+
+@pytest.mark.fast
+def test_drain_skips_already_closed_position() -> None:
+    """If the position is already gone, the drain no-ops without error."""
+    engine = _make_engine()
+    engine.live_position_tracker = Mock()
+    engine.live_position_tracker.get_position = Mock(return_value=None)
+    engine._execute_exit = Mock()
+    engine._pending_fill_exits.put(("gone", 100.0))
+
+    engine._drain_pending_fill_exits()
+
+    engine._execute_exit.assert_not_called()
+    assert engine._pending_fill_exits.empty()
+
+
+@pytest.mark.fast
+def test_drain_failure_is_isolated_and_logged(caplog) -> None:
+    """One failing exit is logged CRITICAL and does NOT abort the rest of the drain."""
+    engine = _make_engine()
+    engine.live_position_tracker = Mock()
+    engine.live_position_tracker.get_position = Mock(return_value=Mock())
+    engine._execute_exit = Mock(side_effect=[RuntimeError("db down"), None])
+    engine._pending_fill_exits.put(("p1", 100.0))
+    engine._pending_fill_exits.put(("p2", 101.0))
+
+    with caplog.at_level("CRITICAL"):
+        engine._drain_pending_fill_exits()
+
+    assert engine._execute_exit.call_count == 2  # did not abort after the first failure
+    assert "deferred stop-loss exit failed" in caplog.text
+    assert engine._pending_fill_exits.empty()


### PR DESCRIPTION
## What & why

Final fix from the 2026-05-19 silent-outage postmortem (#631). Three concurrency-hardening changes to the live engine's WebSocket and order-fill paths. Each is independent.

### (a) WS health watchdog-on-watchdog
`_ws_health_thread` was the lone WS-staleness watchdog with no supervisor — if its thread died, stale streams went unnoticed and never reconnected. The trading loop now calls **`_ensure_ws_health_monitor_alive()`** each iteration and respawns the monitor if it's dead. The loop is itself liveness-tracked (#627) and crash-exiting (#630), making it a reliable supervisor. Guarded to only respawn when a stream is actually being watched, the engine is running, and not stopping; respawns are naturally spaced by the monitor's grace-period wait (no respawn storm).

### (a2) Bounded disconnect-path REST calls
**Root cause:** the python-binance `Client` was constructed with **no socket timeout**, so `get_order`/`cancel_order`/`get_account`/`get_all_orders`/`get_balance` — used by order polling, reconciliation, and the WS reconnect path — could hang forever on a half-open TCP socket. Fix: pass `requests_params={"timeout": DEFAULT_BINANCE_REST_TIMEOUT}` (15s, overridable via `BINANCE_REST_TIMEOUT_SECONDS`) to **all four** `Client(...)` constructors — bounding every REST call in one place. Complementary: the kline/user disconnect handlers are now exception-safe per step, so a timeout in one recovery step degrades to REST polling instead of aborting recovery.

### (c) Non-blocking, exception-safe stop-loss fill handling
`_handle_order_fill` ran `_execute_exit` **synchronously on the OrderTracker poll thread**, so a slow/failing close blocked **all** order polling and, after `MAX_CALLBACK_RETRIES`, force-removed the filled order (orphaning the position). It now **enqueues** the close (`_pending_fill_exits`, a `queue.SimpleQueue`); the trading loop **drains** it (`_drain_pending_fill_exits`) and runs the exit with `skip_live_close=True`.

This is safe because the heavy path is **stop-loss-fill-only**, where the SL has **already executed on-exchange** — so the deferred work is pure local bookkeeping (balance/P&L), not a race to place orders:
- **No double exchange order:** the normal exit path routes SL-protected positions through `_check_stop_loss_filled` (queries the exchange; `skip_live_close`), and `_execute_exit` re-checks `has_position()`.
- **Crash-before-drain recovery:** an open position whose SL filled on-exchange is exactly what the periodic/startup reconcilers (#628/#629) + `_verify_asset_holdings` already detect and close — the *same* window the synchronous path already relied on, only slightly widened.
- **Latency** is bounded by `check_interval` and harmless (position already flat on-exchange).

## Testing
- `atb test unit` (live + provider + resilience): **563 passed**.
- New unit tests: client REST-timeout (`requests_params`); watchdog respawn + 3 no-op guards; `_handle_order_fill` enqueues-not-inline (SL) / no-enqueue (entry); drain executes / skips-already-closed / isolates-and-logs failures. Updated `test_handle_fill_detects_stop_loss_fill` to the new enqueue→drain flow.
- `ruff` clean on changed regions (2 pre-existing repo-wide ruff items left untouched).

## Risk
Low–moderate. (a)/(a2) are additive/defensive. (c) changes money-affecting *bookkeeping* control flow but not order placement; verified against double-close, crash recovery, and latency. Designed via a planning pass with the 4 safety preconditions verified before coding.

Completes the 6-issue postmortem series (#626, #628, #629, #627, #630 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)