### PR TITLE
Promote to production: postmortem hardening fixes (#626–#631)

### DIFF
--- a/cli/commands/live_health.py
+++ b/cli/commands/live_health.py
@@ -2,12 +2,48 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import os
 import threading
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from cli.core.forward import forward_to_module_main
+
+logger = logging.getLogger(__name__)
+
+
+def _health_payload() -> tuple[int, dict]:
+    """Build the (http_status, body) for /health from trading-loop liveness.
+
+    Returns 503 when the trading loop has gone silent (a zombie: HTTP server up but
+    loop dead) so the process is no longer always reported healthy — the failure
+    mode that hid the 2026-05-19 outage (#627). Returns 200 while the loop is
+    running or still starting up.
+    """
+    body: dict = {
+        "status": "healthy",
+        "timestamp": datetime.now(UTC).isoformat(),
+        "service": "ai-trading-bot",
+    }
+    try:
+        from src.config.constants import DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS
+        from src.infrastructure import liveness
+
+        age = liveness.seconds_since_beat()
+    except ImportError as e:  # liveness/constants unavailable — don't fail the healthcheck
+        logger.warning("Health liveness probe unavailable, reporting healthy: %s", e)
+        return 200, body
+
+    if age is None:
+        body["loop"] = "starting"
+        return 200, body
+    body["loop_heartbeat_age_seconds"] = round(age, 1)
+    if age > DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS:
+        body["status"] = "unhealthy"
+        body["reason"] = f"trading loop stalled: no heartbeat for {age:.0f}s"
+        return 503, body
+    return 200, body
 
 
 class _HealthCheckHandler(BaseHTTPRequestHandler):
@@ -21,12 +57,8 @@ class _HealthCheckHandler(BaseHTTPRequestHandler):
 
     def _handle_health(self):
         try:
-            response = {
-                "status": "healthy",
-                "timestamp": datetime.now(UTC).isoformat(),
-                "service": "ai-trading-bot",
-            }
-            self.send_response(200)
+            code, response = _health_payload()
+            self.send_response(code)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
             self.wfile.write(json.dumps(response).encode())

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -69,6 +69,10 @@ DEFAULT_DB_OUTAGE_CLOSE_ONLY_SECONDS = 1800  # 30 minutes
 
 # Health Monitor Constants (distinct from CPU optimization intervals)
 DEFAULT_HEALTH_BASE_CHECK_INTERVAL = 60  # Base health check interval in seconds
+# /health reports unhealthy (503) if the trading loop has not iterated within this
+# many seconds, so a zombie (HTTP server up, loop dead) is detectable (#627).
+# Must exceed DEFAULT_MAX_CHECK_INTERVAL (300) with margin.
+DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS = 900  # 15 minutes
 DEFAULT_HEALTH_MIN_CHECK_INTERVAL = 10  # Minimum health check interval (aggressive recovery)
 DEFAULT_HEALTH_MAX_CHECK_INTERVAL = 300  # Maximum health check interval
 
@@ -275,10 +279,16 @@ DEFAULT_MFE_MAE_LOG_LEVEL = "INFO"
 # - INFERENCE_TIMEOUT_SECONDS
 # - API_REQUEST_TIMEOUT_SECONDS
 # - DATA_FETCH_TIMEOUT_SECONDS
+# - BINANCE_REST_TIMEOUT_SECONDS
 DEFAULT_MODEL_LOAD_TIMEOUT = 60.0  # Timeout for loading ML models (ONNX, Keras)
 DEFAULT_INFERENCE_TIMEOUT = 30.0  # Timeout for model inference
 DEFAULT_API_REQUEST_TIMEOUT = 30.0  # Timeout for external API requests
 DEFAULT_DATA_FETCH_TIMEOUT = 60.0  # Timeout for historical data fetches
+# Socket timeout (seconds) applied to every Binance REST call via the client's
+# requests_params. Bounds disconnect-path resync/reconnect and order polling so
+# a half-open TCP socket can't hang the WS health thread or loop (#631). Kept
+# below the WS health check interval so a stuck call returns before stalling.
+DEFAULT_BINANCE_REST_TIMEOUT = 15.0
 
 # Numeric Precision Constants
 DEFAULT_EPSILON = 1e-9  # Small value for floating point comparisons
@@ -330,6 +340,14 @@ DEFAULT_RECONCILIATION_BALANCE_THRESHOLD_PCT = 0.05  # 5% balance discrepancy tr
 DEFAULT_RECONCILIATION_DUST_THRESHOLD = 0.00001  # Ignore dust-level asset discrepancies
 DEFAULT_RECONCILIATION_ORDER_MATCH_TOLERANCE_PCT = 0.01  # 1% qty tolerance for order matching
 DEFAULT_RECONCILIATION_ORDER_MATCH_TIME_WINDOW_MIN = 10  # Minutes for timestamp matching
+# Bound startup order reconciliation so a large stale-order backlog cannot block
+# the trading loop for hours (#628). Each unresolved order costs a REST round-trip;
+# excess beyond the cap / time budget is deferred to the next startup run.
+DEFAULT_MAX_PENDING_ORDERS_PER_RECONCILE = 200
+DEFAULT_RECONCILE_TIME_BUDGET_SECONDS = 120
+# Age (minutes) past which a never-sent PENDING_SUBMIT order (no exchange id) is
+# bulk-failed by the startup cleanup, draining stale-order backlogs (#629).
+DEFAULT_PENDING_SUBMIT_EXPIRY_MINUTES = 60
 
 # WebSocket Stream Constants
 DEFAULT_WS_KLINE_STALENESS_THRESHOLD = 120  # Seconds before kline stream considered stale

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -24,6 +24,7 @@ import pandas as pd
 
 from src.config import get_config
 from src.config.constants import (
+    DEFAULT_BINANCE_REST_TIMEOUT,
     DEFAULT_DATA_FETCH_TIMEOUT,
     DEFAULT_STARTUP_BAN_MAX_RETRIES,
     DEFAULT_STARTUP_BAN_MAX_WAIT,
@@ -420,18 +421,37 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             self.testnet,
         )
 
+        # Socket timeout on every REST call so a half-open TCP connection can't
+        # hang order polling, reconciliation, or the WS disconnect-recovery path
+        # indefinitely (#631). python-binance forwards requests_params to requests.
+        rest_timeout = get_config().get_float(
+            "BINANCE_REST_TIMEOUT_SECONDS", DEFAULT_BINANCE_REST_TIMEOUT
+        )
+        requests_params = {"timeout": rest_timeout}
+
         if self.api_key and self.api_secret:
             logger.debug("Creating authenticated %s client...", api_endpoint)
             if api_endpoint == "binanceus":
-                client = Client(self.api_key, self.api_secret, testnet=self.testnet, tld="us")
+                client = Client(
+                    self.api_key,
+                    self.api_secret,
+                    testnet=self.testnet,
+                    tld="us",
+                    requests_params=requests_params,
+                )
             else:
-                client = Client(self.api_key, self.api_secret, testnet=self.testnet)
+                client = Client(
+                    self.api_key,
+                    self.api_secret,
+                    testnet=self.testnet,
+                    requests_params=requests_params,
+                )
         else:
             logger.debug("Creating public %s client...", api_endpoint)
             if api_endpoint == "binanceus":
-                client = Client(tld="us")
+                client = Client(tld="us", requests_params=requests_params)
             else:
-                client = Client()
+                client = Client(requests_params=requests_params)
 
         auth_mode = "with credentials" if self.api_key and self.api_secret else "public mode"
         logger.info(

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -3460,6 +3460,47 @@ class DatabaseManager:
             )
             return True
 
+    def expire_stale_pending_orders(self, session_id: int, older_than_minutes: int = 60) -> int:
+        """Fail PENDING_SUBMIT order rows that never reached the exchange.
+
+        A ``PENDING_SUBMIT`` row with no ``exchange_order_id`` older than the cutoff
+        was journaled but never confirmed sent (e.g. a SHORT rejected by the inventory
+        guard before #626, or a crash between journal and submit). It can never be
+        resolved against the exchange, so these accumulate and make startup
+        reconciliation waste a REST round-trip each (4,786 piled up before the
+        2026-05-19 recovery). Failing them in one UPDATE drains the backlog (#629);
+        an order that actually filled is still recovered by position reconciliation.
+
+        Returns the number of rows failed.
+        """
+        now = datetime.now(UTC)
+        cutoff = now - timedelta(minutes=older_than_minutes)
+        with self.get_session() as session:
+            result = session.execute(
+                sa.text(
+                    """
+                    UPDATE orders
+                    SET status = 'FAILED', last_update = :now
+                    WHERE session_id = :sid
+                      AND status = 'PENDING_SUBMIT'
+                      AND exchange_order_id IS NULL
+                      AND created_at < :cutoff
+                    """
+                ),
+                {"now": now, "sid": session_id, "cutoff": cutoff},
+            )
+            failed = int(result.rowcount or 0)
+            session.commit()
+        if failed:
+            logger.info(
+                "Expired %d stale PENDING_SUBMIT order(s) (never sent, older than %dm) "
+                "for session %s",
+                failed,
+                older_than_minutes,
+                session_id,
+            )
+        return failed
+
     def get_unresolved_orders(self, session_id: int) -> list[dict]:
         """Get orders in PENDING_SUBMIT, SUBMITTED, or UNKNOWN status for crash recovery.
 

--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -645,32 +645,10 @@ class LiveExecutionEngine:
             if quantity <= 0:
                 return None, None
 
-            # Generate deterministic client order ID for idempotency
-            # Format: atb_{timestamp_hex}_{uuid8} (~24 chars, within Binance 36-char limit)
-            # Symbol and side are already in the order params, so omitted from the ID
-            timestamp_ms = int(time.time() * 1000)
-            unique_suffix = uuid.uuid4().hex[:8]
-            client_order_id = f"atb_{timestamp_ms:x}_{unique_suffix}"
-
-            # Journal the order BEFORE submission (crash recovery anchor)
-            if self.db_manager and self.session_id:
-                try:
-                    self.db_manager.create_order_journal_entry(
-                        session_id=self.session_id,
-                        client_order_id=client_order_id,
-                        symbol=symbol,
-                        side=side.value,
-                        order_type="ENTRY",
-                        quantity=quantity,
-                        strategy_name=self.strategy_name,
-                    )
-                except Exception as e:
-                    logger.warning("Failed to journal entry order: %s", e)
-                    # Journal failure means no crash-recovery anchor exists.
-                    # Proceeding would risk a phantom position on restart.
-                    return None, None
-
-            # Determine margin side_effect_type based on position side:
+            # Determine margin side_effect_type and run the SHORT inventory guard
+            # BEFORE journaling, so an order rejected here never leaks an orphan
+            # PENDING_SUBMIT journal row (#626). The guard uses only symbol/side/
+            # price — never client_order_id — so it is safe to run first.
             # - Long entry (BUY): None — use existing USDT, no borrow needed
             # - Short entry (SELL): "MARGIN_BUY" — auto-borrow base asset to sell.
             #   NOTE: MARGIN_BUY only borrows when free base inventory is insufficient.
@@ -720,6 +698,32 @@ class LiveExecutionEngine:
                                 base_asset,
                             )
                             return None, None
+
+            # Generate deterministic client order ID for idempotency
+            # Format: atb_{timestamp_hex}_{uuid8} (~24 chars, within Binance 36-char limit)
+            timestamp_ms = int(time.time() * 1000)
+            unique_suffix = uuid.uuid4().hex[:8]
+            client_order_id = f"atb_{timestamp_ms:x}_{unique_suffix}"
+
+            # Journal the order BEFORE submission (crash recovery anchor). Reached
+            # only after the SHORT guard above accepts the order, so a rejected
+            # short never creates an orphan PENDING_SUBMIT journal row (#626).
+            if self.db_manager and self.session_id:
+                try:
+                    self.db_manager.create_order_journal_entry(
+                        session_id=self.session_id,
+                        client_order_id=client_order_id,
+                        symbol=symbol,
+                        side=side.value,
+                        order_type="ENTRY",
+                        quantity=quantity,
+                        strategy_name=self.strategy_name,
+                    )
+                except Exception as e:
+                    logger.warning("Failed to journal entry order: %s", e)
+                    # Journal failure means no crash-recovery anchor exists.
+                    # Proceeding would risk a phantom position on restart.
+                    return None, None
 
             try:
                 order_result = self.exchange_interface.place_order(

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -19,6 +19,9 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from src.config.constants import (
+    DEFAULT_MAX_PENDING_ORDERS_PER_RECONCILE,
+    DEFAULT_PENDING_SUBMIT_EXPIRY_MINUTES,
+    DEFAULT_RECONCILE_TIME_BUDGET_SECONDS,
     DEFAULT_RECONCILIATION_BALANCE_THRESHOLD_PCT,
     DEFAULT_RECONCILIATION_DUST_THRESHOLD,
     DEFAULT_RECONCILIATION_INTERVAL_SECONDS,
@@ -163,7 +166,26 @@ class PositionReconciler:
         return results
 
     def resolve_pending_orders(self) -> list[ReconciliationResult]:
-        """Resolve orders stuck in PENDING_SUBMIT/SUBMITTED/UNKNOWN."""
+        """Resolve orders stuck in PENDING_SUBMIT/SUBMITTED/UNKNOWN.
+
+        Bounded by a count cap and a time budget so a large stale-order backlog
+        cannot block startup (#628): each unresolved order costs a REST round-trip,
+        so an unbounded backlog could hang the trading loop for hours. Orders are
+        processed most-recent first; any excess is deferred (and logged, never
+        silently) and retried on the next startup run. Never-sent rows are bulk-failed
+        first (spot mode only) to collapse the stale backlog (#629).
+        """
+        # Drain never-sent PENDING_SUBMIT rows (no exchange id) that can never resolve
+        # here. ONLY safe in spot mode: account synchronization independently re-adopts
+        # any exchange holding that has no DB position, so wrongly failing a row that did
+        # fill is still recovered. In margin mode that backstop is skipped, so leave those
+        # rows to the bounded per-order loop below, which confirms absence on the exchange
+        # before failing (#629).
+        if not self._use_margin:
+            self.db_manager.expire_stale_pending_orders(
+                self.session_id, older_than_minutes=DEFAULT_PENDING_SUBMIT_EXPIRY_MINUTES
+            )
+
         results: list[ReconciliationResult] = []
         unresolved = self.db_manager.get_unresolved_orders(self.session_id)
 
@@ -171,11 +193,32 @@ class PositionReconciler:
             logger.info("No pending orders to resolve")
             return results
 
-        logger.info("Resolving %d pending orders...", len(unresolved))
+        total = len(unresolved)
+        deadline = time.monotonic() + DEFAULT_RECONCILE_TIME_BUDGET_SECONDS
+        processed = 0
+        # get_unresolved_orders returns oldest-first; process newest-first so recent,
+        # relevant orders are resolved before any old backlog gets deferred.
+        for order_data in reversed(unresolved):
+            if (
+                processed >= DEFAULT_MAX_PENDING_ORDERS_PER_RECONCILE
+                or time.monotonic() >= deadline
+            ):
+                break
+            results.append(self._resolve_single_order(order_data))
+            processed += 1
 
-        for order_data in unresolved:
-            result = self._resolve_single_order(order_data)
-            results.append(result)
+        if processed < total:
+            logger.warning(
+                "Reconciled %d of %d pending orders this run (cap=%d, budget=%ds); "
+                "deferred %d to the next startup run so the trading loop is not blocked.",
+                processed,
+                total,
+                DEFAULT_MAX_PENDING_ORDERS_PER_RECONCILE,
+                DEFAULT_RECONCILE_TIME_BUDGET_SECONDS,
+                total - processed,
+            )
+        else:
+            logger.info("Resolved %d pending orders", processed)
 
         return results
 

--- a/src/engines/live/runner.py
+++ b/src/engines/live/runner.py
@@ -287,7 +287,10 @@ def main():
 
         # Start trading
         logger.info(f"Starting trading engine for {args.symbol} on {args.timeframe}")
-        engine.start(args.symbol, args.timeframe)
+        # Production entry point: exit non-zero on abnormal loop death so the
+        # orchestrator (Railway ON_FAILURE) restarts the process instead of
+        # leaving the bot silently dead (#630).
+        engine.start(args.symbol, args.timeframe, exit_on_crash=True)
 
     except KeyboardInterrupt:
         logger.info("🛑 Trading stopped by user")

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4,6 +4,7 @@ import json
 import logging
 import math
 import os
+import queue
 import signal
 import sys
 import threading
@@ -470,6 +471,10 @@ class LiveTradingEngine:
         self._ws_kline_active = False
         self._ws_kline_provider = None
         self._ws_health_thread = None
+        # Stop-loss fills are detected on the OrderTracker poll thread but their
+        # bookkeeping exit is deferred to the trading loop so a slow/failing close
+        # can't block order polling or force-remove a filled order (#631).
+        self._pending_fill_exits: queue.SimpleQueue = queue.SimpleQueue()
 
         # Performance tracker (unified with backtest engine)
         from src.performance.tracker import PerformanceTracker
@@ -532,6 +537,9 @@ class LiveTradingEngine:
 
         # Threading
         self.main_thread = None
+        # Set when the trading loop dies abnormally (unhandled crash or error
+        # exhaustion) so start() can exit non-zero for an orchestrator restart (#630).
+        self._loop_crashed = False
         self.stop_event = threading.Event()
 
         # Optional regime detector (feature-gated)
@@ -1156,8 +1164,20 @@ class LiveTradingEngine:
                 self._runtime_dataset = None
                 self._runtime_warmup = 0
 
-    def start(self, symbol: str, timeframe: str = "1h", max_steps: int | None = None) -> None:
-        """Start the live trading engine"""
+    def start(
+        self,
+        symbol: str,
+        timeframe: str = "1h",
+        max_steps: int | None = None,
+        exit_on_crash: bool = False,
+    ) -> None:
+        """Start the live trading engine.
+
+        ``exit_on_crash`` makes an abnormal loop death exit the process non-zero
+        so an orchestrator restarts it (#630). It defaults to False so start()
+        stays a well-behaved library call for callers that read results after it
+        returns (e.g. the migration baseline tool); the production runner opts in.
+        """
         if self.is_running:
             logger.warning("Trading engine is already running")
             return
@@ -1338,7 +1358,7 @@ class LiveTradingEngine:
 
         # Start main trading loop in separate thread
         self.main_thread = threading.Thread(
-            target=self._trading_loop, args=(symbol, timeframe, max_steps)
+            target=self._run_trading_loop, args=(symbol, timeframe, max_steps)
         )
         self.main_thread.daemon = True
         self.main_thread.start()
@@ -1351,6 +1371,11 @@ class LiveTradingEngine:
             logger.info("Received interrupt signal")
         finally:
             self.stop()
+
+        # After a clean stop this is a no-op; after an abnormal loop death it
+        # exits the process non-zero (when opted in) so the orchestrator
+        # restarts it (#630).
+        self._exit_if_loop_crashed(exit_on_crash)
 
     def _enter_close_only_mode(self) -> None:
         """Enter close-only mode: no new entries, exits/stops/trailing still active."""
@@ -1434,6 +1459,80 @@ class LiveTradingEngine:
         self._ws_health_thread.start()
         logger.info("WebSocket health monitor started")
 
+    def _ensure_ws_health_monitor_alive(self) -> None:
+        """Watchdog-on-watchdog: restart the WS health monitor if its thread died.
+
+        The monitor is the lone WS-staleness watchdog; if its thread dies, stale
+        streams go unnoticed and never reconnect. The main trading loop — itself
+        liveness-tracked (#627) and crash-exiting (#630) — supervises it here (#631).
+        The initial ``self._ws_health_thread`` write happens-before the loop thread
+        is started, and thereafter only the loop thread writes it, so the two
+        writers never overlap and no lock is needed. Respawns are naturally spaced
+        (the monitor's grace-period wait) so a thread that re-dies immediately
+        can't busy-respawn.
+        """
+        # Only relevant once a stream the monitor watches has been started.
+        if not (self._ws_kline_active or self._user_data_processor):
+            return
+        if not self.is_running or self.stop_event.is_set():
+            return
+        t = self._ws_health_thread
+        if t is not None and t.is_alive():
+            return
+        logger.critical("WS health monitor thread is dead — restarting it (watchdog).")
+        try:
+            self._start_ws_health_monitor()
+        except Exception as e:
+            logger.error("Failed to restart WS health monitor: %s", e)
+
+    def _drain_pending_fill_exits(self) -> None:
+        """Execute stop-loss-fill exits deferred from the OrderTracker poll thread.
+
+        The poll thread enqueues only identifiers (it must stay fast and unblocked);
+        the actual close runs here, on the trading loop, where exits already happen.
+        Each item is isolated so one bad item can't abort the rest of the queue. A
+        close that fails is logged and absorbed by ``_execute_exit`` itself, and the
+        periodic/startup reconcilers (#628/#629) recover an unclosed position (they
+        detect one whose stop-loss has filled on the exchange). The stop-loss has
+        already executed on-exchange, so this is purely local bookkeeping and a
+        small latency here is harmless (#631).
+        """
+        while True:
+            try:
+                position_order_id, fill_price = self._pending_fill_exits.get_nowait()
+            except queue.Empty:
+                return
+            try:
+                position = self.live_position_tracker.get_position(position_order_id)
+                if position is None:
+                    logger.info(
+                        "Deferred stop-loss exit skipped — position %s already closed",
+                        position_order_id,
+                    )
+                    continue
+                self._execute_exit(
+                    position,
+                    reason="stop_loss",
+                    limit_price=fill_price,
+                    current_price=float(fill_price),
+                    candle_high=None,
+                    candle_low=None,
+                    candle=None,
+                    skip_live_close=True,
+                )
+            except Exception as e:
+                # _execute_exit logs and absorbs its own close failures (reconciliation
+                # then recovers an unclosed position); reaching here means an unexpected
+                # error in the drain itself (e.g. the position lookup). Isolate it so
+                # one bad item can't abort the rest of the queue.
+                logger.critical(
+                    "CRITICAL: unexpected error draining deferred stop-loss exit for "
+                    "position %s: %s. Left for reconciliation to recover.",
+                    position_order_id,
+                    e,
+                    exc_info=True,
+                )
+
     def _ws_health_loop(self) -> None:
         """Monitor WebSocket streams and trigger reconnection on failure."""
         from src.config.constants import DEFAULT_WS_HEALTH_CHECK_INTERVAL
@@ -1497,11 +1596,18 @@ class LiveTradingEngine:
                 )
             except Exception as e:
                 logger.error("Kline REST resync failed: %s", e)
-        # Attempt reconnect
-        if (
-            hasattr(self._ws_kline_provider, "reconnect_kline")
-            and self._ws_kline_provider.reconnect_kline()
-        ):
+        # Attempt reconnect. The call is bounded by the REST socket timeout
+        # (#631); treat any failure as "stay on REST polling" rather than letting
+        # it abort recovery / propagate into the WS health thread.
+        reconnected = False
+        try:
+            reconnected = bool(
+                hasattr(self._ws_kline_provider, "reconnect_kline")
+                and self._ws_kline_provider.reconnect_kline()
+            )
+        except Exception as e:
+            logger.error("Kline reconnect attempt failed: %s", e)
+        if reconnected:
             self._ws_kline_active = True
             logger.info("Kline WebSocket reconnected")
         else:
@@ -1526,11 +1632,16 @@ class LiveTradingEngine:
         # 3. Enable REST polling as fallback
         if self.order_tracker:
             self.order_tracker.enable_polling()
-        # 4. Resync order and position state from REST
-        if self.order_tracker:
-            self.order_tracker.poll_once()
-        if self._periodic_reconciler:
-            self._periodic_reconciler.reconcile_once()
+        # 4. Resync order and position state from REST. Bounded by the REST
+        #    socket timeout (#631); a failed resync must not abort the rest of
+        #    recovery — REST polling (step 3) keeps orders tracked meanwhile.
+        try:
+            if self.order_tracker:
+                self.order_tracker.poll_once()
+            if self._periodic_reconciler:
+                self._periodic_reconciler.reconcile_once()
+        except Exception as e:
+            logger.error("User-stream REST resync failed: %s", e)
         # 5. If processor didn't stop cleanly, stay degraded — don't reconnect
         #    while the old thread may still be mutating order state
         if not processor_clean:
@@ -1542,24 +1653,34 @@ class LiveTradingEngine:
         # 6. Attempt user stream reconnect with fresh callback
         reconnected = False
         if hasattr(self.exchange_interface, "reconnect_user"):
-            new_processor = UserDataProcessor(
-                order_tracker=self.order_tracker,
-            )
-            if self.exchange_interface.reconnect_user(
-                on_user_event=new_processor.enqueue,
-            ):
-                self._user_data_processor = new_processor
-                self._user_data_processor.start()
-                # Post-reconnect catch-up: reconcile events from the handoff gap
-                # before disabling polling, so nothing is lost
-                if self.order_tracker:
-                    self.order_tracker.poll_once()
-                if self._periodic_reconciler:
-                    self._periodic_reconciler.reconcile_once()
-                if self.order_tracker:
-                    self.order_tracker.disable_polling()
-                logger.info("User data WebSocket reconnected")
-                reconnected = True
+            try:
+                new_processor = UserDataProcessor(
+                    order_tracker=self.order_tracker,
+                )
+                if self.exchange_interface.reconnect_user(
+                    on_user_event=new_processor.enqueue,
+                ):
+                    self._user_data_processor = new_processor
+                    self._user_data_processor.start()
+                    reconnected = True
+                    logger.info("User data WebSocket reconnected")
+                    # Post-reconnect catch-up: reconcile events from the handoff
+                    # gap before disabling polling, so nothing is lost. A catch-up
+                    # failure leaves REST polling on as a safe fallback rather than
+                    # undoing the reconnect.
+                    try:
+                        if self.order_tracker:
+                            self.order_tracker.poll_once()
+                        if self._periodic_reconciler:
+                            self._periodic_reconciler.reconcile_once()
+                        if self.order_tracker:
+                            self.order_tracker.disable_polling()
+                    except Exception as e:
+                        logger.error(
+                            "Post-reconnect catch-up failed (staying on REST polling): %s", e
+                        )
+            except Exception as e:
+                logger.error("User stream reconnect attempt failed: %s", e)
         if not reconnected:
             self.exchange_interface.mark_user_degraded()
             logger.warning("User stream reconnect failed — order polling resumed")
@@ -1657,8 +1778,52 @@ class LiveTradingEngine:
         self.stop()
         sys.exit(0)
 
+    def _run_trading_loop(self, symbol: str, timeframe: str, max_steps: int | None = None) -> None:
+        """Thread target so an unhandled exception can't kill the loop *silently*.
+
+        A bare daemon thread that raises just vanishes, leaving the process alive
+        but brain-dead (HTTP server up, loop gone) — the zombie that hid the
+        2026-05-19 outage for 12 days. Catch any unhandled exception, record it,
+        and let start() turn it into a non-zero exit for an orchestrator restart (#630).
+        """
+        try:
+            self._trading_loop(symbol, timeframe, max_steps)
+        except Exception as e:
+            self._loop_crashed = True
+            logger.critical("Trading loop terminated unexpectedly: %s", e, exc_info=True)
+
+    def _exit_if_loop_crashed(self, exit_on_crash: bool) -> None:
+        """Exit the process non-zero if the trading loop died abnormally (#630).
+
+        A clean stop (signal, explicit stop, or max_steps) leaves this a no-op.
+        On an abnormal death (unhandled crash or consecutive-error exhaustion):
+        when *exit_on_crash* (the production runner), exit 1 so the orchestrator
+        restarts the process instead of leaving the bot silently dead; otherwise
+        return so library callers that read results after start() keep working.
+        """
+        if not (self._loop_crashed and exit_on_crash):
+            return
+        # The loop thread may still be unwinding its own shutdown (e.g. closing
+        # positions); wait so a daemon thread isn't killed mid-cleanup. We exit
+        # regardless of the join result (the daemon dies with the process), but
+        # surface a wedged cleanup so it's visible rather than silent.
+        if self.main_thread is not None and self.main_thread != threading.current_thread():
+            self.main_thread.join(timeout=30)
+            if self.main_thread.is_alive():
+                logger.error(
+                    "Loop thread still alive after 30s join; exiting anyway — "
+                    "shutdown cleanup may be incomplete."
+                )
+        logger.critical(
+            "Trading loop ended abnormally; exiting with code 1 to trigger an "
+            "orchestrator restart instead of running dead."
+        )
+        sys.exit(1)
+
     def _trading_loop(self, symbol: str, timeframe: str, max_steps: int | None = None) -> None:
         """Main trading loop"""
+        from src.infrastructure import liveness  # shared loop-liveness for /health (#627)
+
         logger.info("Trading loop started")
         steps = 0
         cfg = get_config()
@@ -1673,7 +1838,13 @@ class LiveTradingEngine:
                 self.stop()
                 break
             steps += 1
+            liveness.beat()  # record loop liveness for the /health endpoint (#627)
             try:
+                # Supervise the WS health monitor and drain deferred stop-loss
+                # exits first, so both run every iteration even when a data outage
+                # would `continue` below before reaching them (#631).
+                self._ensure_ws_health_monitor_alive()
+                self._drain_pending_fill_exits()
                 # For mock and real providers, update live data if supported.
                 # Skip when WS kline cache is active (no REST needed).
                 if not self._ws_kline_active and hasattr(self.data_provider, "update_live_data"):
@@ -2017,6 +2188,8 @@ class LiveTradingEngine:
                         f"Too many consecutive errors ({self.consecutive_errors}). Stopping engine.",
                         exc_info=True,
                     )
+                    # Abnormal stop: signal start() to exit non-zero for a restart (#630).
+                    self._loop_crashed = True
                     self.stop()
                     break
                 # Exponential backoff with adaptive intervals
@@ -3139,34 +3312,25 @@ class LiveTradingEngine:
             average_price=avg_price,
         )
 
-        # Check if this is a stop-loss order fill - need to close the position.
-        # positions property returns a thread-safe copy. _execute_exit has its
-        # own defensive has_position() check to handle the race where another
-        # thread closes the position between our lookup and the exit call.
-        position_to_close: Position | None = None
+        # If this is a stop-loss order fill, the position must be closed — but the
+        # close (DB writes, P&L bookkeeping) is DEFERRED to the trading loop via a
+        # queue rather than run here on the OrderTracker poll thread. Running it
+        # inline blocked all order polling on a slow close and, on failure, drove
+        # the order toward force-removal (orphaning the position). The stop-loss
+        # has already executed on-exchange, so the loop drains and runs the exit
+        # with skip_live_close=True; a drain failure is backstopped by the
+        # periodic/startup reconcilers (#631). positions returns a thread-safe copy.
         for pos_order_id, position in self.live_position_tracker.positions.items():
             if position.stop_loss_order_id == order_id:
-                position_to_close = position
                 logger.warning(
-                    "Stop-loss order %s filled for position %s at $%.2f - closing position",
+                    "Stop-loss order %s filled for position %s at $%.2f - "
+                    "queuing position close for the trading loop",
                     order_id,
                     pos_order_id,
                     avg_price,
                 )
+                self._pending_fill_exits.put((pos_order_id, float(avg_price)))
                 break
-        if position_to_close:
-            # _execute_exit re-verifies the position still exists under the
-            # tracker lock before proceeding, preventing double-close races.
-            self._execute_exit(
-                position_to_close,
-                reason="stop_loss",
-                limit_price=avg_price,
-                current_price=float(avg_price),
-                candle_high=None,
-                candle_low=None,
-                candle=None,
-                skip_live_close=True,
-            )
 
     def _handle_partial_fill(
         self, order_id: str, symbol: str, new_filled_qty: float, avg_price: float

--- a/src/infrastructure/liveness.py
+++ b/src/infrastructure/liveness.py
@@ -1,0 +1,39 @@
+"""Process-wide trading-loop liveness heartbeat.
+
+The live engine's trading loop and the embedded ``/health`` HTTP server run in the
+same process but different threads, and the health handler holds no reference to
+the engine. This module is their shared signal: the loop records a heartbeat each
+iteration, and ``/health`` reports unhealthy once it goes stale — so a zombie
+process (HTTP server alive, trading loop dead) is detectable instead of always
+reporting healthy, which masked the 2026-05-19 silent outage (#627).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+_lock = threading.Lock()
+_last_beat: float | None = None  # time.monotonic() of the last loop iteration
+
+
+def beat() -> None:
+    """Record that the trading loop completed an iteration."""
+    global _last_beat
+    with _lock:
+        _last_beat = time.monotonic()
+
+
+def seconds_since_beat() -> float | None:
+    """Seconds since the last loop heartbeat, or None if the loop has not beaten yet."""
+    with _lock:
+        last = _last_beat
+    return None if last is None else time.monotonic() - last
+
+
+def reset() -> None:
+    """Clear the heartbeat (used by tests; the running loop never resets it, so a
+    stopped loop correctly goes stale rather than reporting "starting" forever)."""
+    global _last_beat
+    with _lock:
+        _last_beat = None

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -36,6 +36,25 @@ class TestBinanceDataProvider:
 
     @pytest.mark.data_provider
     @patch("src.data_providers.binance_provider.Client")
+    def test_client_constructed_with_rest_timeout(self, mock_client_class):
+        """Every Binance REST call gets a socket timeout via requests_params (#631).
+
+        A timeout-less client lets a half-open TCP socket hang order polling,
+        reconciliation, and the WS disconnect-recovery path indefinitely.
+        """
+        mock_client_class.return_value = Mock()
+        with patch("src.data_providers.binance_provider.get_config") as mock_config:
+            mock_config_obj = Mock()
+            mock_config_obj.get_required.return_value = "fake_key"
+            mock_config_obj.get_float.return_value = 15.0
+            mock_config.return_value = mock_config_obj
+            BinanceProvider()
+
+        assert mock_client_class.called
+        assert mock_client_class.call_args.kwargs.get("requests_params") == {"timeout": 15.0}
+
+    @pytest.mark.data_provider
+    @patch("src.data_providers.binance_provider.Client")
     def test_binance_historical_data_success(self, mock_client_class):
         mock_client = Mock()
         mock_client_class.return_value = mock_client

--- a/tests/unit/live/test_order_execution.py
+++ b/tests/unit/live/test_order_execution.py
@@ -429,20 +429,31 @@ class TestHandleOrderFill:
             assert mock_log.call_args.args[0] == "order_filled"
 
     def test_handle_fill_detects_stop_loss_fill(self, engine_with_exchange, sample_position):
-        """Fill callback detects and handles stop-loss fills."""
+        """A stop-loss fill is queued for the trading loop, which then closes it (#631).
+
+        The OrderTracker poll thread must not run the close inline (it blocked all
+        polling and could force-remove the filled order); it only enqueues, and
+        the loop's drain performs the actual close.
+        """
         sample_position.stop_loss_order_id = "sl_order_456"
         engine_with_exchange.live_position_tracker.track_recovered_position(
             sample_position, db_id=None
         )
 
         with patch.object(engine_with_exchange, "_execute_exit") as mock_close:
+            # Poll-thread callback: enqueue only, no inline close.
             engine_with_exchange._handle_order_fill("sl_order_456", "BTCUSDT", 0.02, 48000.0)
+            mock_close.assert_not_called()
+
+            # Trading-loop drain: perform the deferred close.
+            engine_with_exchange._drain_pending_fill_exits()
 
             mock_close.assert_called_once()
             call_args = mock_close.call_args
             assert call_args.args[0] == sample_position
             assert call_args.kwargs["reason"] == "stop_loss"
             assert call_args.kwargs["limit_price"] == 48000.0
+            assert call_args.kwargs["skip_live_close"] is True
 
     def test_handle_fill_skips_if_position_already_closed(
         self, engine_with_exchange, sample_position

--- a/tests/unit/live/test_order_journal_leak.py
+++ b/tests/unit/live/test_order_journal_leak.py
@@ -1,0 +1,66 @@
+"""Regression tests for #626: SHORT-guard rejection must not leak a journal row.
+
+Before the fix, `_execute_live_order` wrote a `PENDING_SUBMIT` journal row BEFORE
+the SHORT inventory guard, so every guard-rejected short leaked an orphan row
+(4,786 accumulated in production and jammed startup reconciliation). The guard
+now runs before journaling.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from src.engines.live.execution.execution_engine import LiveExecutionEngine
+from src.engines.shared.models import PositionSide
+
+
+def _engine(balance_free: float) -> tuple[LiveExecutionEngine, Mock]:
+    exchange = Mock()
+    exchange.is_margin_mode = True
+    exchange.get_balance.return_value = Mock(free=balance_free)
+    exchange.place_order.return_value = None
+    engine = LiveExecutionEngine(enable_live_trading=True, exchange_interface=exchange)
+    engine.db_manager = Mock()
+    engine.session_id = 1
+    engine.strategy_name = "test"
+    # Bypass exchange LOT_SIZE/notional lookups — not under test here.
+    engine._normalize_quantity = Mock(return_value=0.05)
+    return engine, exchange
+
+
+@pytest.mark.fast
+def test_short_rejected_by_inventory_guard_does_not_journal():
+    """A short blocked by the inventory guard must NOT write a journal row (#626)."""
+    # free base value = 0.05 * 2000 = $100 (> $1 dust threshold) -> guard rejects.
+    engine, exchange = _engine(balance_free=0.05)
+
+    result = engine._execute_live_order(
+        symbol="ETHUSDT", side=PositionSide.SHORT, value=100.0, price=2000.0
+    )
+
+    assert result == (None, None)
+    engine.db_manager.create_order_journal_entry.assert_not_called()  # no leaked row
+    exchange.place_order.assert_not_called()  # order never sent
+
+
+@pytest.mark.fast
+def test_short_accepted_when_no_inventory_is_journaled():
+    """With no significant inventory the guard passes and the order is journaled."""
+    engine, exchange = _engine(balance_free=0.0)  # no inventory -> guard passes
+
+    engine._execute_live_order(symbol="ETHUSDT", side=PositionSide.SHORT, value=100.0, price=2000.0)
+
+    # Journal anchor is still written for an order that is actually sent.
+    engine.db_manager.create_order_journal_entry.assert_called_once()
+    exchange.place_order.assert_called_once()
+
+
+@pytest.mark.fast
+def test_long_entry_is_journaled():
+    """Long entries are unaffected — journaled then placed (no guard)."""
+    engine, exchange = _engine(balance_free=0.0)
+
+    engine._execute_live_order(symbol="ETHUSDT", side=PositionSide.LONG, value=100.0, price=2000.0)
+
+    engine.db_manager.create_order_journal_entry.assert_called_once()
+    exchange.place_order.assert_called_once()

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -167,6 +167,110 @@ class TestPositionReconciler:
         assert calls[0].kwargs["status"] == "SUBMITTED"
         assert calls[1].kwargs["status"] == "CONFIRMED"
 
+    def test_resolve_pending_orders_is_bounded(self, reconciler, mock_db):
+        """A large backlog is capped and processed newest-first so startup is bounded (#628)."""
+        from src.config.constants import DEFAULT_MAX_PENDING_ORDERS_PER_RECONCILE as CAP
+
+        # Oldest-first, like the real get_unresolved_orders query.
+        backlog = [
+            {
+                "id": i,
+                "client_order_id": f"c{i}",
+                "symbol": "BTCUSDT",
+                "side": "LONG",
+                "quantity": 0.001,
+                "status": "UNKNOWN",
+                "created_at": datetime.now(UTC),
+            }
+            for i in range(CAP + 50)
+        ]
+        mock_db.get_unresolved_orders.return_value = backlog
+        reconciler._resolve_single_order = MagicMock(
+            side_effect=lambda od: ReconciliationResult(
+                entity_type="order", entity_id=od["id"], status="resolved"
+            )
+        )
+
+        results = reconciler.resolve_pending_orders()
+
+        # Only the cap is processed; the rest is deferred (not silently dropped).
+        assert reconciler._resolve_single_order.call_count == CAP
+        assert len(results) == CAP
+        # Newest-first: the first processed order is the newest backlog entry.
+        first_processed = reconciler._resolve_single_order.call_args_list[0].args[0]
+        assert first_processed["id"] == CAP + 49
+
+    def test_resolve_pending_orders_respects_time_budget(self, reconciler, mock_db):
+        """The loop stops on the time budget even below the count cap (#628)."""
+        from unittest.mock import patch
+
+        # 50 orders is below the count cap, so only the time budget can stop the loop.
+        backlog = [
+            {
+                "id": i,
+                "client_order_id": f"c{i}",
+                "symbol": "BTCUSDT",
+                "side": "LONG",
+                "quantity": 0.001,
+                "status": "UNKNOWN",
+                "created_at": datetime.now(UTC),
+            }
+            for i in range(50)
+        ]
+        mock_db.get_unresolved_orders.return_value = backlog
+        reconciler._resolve_single_order = MagicMock(
+            side_effect=lambda od: ReconciliationResult(
+                entity_type="order", entity_id=od["id"], status="resolved"
+            )
+        )
+
+        # monotonic call 1 = deadline; calls 2-4 = checks for the first 3 orders
+        # (within budget); call 5 = check for the 4th order -> past the budget -> break.
+        counter = {"n": 0}
+
+        def fake_monotonic() -> float:
+            counter["n"] += 1
+            return 0.0 if counter["n"] <= 4 else 10_000.0
+
+        with patch("src.engines.live.reconciliation.time.monotonic", side_effect=fake_monotonic):
+            results = reconciler.resolve_pending_orders()
+
+        # Stopped by the budget at 3 orders, not by the count cap.
+        assert reconciler._resolve_single_order.call_count == 3
+        assert len(results) == 3
+
+    def test_resolve_pending_orders_bulk_fails_stale_first_spot(self, reconciler, mock_db):
+        """Spot mode bulk-fails never-sent PENDING_SUBMIT rows before the per-order loop (#629)."""
+        from src.config.constants import DEFAULT_PENDING_SUBMIT_EXPIRY_MINUTES
+
+        # The default reconciler fixture is spot (use_margin=False).
+        mock_db.get_unresolved_orders.return_value = []
+
+        reconciler.resolve_pending_orders()
+
+        mock_db.expire_stale_pending_orders.assert_called_once_with(
+            reconciler.session_id, older_than_minutes=DEFAULT_PENDING_SUBMIT_EXPIRY_MINUTES
+        )
+
+    def test_resolve_pending_orders_skips_bulk_fail_in_margin_mode(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Margin mode skips the bulk-fail (no spot account-sync backstop) so a
+        crash-interrupted fill is not orphaned; rows go through the per-order exchange
+        check instead (#629)."""
+        margin_reconciler = PositionReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            use_margin=True,
+        )
+        mock_db.get_unresolved_orders.return_value = []
+
+        margin_reconciler.resolve_pending_orders()
+
+        mock_db.expire_stale_pending_orders.assert_not_called()
+
     def test_resolve_pending_order_not_found_pending_submit(
         self, reconciler, mock_exchange, mock_db
     ):
@@ -224,7 +328,9 @@ class TestPositionReconciler:
         result = reconciler.reconcile_position(pos)
         assert result.entity_type == "position"
 
-    def test_reconcile_position_entry_cancelled_is_high(self, reconciler, mock_exchange, mock_db, mock_position_tracker):
+    def test_reconcile_position_entry_cancelled_is_high(
+        self, reconciler, mock_exchange, mock_db, mock_position_tracker
+    ):
         """Position whose entry was cancelled gets HIGH severity and removes from tracker."""
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
@@ -272,16 +378,16 @@ class TestPositionReconciler:
         mock_position_tracker.remove_position.assert_called_once()
         mock_db.close_position.assert_not_called()
 
-    def test_reconcile_position_sl_filled_offline(self, reconciler, mock_exchange, mock_db, mock_position_tracker):
+    def test_reconcile_position_sl_filled_offline(
+        self, reconciler, mock_exchange, mock_db, mock_position_tracker
+    ):
         """Stop-loss filled while offline removes position and closes DB record."""
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
         pos = MockPosition(stop_loss_order_id="sl_123", db_position_id=7)
         # Entry order is fine
         entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
-        sl_order = MockExchangeOrder(
-            order_id="sl_123", status=ExOS.FILLED, average_price=49000.0
-        )
+        sl_order = MockExchangeOrder(order_id="sl_123", status=ExOS.FILLED, average_price=49000.0)
         mock_exchange.get_order.side_effect = [entry_order, sl_order]
 
         result = reconciler.reconcile_position(pos)
@@ -300,9 +406,7 @@ class TestPositionReconciler:
 
         pos = MockPosition(stop_loss_order_id="sl_456", db_position_id=8)
         entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
-        sl_order = MockExchangeOrder(
-            order_id="sl_456", status=ExOS.FILLED, average_price=None
-        )
+        sl_order = MockExchangeOrder(order_id="sl_456", status=ExOS.FILLED, average_price=None)
         mock_exchange.get_order.side_effect = [entry_order, sl_order]
 
         result = reconciler.reconcile_position(pos)
@@ -330,7 +434,8 @@ class TestPositionReconciler:
         # Correction recorded with MEDIUM severity
         assert result.severity >= Severity.MEDIUM
         sl_corrections = [
-            c for c in result.corrections
+            c
+            for c in result.corrections
             if "unprotected" in c.reason and c.field == "stop_loss_order_id"
         ]
         assert len(sl_corrections) == 1
@@ -359,7 +464,8 @@ class TestPositionReconciler:
         assert pos.stop_loss_order_id == "new_sl_exp"
         assert result.severity >= Severity.MEDIUM
         sl_corrections = [
-            c for c in result.corrections
+            c
+            for c in result.corrections
             if "expired" in c.reason and c.field == "stop_loss_order_id"
         ]
         assert len(sl_corrections) == 1
@@ -929,9 +1035,7 @@ class TestPeriodicReconcilerAssetCheck:
         mock_position_tracker.positions = {"key1": pos}
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
-        mock_exchange.get_order.return_value = MockExchangeOrder(
-            status=ExOS.FILLED
-        )
+        mock_exchange.get_order.return_value = MockExchangeOrder(status=ExOS.FILLED)
         # Asset balance is zero, but USDT balance is fine
         mock_exchange.get_balance.side_effect = lambda asset: (
             MockBalance(asset="USDT", total=1000.0)
@@ -951,9 +1055,7 @@ class TestPeriodicReconcilerAssetCheck:
 
         # Audit event logged for external close
         audit_calls = mock_db.log_audit_event.call_args_list
-        external_close_logged = any(
-            "closed externally" in str(call) for call in audit_calls
-        )
+        external_close_logged = any("closed externally" in str(call) for call in audit_calls)
         assert external_close_logged
 
     def test_cycle_no_false_positive_when_balance_sufficient(
@@ -964,9 +1066,7 @@ class TestPeriodicReconcilerAssetCheck:
         mock_position_tracker.positions = {"key1": pos}
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
-        mock_exchange.get_order.return_value = MockExchangeOrder(
-            status=ExOS.FILLED
-        )
+        mock_exchange.get_order.return_value = MockExchangeOrder(status=ExOS.FILLED)
         mock_exchange.get_balance.side_effect = lambda asset: (
             MockBalance(asset="USDT", total=1000.0)
             if asset == "USDT"
@@ -985,9 +1085,7 @@ class TestPeriodicReconcilerAssetCheck:
 
         # No external close audit event should be logged
         audit_calls = mock_db.log_audit_event.call_args_list
-        external_close_logged = any(
-            "closed externally" in str(call) for call in audit_calls
-        )
+        external_close_logged = any("closed externally" in str(call) for call in audit_calls)
         assert not external_close_logged
 
 
@@ -1044,8 +1142,16 @@ class TestBalanceAccountsForPositionNotional:
         Scenario: $20,000 DB, two positions totaling $15,000 notional.
         Exchange USDT = $5,000 (correct).
         """
-        pos1 = MockPosition(entry_price=50000.0, current_size=0.1, original_size=0.1, quantity=0.1, symbol="BTCUSDT")
-        pos2 = MockPosition(entry_price=3000.0, current_size=0.5, original_size=0.5, quantity=10.0 / 3, symbol="ETHUSDT")
+        pos1 = MockPosition(
+            entry_price=50000.0, current_size=0.1, original_size=0.1, quantity=0.1, symbol="BTCUSDT"
+        )
+        pos2 = MockPosition(
+            entry_price=3000.0,
+            current_size=0.5,
+            original_size=0.5,
+            quantity=10.0 / 3,
+            symbol="ETHUSDT",
+        )
         mock_position_tracker.positions = {"pos_1": pos1, "pos_2": pos2}
         mock_exchange.get_balance.return_value = MockBalance(total=5000.0)
         mock_db.get_current_balance.return_value = 20000.0
@@ -1071,9 +1177,7 @@ class TestBalanceAccountsForPositionNotional:
 
         Same scenario as startup: position notional explains USDT drop.
         """
-        pos = MockPosition(
-            entry_price=50000.0, current_size=0.1, exchange_order_id="ex_100"
-        )
+        pos = MockPosition(entry_price=50000.0, current_size=0.1, exchange_order_id="ex_100")
         mock_position_tracker.positions = {"pos_1": pos}
 
         from src.data_providers.exchange_interface import OrderStatus as ExOS
@@ -1165,10 +1269,7 @@ class TestFilledOrderPositionReconciliation:
         assert pos_arg.stop_loss == pytest.approx(50000.0 * 0.95)
         # First call persists stop-loss price, second persists SL order ID
         update_calls = mock_db.update_position.call_args_list
-        assert any(
-            c == call(42, stop_loss=pos_arg.stop_loss)
-            for c in update_calls
-        )
+        assert any(c == call(42, stop_loss=pos_arg.stop_loss) for c in update_calls)
 
     def test_filled_entry_skips_if_position_already_tracked(
         self, reconciler, mock_exchange, mock_db, mock_position_tracker
@@ -1595,9 +1696,7 @@ class TestFilledOrderPositionReconciliation:
         mock_position_tracker.track_recovered_position.assert_called_once()
 
         # Remaining order cancelled on exchange
-        mock_exchange.cancel_order.assert_called_once_with(
-            exchange_order.order_id, "BTCUSDT"
-        )
+        mock_exchange.cancel_order.assert_called_once_with(exchange_order.order_id, "BTCUSDT")
 
         # Journal marked CONFIRMED (filled portion accounted, remainder cancelled)
         journal_kwargs = mock_db.update_order_journal.call_args.kwargs
@@ -1756,10 +1855,7 @@ class TestFilledOrderPositionReconciliation:
         assert pos_arg.stop_loss == pytest.approx(40000.0 * 1.05)
         # First call persists stop-loss price, second persists SL order ID
         update_calls = mock_db.update_position.call_args_list
-        assert any(
-            c == call(55, stop_loss=pos_arg.stop_loss)
-            for c in update_calls
-        )
+        assert any(c == call(55, stop_loss=pos_arg.stop_loss) for c in update_calls)
 
     def test_filled_entry_db_failure_still_sets_in_memory_stop_loss(
         self, reconciler, mock_exchange, mock_db, mock_position_tracker
@@ -1894,12 +1990,8 @@ class TestAssetHoldingsExcessDetection:
             db_position_id=42,
         )
         # Held quantity is 200% of tracked — exceeds 150% threshold
-        mock_exchange.get_balance.return_value = MockBalance(
-            asset="BTC", total=0.2, free=0.2
-        )
-        result = ReconciliationResult(
-            entity_type="position", entity_id="test", status="resolved"
-        )
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.2, free=0.2)
+        result = ReconciliationResult(entity_type="position", entity_id="test", status="resolved")
 
         reconciler._verify_asset_holdings(pos, result)
 
@@ -1925,20 +2017,14 @@ class TestAssetHoldingsExcessDetection:
             db_position_id=42,
         )
         # 140% — below the 150% threshold
-        mock_exchange.get_balance.return_value = MockBalance(
-            asset="BTC", total=0.14, free=0.14
-        )
-        result = ReconciliationResult(
-            entity_type="position", entity_id="test", status="resolved"
-        )
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.14, free=0.14)
+        result = ReconciliationResult(entity_type="position", entity_id="test", status="resolved")
 
         reconciler._verify_asset_holdings(pos, result)
 
         # No corrections for excess (there might be none at all since
         # 140% is also above the 50% lower bound)
-        excess_corrections = [
-            c for c in result.corrections if "untracked fills" in c.reason
-        ]
+        excess_corrections = [c for c in result.corrections if "untracked fills" in c.reason]
         assert len(excess_corrections) == 0
 
 
@@ -1989,9 +2075,7 @@ class TestPeriodicReconcilerSLVerification:
             severity="HIGH",
         )
 
-    def test_cycle_replaces_cancelled_sl(
-        self, mock_exchange, mock_position_tracker, mock_db
-    ):
+    def test_cycle_replaces_cancelled_sl(self, mock_exchange, mock_position_tracker, mock_db):
         """Periodic cycle re-places a cancelled SL order."""
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
@@ -2033,9 +2117,7 @@ class TestPeriodicReconcilerSLVerification:
             position_id=51, stop_loss_order_id="new_sl_99", current_size=0.5
         )
 
-    def test_cycle_replaces_missing_sl(
-        self, mock_exchange, mock_position_tracker, mock_db
-    ):
+    def test_cycle_replaces_missing_sl(self, mock_exchange, mock_position_tracker, mock_db):
         """Periodic cycle re-places an SL order not found on exchange."""
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
@@ -2101,9 +2183,7 @@ class TestPeriodicReconcilerSLVerification:
         # Critical callback invoked
         critical_callback.assert_called_once()
 
-    def test_cycle_skips_positions_without_sl(
-        self, mock_exchange, mock_position_tracker, mock_db
-    ):
+    def test_cycle_skips_positions_without_sl(self, mock_exchange, mock_position_tracker, mock_db):
         """Positions without stop_loss_order_id are not queried for SL status."""
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
@@ -2665,9 +2745,7 @@ class TestReconciliationFeeAccounting:
         mock_db.atomic_balance_update = mock_atomic_balance_update
         mock_position_tracker._positions_lock = MagicMock()
         mock_position_tracker._positions = {}
-        mock_exchange.place_stop_loss_order.return_value = MagicMock(
-            order_id="sl_z", status="NEW"
-        )
+        mock_exchange.place_stop_loss_order.return_value = MagicMock(order_id="sl_z", status="NEW")
 
         reconciler._reconcile_filled_entry(
             order_data, exchange_order, "BTCUSDT", "LONG", 50000.0, 0.001
@@ -2707,9 +2785,7 @@ class TestReconciliationFeeAccounting:
         mock_db.atomic_balance_update = mock_atomic_balance_update
         mock_position_tracker._positions_lock = MagicMock()
         mock_position_tracker._positions = {}
-        mock_exchange.place_stop_loss_order.return_value = MagicMock(
-            order_id="sl_f", status="NEW"
-        )
+        mock_exchange.place_stop_loss_order.return_value = MagicMock(order_id="sl_f", status="NEW")
 
         # Should not raise — fee failure is non-fatal
         reconciler._reconcile_filled_entry(
@@ -2751,9 +2827,7 @@ class TestReconciliationFeeAccounting:
         )
         mock_db.get_current_balance.return_value = 1000.0
 
-        reconciler._realize_pnl_on_close(
-            position, exit_price=51000.0, reason="test_no_fee"
-        )
+        reconciler._realize_pnl_on_close(position, exit_price=51000.0, reason="test_no_fee")
 
         # P&L = 1.0, no fee
         # new_balance = 1000 + 1.0 = 1001.0

--- a/tests/unit/test_db_resilience.py
+++ b/tests/unit/test_db_resilience.py
@@ -11,6 +11,9 @@ Covers:
 - Loop behaviour: transient DB errors are ridden out (not counted toward
   ``max_consecutive_errors``); permanent/unrelated errors still trigger
   shutdown; a prolonged outage escalates to close-only mode.
+- An abnormal loop death (unhandled crash or error exhaustion) is recorded so
+  ``start()`` exits non-zero for an orchestrator restart instead of exiting 0
+  and leaving the bot silently dead (#630).
 """
 
 from __future__ import annotations
@@ -155,6 +158,8 @@ def test_transient_db_error_in_loop_is_ridden_out() -> None:
     assert engine._get_latest_data.call_count == 3
     assert engine.consecutive_errors == 0
     assert engine.db_unreachable_since is not None
+    # A clean max_steps stop is not a crash — start() would exit 0 here.
+    assert engine._loop_crashed is False
 
 
 @pytest.mark.fast
@@ -171,6 +176,8 @@ def test_non_transient_error_in_loop_still_shuts_down() -> None:
     # Shut down after the first counted error — did not run all five iterations.
     assert engine._get_latest_data.call_count == 1
     assert engine.is_running is False
+    # Error exhaustion is an abnormal stop: start() must exit non-zero (#630).
+    assert engine._loop_crashed is True
 
 
 @pytest.mark.fast
@@ -189,3 +196,288 @@ def test_prolonged_db_outage_enters_close_only() -> None:
     engine._trading_loop("BTCUSDT", "1h", max_steps=1)
 
     assert engine._close_only_mode is True
+
+
+# --------------------------------------------------------------------------- #
+# Loop-death -> non-zero exit so the orchestrator restarts the process (#630)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+def test_run_trading_loop_records_unhandled_crash() -> None:
+    """A crash escaping the loop is caught and recorded, not silently swallowed."""
+    engine = _make_engine()
+    engine._trading_loop = Mock(side_effect=RuntimeError("loop blew up"))
+
+    # The thread target must not propagate — it records the crash instead.
+    engine._run_trading_loop("BTCUSDT", "1h")
+
+    assert engine._loop_crashed is True
+
+
+@pytest.mark.fast
+def test_exit_if_loop_crashed_exits_nonzero_when_opted_in() -> None:
+    """An abnormal loop death makes start() exit 1 so Railway ON_FAILURE restarts."""
+    engine = _make_engine()
+    engine._loop_crashed = True
+    engine.main_thread = None  # nothing to join in this unit
+
+    with pytest.raises(SystemExit) as exc_info:
+        engine._exit_if_loop_crashed(exit_on_crash=True)
+
+    assert exc_info.value.code == 1
+
+
+@pytest.mark.fast
+def test_exit_if_loop_crashed_is_noop_after_clean_stop() -> None:
+    """A clean stop leaves the process to exit 0 (no SystemExit raised)."""
+    engine = _make_engine()
+    engine._loop_crashed = False
+
+    # Must return normally — start() then exits 0 as before.
+    assert engine._exit_if_loop_crashed(exit_on_crash=True) is None
+
+
+@pytest.mark.fast
+def test_exit_if_loop_crashed_returns_when_not_opted_in() -> None:
+    """A crash must NOT kill library callers (e.g. the migration baseline tool)
+    that drive start() and read results afterward — only the runner opts in."""
+    engine = _make_engine()
+    engine._loop_crashed = True
+    engine.main_thread = None
+
+    # exit_on_crash defaults False: returns instead of calling sys.exit().
+    assert engine._exit_if_loop_crashed(exit_on_crash=False) is None
+
+
+@pytest.mark.fast
+def test_start_exits_nonzero_on_loop_crash_when_opted_in() -> None:
+    """End-to-end wiring: start(exit_on_crash=True) routes the loop through the
+    crash-catching wrapper and exits 1 when it dies (locks the thread target)."""
+    engine = _make_engine()
+    engine.resume_from_last_balance = False
+    engine._start_websocket_streams = Mock()  # no real WS in this unit
+    engine._trading_loop = Mock(side_effect=RuntimeError("loop blew up"))
+
+    with pytest.raises(SystemExit) as exc_info:
+        engine.start("BTCUSDT", "1h", exit_on_crash=True)
+
+    assert exc_info.value.code == 1
+    assert engine._loop_crashed is True
+
+
+@pytest.mark.fast
+def test_start_returns_on_loop_crash_when_not_opted_in() -> None:
+    """End-to-end wiring: without opt-in, start() returns even if the loop crashes."""
+    engine = _make_engine()
+    engine.resume_from_last_balance = False
+    engine._start_websocket_streams = Mock()
+    engine._trading_loop = Mock(side_effect=RuntimeError("loop blew up"))
+
+    engine.start("BTCUSDT", "1h")  # exit_on_crash defaults False
+
+    # Recorded the crash but did not exit the process.
+    assert engine._loop_crashed is True
+
+
+# --------------------------------------------------------------------------- #
+# WS health watchdog — the main loop restarts a dead monitor thread (#631)
+# --------------------------------------------------------------------------- #
+
+
+def _dead_thread() -> Mock:
+    t = Mock()
+    t.is_alive.return_value = False
+    return t
+
+
+@pytest.mark.fast
+def test_watchdog_respawns_dead_ws_thread() -> None:
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = True
+    engine._ws_health_thread = _dead_thread()
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_called_once()
+
+
+@pytest.mark.fast
+def test_watchdog_noop_when_thread_alive() -> None:
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = True
+    alive = Mock()
+    alive.is_alive.return_value = True
+    engine._ws_health_thread = alive
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_not_called()
+
+
+@pytest.mark.fast
+def test_watchdog_noop_when_no_stream_configured() -> None:
+    """No WS stream is being watched → nothing to supervise (pure REST mode)."""
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = False
+    engine._user_data_processor = None
+    engine._ws_health_thread = _dead_thread()
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_not_called()
+
+
+@pytest.mark.fast
+def test_watchdog_noop_when_stopping() -> None:
+    """A shutting-down engine must not respawn the monitor."""
+    engine = _make_engine()
+    engine.is_running = True
+    engine._ws_kline_active = True
+    engine.stop_event.set()
+    engine._ws_health_thread = _dead_thread()
+    engine._start_ws_health_monitor = Mock()
+
+    engine._ensure_ws_health_monitor_alive()
+
+    engine._start_ws_health_monitor.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Deferred stop-loss fill exits — non-blocking, off the OrderTracker thread (#631)
+# --------------------------------------------------------------------------- #
+
+
+def _seed_sl_position(engine, order_id: str = "pos1", sl_order_id: str = "sl1"):
+    """Give the engine a position whose stop-loss is `sl_order_id`."""
+    pos = Mock()
+    pos.order_id = order_id
+    pos.stop_loss_order_id = sl_order_id
+    engine.live_position_tracker = Mock()
+    engine.live_position_tracker.positions = {order_id: pos}
+    engine.live_position_tracker.get_position = Mock(
+        side_effect=lambda oid: pos if oid == order_id else None
+    )
+    return pos
+
+
+@pytest.mark.fast
+def test_handle_order_fill_enqueues_sl_exit_instead_of_running_it() -> None:
+    """A stop-loss fill is queued for the loop, NOT executed on the poll thread."""
+    engine = _make_engine()
+    _seed_sl_position(engine, order_id="pos1", sl_order_id="sl1")
+    engine._execute_exit = Mock()
+
+    engine._handle_order_fill("sl1", "BTCUSDT", 0.5, 100.0)
+
+    assert engine._pending_fill_exits.get_nowait() == ("pos1", 100.0)
+    engine._execute_exit.assert_not_called()  # deferred, not run inline
+
+
+@pytest.mark.fast
+def test_handle_order_fill_entry_does_not_enqueue() -> None:
+    """A non-stop-loss (entry) fill enqueues nothing."""
+    engine = _make_engine()
+    _seed_sl_position(engine, order_id="pos1", sl_order_id="sl1")
+    engine._execute_exit = Mock()
+
+    engine._handle_order_fill("some-entry-order", "BTCUSDT", 0.5, 100.0)
+
+    assert engine._pending_fill_exits.empty()
+    engine._execute_exit.assert_not_called()
+
+
+@pytest.mark.fast
+def test_drain_executes_pending_exit() -> None:
+    engine = _make_engine()
+    _seed_sl_position(engine, order_id="pos1", sl_order_id="sl1")
+    engine._execute_exit = Mock()
+    engine._pending_fill_exits.put(("pos1", 100.0))
+
+    engine._drain_pending_fill_exits()
+
+    engine._execute_exit.assert_called_once()
+    kwargs = engine._execute_exit.call_args.kwargs
+    assert kwargs["skip_live_close"] is True
+    assert kwargs["reason"] == "stop_loss"
+    assert engine._pending_fill_exits.empty()
+
+
+@pytest.mark.fast
+def test_drain_skips_already_closed_position() -> None:
+    """If the position is already gone, the drain no-ops without error."""
+    engine = _make_engine()
+    engine.live_position_tracker = Mock()
+    engine.live_position_tracker.get_position = Mock(return_value=None)
+    engine._execute_exit = Mock()
+    engine._pending_fill_exits.put(("gone", 100.0))
+
+    engine._drain_pending_fill_exits()
+
+    engine._execute_exit.assert_not_called()
+    assert engine._pending_fill_exits.empty()
+
+
+@pytest.mark.fast
+def test_drain_failure_is_isolated_and_logged(caplog) -> None:
+    """One failing exit is logged CRITICAL and does NOT abort the rest of the drain."""
+    engine = _make_engine()
+    engine.live_position_tracker = Mock()
+    engine.live_position_tracker.get_position = Mock(return_value=Mock())
+    engine._execute_exit = Mock(side_effect=[RuntimeError("db down"), None])
+    engine._pending_fill_exits.put(("p1", 100.0))
+    engine._pending_fill_exits.put(("p2", 101.0))
+
+    with caplog.at_level("CRITICAL"):
+        engine._drain_pending_fill_exits()
+
+    assert engine._execute_exit.call_count == 2  # did not abort after the first failure
+    assert "draining deferred stop-loss exit" in caplog.text
+    assert engine._pending_fill_exits.empty()
+
+
+# --------------------------------------------------------------------------- #
+# Disconnect handlers stay exception-safe once REST calls can time out (#631)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.fast
+def test_kline_disconnect_degrades_when_reconnect_raises() -> None:
+    """A raising kline reconnect (e.g. REST timeout) degrades to polling, not crash."""
+    engine = _make_engine()
+    engine._kline_buffer = None  # skip REST resync
+    provider = Mock()
+    provider.reconnect_kline.side_effect = TimeoutError("rest socket hung")
+    engine._ws_kline_provider = provider
+    engine._ws_kline_active = True
+
+    engine._handle_kline_disconnect()  # must not propagate
+
+    provider.mark_kline_degraded.assert_called_once()
+    assert engine._ws_kline_active is False
+
+
+@pytest.mark.fast
+def test_user_stream_disconnect_survives_resync_timeout() -> None:
+    """A REST resync timeout mid-recovery must not abort the handler (#631)."""
+    engine = _make_engine()
+    engine.enable_live_trading = True
+    exchange = Mock()
+    exchange.reconnect_user.return_value = False  # force the degraded fallback
+    engine.exchange_interface = exchange
+    tracker = Mock()
+    tracker.poll_once.side_effect = TimeoutError("rest socket hung")  # step-4 resync
+    engine.order_tracker = tracker
+    engine._user_data_processor = None
+    engine._periodic_reconciler = None
+
+    with patch("src.engines.live.user_data_processor.UserDataProcessor"):
+        engine._handle_user_stream_disconnect()  # must not propagate
+
+    exchange.mark_user_degraded.assert_called_once()

--- a/tests/unit/test_health_liveness.py
+++ b/tests/unit/test_health_liveness.py
@@ -1,0 +1,61 @@
+"""Tests for the deep /health loop-liveness check (#627).
+
+Before this, /health returned a hardcoded "healthy" with no reference to the
+engine, so a zombie process (HTTP server up, trading loop dead) reported healthy
+for 12 days during the 2026-05-19 outage. /health now reflects loop liveness.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from cli.commands.live_health import _health_payload
+from src.infrastructure import liveness
+
+
+@pytest.fixture(autouse=True)
+def _reset_liveness():
+    """Isolate each test from the process-global heartbeat (order-independent)."""
+    liveness.reset()
+    yield
+    liveness.reset()
+
+
+@pytest.mark.fast
+def test_liveness_beat_and_reset():
+    liveness.reset()
+    assert liveness.seconds_since_beat() is None
+    liveness.beat()
+    age = liveness.seconds_since_beat()
+    assert age is not None and 0 <= age < 1.0
+    liveness.reset()
+    assert liveness.seconds_since_beat() is None
+
+
+@pytest.mark.fast
+def test_health_starting_when_loop_not_beaten():
+    """Before the loop's first beat, /health is healthy+starting (let the deploy come up)."""
+    liveness.reset()
+    code, body = _health_payload()
+    assert code == 200
+    assert body["status"] == "healthy"
+    assert body["loop"] == "starting"
+
+
+@pytest.mark.fast
+def test_health_ok_when_loop_fresh():
+    liveness.beat()
+    code, body = _health_payload()
+    assert code == 200
+    assert body["status"] == "healthy"
+    assert body["loop_heartbeat_age_seconds"] < 5
+
+
+@pytest.mark.fast
+def test_health_unhealthy_when_loop_stale():
+    """A stalled loop makes /health return 503 so the zombie is detectable."""
+    with patch("src.infrastructure.liveness.seconds_since_beat", return_value=10_000.0):
+        code, body = _health_payload()
+    assert code == 503
+    assert body["status"] == "unhealthy"
+    assert "stalled" in body["reason"]

--- a/tests/unit/test_order_status_methods.py
+++ b/tests/unit/test_order_status_methods.py
@@ -48,6 +48,31 @@ class TestOrderStatusMethods:
             assert float(mock_order.filled_price) == 50100.0  # Convert Decimal to float
             mock_session.commit.assert_called_once()
 
+    def test_expire_stale_pending_orders_scoped_update(self):
+        """Bulk-fails only old, never-sent PENDING_SUBMIT rows, scoped to the session (#629)."""
+        from datetime import timedelta
+
+        db_manager = DatabaseManager()
+        with patch.object(db_manager, "get_session") as mock_get_session:
+            mock_session = Mock()
+            mock_get_session.return_value.__enter__.return_value = mock_session
+            mock_session.execute.return_value = Mock(rowcount=4)
+
+            failed = db_manager.expire_stale_pending_orders(session_id=7, older_than_minutes=90)
+
+            assert failed == 4
+            mock_session.commit.assert_called_once()
+            sql, params = mock_session.execute.call_args.args
+            sql_str = " ".join(str(sql).split())
+            assert "SET status = 'FAILED'" in sql_str
+            assert "status = 'PENDING_SUBMIT'" in sql_str
+            assert "exchange_order_id IS NULL" in sql_str
+            assert "session_id = :sid" in sql_str
+            assert "created_at < :cutoff" in sql_str
+            assert params["sid"] == 7
+            # cutoff is ~90 min in the past
+            assert params["cutoff"] < datetime.now(UTC) - timedelta(minutes=89)
+
     def test_update_order_status_new_not_found(self):
         """Test updating order when not found."""
         db_manager = DatabaseManager()


### PR DESCRIPTION
Promotes the six 2026-05-19 silent-outage postmortem fixes from `develop` to `main` (production). Supersedes #638 (which conflicted only on `tests/unit/test_db_resilience.py` due to squash-merge history; resolved here by taking develop's newer version).

| Issue | PR | Fix |
|---|---|---|
| #626 | #632 | SHORT inventory guard before order journaling — stops `PENDING_SUBMIT` leak |
| #628 | #633 | Bound startup order reconciliation (cap + time budget) |
| #629 | #634 | Bulk-fail never-sent stale `PENDING_SUBMIT` orders (spot-mode only) |
| #627 | #635 | Deep `/health` reflects trading-loop liveness — detects a zombie process |
| #630 | #636 | Exit non-zero on abnormal loop death so Railway restarts |
| #631 | #637 | WS health watchdog restart + bounded Binance REST timeout + non-blocking stop-loss fills |

**This branch's tree is byte-identical to `develop`** (verified: `git diff develop` empty). Delta vs `main` = exactly these 6 fixes (16 files, +1077/−165). `#623`/`#620` content is already in production. Resilience hardening only — no strategy/signal changes.