### PR TITLE
fix(live): circuit-breaker for dead margin user-stream reconnect churn (#616)

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -354,6 +354,12 @@ DEFAULT_WS_KLINE_STALENESS_THRESHOLD = 120  # Seconds before kline stream consid
 DEFAULT_WS_USER_STALENESS_THRESHOLD = 120  # Seconds before user stream considered stale (only when orders tracked)
 DEFAULT_WS_HEALTH_CHECK_INTERVAL = 30  # Seconds between health monitor checks
 DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_DEGRADED
+# Consecutive unproductive user-stream reconnects (stale again with no real event)
+# before the watchdog opens a circuit breaker: stop the futile ~2-min reconnect loop
+# and run REST-polling-only. python-binance's start_margin_socket is fire-and-forget
+# and reports success even on a dead multiplexed ws_api socket, so reconnects never
+# self-terminate and churn forever (#616).
+DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT = 3
 DEFAULT_STARTUP_BAN_MAX_WAIT = 600  # Max seconds to wait for an IP ban to lift during startup
 DEFAULT_STARTUP_BAN_MAX_RETRIES = 3  # Max retry attempts for ban-related startup failures
 

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1604,8 +1604,8 @@ class LiveTradingEngine:
         # then short-circuits this check — the warning below logs exactly once (#616).
         if self._user_reconnect_failures >= DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT:
             logger.warning(
-                "User data stream did not recover after %d reconnects — staying on "
-                "REST polling until a real event or restart (circuit open) (#616).",
+                "User data stream did not recover after %d reconnects — circuit open, "
+                "staying on REST polling until the next restart (#616).",
                 self._user_reconnect_failures,
             )
             if hasattr(exchange, "mark_user_degraded"):

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -471,6 +471,9 @@ class LiveTradingEngine:
         self._ws_kline_active = False
         self._ws_kline_provider = None
         self._ws_health_thread = None
+        # Consecutive unproductive user-stream reconnects; trips a circuit breaker
+        # that stops the futile reconnect loop and runs REST-only (#616).
+        self._user_reconnect_failures = 0
         # Stop-loss fills are detected on the OrderTracker poll thread but their
         # bookkeeping exit is deferred to the trading loop so a slow/failing close
         # can't block order polling or force-remove a filled order (#631).
@@ -1571,18 +1574,54 @@ class LiveTradingEngine:
         if not self.order_tracker or self.order_tracker.get_tracked_count() == 0:
             return
 
-        from src.config.constants import DEFAULT_WS_USER_STALENESS_THRESHOLD
+        # A genuinely healthy stream (a real user event arrived since the last
+        # reconnect — user_ws_healthy requires _user_event_received) clears the
+        # reconnect circuit breaker.
+        if getattr(exchange, "user_ws_healthy", False):
+            self._user_reconnect_failures = 0
+
+        from src.config.constants import (
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
+            DEFAULT_WS_USER_STALENESS_THRESHOLD,
+        )
 
         last_event = getattr(exchange, "_last_user_event_time", None)
         if not last_event:
             return
         age = (datetime.now(UTC) - last_event).total_seconds()
-        if age > DEFAULT_WS_USER_STALENESS_THRESHOLD:
+        if age <= DEFAULT_WS_USER_STALENESS_THRESHOLD:
+            return
+
+        # Stale while PRIMARY with tracked orders means the previous reconnect
+        # produced no real events. python-binance's start_margin_socket is
+        # fire-and-forget and reports success even on a dead multiplexed ws_api
+        # socket, so reconnect_user returns True and this watchdog would otherwise
+        # reconnect every ~2 min forever (spewing asyncio re-entrancy errors).
+        # After a few unproductive reconnects, open the circuit: stop reconnecting
+        # and run REST-polling-only, which the engine already falls back to
+        # (OrderTracker polls every 10s; the periodic reconciler backstops at 120s).
+        # mark_user_degraded() sets REST_DEGRADED, so the != PRIMARY guard above
+        # then short-circuits this check — the warning below logs exactly once (#616).
+        if self._user_reconnect_failures >= DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT:
             logger.warning(
-                "User data stream stale (%ds) with tracked orders — reconnecting",
-                int(age),
+                "User data stream did not recover after %d reconnects — staying on "
+                "REST polling until a real event or restart (circuit open) (#616).",
+                self._user_reconnect_failures,
             )
-            self._handle_user_stream_disconnect()
+            if hasattr(exchange, "mark_user_degraded"):
+                exchange.mark_user_degraded()
+            if self.order_tracker:
+                self.order_tracker.enable_polling()
+            return
+
+        self._user_reconnect_failures += 1
+        logger.warning(
+            "User data stream stale (%ds) with tracked orders — reconnecting (attempt %d/%d)",
+            int(age),
+            self._user_reconnect_failures,
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
+        )
+        self._handle_user_stream_disconnect()
 
     def _handle_kline_disconnect(self) -> None:
         """Handle kline stream failure. Resync from REST and attempt reconnect."""

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -215,6 +215,42 @@ class TestCheckUserStreamHealth:
         assert disc.call_count == LIMIT  # bounded, not 20
         ex.mark_user_degraded.assert_called_once()  # degraded exactly once
 
+    @pytest.mark.fast
+    def test_breaker_survives_post_reconnect_fresh_timestamp(self, mock_engine):
+        """Real-timing regression: each reconnect refreshes _last_user_event_time to
+        now (as start_user_stream does), so the next health checks see age<threshold
+        and skip. The breaker must still accumulate across stale cycles — only a real
+        event (user_ws_healthy) may reset it, never the fresh post-reconnect timestamp.
+        """
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        ex, _tracker = self._dead_socket_engine(mock_engine)
+
+        # Faithful reconnect: refresh the timestamp but leave the socket dead — no
+        # real event arrives, so user_ws_healthy stays False.
+        def _reconnect():
+            ex._last_user_event_time = datetime.now(UTC)
+
+        with patch.object(
+            mock_engine, "_handle_user_stream_disconnect", side_effect=_reconnect
+        ) as disc:
+            for cycle in range(1, LIMIT + 1):
+                # Stale again (simulate ~150s elapsed since the last reconnect refresh).
+                ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+                mock_engine._check_user_stream_health()  # increment + reconnect (refreshes ts)
+                assert mock_engine._user_reconnect_failures == cycle
+                # Immediately after: fresh timestamp → NOT stale → no-op; the counter
+                # must be PRESERVED (the fresh timestamp must not reset it).
+                mock_engine._check_user_stream_health()
+                assert mock_engine._user_reconnect_failures == cycle
+                assert disc.call_count == cycle
+
+            # Next stale cycle: circuit trips → degrade, no further reconnect.
+            ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+            mock_engine._check_user_stream_health()
+            ex.mark_user_degraded.assert_called_once()
+            assert disc.call_count == LIMIT
+
 
 class TestHandleKlineDisconnect:
     """Tests for _handle_kline_disconnect()."""

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -128,6 +128,93 @@ class TestCheckUserStreamHealth:
             mock_engine._check_user_stream_health()
             mock_disconnect.assert_not_called()
 
+    @staticmethod
+    def _dead_socket_engine(mock_engine):
+        """Engine whose user stream is PRIMARY+stale and never gets a real event
+        (user_ws_healthy False) — the #616 dead multiplexed ws_api socket."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        ex.user_ws_healthy = False
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        return ex, tracker
+
+    @pytest.mark.fast
+    def test_breaker_trips_after_limit_unproductive_reconnects(self, mock_engine):
+        """After LIMIT dead reconnects, stop reconnecting and degrade to REST (#616)."""
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        ex, tracker = self._dead_socket_engine(mock_engine)
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            for _ in range(LIMIT):
+                mock_engine._check_user_stream_health()
+            assert disc.call_count == LIMIT
+            assert mock_engine._user_reconnect_failures == LIMIT
+            ex.mark_user_degraded.assert_not_called()
+
+            # Next cycle: circuit open — degrade to REST, no further reconnect.
+            mock_engine._check_user_stream_health()
+            assert disc.call_count == LIMIT  # unchanged
+            ex.mark_user_degraded.assert_called_once()
+            tracker.enable_polling.assert_called()
+
+    @pytest.mark.fast
+    def test_breaker_resets_on_real_event(self, mock_engine):
+        """A genuinely healthy stream (real event) clears the failure counter."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = True  # a real user event arrived
+        ex._last_user_event_time = datetime.now(UTC)  # fresh
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        mock_engine._user_reconnect_failures = 2  # had prior failures
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            mock_engine._check_user_stream_health()
+            assert mock_engine._user_reconnect_failures == 0  # reset by healthy stream
+            disc.assert_not_called()  # not stale → no reconnect
+
+    @pytest.mark.fast
+    def test_degraded_state_short_circuits(self, mock_engine):
+        """Once REST_DEGRADED, the check returns early (warning logged only once)."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            mock_engine._check_user_stream_health()
+            disc.assert_not_called()
+            ex.mark_user_degraded.assert_not_called()
+
+    @pytest.mark.fast
+    def test_reconnect_calls_bounded_over_many_cycles(self, mock_engine):
+        """Regression for the #616 churn: a dead socket yields BOUNDED reconnects,
+        not an unbounded ~2-min loop."""
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        ex, tracker = self._dead_socket_engine(mock_engine)
+        # mark_user_degraded flips state to REST_DEGRADED, as the real method does.
+        ex.mark_user_degraded.side_effect = lambda: setattr(
+            ex, "_user_ws_state", WebSocketState.REST_DEGRADED
+        )
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            for _ in range(20):
+                mock_engine._check_user_stream_health()
+
+        assert disc.call_count == LIMIT  # bounded, not 20
+        ex.mark_user_degraded.assert_called_once()  # degraded exactly once
+
 
 class TestHandleKlineDisconnect:
     """Tests for _handle_kline_disconnect()."""


### PR DESCRIPTION
## What & why

Production (cross-margin, live) churns its user-data WebSocket every ~2 minutes — `User data stream stale (120s) — reconnecting` on a permanent loop, producing **~2,100/hr** asyncio `cannot enter context` re-entrancy errors. Observed in prod logs 2026-06-02 after the postmortem promote.

**Root cause:** python-binance's `start_margin_socket` → `_start_async_socket` is **fire-and-forget** — it returns a socket path immediately and never raises, even on a dead multiplexed `ws_api` socket. So `start_user_stream` unconditionally sets `_user_ws_state = PRIMARY` and resets `_last_user_event_time = now`, and `reconnect_user` returns `True`. No real events arrive → stale again 120s later → reconnect → repeat forever. Because the reconnect "succeeds," the code never reaches the existing `mark_user_degraded()` terminal branch, so it self-perpetuates. (The asyncio errors are nest_asyncio + cross-thread re-entry on the shared loop during each reconnect.)

## Fix — circuit breaker (`_check_user_stream_health`)

Count consecutive **unproductive** reconnects (stale again while `user_ws_healthy` is `False` — i.e. no real event arrived, since `user_ws_healthy` requires `_user_event_received`). After `DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT` (3): stop reconnecting, `mark_user_degraded()` (→ `REST_DEGRADED`), and keep `order_tracker.enable_polling()` on. A genuinely healthy stream (a real event) resets the counter. Because the stale branch only runs while `PRIMARY`, the degrade transition makes the check short-circuit thereafter — so the warning logs **once** and the loop stops.

## Why it's safe (no execution change)

The bot already runs on REST fallback during the churn. After the breaker opens it runs REST-**only**, which is **strictly better**:
- Order fills: `OrderTracker` polls every **10s**; the **120s** periodic reconciler backstops stop-loss fills.
- During the churn today, each fake-success reconnect calls `disable_polling()`, so REST polling is actually *off* for most of each 120s window — the breaker makes REST tracking **continuous**.
- No new exchange orders, no position-logic change. State only transitions to the already-existing `REST_DEGRADED`.

Resets to a fresh WS attempt on the next process restart.

## Testing
- `tests/unit/test_trading_engine_ws_health.py`: breaker trips after N dead reconnects → degrade; resets on a real event; `REST_DEGRADED` short-circuits; **reconnects bounded over 20 cycles** (the churn regression guard — would have caught the infinite loop). 479 live unit tests pass; ruff clean.

## Notes
- Independent of the #626–#631 postmortem fixes (predates them; #631's exception-safe disconnect handler is orthogonal).
- Separate latent issue spotted (not fixed here): `requirements.txt`/`-server` pin python-binance 1.0.36 but `-github` pins 1.0.19 — CI may exercise a different WS impl than prod. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)