### PR TITLE
Promote to production: WS circuit breaker (#616) + cache-test de-flake (#640)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   missing role/database, permission denied) are excluded and still fail fast,
   and an outage lasting more than 30 minutes drops the engine into close-only
   mode (new entries suspended; exits and server-side stop-losses continue).
+- Prediction-cache performance test (`test_cache_performance_characteristics`)
+  is no longer timing-flaky on loaded CI runners. It previously took the *mean*
+  of `time.time()` over 100 cold, fully-mocked operations and asserted cache-hit
+  was within 5× a tiny (~0.13ms/op) noise-dominated cache-miss baseline, so a
+  single GC/scheduler pause inflating the mean would trip it (it failed twice on
+  PR #637). It now warms up, samples many ops with `perf_counter`, and asserts
+  the *median* (immune to those outliers) against a generous absolute budget. It
+  is also marked `@pytest.mark.performance` so it runs in the nightly performance
+  workflow rather than the blocking PR integration gate.
 
 ### Added
 - Heartbeat staleness monitor (`scripts/check_heartbeat.py` +

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -354,6 +354,12 @@ DEFAULT_WS_KLINE_STALENESS_THRESHOLD = 120  # Seconds before kline stream consid
 DEFAULT_WS_USER_STALENESS_THRESHOLD = 120  # Seconds before user stream considered stale (only when orders tracked)
 DEFAULT_WS_HEALTH_CHECK_INTERVAL = 30  # Seconds between health monitor checks
 DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_DEGRADED
+# Consecutive unproductive user-stream reconnects (stale again with no real event)
+# before the watchdog opens a circuit breaker: stop the futile ~2-min reconnect loop
+# and run REST-polling-only. python-binance's start_margin_socket is fire-and-forget
+# and reports success even on a dead multiplexed ws_api socket, so reconnects never
+# self-terminate and churn forever (#616).
+DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT = 3
 DEFAULT_STARTUP_BAN_MAX_WAIT = 600  # Max seconds to wait for an IP ban to lift during startup
 DEFAULT_STARTUP_BAN_MAX_RETRIES = 3  # Max retry attempts for ban-related startup failures
 

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -471,6 +471,9 @@ class LiveTradingEngine:
         self._ws_kline_active = False
         self._ws_kline_provider = None
         self._ws_health_thread = None
+        # Consecutive unproductive user-stream reconnects; trips a circuit breaker
+        # that stops the futile reconnect loop and runs REST-only (#616).
+        self._user_reconnect_failures = 0
         # Stop-loss fills are detected on the OrderTracker poll thread but their
         # bookkeeping exit is deferred to the trading loop so a slow/failing close
         # can't block order polling or force-remove a filled order (#631).
@@ -1571,18 +1574,54 @@ class LiveTradingEngine:
         if not self.order_tracker or self.order_tracker.get_tracked_count() == 0:
             return
 
-        from src.config.constants import DEFAULT_WS_USER_STALENESS_THRESHOLD
+        # A genuinely healthy stream (a real user event arrived since the last
+        # reconnect — user_ws_healthy requires _user_event_received) clears the
+        # reconnect circuit breaker.
+        if getattr(exchange, "user_ws_healthy", False):
+            self._user_reconnect_failures = 0
+
+        from src.config.constants import (
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
+            DEFAULT_WS_USER_STALENESS_THRESHOLD,
+        )
 
         last_event = getattr(exchange, "_last_user_event_time", None)
         if not last_event:
             return
         age = (datetime.now(UTC) - last_event).total_seconds()
-        if age > DEFAULT_WS_USER_STALENESS_THRESHOLD:
+        if age <= DEFAULT_WS_USER_STALENESS_THRESHOLD:
+            return
+
+        # Stale while PRIMARY with tracked orders means the previous reconnect
+        # produced no real events. python-binance's start_margin_socket is
+        # fire-and-forget and reports success even on a dead multiplexed ws_api
+        # socket, so reconnect_user returns True and this watchdog would otherwise
+        # reconnect every ~2 min forever (spewing asyncio re-entrancy errors).
+        # After a few unproductive reconnects, open the circuit: stop reconnecting
+        # and run REST-polling-only, which the engine already falls back to
+        # (OrderTracker polls every 10s; the periodic reconciler backstops at 120s).
+        # mark_user_degraded() sets REST_DEGRADED, so the != PRIMARY guard above
+        # then short-circuits this check — the warning below logs exactly once (#616).
+        if self._user_reconnect_failures >= DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT:
             logger.warning(
-                "User data stream stale (%ds) with tracked orders — reconnecting",
-                int(age),
+                "User data stream did not recover after %d reconnects — circuit open, "
+                "staying on REST polling until the next restart (#616).",
+                self._user_reconnect_failures,
             )
-            self._handle_user_stream_disconnect()
+            if hasattr(exchange, "mark_user_degraded"):
+                exchange.mark_user_degraded()
+            if self.order_tracker:
+                self.order_tracker.enable_polling()
+            return
+
+        self._user_reconnect_failures += 1
+        logger.warning(
+            "User data stream stale (%ds) with tracked orders — reconnecting (attempt %d/%d)",
+            int(age),
+            self._user_reconnect_failures,
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
+        )
+        self._handle_user_stream_disconnect()
 
     def _handle_kline_disconnect(self) -> None:
         """Handle kline stream failure. Resync from REST and attempt reconnect."""

--- a/tests/integration/predictions/test_prediction_caching_integration.py
+++ b/tests/integration/predictions/test_prediction_caching_integration.py
@@ -5,6 +5,7 @@ This module tests the complete prediction caching pipeline including
 database operations, cache hit/miss scenarios, and performance characteristics.
 """
 
+import statistics
 import time
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -217,64 +218,91 @@ class TestPredictionCachingIntegration:
         engine.get_cache_stats()
         mock_cache_manager.get_stats.assert_called_once()
 
+    @pytest.mark.performance
     def test_cache_performance_characteristics(self, mock_db_manager):
-        """Test cache performance characteristics using relative comparisons.
+        """Microbenchmark: the cache-hit code path must not be pathologically slow.
 
-        Uses relative timing comparisons instead of absolute thresholds to avoid
-        flaky tests on CI runners with variable performance. With mocked database
-        operations, both cache hit and miss paths should have similar performance
-        characteristics.
+        The database is fully mocked, so this measures only in-process overhead
+        (feature/config hashing, the stats lock, dict construction) of the hit and
+        miss paths. It is therefore a timing microbenchmark and is marked
+        ``performance`` so it runs in the dedicated nightly performance workflow
+        (.github/workflows/performance-tests.yml) rather than the blocking PR
+        integration gate.
+
+        Robustness: a single GC pause or scheduler hiccup can make one mocked op
+        take tens of milliseconds, which wrecks a mean taken over a small sample
+        (the historical cause of this test's flakiness on loaded CI runners). We
+        therefore warm up, collect many per-op samples, and assert on the
+        ``median`` -- which ignores those rare outliers -- against a generous
+        absolute budget. A relative check is kept only as a floor-guarded sanity
+        check so it never fires on a noise-dominated baseline.
         """
         mock_db, mock_session = mock_db_manager
 
         # Create cache manager
         cache_manager = PredictionCacheManager(mock_db, ttl=60, max_size=100)
 
-        # Use same number of operations for fair comparison
-        num_ops = 100
+        warmup_ops = 50
+        num_ops = 500
 
-        # Test cache miss performance
+        def measure(n):
+            """Return per-op durations (seconds) for ``n`` get() calls."""
+            samples = []
+            for _ in range(n):
+                start = time.perf_counter()
+                cache_manager.get(self.features, "test_model", {"param": "value"})
+                samples.append(time.perf_counter() - start)
+            return samples
+
+        # Cache miss path: query returns nothing.
         mock_session.query.return_value.filter.return_value.first.return_value = None
+        measure(warmup_ops)  # warm code paths; discard timings
+        miss_samples = measure(num_ops)
 
-        start_time = time.time()
-        for _ in range(num_ops):
-            cache_manager.get(self.features, "test_model", {"param": "value"})
-        cache_miss_time = time.time() - start_time
-
-        # Test cache hit performance
+        # Cache hit path: query returns a live (non-expired) entry.
         mock_entry = MagicMock()
         mock_entry.predicted_price = 100.5
         mock_entry.confidence = 0.8
         mock_entry.direction = 1
         mock_entry.access_count = 0
         mock_entry.expires_at = datetime.now(UTC) + timedelta(seconds=30)
-
         mock_session.query.return_value.filter.return_value.first.return_value = mock_entry
+        measure(warmup_ops)  # warm code paths; discard timings
+        hit_samples = measure(num_ops)
 
-        start_time = time.time()
-        for _ in range(num_ops):
-            cache_manager.get(self.features, "test_model", {"param": "value"})
-        cache_hit_time = time.time() - start_time
+        median_miss = statistics.median(miss_samples)
+        median_hit = statistics.median(hit_samples)
 
-        # Relative comparison: with mocked database, both paths should have similar
-        # performance. Allow 5x variance to account for CI runner variability.
-        # This tests that neither path has unexpected overhead, not absolute speed.
-        cache_miss_per_op = cache_miss_time / num_ops
-        cache_hit_per_op = cache_hit_time / num_ops
-
-        assert cache_hit_per_op < cache_miss_per_op * 5, (
-            f"Cache hit operations unexpectedly slower than cache miss: "
-            f"hit={cache_hit_per_op*1000:.2f}ms/op vs miss={cache_miss_per_op*1000:.2f}ms/op"
+        # Primary check: hits must not be pathologically slow in absolute terms.
+        # Mocked hits are ~0.07ms/op locally; even on a slow, loaded CI runner the
+        # median stays well under a millisecond because it ignores the occasional
+        # multi-ms GC/scheduler outlier. A 5ms/op ceiling is a >50x margin over
+        # realistic medians yet still trips on a genuine pathology -- e.g. an
+        # accidental real DB/network round-trip or O(n) work creeping into the path.
+        max_hit_per_op = 0.005  # 5 ms/op
+        assert median_hit < max_hit_per_op, (
+            f"Cache hit path pathologically slow: "
+            f"median={median_hit * 1000:.3f}ms/op (budget {max_hit_per_op * 1000:.0f}ms/op)"
         )
 
-        assert cache_miss_per_op < cache_hit_per_op * 5, (
-            f"Cache miss operations unexpectedly slower than cache hit: "
-            f"miss={cache_miss_per_op*1000:.2f}ms/op vs hit={cache_hit_per_op*1000:.2f}ms/op"
-        )
+        # Secondary check (floor-guarded relative comparison): both paths do
+        # comparable mocked work, so a hit should stay within a wide multiple of the
+        # miss baseline. Only assert this when the miss baseline is above the noise
+        # floor -- below it we would just be amplifying measurement jitter.
+        relative_limit = 10
+        noise_floor_per_op = 0.0005  # 0.5 ms/op
+        if median_miss >= noise_floor_per_op:
+            assert median_hit < median_miss * relative_limit, (
+                f"Cache hit path anomalously slower than miss baseline: "
+                f"hit={median_hit * 1000:.3f}ms/op vs miss={median_miss * 1000:.3f}ms/op "
+                f"({median_hit / median_miss:.1f}x, limit {relative_limit}x)"
+            )
 
-        # Verify cache stats are being tracked correctly
-        assert cache_manager._stats["misses"] == num_ops
-        assert cache_manager._stats["hits"] == num_ops
+        # Behavioral coverage (deterministic, not timing-based): hit/miss accounting
+        # must be exact across every operation, including warmup.
+        total_ops = warmup_ops + num_ops
+        assert cache_manager._stats["misses"] == total_ops
+        assert cache_manager._stats["hits"] == total_ops
 
     def test_cache_consistency(self, mock_db_manager):
         """Test cache consistency across multiple operations"""

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -128,6 +128,129 @@ class TestCheckUserStreamHealth:
             mock_engine._check_user_stream_health()
             mock_disconnect.assert_not_called()
 
+    @staticmethod
+    def _dead_socket_engine(mock_engine):
+        """Engine whose user stream is PRIMARY+stale and never gets a real event
+        (user_ws_healthy False) — the #616 dead multiplexed ws_api socket."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        ex.user_ws_healthy = False
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        return ex, tracker
+
+    @pytest.mark.fast
+    def test_breaker_trips_after_limit_unproductive_reconnects(self, mock_engine):
+        """After LIMIT dead reconnects, stop reconnecting and degrade to REST (#616)."""
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        ex, tracker = self._dead_socket_engine(mock_engine)
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            for _ in range(LIMIT):
+                mock_engine._check_user_stream_health()
+            assert disc.call_count == LIMIT
+            assert mock_engine._user_reconnect_failures == LIMIT
+            ex.mark_user_degraded.assert_not_called()
+
+            # Next cycle: circuit open — degrade to REST, no further reconnect.
+            mock_engine._check_user_stream_health()
+            assert disc.call_count == LIMIT  # unchanged
+            ex.mark_user_degraded.assert_called_once()
+            tracker.enable_polling.assert_called()
+
+    @pytest.mark.fast
+    def test_breaker_resets_on_real_event(self, mock_engine):
+        """A genuinely healthy stream (real event) clears the failure counter."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = True  # a real user event arrived
+        ex._last_user_event_time = datetime.now(UTC)  # fresh
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        mock_engine._user_reconnect_failures = 2  # had prior failures
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            mock_engine._check_user_stream_health()
+            assert mock_engine._user_reconnect_failures == 0  # reset by healthy stream
+            disc.assert_not_called()  # not stale → no reconnect
+
+    @pytest.mark.fast
+    def test_degraded_state_short_circuits(self, mock_engine):
+        """Once REST_DEGRADED, the check returns early (warning logged only once)."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            mock_engine._check_user_stream_health()
+            disc.assert_not_called()
+            ex.mark_user_degraded.assert_not_called()
+
+    @pytest.mark.fast
+    def test_reconnect_calls_bounded_over_many_cycles(self, mock_engine):
+        """Regression for the #616 churn: a dead socket yields BOUNDED reconnects,
+        not an unbounded ~2-min loop."""
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        ex, tracker = self._dead_socket_engine(mock_engine)
+        # mark_user_degraded flips state to REST_DEGRADED, as the real method does.
+        ex.mark_user_degraded.side_effect = lambda: setattr(
+            ex, "_user_ws_state", WebSocketState.REST_DEGRADED
+        )
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            for _ in range(20):
+                mock_engine._check_user_stream_health()
+
+        assert disc.call_count == LIMIT  # bounded, not 20
+        ex.mark_user_degraded.assert_called_once()  # degraded exactly once
+
+    @pytest.mark.fast
+    def test_breaker_survives_post_reconnect_fresh_timestamp(self, mock_engine):
+        """Real-timing regression: each reconnect refreshes _last_user_event_time to
+        now (as start_user_stream does), so the next health checks see age<threshold
+        and skip. The breaker must still accumulate across stale cycles — only a real
+        event (user_ws_healthy) may reset it, never the fresh post-reconnect timestamp.
+        """
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        ex, _tracker = self._dead_socket_engine(mock_engine)
+
+        # Faithful reconnect: refresh the timestamp but leave the socket dead — no
+        # real event arrives, so user_ws_healthy stays False.
+        def _reconnect():
+            ex._last_user_event_time = datetime.now(UTC)
+
+        with patch.object(
+            mock_engine, "_handle_user_stream_disconnect", side_effect=_reconnect
+        ) as disc:
+            for cycle in range(1, LIMIT + 1):
+                # Stale again (simulate ~150s elapsed since the last reconnect refresh).
+                ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+                mock_engine._check_user_stream_health()  # increment + reconnect (refreshes ts)
+                assert mock_engine._user_reconnect_failures == cycle
+                # Immediately after: fresh timestamp → NOT stale → no-op; the counter
+                # must be PRESERVED (the fresh timestamp must not reset it).
+                mock_engine._check_user_stream_health()
+                assert mock_engine._user_reconnect_failures == cycle
+                assert disc.call_count == cycle
+
+            # Next stale cycle: circuit trips → degrade, no further reconnect.
+            ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+            mock_engine._check_user_stream_health()
+            ex.mark_user_degraded.assert_called_once()
+            assert disc.call_count == LIMIT
+
 
 class TestHandleKlineDisconnect:
     """Tests for _handle_kline_disconnect()."""


### PR DESCRIPTION
Promotes `develop`→`main`. Source change to the live bot is the **#616** WS user-stream circuit breaker (`src/engines/live/trading_engine.py` + one constant): after 3 unproductive reconnects on a dead margin ws_api socket, stop the futile ~2-min reconnect loop and run REST-polling-only (kills the ~2,100/hr asyncio `cannot enter context` spam). No execution change — the bot already falls back to REST (OrderTracker 10s + reconciler 120s). Both reviewers found no blocking issues; CI fully green. Also includes the **#640** prediction-cache perf test de-flake (test-only). Tree is byte-identical to develop.