### PR TITLE
fix(live): tear down dead user socket on circuit-open to stop asyncio spam (#616)

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1608,6 +1608,14 @@ class LiveTradingEngine:
                 "staying on REST polling until the next restart (#616).",
                 self._user_reconnect_failures,
             )
+            # Tear down the dead user socket so its asyncio _read_ready callback stops
+            # firing on the shared event loop. Marking degraded alone stops reconnects
+            # but leaves the orphaned socket attached, which keeps spewing
+            # "cannot enter context" errors (~2,100/hr) indefinitely. stop_user_stream
+            # closes only the user socket (not kline), correct here since we are
+            # dropping to REST polling (#616).
+            if hasattr(exchange, "stop_user_stream"):
+                exchange.stop_user_stream()
             if hasattr(exchange, "mark_user_degraded"):
                 exchange.mark_user_degraded()
             if self.order_tracker:

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -160,6 +160,8 @@ class TestCheckUserStreamHealth:
             mock_engine._check_user_stream_health()
             assert disc.call_count == LIMIT  # unchanged
             ex.mark_user_degraded.assert_called_once()
+            # The dead socket is torn down so its asyncio _read_ready spam stops.
+            ex.stop_user_stream.assert_called_once()
             tracker.enable_polling.assert_called()
 
     @pytest.mark.fast
@@ -214,6 +216,7 @@ class TestCheckUserStreamHealth:
 
         assert disc.call_count == LIMIT  # bounded, not 20
         ex.mark_user_degraded.assert_called_once()  # degraded exactly once
+        ex.stop_user_stream.assert_called_once()  # dead socket torn down (asyncio spam stops)
 
     @pytest.mark.fast
     def test_breaker_survives_post_reconnect_fresh_timestamp(self, mock_engine):

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -163,6 +163,10 @@ class TestCheckUserStreamHealth:
             # The dead socket is torn down so its asyncio _read_ready spam stops.
             ex.stop_user_stream.assert_called_once()
             tracker.enable_polling.assert_called()
+            # Teardown must happen BEFORE degrade, else the terminal state is
+            # DISCONNECTED instead of REST_DEGRADED and the one-shot guard breaks.
+            ordered = [c[0] for c in ex.mock_calls if c[0] in ("stop_user_stream", "mark_user_degraded")]
+            assert ordered == ["stop_user_stream", "mark_user_degraded"]
 
     @pytest.mark.fast
     def test_breaker_resets_on_real_event(self, mock_engine):


### PR DESCRIPTION
## What & why (prod-verified follow-up to #616)

The #616 circuit breaker shipped to prod and **worked** — it stopped the ~2-min reconnect loop (degrade logged at 10:42:27 UTC). But production logs show the asyncio `cannot enter context` spam **continued at the same ~35/min (~2,100/hr) rate after the degrade**:

```
10:41  34   10:42  34 ←DEGRADE   10:43  35  ...  10:52  34
```

**Root cause of the remaining spam:** `mark_user_degraded()` only sets `REST_DEGRADED` (stops reconnects) but leaves the **orphaned dead user socket attached to the shared event loop**. Its `_SelectorSocketTransport._read_ready()` callback keeps firing and hitting the nest_asyncio re-entrancy error, independent of reconnects.

## Fix
On circuit-open, call `exchange.stop_user_stream()` to close the dead socket before marking degraded + enabling REST polling. `stop_user_stream` closes **only the user socket** (`stop_socket(self._user_socket_key)`), not the healthy kline price feed — correct here since we're dropping to REST polling anyway. This removes the `_read_ready` source.

## Safety
- Same `stop_user_stream()` call the reconnect path already uses every cycle (step 1 of `_handle_user_stream_disconnect`) — known-safe.
- No execution change; the bot stays on REST polling (OrderTracker 10s + reconciler 120s). Kline/price feed untouched.

## Testing
- `tests/unit/test_trading_engine_ws_health.py`: both breaker tests now assert `stop_user_stream()` is called on degrade. 14 pass; ruff clean.
- Will verify in prod after promote: asyncio `cannot enter context` rate drops to ~0 after the degrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)