### PR TITLE
Promote to production: tear down dead user socket on circuit-open (#616 follow-up)

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1608,6 +1608,14 @@ class LiveTradingEngine:
                 "staying on REST polling until the next restart (#616).",
                 self._user_reconnect_failures,
             )
+            # Tear down the dead user socket so its asyncio _read_ready callback stops
+            # firing on the shared event loop. Marking degraded alone stops reconnects
+            # but leaves the orphaned socket attached, which keeps spewing
+            # "cannot enter context" errors (~2,100/hr) indefinitely. stop_user_stream
+            # closes only the user socket (not kline), correct here since we are
+            # dropping to REST polling (#616).
+            if hasattr(exchange, "stop_user_stream"):
+                exchange.stop_user_stream()
             if hasattr(exchange, "mark_user_degraded"):
                 exchange.mark_user_degraded()
             if self.order_tracker:

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -160,7 +160,13 @@ class TestCheckUserStreamHealth:
             mock_engine._check_user_stream_health()
             assert disc.call_count == LIMIT  # unchanged
             ex.mark_user_degraded.assert_called_once()
+            # The dead socket is torn down so its asyncio _read_ready spam stops.
+            ex.stop_user_stream.assert_called_once()
             tracker.enable_polling.assert_called()
+            # Teardown must happen BEFORE degrade, else the terminal state is
+            # DISCONNECTED instead of REST_DEGRADED and the one-shot guard breaks.
+            ordered = [c[0] for c in ex.mock_calls if c[0] in ("stop_user_stream", "mark_user_degraded")]
+            assert ordered == ["stop_user_stream", "mark_user_degraded"]
 
     @pytest.mark.fast
     def test_breaker_resets_on_real_event(self, mock_engine):
@@ -214,6 +220,7 @@ class TestCheckUserStreamHealth:
 
         assert disc.call_count == LIMIT  # bounded, not 20
         ex.mark_user_degraded.assert_called_once()  # degraded exactly once
+        ex.stop_user_stream.assert_called_once()  # dead socket torn down (asyncio spam stops)
 
     @pytest.mark.fast
     def test_breaker_survives_post_reconnect_fresh_timestamp(self, mock_engine):


### PR DESCRIPTION
Promotes `develop`→`main`. Follow-up to the #616 circuit breaker: on circuit-open, `stop_user_stream()` tears down the orphaned dead user socket so its asyncio `_read_ready` callback stops firing — fixing the ~2,100/hr `cannot enter context` spam that persisted after the breaker degraded (prod-verified gap). Closes only the user socket, not the kline price feed. Both reviewers clean, CI green. Tree byte-identical to develop.