### PR TITLE
fix(ws): remove vestigial nest_asyncio causing continuous asyncio re-entrancy spam (#616)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "python-binance>=1.0.36",
-    "nest_asyncio>=1.6.0",
     "pandas>=2.1.4",
     "python-dotenv>=1.0.0",
     "numpy>=1.26.2",

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,8 +1,6 @@
 # Server requirements - lighter build without heavy libraries for training models
 # Production dependencies with pinned versions for stability
-# Cache bust: nest_asyncio added 2026-04-02
 python-binance==1.0.36
-nest_asyncio==1.6.0
 pandas==2.1.4
 python-dotenv==1.0.0
 numpy==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Use locally - includes heavy libraries for training models
 python-binance==1.0.36
-nest_asyncio==1.6.0
 pandas==2.2.0
 python-dotenv==1.0.0
 numpy==1.26.4

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -52,10 +52,6 @@ from .exchange_interface import (
 logger = logging.getLogger(__name__)
 
 try:
-    import nest_asyncio
-
-    nest_asyncio.apply()  # Allow nested run_until_complete for TWM event loop
-
     from binance import ThreadedWebsocketManager
     from binance.client import Client
     from binance.enums import SIDE_BUY, SIDE_SELL

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -23,6 +23,22 @@ except ImportError:
     OrderSide = Mock
 
 
+@pytest.mark.unit
+def test_binance_provider_does_not_apply_nest_asyncio():
+    """Importing binance_provider must NOT monkey-patch asyncio via nest_asyncio.
+
+    nest_asyncio.apply() made the shared TWM event loop reentrant but did not
+    restore the contextvars Context, so the always-active kline socket's
+    _read_ready spewed ~2,100/hr 'cannot enter context' errors. It was vestigial
+    (left over from a removed custom-loop design) and was removed (#616).
+    """
+    import asyncio
+
+    import src.data_providers.binance_provider  # noqa: F401 — import runs any apply()
+
+    assert getattr(asyncio, "_nest_patched", False) is False
+
+
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
 class TestBinanceDataProvider:
     @pytest.mark.data_provider


### PR DESCRIPTION
## Root cause (empirically reproduced)

The ~2,100/hr `RuntimeError: cannot enter context: <Context …> is already entered` (logger `atb.asyncio`, `_SelectorSocketTransport._read_ready`) is caused by **`nest_asyncio.apply()`** in `binance_provider.py`. It monkey-patches the event loop's `_run_once` to be reentrant but does **not** save/restore the `contextvars.Context`, so the **always-active kline socket's** `_read_ready` (~1 msg/sec) sometimes gets re-dispatched while its Context is still entered → CPython raises. This is **continuous and independent of the user-stream reconnect churn** — verified flat at ~37/min in prod even when the bot is flat (no positions/orders) with the #616 breaker dormant. (The byte-for-byte error was reproduced with just `nest_asyncio` + a stock selector loop, no Binance.)

## Why removal is the right (and smallest) fix
- `nest_asyncio` was added in **PR #590** for an old design that passed a **custom loop** to `ThreadedWebsocketManager`. That design is gone — TWM is now created with **no `_loop`** (`binance_provider.py` `_ensure_twm`).
- python-binance schedules sockets via `loop.call_soon_threadsafe(...)` (submitted to the running loop, never a nested `run_until_complete`); `TWM.stop()` uses `run_coroutine_threadsafe`. **Nothing nests.**
- `src/` has **zero** other asyncio usage — no `asyncio.run`, no `run_until_complete`, no `async def`. The sync `Client` is `requests`-based; `run_with_timeout` is threading. **No code depends on the patch.**
- The WS callbacks are asyncio-free (`KlineBuffer.on_kline` = pandas under a lock; `UserDataProcessor.enqueue` = `queue.put`).

## Change
- Remove `import nest_asyncio` + `nest_asyncio.apply()` (binance_provider.py).
- Remove the `nest_asyncio==1.6.0` pins from `requirements.txt` + `requirements-server.txt`.
- Regression test: `asyncio` is not `_nest_patched` after importing `binance_provider`.

## Safety + verification
- **Safe-by-failure:** if WS regressed, the engine already falls back to REST (kline staleness → REST; OrderTracker polls 10s; reconciler 120s) — it never trades on stale data.
- **Runtime verification (the decisive check, since the bug is loop-runtime):** the kline socket runs in **paper mode too**, so this will be verified on the **dev/staging** bot (real wss, no funds) before prod — confirm `cannot enter context` count drops to 0 AND the kline feed stays fresh (prices advancing). Then prod-verify (grep the fingerprint over 1h → expect 0, was ~2,100/hr).
- 499 live/provider unit tests pass; ruff clean (the 3 reported errors pre-exist on develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)