### PR TITLE
Promote to production: remove vestigial nest_asyncio (#616)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "python-binance>=1.0.36",
-    "nest_asyncio>=1.6.0",
     "pandas>=2.1.4",
     "python-dotenv>=1.0.0",
     "numpy>=1.26.2",

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,8 +1,6 @@
 # Server requirements - lighter build without heavy libraries for training models
 # Production dependencies with pinned versions for stability
-# Cache bust: nest_asyncio added 2026-04-02
 python-binance==1.0.36
-nest_asyncio==1.6.0
 pandas==2.1.4
 python-dotenv==1.0.0
 numpy==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # Use locally - includes heavy libraries for training models
 python-binance==1.0.36
-nest_asyncio==1.6.0
 pandas==2.2.0
 python-dotenv==1.0.0
 numpy==1.26.4

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -52,10 +52,6 @@ from .exchange_interface import (
 logger = logging.getLogger(__name__)
 
 try:
-    import nest_asyncio
-
-    nest_asyncio.apply()  # Allow nested run_until_complete for TWM event loop
-
     from binance import ThreadedWebsocketManager
     from binance.client import Client
     from binance.enums import SIDE_BUY, SIDE_SELL

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -23,6 +23,22 @@ except ImportError:
     OrderSide = Mock
 
 
+@pytest.mark.unit
+def test_binance_provider_does_not_apply_nest_asyncio():
+    """Importing binance_provider must NOT monkey-patch asyncio via nest_asyncio.
+
+    nest_asyncio.apply() made the shared TWM event loop reentrant but did not
+    restore the contextvars Context, so the always-active kline socket's
+    _read_ready spewed ~2,100/hr 'cannot enter context' errors. It was vestigial
+    (left over from a removed custom-loop design) and was removed (#616).
+    """
+    import asyncio
+
+    import src.data_providers.binance_provider  # noqa: F401 — import runs any apply()
+
+    assert getattr(asyncio, "_nest_patched", False) is False
+
+
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
 class TestBinanceDataProvider:
     @pytest.mark.data_provider


### PR DESCRIPTION
Promotes `develop`→`main`. Removes the vestigial `nest_asyncio.apply()` (binance_provider.py + requirements + pyproject) that caused ~2,100/hr `cannot enter context` asyncio re-entrancy spam via its broken `_run_once` patch on the shared WS loop. Both reviewers cleared it (nothing depends on the patch; TWM owns its own loop). Dev safety gate passed: kline WS active + trading + 0 errors on the new code. The spam only manifests in prod (live margin) — will grep the fingerprint after deploy (expect 0). Clean 4-line revert if needed. Tree byte-identical to develop.