### PR TITLE
Promote to production: cap SELL stop-loss at free base balance (#648)

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -1579,6 +1579,36 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             client_order_id=client_oid,
         )
 
+    def _base_asset_from_symbol(self, symbol: str) -> str:
+        """Best-effort base asset for ``symbol`` by stripping a known quote suffix.
+
+        Fallback only — prefer the exchange-authoritative ``base_asset`` from
+        ``get_symbol_info`` when it is available. Quotes are checked longest-first
+        so e.g. ``ETHUSDT`` resolves to ``ETH``. Returns ``symbol`` unchanged when
+        no known quote matches.
+        """
+        for quote in ("USDT", "BUSD", "USDC", "USD"):
+            if symbol.endswith(quote) and len(symbol) > len(quote):
+                return symbol[: -len(quote)]
+        return symbol
+
+    def _free_base_balance(self, base_asset: str) -> float | None:
+        """Free (un-locked) balance of ``base_asset`` (e.g. ETH), or None on failure.
+
+        Used to cap a SELL stop-loss so we never order more than we hold. ``free``
+        is the amount available to sell — reported identically in spot and margin
+        mode, and it already excludes inventory locked by an existing stop-loss, so
+        capping against it won't double-commit the same base asset.
+        """
+        try:
+            bal = self.get_balance(base_asset)
+            return float(bal.free) if bal is not None else None
+        except Exception as e:
+            logger.warning(
+                "Could not read free %s balance for stop-loss sizing: %s", base_asset, e
+            )
+            return None
+
     # Only retry transient -1015 (too many orders), NOT -1003 (IP ban).
     # IP bans last minutes — sleeping blocks SL placement and leaves the
     # position unprotected. The caller handles -1003 by entering close-only mode.
@@ -1620,8 +1650,10 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 else:
                     limit_price = stop_price * (1 + STOP_LOSS_LIMIT_SLIPPAGE_FACTOR)
 
-            # Round prices to valid tick size
+            # Round prices to a valid tick size and size the quantity to a valid lot.
             symbol_info = self.get_symbol_info(symbol)
+            step_size = 0.0
+            base_asset: str | None = None
             if symbol_info:
                 # Validate tick_size is numeric before division to prevent TypeError
                 tick_size_raw = symbol_info.get("tick_size", 0.01)
@@ -1635,8 +1667,44 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 step_size = (
                     float(step_size_raw) if isinstance(step_size_raw, int | float) else 0.00001
                 )
+                base_asset = symbol_info.get("base_asset")
+
+            # A SELL stop-loss can never order more of the base asset than is actually
+            # free: Binance deducts the trade fee from a buy's fill and round-to-nearest
+            # can round UP, so the tracked position quantity can exceed holdings and
+            # Binance rejects with -2010 (insufficient balance), leaving the position
+            # unprotected. Cap at the free balance and round DOWN so the order is always
+            # coverable. This runs even when symbol_info is missing — a transient
+            # get_symbol_info failure must not silently disable the protection. A BUY
+            # (short cover) is funded from quote, so it isn't constrained by base holdings.
+            if side == OrderSide.SELL:
+                free_base = self._free_base_balance(
+                    base_asset or self._base_asset_from_symbol(symbol)
+                )
+                if free_base is not None and free_base < quantity:
+                    logger.warning(
+                        "Stop-loss sell qty %.8f for %s exceeds free base balance "
+                        "%.8f — capping to holdings to avoid -2010.",
+                        quantity,
+                        symbol,
+                        free_base,
+                    )
+                    quantity = free_base
                 if step_size > 0:
-                    quantity = round(quantity / step_size) * step_size
+                    # +epsilon so a size that is mathematically an exact lot multiple but
+                    # stored a hair low (float noise) isn't truncated a whole step down.
+                    quantity = math.floor(quantity / step_size + 1e-9) * step_size
+            elif step_size > 0:
+                quantity = round(quantity / step_size) * step_size
+
+            if quantity <= 0:
+                logger.error(
+                    "Stop-loss quantity is %s after sizing for %s — no free base asset to "
+                    "protect; skipping order.",
+                    quantity,
+                    symbol,
+                )
+                return None
 
             sl_params = {
                 "symbol": symbol,

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -357,6 +357,193 @@ class TestPlaceStopLossOrder:
 
     @patch("src.data_providers.binance_provider.Client")
     @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_stop_loss_capped_at_free_balance(self, mock_config, mock_client_class):
+        """A SELL SL is capped at the free base balance + rounded DOWN, avoiding -2010.
+
+        Binance deducts the trade fee from a buy's fill, so the tracked position
+        quantity can exceed the free ETH; without the cap the SL was rejected with
+        -2010 and the position was left unprotected.
+        """
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "sl1"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(
+            return_value={"step_size": 0.0001, "tick_size": 0.01, "base_asset": "ETH"}
+        )
+        # Free ETH is slightly under the tracked position (fee taken from the buy fill).
+        provider.get_balance = Mock(return_value=Mock(free=0.004995))
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=0.005, stop_price=1900.0
+        )
+
+        assert result == "sl1"
+        provider.get_balance.assert_called_once_with("ETH")
+        # min(0.005, 0.004995)=0.004995 -> floor(/0.0001)*0.0001 = 0.0049 (never > holdings)
+        assert mock_client.create_order.call_args.kwargs["quantity"] == pytest.approx(
+            0.0049, abs=1e-9
+        )
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_stop_loss_zero_free_balance_skips_order(self, mock_config, mock_client_class):
+        """No free base asset to protect -> return None, place nothing."""
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(return_value={"step_size": 0.0001, "tick_size": 0.01})
+        provider.get_balance = Mock(return_value=Mock(free=0.0))
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=0.005, stop_price=1900.0
+        )
+
+        assert result is None
+        mock_client.create_order.assert_not_called()
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_buy_stop_loss_not_capped_by_base_balance(self, mock_config, mock_client_class):
+        """A BUY (short cover) SL is funded from quote, so it is NOT capped by base holdings."""
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "sl2"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(return_value={"step_size": 0.0001, "tick_size": 0.01})
+        provider.get_balance = Mock()
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.BUY, quantity=0.005, stop_price=2100.0
+        )
+
+        assert result == "sl2"
+        provider.get_balance.assert_not_called()
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_stop_loss_caps_without_symbol_info(self, mock_config, mock_client_class):
+        """A transient get_symbol_info failure must NOT disable the free-balance cap.
+
+        With no symbol_info there is no step size, so the capped quantity is sent
+        without lot-rounding — but it is still capped to holdings, so no -2010.
+        The base asset is derived via the fallback suffix-strip.
+        """
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "sl3"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(return_value=None)  # transient API failure
+        provider.get_balance = Mock(return_value=Mock(free=0.004))
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=0.005, stop_price=1900.0
+        )
+
+        assert result == "sl3"
+        provider.get_balance.assert_called_once_with("ETH")
+        assert mock_client.create_order.call_args.kwargs["quantity"] == pytest.approx(
+            0.004, abs=1e-9
+        )
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_stop_loss_places_uncapped_when_balance_unreadable(
+        self, mock_config, mock_client_class
+    ):
+        """If the free balance can't be read, don't block the SL — place it uncapped.
+
+        A failed balance read must not leave the position unprotected; fall back to
+        the (lot-rounded) requested quantity rather than skipping the order.
+        """
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "sl4"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(
+            return_value={"step_size": 0.0001, "tick_size": 0.01, "base_asset": "ETH"}
+        )
+        provider.get_balance = Mock(side_effect=RuntimeError("balance read failed"))
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=0.005, stop_price=1900.0
+        )
+
+        assert result == "sl4"
+        assert mock_client.create_order.call_args.kwargs["quantity"] == pytest.approx(
+            0.005, abs=1e-9
+        )
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_stop_loss_not_capped_when_balance_sufficient(
+        self, mock_config, mock_client_class
+    ):
+        """When free balance comfortably covers the position, no cap is applied."""
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "sl5"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(
+            return_value={"step_size": 0.0001, "tick_size": 0.01, "base_asset": "ETH"}
+        )
+        provider.get_balance = Mock(return_value=Mock(free=1.0))
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=0.005, stop_price=1900.0
+        )
+
+        assert result == "sl5"
+        assert mock_client.create_order.call_args.kwargs["quantity"] == pytest.approx(
+            0.005, abs=1e-9
+        )
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_stop_loss_floor_preserves_exact_lot(self, mock_config, mock_client_class):
+        """floor(qty/step) must not shed a whole lot to float noise (0.29, not 0.28)."""
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "sl6"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(
+            return_value={"step_size": 0.01, "tick_size": 0.01, "base_asset": "ETH"}
+        )
+        provider.get_balance = Mock(return_value=Mock(free=1.0))
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=0.29, stop_price=1900.0
+        )
+
+        assert result == "sl6"
+        # 0.29 / 0.01 = 28.9999996 in float; a naive floor -> 0.28. Epsilon keeps 0.29.
+        assert mock_client.create_order.call_args.kwargs["quantity"] == pytest.approx(
+            0.29, abs=1e-9
+        )
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
     def test_auto_limit_price_calculation_sell(self, mock_config, mock_client_class):
         """Verify limit price is calculated below stop for sell orders."""
         # Arrange


### PR DESCRIPTION
Surgical promote of **#648** only (`develop` → `main`), following the established per-fix promote pattern (#639/#642/#644/#646). Verified by patch-id that the `main↔develop` diff for the two touched files equals the #648 squash exactly — no unrelated develop work (Dashboard V2 etc.) rides along.

## What ships
- `src/data_providers/binance_provider.py` — SELL stop-loss capped at free base balance, rounded DOWN (+1e-9 epsilon), hoisted above the `symbol_info` gate, authoritative `base_asset` with fallback helper, `quantity<=0` skip guard.
- `tests/unit/data_providers/test_binance_provider.py` — 7 cap/epsilon/fallback cases.

## Why (live prod failure)
The production margin bot logged `Failed to place stop-loss order: APIError(code=-2010)` → `position is unprotected` every ~120s; the open ETHUSDT long had **no hard stop on the exchange**. Root cause: buy-fee deduction + round-to-nearest made the tracked qty exceed free ETH.

## Review
Architecture + code + deep-technical reviewers — **0 P0, 0 P1**. Holdings invariant fuzzed over 5M cases; BUY path byte-identical; `symbol_info`-missing path strictly safer than before.

## Post-deploy verification
The 120s periodic reconciler retries the missing SL, so this should heal the **currently open** position within ~2 min of deploy — I'll confirm a `Stop-loss order placed` for ETHUSDT and that the `-2010` loop stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)