### PR TITLE
docs(deploy): fix stale deploy skills + protect staging branch from deletion

### DIFF
--- a/.claude/commands/deploy-prod.md
+++ b/.claude/commands/deploy-prod.md
@@ -1,47 +1,82 @@
 # Deploy to Production
 
-Merge the `staging` branch into `main` with a clean history, then push to remote.
+Promote the current release line to the **production** Railway environment
+(`main`) via a **"Promote to production" pull request** — never a force-push.
 
-**⚠️ CRITICAL: This deploys to production. Ensure staging has been tested.**
+**⚠️ CRITICAL: This deploys a real-capital trading bot. Soak on staging first
+(`/deploy-staging`) and only promote a green, reviewed `develop`.**
+
+> **Why not `git reset --hard` + force-push?**
+> `main` carries its own history that does **not** exist on `develop`: every
+> prior production cutover is a "Promote to production: …" merge/squash commit
+> made directly on `main`. Resetting `main` to another branch and force-pushing
+> would **rewrite production history and discard those promotion commits** — a
+> destructive operation on the production branch, which `CLAUDE.md` forbids.
+> Promotion is therefore done with an additive merge commit via a PR.
 
 ## Instructions
 
-1. **Verify Clean Working Tree**
+1. **Verify Clean Working Tree & Fetch**
    ```bash
    git status --porcelain
+   git fetch origin develop main
    ```
-   - If there are uncommitted changes, warn the user and stop
+   - If there are uncommitted changes, warn the user and stop.
 
-2. **Fetch Latest from Remote**
+2. **Confirm the release point is ready**
+   - `develop` (or `staging`) is the source of truth. Ideally it has already
+     been soaked via `/deploy-staging`.
+   - Sanity check what will ship:
+     ```bash
+     git log --oneline origin/main..origin/develop
+     ```
+
+3. **Open the "Promote to production" PR**
+   Create a PR with **base `main`** and **head `develop`** (prefer the GitHub
+   MCP server; otherwise `gh pr create --base main --head develop`). Title it:
+   ```
+   Promote to production: <one-line summary of what's shipping>
+   ```
+   Body should list the PRs/changes included and the testing performed.
+
+4. **Reconcile conflicts additively (do NOT force-push `main`)**
+   The PR is often `dirty` because `main` and `develop` both touched
+   `docs/changelog.md` (and occasionally code). Resolve by **merging `main`
+   into the head branch**, never by resetting `main`:
    ```bash
-   git fetch origin staging main
+   git checkout develop          # or a dedicated release branch
+   git merge origin/main         # resolve conflicts (usually just the changelog: keep both sides)
+   git push origin develop
    ```
+   This makes the PR mergeable while preserving `main`'s promotion history.
 
-3. **Checkout and Reset Main to Match Staging**
-   ```bash
-   git checkout main
-   git reset --hard origin/staging
-   ```
-   - This ensures main has identical history to staging
+5. **Wait for green CI**
+   All required checks (unit-tests shards, integration-tests, claude-review)
+   must pass on the PR before merging. Do not merge a red or in-progress PR to
+   production.
 
-4. **Push to Remote**
-   ```bash
-   git push origin main --force-with-lease
-   ```
-   - Uses `--force-with-lease` for safety (fails if remote has unexpected changes)
+6. **Merge the PR with a merge commit**
+   Use a **merge commit** (not squash/rebase) so `main` keeps the promotion
+   marker and full history. Via GitHub MCP `merge_pull_request`
+   (`merge_method: "merge"`) or `gh pr merge <n> --merge`.
 
-5. **Return to Original Branch**
-   ```bash
-   git checkout develop
-   ```
-
-6. **Verify Deployment**
-   - Confirm the push succeeded
-   - Report the commit SHA now on main (production)
+7. **Verify Deployment**
+   - Confirm `main` advanced and now contains the release:
+     ```bash
+     git fetch origin main
+     git rev-list --count origin/main..origin/develop   # expect 0
+     ```
+   - Confirm Railway picked up the deploy on the **main / production**
+     environment (Railway MCP / `railway` CLI / dashboard) and that `/health`
+     is green.
+   - Watch the production bot's liveness (account_history freshness /
+     heartbeat) for a few cycles after cutover, since this ships live-engine
+     changes. Do **not** perform destructive operations against production.
 
 ## Output
 
 Report:
-- The commit SHA deployed to production
-- Confirmation that main now matches staging
-- Any warnings or errors encountered
+- The promotion PR number and the merge commit SHA now on `main` (production).
+- Confirmation that `main..develop` is empty (fully promoted).
+- Railway production deploy status (and `/health`) if available.
+- Any warnings or errors encountered.

--- a/.claude/commands/deploy-prod.md
+++ b/.claude/commands/deploy-prod.md
@@ -1,52 +1,60 @@
 # Deploy to Production
 
-Promote the current release line to the **production** Railway environment
-(`main`) via a **"Promote to production" pull request** — never a force-push.
+Promote **`staging` → `main`** (the production Railway environment) via a
+**"Promote to production" pull request** — never a force-push.
 
 **⚠️ CRITICAL: This deploys a real-capital trading bot. Soak on staging first
-(`/deploy-staging`) and only promote a green, reviewed `develop`.**
+(`/deploy-staging`) and only promote a green, reviewed `staging`.**
 
+> **Environment chain:** `develop` → `staging` → `main`, mapping to Railway
+> `development` → `staging` → `production`. Production is always promoted from
+> **`staging`**, not directly from `develop`.
+>
 > **Why not `git reset --hard` + force-push?**
-> `main` carries its own history that does **not** exist on `develop`: every
-> prior production cutover is a "Promote to production: …" merge/squash commit
-> made directly on `main`. Resetting `main` to another branch and force-pushing
+> `main` carries its own history that does **not** exist on `staging`/`develop`:
+> every prior production cutover is a "Promote to production: …" merge/squash
+> commit made on `main`. Resetting `main` to another branch and force-pushing
 > would **rewrite production history and discard those promotion commits** — a
 > destructive operation on the production branch, which `CLAUDE.md` forbids.
-> Promotion is therefore done with an additive merge commit via a PR.
+> Promotion is therefore an additive merge commit via a PR.
+>
+> **`staging` is a protected long-running branch** (`allow_deletions: false`),
+> so merging a `staging`→`main` PR will **not** delete it (the repo has
+> `delete_branch_on_merge: true`, which skips protected branches). Do not
+> recreate `staging` after a promotion — it persists by design.
 
 ## Instructions
 
 1. **Verify Clean Working Tree & Fetch**
    ```bash
    git status --porcelain
-   git fetch origin develop main
+   git fetch origin develop staging main
    ```
    - If there are uncommitted changes, warn the user and stop.
 
-2. **Confirm the release point is ready**
-   - `develop` (or `staging`) is the source of truth. Ideally it has already
-     been soaked via `/deploy-staging`.
-   - Sanity check what will ship:
+2. **Ensure `staging` is up to date and soaked**
+   - Run `/deploy-staging` first if `staging` is behind `develop`.
+   - Sanity check what will ship to production:
      ```bash
-     git log --oneline origin/main..origin/develop
+     git log --oneline origin/main..origin/staging
      ```
 
 3. **Open the "Promote to production" PR**
-   Create a PR with **base `main`** and **head `develop`** (prefer the GitHub
-   MCP server; otherwise `gh pr create --base main --head develop`). Title it:
+   Create a PR with **base `main`** and **head `staging`** (prefer the GitHub
+   MCP server; otherwise `gh pr create --base main --head staging`). Title it:
    ```
    Promote to production: <one-line summary of what's shipping>
    ```
    Body should list the PRs/changes included and the testing performed.
 
 4. **Reconcile conflicts additively (do NOT force-push `main`)**
-   The PR is often `dirty` because `main` and `develop` both touched
+   The PR is often `dirty` because `main` and the release line both touched
    `docs/changelog.md` (and occasionally code). Resolve by **merging `main`
-   into the head branch**, never by resetting `main`:
+   into `staging`**, never by resetting `main`:
    ```bash
-   git checkout develop          # or a dedicated release branch
+   git checkout staging
    git merge origin/main         # resolve conflicts (usually just the changelog: keep both sides)
-   git push origin develop
+   git push origin staging
    ```
    This makes the PR mergeable while preserving `main`'s promotion history.
 
@@ -59,16 +67,20 @@ Promote the current release line to the **production** Railway environment
    Use a **merge commit** (not squash/rebase) so `main` keeps the promotion
    marker and full history. Via GitHub MCP `merge_pull_request`
    (`merge_method: "merge"`) or `gh pr merge <n> --merge`.
+   `staging` is protected and will survive the merge.
 
 7. **Verify Deployment**
    - Confirm `main` advanced and now contains the release:
      ```bash
-     git fetch origin main
-     git rev-list --count origin/main..origin/develop   # expect 0
+     git fetch origin main staging
+     git rev-list --count origin/main..origin/staging   # expect 0
      ```
-   - Confirm Railway picked up the deploy on the **main / production**
-     environment (Railway MCP / `railway` CLI / dashboard) and that `/health`
-     is green.
+   - Confirm `staging` still exists (it must, being protected):
+     ```bash
+     git ls-remote --heads origin staging
+     ```
+   - Confirm Railway picked up the deploy on the **production** environment
+     (Railway MCP / `railway` CLI / dashboard) and that `/health` is green.
    - Watch the production bot's liveness (account_history freshness /
      heartbeat) for a few cycles after cutover, since this ships live-engine
      changes. Do **not** perform destructive operations against production.
@@ -77,6 +89,7 @@ Promote the current release line to the **production** Railway environment
 
 Report:
 - The promotion PR number and the merge commit SHA now on `main` (production).
-- Confirmation that `main..develop` is empty (fully promoted).
+- Confirmation that `main..staging` is empty (fully promoted) and `staging`
+  still exists.
 - Railway production deploy status (and `/health`) if available.
 - Any warnings or errors encountered.

--- a/.claude/commands/deploy-staging.md
+++ b/.claude/commands/deploy-staging.md
@@ -1,6 +1,14 @@
 # Deploy to Staging
 
-Merge the `develop` branch into `staging` with a clean history, then push to remote.
+Deploy the current `develop` line to the **staging** Railway environment by
+updating the `staging` branch to match `develop`.
+
+> **Branch model (read first).** PRs squash-merge into `develop` (integration).
+> `staging` is a **disposable** environment branch that simply tracks whatever
+> `develop` currently is — it never carries unique commits of its own and may be
+> auto-deleted after a promotion, so recreating it from `develop` is always safe.
+> Production (`main`) is **different**: it carries its own "Promote to production"
+> merge history and must NEVER be force-pushed. See `/deploy-prod`.
 
 ## Instructions
 
@@ -8,38 +16,51 @@ Merge the `develop` branch into `staging` with a clean history, then push to rem
    ```bash
    git status --porcelain
    ```
-   - If there are uncommitted changes, warn the user and stop
+   - If there are uncommitted changes, warn the user and stop.
 
 2. **Fetch Latest from Remote**
    ```bash
    git fetch origin develop staging
    ```
 
-3. **Checkout and Reset Staging to Match Develop**
+3. **Point `staging` at the current `develop`**
+   `staging` is disposable, so reset it to `develop` (create it if it does not
+   exist — it is frequently cleaned up after a promotion):
    ```bash
-   git checkout staging
-   git reset --hard origin/develop
+   git checkout -B staging origin/develop
    ```
-   - This ensures staging has identical history to develop
 
 4. **Push to Remote**
    ```bash
    git push origin staging --force-with-lease
    ```
-   - Uses `--force-with-lease` for safety (fails if remote has unexpected changes)
+   - `staging` carries no unique history, so a reset-and-push is safe here.
+     `--force-with-lease` still guards against a surprise concurrent push.
+   - If the remote `staging` was deleted, this recreates it
+     (`git push -u origin staging`).
 
-5. **Return to Original Branch**
+5. **Return to `develop`**
    ```bash
    git checkout develop
    ```
 
 6. **Verify Deployment**
-   - Confirm the push succeeded
-   - Report the commit SHA now on staging
+   - Confirm the push succeeded and report the commit SHA now on `staging`.
+   - Confirm Railway has picked up the deploy on the **staging** environment
+     (Railway MCP server / `railway` CLI / dashboard) and that the
+     `/health` check is green.
 
 ## Output
 
 Report:
-- The commit SHA deployed to staging
-- Confirmation that staging now matches develop
-- Any warnings or errors encountered
+- The commit SHA deployed to staging.
+- Confirmation that `staging` now matches `develop`.
+- Railway staging deploy status (and `/health`) if available.
+- Any warnings or errors encountered.
+
+## Notes
+
+- This is the recommended pre-production soak step: deploy here first, let the
+  staging bot run, then run `/deploy-prod` to promote.
+- Staging and production use separate databases
+  (`RAILWAY_STAGING_DATABASE_URL` / `RAILWAY_PRODUCTION_DATABASE_URL`).

--- a/.claude/commands/deploy-staging.md
+++ b/.claude/commands/deploy-staging.md
@@ -1,14 +1,20 @@
 # Deploy to Staging
 
 Deploy the current `develop` line to the **staging** Railway environment by
-updating the `staging` branch to match `develop`.
+syncing the long-running `staging` branch to `develop`.
 
-> **Branch model (read first).** PRs squash-merge into `develop` (integration).
-> `staging` is a **disposable** environment branch that simply tracks whatever
-> `develop` currently is — it never carries unique commits of its own and may be
-> auto-deleted after a promotion, so recreating it from `develop` is always safe.
-> Production (`main`) is **different**: it carries its own "Promote to production"
-> merge history and must NEVER be force-pushed. See `/deploy-prod`.
+> **Environment chain:** `develop` → `staging` → `main`, mapping to Railway
+> `development` → `staging` → `production`.
+>
+> **`staging` is a protected, long-running branch.** It maps 1:1 to the Railway
+> staging environment and must **never be deleted**. It is protected
+> (`allow_deletions: false`), so the repo-wide `delete_branch_on_merge: true`
+> will skip it — merging a `staging`→`main` promotion PR will not remove it.
+> Never delete `staging`; this command only fast-forwards/resets its **content**
+> to `develop` (force-push is allowed on the branch, the ref itself persists).
+>
+> Production (`main`) is **different**: it carries its own "Promote to
+> production" merge history and must NEVER be force-pushed. See `/deploy-prod`.
 
 ## Instructions
 
@@ -22,22 +28,27 @@ updating the `staging` branch to match `develop`.
    ```bash
    git fetch origin develop staging
    ```
+   - Confirm `staging` exists on the remote:
+     ```bash
+     git ls-remote --heads origin staging
+     ```
+     It always should (it is protected). If it is somehow missing, STOP and
+     alert the user — branch protection may have been removed — rather than
+     silently recreating it.
 
-3. **Point `staging` at the current `develop`**
-   `staging` is disposable, so reset it to `develop` (create it if it does not
-   exist — it is frequently cleaned up after a promotion):
+3. **Sync `staging`'s content to `develop`**
    ```bash
    git checkout -B staging origin/develop
    ```
+   - This points the local `staging` at `develop`'s tree. The remote branch
+     ref is never deleted; only its content is updated.
 
 4. **Push to Remote**
    ```bash
    git push origin staging --force-with-lease
    ```
-   - `staging` carries no unique history, so a reset-and-push is safe here.
-     `--force-with-lease` still guards against a surprise concurrent push.
-   - If the remote `staging` was deleted, this recreates it
-     (`git push -u origin staging`).
+   - `staging` only ever mirrors the release line, so a fast-forward/reset push
+     is expected. `--force-with-lease` guards against a surprise concurrent push.
 
 5. **Return to `develop`**
    ```bash
@@ -46,6 +57,7 @@ updating the `staging` branch to match `develop`.
 
 6. **Verify Deployment**
    - Confirm the push succeeded and report the commit SHA now on `staging`.
+   - Confirm `staging` still exists on the remote.
    - Confirm Railway has picked up the deploy on the **staging** environment
      (Railway MCP server / `railway` CLI / dashboard) and that the
      `/health` check is green.
@@ -54,13 +66,13 @@ updating the `staging` branch to match `develop`.
 
 Report:
 - The commit SHA deployed to staging.
-- Confirmation that `staging` now matches `develop`.
+- Confirmation that `staging` now matches `develop` and still exists.
 - Railway staging deploy status (and `/health`) if available.
 - Any warnings or errors encountered.
 
 ## Notes
 
 - This is the recommended pre-production soak step: deploy here first, let the
-  staging bot run, then run `/deploy-prod` to promote.
+  staging bot run, then run `/deploy-prod` to promote `staging` → `main`.
 - Staging and production use separate databases
   (`RAILWAY_STAGING_DATABASE_URL` / `RAILWAY_PRODUCTION_DATABASE_URL`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,6 +65,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `railway.json`: raised the Trading Bot `restartPolicyMaxRetries` from 3 to 10
   so Railway keeps retrying through longer transient infrastructure failures.
+- `/deploy-staging` and `/deploy-prod` slash-command skills rewritten to match
+  the actual promotion workflow. `/deploy-prod` no longer does
+  `git reset --hard origin/staging` + force-push to `main` (which would rewrite
+  production history and drop the "Promote to production" commits that live only
+  on `main`); it now opens an additive **"Promote to production" PR**
+  (`develop`→`main`), reconciles changelog conflicts by merging `main` into the
+  head branch, waits for green CI, and merges with a merge commit.
+  `/deploy-staging` documents that `staging` is a disposable env branch safely
+  recreatable from `develop`.
 
 ### Security
 - Hardened a batch of security findings from a repo-wide scan (bandit + manual

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -66,14 +66,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `railway.json`: raised the Trading Bot `restartPolicyMaxRetries` from 3 to 10
   so Railway keeps retrying through longer transient infrastructure failures.
 - `/deploy-staging` and `/deploy-prod` slash-command skills rewritten to match
-  the actual promotion workflow. `/deploy-prod` no longer does
+  the actual `develop` → `staging` → `main` promotion workflow (Railway
+  development → staging → production). `/deploy-prod` no longer does
   `git reset --hard origin/staging` + force-push to `main` (which would rewrite
   production history and drop the "Promote to production" commits that live only
   on `main`); it now opens an additive **"Promote to production" PR**
-  (`develop`→`main`), reconciles changelog conflicts by merging `main` into the
-  head branch, waits for green CI, and merges with a merge commit.
-  `/deploy-staging` documents that `staging` is a disposable env branch safely
-  recreatable from `develop`.
+  (`staging`→`main`), reconciles changelog conflicts by merging `main` into
+  `staging`, waits for green CI, and merges with a merge commit. `/deploy-staging`
+  syncs the long-running `staging` branch to `develop`.
+- Protected the `staging` branch (`allow_deletions: false`, force-push still
+  allowed) so the repo-wide `delete_branch_on_merge: true` no longer
+  auto-deletes it when a `staging`→`main` promotion PR is merged. `staging` is a
+  long-running branch bound to the Railway staging environment and must persist.
 
 ### Security
 - Hardened a batch of security findings from a repo-wide scan (bandit + manual


### PR DESCRIPTION
## Summary

Rewrites the stale `/deploy-staging` and `/deploy-prod` slash-command skills to match the **actual** `develop` → `staging` → `main` promotion workflow (Railway development → staging → production), and **protects the `staging` branch from deletion**.

### Why
The old skills were unsafe/inaccurate:
- `/deploy-prod` did `git checkout main && git reset --hard origin/staging && git push --force-with-lease`. But `main` carries its own "Promote to production: …" commits that don't exist on `staging`/`develop`. A reset + force-push would **rewrite production history and discard those promotion commits** — a destructive op on the real-capital production branch (forbidden by `CLAUDE.md`).
- Both skills assumed a clean linear topology and a `staging` branch that wasn't reliably present.

### What changed
- **`.claude/commands/deploy-prod.md`** — promote **`staging`→`main`** via an additive **"Promote to production" PR**: open PR (base `main`, head `staging`), reconcile changelog conflicts by merging `main` into `staging` (never reset `main`), wait for green CI, merge with a **merge commit**. Adds post-deploy verification (`main..staging` empty, `staging` still exists, Railway `/health`, liveness watch).
- **`.claude/commands/deploy-staging.md`** — sync the **long-running, protected** `staging` branch to `develop`; documents that `staging` must never be deleted and to STOP rather than silently recreate it if missing.
- **`docs/changelog.md`** — entries for both.

### Branch protection applied (outside this diff)
Set a protection rule on `staging`: `allow_deletions: false`, `allow_force_pushes: true`, no required reviews/checks. This makes the repo-wide `delete_branch_on_merge: true` **skip `staging`**, so merging a `staging`→`main` promotion PR no longer auto-deletes it. (This was the root cause of `staging` disappearing after the #647 promotion — its head branch was `staging` and auto-delete removed it.)

## Testing
- Docs/skill-only change + a repo settings change; no code paths affected.
- Verified `staging` protection read-back: `{allow_deletions: false, allow_force_pushes: true}` and `staging` present on remote.

https://claude.ai/code/session_01Sr9swFuoeY9CdzSysrtFGj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr9swFuoeY9CdzSysrtFGj)_