### PR TITLE
Promote to production: ThreadedWebsocketManager own event loop (#650)

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -9,6 +9,7 @@ providing a single interface for all Binance operations including:
 - Position management
 """
 
+import asyncio
 import logging
 import math
 import re
@@ -290,6 +291,9 @@ class BinanceProvider(DataProvider, ExchangeInterface):
 
         # WebSocket stream state (initialized regardless of credentials)
         self._twm: ThreadedWebsocketManager | None = None
+        # Each TWM owns a private event loop (created in _ensure_twm); closed in
+        # stop_streams so its selector/self-pipe FDs aren't leaked (CODE.md §241).
+        self._twm_loop: asyncio.AbstractEventLoop | None = None
         self._twm_lock = threading.Lock()  # Guards _ensure_twm() check-then-set
         self._kline_ws_state = WebSocketState.DISCONNECTED
         self._user_ws_state = WebSocketState.DISCONNECTED
@@ -1934,6 +1938,18 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             api_endpoint = get_binance_api_endpoint()
             if api_endpoint == "binanceus":
                 twm_kwargs["tld"] = "us"
+            # Each ThreadedWebsocketManager must own a DISTINCT event loop. The engine
+            # runs the kline and user/margin streams on two separate BinanceProvider
+            # instances; python-binance's ThreadedApiManager captures the *current* loop
+            # at construction time, so without an explicit loop both managers would grab
+            # the same (main-thread) loop. Whichever stream starts second then calls
+            # run_until_complete() on the already-running loop and dies with
+            # "This event loop is already running" — which is why the margin user-stream
+            # stopped starting after nest_asyncio was removed (#646). A fresh per-manager
+            # loop has no run_until_complete nesting, so it does NOT reintroduce the
+            # "cannot enter context" re-entrancy spam that #646 fixed.
+            self._twm_loop = asyncio.new_event_loop()
+            twm_kwargs["loop"] = self._twm_loop
             self._twm = ThreadedWebsocketManager(**twm_kwargs)
             self._twm.start()
 
@@ -2025,8 +2041,19 @@ class BinanceProvider(DataProvider, ExchangeInterface):
     def stop_streams(self) -> None:
         """Stop all WebSocket streams. Recreates TWM on reconnect."""
         if self._twm:
-            self._twm.stop()
+            twm, loop = self._twm, self._twm_loop
+            twm.stop()
+            # The TWM runs its loop on its own thread; wait for that thread to leave
+            # run_until_complete before closing the loop, so we neither close a running
+            # loop nor leak its selector/self-pipe FDs (CODE.md §241).
+            twm.join(timeout=5)
+            if loop is not None and not loop.is_closed() and not loop.is_running():
+                try:
+                    loop.close()
+                except Exception as e:
+                    logger.debug("Could not close TWM event loop on stop: %s", e)
             self._twm = None
+            self._twm_loop = None
             self._kline_socket_key = None
             self._user_socket_key = None
             self._kline_ws_state = WebSocketState.DISCONNECTED

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -40,6 +40,63 @@ def test_binance_provider_does_not_apply_nest_asyncio():
 
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.get_binance_api_endpoint", return_value="binance")
+@patch("src.data_providers.binance_provider.ThreadedWebsocketManager")
+@patch("src.data_providers.binance_provider.Client")
+@patch("src.data_providers.binance_provider.get_config")
+def test_each_twm_gets_its_own_event_loop(mock_config, mock_client, mock_twm, mock_endpoint):
+    """Two providers (kline + user streams) must not share an event loop.
+
+    python-binance's ThreadedApiManager captures the current loop at construction.
+    Two TWMs sharing the main-thread loop make the second stream's
+    run_until_complete() raise 'This event loop is already running' — which stopped
+    the margin user-stream from starting after nest_asyncio was removed (#646). Each
+    TWM must therefore receive a distinct, freshly-created loop, with no nest_asyncio.
+    """
+    import asyncio
+
+    mock_config_obj = Mock()
+    mock_config_obj.get_required.return_value = "fake_key"
+    mock_config.return_value = mock_config_obj
+
+    loops = []
+    try:
+        for _ in range(2):
+            BinanceProvider()._ensure_twm()
+        assert mock_twm.call_count == 2
+        loops = [call.kwargs["loop"] for call in mock_twm.call_args_list]
+        assert all(isinstance(loop, asyncio.AbstractEventLoop) for loop in loops)
+        assert loops[0] is not loops[1]  # distinct loops — not the shared main-thread loop
+        assert getattr(asyncio, "_nest_patched", False) is False  # no nest_asyncio
+    finally:
+        for loop in loops:
+            loop.close()
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.Client")
+@patch("src.data_providers.binance_provider.get_config")
+def test_stop_streams_closes_twm_event_loop(mock_config, mock_client):
+    """stop_streams() must close the per-TWM event loop so its FDs aren't leaked."""
+    import asyncio
+
+    mock_config_obj = Mock()
+    mock_config_obj.get_required.return_value = "fake_key"
+    mock_config.return_value = mock_config_obj
+
+    provider = BinanceProvider()
+    loop = asyncio.new_event_loop()
+    provider._twm = Mock()
+    provider._twm_loop = loop
+
+    provider.stop_streams()
+
+    assert loop.is_closed()
+    assert provider._twm is None
+    assert provider._twm_loop is None
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
 class TestBinanceDataProvider:
     @pytest.mark.data_provider
     def test_binance_provider_initialization(self):


### PR DESCRIPTION
Surgical promote of **#650** only (`develop` → `main`), per the per-fix promote pattern. Patch-id-verified the `main↔develop` diff for the two touched files equals the #650 squash exactly — no unrelated develop work rides along.

## What ships
`src/data_providers/binance_provider.py` (+ its test): each `ThreadedWebsocketManager` is constructed with its own `asyncio.new_event_loop()` (closed in `stop_streams`).

## Why
After nest_asyncio was removed (#646), the margin **user-data stream failed to start** at boot — `RuntimeError: This event loop is already running` — because the kline and user streams (two separate providers) both captured the same main-thread loop and the second `run_until_complete` collided. The bot fell back to REST polling. This restores real-time user-stream events.

## Safety
- **Does not** reintroduce the `cannot enter context` spam #646 fixed (fresh per-manager loop, no `run_until_complete` nesting, no monkey-patch — strictly less loop-sharing).
- Kline feed unaffected (was already the survivor of the collision).
- Reviewed by architecture-reviewer: **APPROVE**; its loop-leak P2 is fixed (loop closed on `stop_streams`).

## Post-deploy verification
Confirm in prod: `event loop is already running` / `Failed to start user data stream` gone, `cannot enter context` stays **0**, kline feed active, bot trading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)