### PR TITLE
fix(live): coerce Decimal to float in stop-loss placement

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -1637,6 +1637,18 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             logger.warning("Binance not available - cannot place stop-loss order")
             return None
 
+        # Callers may pass Decimal values (SQLAlchemy Numeric columns from a DB-loaded
+        # position); coerce to float so the price/lot arithmetic below never raises
+        # "unsupported operand type(s) for *: 'decimal.Decimal' and 'float'".
+        try:
+            stop_price = float(stop_price)
+            quantity = float(quantity)
+            if limit_price is not None:
+                limit_price = float(limit_price)
+        except (TypeError, ValueError) as e:
+            logger.error("Invalid numeric input to stop-loss order for %s: %s", symbol, e)
+            return None
+
         # Validate stop_price is positive and finite
         if not (stop_price > 0 and math.isfinite(stop_price)):
             logger.error("Invalid stop_price: %s", stop_price)

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1165,12 +1165,14 @@ class PositionReconciler:
                     side = getattr(position, "side", "long")
                     side_is_long = side == PositionSide.LONG or str(side).lower() == "long"
                     sl_side = OrderSide.SELL if side_is_long else OrderSide.BUY
-                    # Scale quantity by remaining size after partial exits
-                    qty = getattr(position, "quantity", 0) or 0.0
+                    # Scale quantity by remaining size after partial exits. Coerce to
+                    # float — DB-loaded positions carry Decimal (Numeric) fields, and
+                    # mixing Decimal with float raises "unsupported operand type(s)".
+                    qty = float(getattr(position, "quantity", 0) or 0.0)
                     current = getattr(position, "current_size", None)
                     original = getattr(position, "original_size", None)
-                    if current is not None and original is not None and original > 0:
-                        qty = qty * (current / original)
+                    if current is not None and original is not None and float(original) > 0:
+                        qty = qty * (float(current) / float(original))
                     new_sl_id = self.exchange.place_stop_loss_order(
                         symbol=position.symbol,
                         side=sl_side,

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -601,6 +601,41 @@ class TestPlaceStopLossOrder:
 
     @patch("src.data_providers.binance_provider.Client")
     @patch("src.data_providers.binance_provider.get_config")
+    def test_stop_loss_accepts_decimal_inputs(self, mock_config, mock_client_class):
+        """Decimal stop_price/quantity (DB Numeric columns) must not raise Decimal*float.
+
+        A DB-loaded position carries Decimal fields; without coercion the limit-price
+        and lot arithmetic raised 'unsupported operand type(s) for *' and left the
+        position unprotected (periodic reconciler).
+        """
+        from decimal import Decimal
+
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "sl7"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(
+            return_value={"step_size": 0.0001, "tick_size": 0.01, "base_asset": "ETH"}
+        )
+        provider.get_balance = Mock(return_value=Mock(free=1.0))
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT",
+            side=OrderSide.SELL,
+            quantity=Decimal("0.005"),
+            stop_price=Decimal("1900.0"),
+        )
+
+        assert result == "sl7"
+        sent_qty = mock_client.create_order.call_args.kwargs["quantity"]
+        assert isinstance(sent_qty, float)
+        assert sent_qty == pytest.approx(0.005, abs=1e-9)
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
     def test_auto_limit_price_calculation_sell(self, mock_config, mock_client_class):
         """Verify limit price is calculated below stop for sell orders."""
         # Arrange


### PR DESCRIPTION
## Problem (production, found during monitoring)

After a restart adopted DB-loaded positions, the periodic reconciler failed every ~2 min:
```
Exception placing missing stop-loss for ETHUSDT: unsupported operand type(s) for *: 'decimal.Decimal' and 'float' — position is unprotected
```
A DB-loaded position carries SQLAlchemy `Numeric` → **Decimal** fields (`quantity`, `stop_loss`, `current_size`, `original_size`). The SL path does float arithmetic (`stop_price * (1 - SLIPPAGE)`, lot rounding, `qty * (current/original)`), and mixing `Decimal` with `float` raises a `TypeError` → **the position never gets a protective stop**.

Latent/pre-existing (not the #648 SL-sizing fix); it only surfaces when a position is loaded from the DB rather than created in-session as floats.

## Fix (coerce to float at the boundary)
- `place_stop_loss_order` (`binance_provider.py`): coerce `stop_price`/`quantity`/`limit_price` to `float` on entry (guarded; returns `None` on bad input). Protects the limit-price calc, tick/lot rounding, and the free-balance cap for **all** callers.
- `reconcile_position` (`reconciliation.py`): coerce `quantity`/`current_size`/`original_size` to `float` in the qty-scaling computed before the call.

## Testing
- New `test_stop_loss_accepts_decimal_inputs`: `Decimal` stop_price+quantity → order placed, quantity sent is a `float`. `TestPlaceStopLossOrder` = **16 passed**.
- `tests/unit/live/test_reconciliation.py` + `tests/unit/data_providers/` = **247 passed** (no regression). No new ruff.

## Post-deploy verification
Confirm the `unsupported operand type(s)` exception stops, and the real ETHUSDT position gets a `Stop-loss order placed` (capped at free balance via #648).

🤖 Generated with [Claude Code](https://claude.com/claude-code)