### PR TITLE
feat(live): reconcile margin balance against true exchange equity (prevention layer 2)

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -1004,6 +1004,31 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             logger.error(f"Failed to get account info: {e}")
             return {}
 
+    def get_account_equity(self) -> float | None:
+        """True account equity in USDT, net of liabilities.
+
+        Margin: account-level ``totalNetAssetOfBtc`` valued in USDT — the
+        authoritative cross-margin equity (assets minus borrowed liabilities).
+        Unlike free USDT alone, it reflects realized losses and open shorts, so
+        the bot can reconcile its tracked balance against reality. Spot: total
+        USDT balance. Returns None if unavailable.
+        """
+        if not BINANCE_AVAILABLE or not self._client:
+            return None
+        try:
+            if self._use_margin:
+                acc = self._client.get_margin_account()
+                net_btc = float(acc.get("totalNetAssetOfBtc", 0) or 0)
+                if net_btc <= 0:
+                    return 0.0
+                btc_price = float(self._client.get_symbol_ticker(symbol="BTCUSDT")["price"])
+                return net_btc * btc_price
+            bal = self.get_balance("USDT")
+            return float(bal.total) if bal is not None else None
+        except Exception as e:
+            logger.warning("Could not read account equity: %s", e)
+            return None
+
     def get_balances(self) -> list[AccountBalance]:
         """Get all account balances"""
         if not BINANCE_AVAILABLE or not self._client:

--- a/src/data_providers/exchange_interface.py
+++ b/src/data_providers/exchange_interface.py
@@ -163,6 +163,17 @@ class ExchangeInterface(ABC):
         """Get balance for a specific asset"""
         pass
 
+    def get_account_equity(self) -> float | None:
+        """True account equity in the quote currency (USDT), net of liabilities.
+
+        Default ``None`` when the exchange can't report it. Margin implementations
+        should return account-level net equity (assets minus borrowed liabilities,
+        e.g. ``totalNetAssetOfBtc`` valued in USDT) so callers can reconcile a
+        tracked balance against reality. Not abstract — implementers may rely on
+        the default.
+        """
+        return None
+
     @abstractmethod
     def get_positions(self, symbol: str | None = None) -> list[Position]:
         """Get open positions (for futures/margin trading)"""

--- a/src/engines/live/account_sync.py
+++ b/src/engines/live/account_sync.py
@@ -180,10 +180,13 @@ class AccountSynchronizer:
         silently, and the bot then over-sized on a phantom balance. Here we use
         the exchange's account-level net equity (``get_account_equity``).
 
-        Only *corrected* while FLAT: total equity equals cash only when no open
-        position value is held; with a position open, equity includes the
-        position's value (tracked separately), so equating it to current_balance
-        would double-count. A material divergence is always logged.
+        Only *corrected* while FLAT — and flatness is checked against the
+        EXCHANGE, not the DB: net equity equals USDT cash only when no base-asset
+        position (long) or borrowed liability (short) is held, so comparing
+        equity to the live USDT balance detects an open — or not-yet-reconciled —
+        position regardless of DB state. This prevents a phantom/unpersisted
+        position's market value from leaking into cash (which would over-size).
+        A material divergence is always logged.
         """
         try:
             equity = self.exchange.get_account_equity()
@@ -199,26 +202,37 @@ class AccountSynchronizer:
             if current_db_balance > 0
             else 0.0
         )
+
+        # Flat iff net equity matches USDT cash (no position value or liability).
+        usdt_bal = self.exchange.get_balance("USDT")
+        usdt_total = (
+            float(usdt_bal.total)
+            if usdt_bal is not None and usdt_bal.total is not None
+            else None
+        )
+        flat_tolerance = max(1.0, equity * 0.01)
+        if usdt_total is None or abs(equity - usdt_total) > flat_tolerance:
+            # A position is held (equity diverges from USDT cash) — correcting
+            # would fold position value into cash. Surface divergence, defer.
+            if diff_pct > DEFAULT_BALANCE_DISCREPANCY_THRESHOLD_PCT:
+                logger.warning(
+                    "Margin equity divergence: tracked $%.2f vs true equity $%.2f "
+                    "(%.2f%%), but a position is held (equity $%.2f vs USDT $%s) — "
+                    "deferring correction until flat",
+                    current_db_balance,
+                    equity,
+                    diff_pct,
+                    equity,
+                    usdt_total,
+                )
+            return {"synced": False, "reason": "position held"}
+
         if diff_pct <= DEFAULT_BALANCE_DISCREPANCY_THRESHOLD_PCT:
             return {"synced": True, "corrected": False, "balance": current_db_balance}
 
-        open_positions = self.db_manager.get_active_positions(self.session_id)
-        if open_positions:
-            # Can't safely correct while a position is open (equity includes the
-            # position's value), but surface the divergence loudly.
-            logger.warning(
-                "Margin equity divergence: tracked $%.2f vs true equity $%.2f "
-                "(%.2f%%) with %d open position(s) — not correcting until flat",
-                current_db_balance,
-                equity,
-                diff_pct,
-                len(open_positions),
-            )
-            return {"synced": False, "reason": "positions open", "diff_pct": diff_pct}
-
         logger.warning(
             "Margin equity reconcile: tracked balance $%.2f vs true equity $%.2f "
-            "(%.2f%%) — correcting to true equity",
+            "(%.2f%%) — account is flat (all-USDT), correcting to true equity",
             current_db_balance,
             equity,
             diff_pct,

--- a/src/engines/live/account_sync.py
+++ b/src/engines/live/account_sync.py
@@ -132,12 +132,11 @@ class AccountSynchronizer:
                     exchange_data.get("positions", [])
                 )
             else:
-                balance_sync_result = {"synced": False, "reason": "skipped in margin mode"}
+                # Margin: reconcile the tracked balance against true net equity
+                # (assets minus liabilities), not USDT alone. Position sync stays
+                # skipped; only the balance safety-net is added here.
+                balance_sync_result = self._sync_margin_equity()
                 position_sync_result = {"synced": False, "reason": "skipped in margin mode"}
-                logger.info(
-                    "Skipping balance/position sync in margin mode — "
-                    "USDT netAsset excludes cross-asset liabilities"
-                )
 
             # Sync orders
             order_sync_result = self._sync_orders(exchange_data.get("open_orders", []))
@@ -170,6 +169,69 @@ class AccountSynchronizer:
                 data={},
                 timestamp=datetime.now(UTC),
             )
+
+    def _sync_margin_equity(self) -> dict[str, Any]:
+        """Reconcile the tracked balance against true cross-margin equity.
+
+        Margin USDT alone overstates equity (sale proceeds inflate USDT while a
+        borrowed-asset liability sits on a separate asset row), so the bot
+        historically skipped balance sync in margin mode. That let realized
+        losses which were never booked to the tracked balance accumulate
+        silently, and the bot then over-sized on a phantom balance. Here we use
+        the exchange's account-level net equity (``get_account_equity``).
+
+        Only *corrected* while FLAT: total equity equals cash only when no open
+        position value is held; with a position open, equity includes the
+        position's value (tracked separately), so equating it to current_balance
+        would double-count. A material divergence is always logged.
+        """
+        try:
+            equity = self.exchange.get_account_equity()
+        except Exception as e:
+            logger.warning("Margin equity read failed: %s", e)
+            return {"synced": False, "reason": f"equity unavailable: {e}"}
+        if equity is None or equity <= 0:
+            return {"synced": False, "reason": "equity unavailable"}
+
+        current_db_balance = self.db_manager.get_current_balance(self.session_id)
+        diff_pct = (
+            abs(equity - current_db_balance) / current_db_balance * 100
+            if current_db_balance > 0
+            else 0.0
+        )
+        if diff_pct <= DEFAULT_BALANCE_DISCREPANCY_THRESHOLD_PCT:
+            return {"synced": True, "corrected": False, "balance": current_db_balance}
+
+        open_positions = self.db_manager.get_active_positions(self.session_id)
+        if open_positions:
+            # Can't safely correct while a position is open (equity includes the
+            # position's value), but surface the divergence loudly.
+            logger.warning(
+                "Margin equity divergence: tracked $%.2f vs true equity $%.2f "
+                "(%.2f%%) with %d open position(s) — not correcting until flat",
+                current_db_balance,
+                equity,
+                diff_pct,
+                len(open_positions),
+            )
+            return {"synced": False, "reason": "positions open", "diff_pct": diff_pct}
+
+        logger.warning(
+            "Margin equity reconcile: tracked balance $%.2f vs true equity $%.2f "
+            "(%.2f%%) — correcting to true equity",
+            current_db_balance,
+            equity,
+            diff_pct,
+        )
+        self.db_manager.update_balance(
+            equity, "margin_equity_sync_correction", "system", self.session_id
+        )
+        return {
+            "synced": True,
+            "corrected": True,
+            "old_balance": current_db_balance,
+            "new_balance": equity,
+        }
 
     def _sync_balances(self, exchange_balances: list[AccountBalance]) -> dict[str, Any]:
         """Synchronize account balances"""

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2214,6 +2214,21 @@ class LiveTradingEngine:
                             )
                             if sync_result.success:
                                 logger.debug("Periodic account sync completed")
+                                # Apply any balance correction to the in-memory balance
+                                # that drives sizing (the DB is already updated inside the
+                                # sync). Without this a mid-session margin-equity
+                                # correction would not reach live sizing until restart.
+                                balance_sync = sync_result.data.get("balance_sync", {})
+                                if balance_sync.get("corrected", False):
+                                    corrected = balance_sync.get("new_balance")
+                                    if corrected is not None:
+                                        with self._balance_lock:
+                                            self.current_balance = corrected
+                                        logger.info(
+                                            "💰 Balance corrected mid-session from "
+                                            "exchange: $%.2f",
+                                            corrected,
+                                        )
                             else:
                                 logger.warning(
                                     "Periodic account sync failed: %s",

--- a/tests/unit/engines/live/test_account_sync_margin.py
+++ b/tests/unit/engines/live/test_account_sync_margin.py
@@ -1,0 +1,104 @@
+"""Unit tests for margin balance reconciliation (prevention layer 2).
+
+Margin mode used to skip balance sync entirely, so realized losses that were
+never booked to the tracked balance drifted from true equity unnoticed (a ~15%
+gap was observed in production). These cover the reconcile that uses the
+exchange's account-level net equity (`get_account_equity`) and only corrects
+while flat.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.engines.live.account_sync import AccountSynchronizer
+
+pytestmark = pytest.mark.unit
+
+
+@patch("src.data_providers.binance_provider.Client")
+@patch("src.data_providers.binance_provider.get_config")
+def test_get_account_equity_margin_uses_total_net_asset(mock_config, mock_client_class):
+    """Margin equity = totalNetAssetOfBtc (net of liabilities) valued in USDT."""
+    from src.data_providers.binance_provider import BinanceProvider
+
+    mock_config.return_value = Mock(get_required=Mock(return_value="fake_key"))
+    mock_client = Mock()
+    mock_client_class.return_value = mock_client
+    mock_client.get_margin_account.return_value = {"totalNetAssetOfBtc": "0.00125"}
+    mock_client.get_symbol_ticker.return_value = {"price": "67000.0"}
+
+    provider = BinanceProvider()
+    provider._use_margin = True
+
+    assert provider.get_account_equity() == pytest.approx(0.00125 * 67000.0)
+
+
+@patch("src.data_providers.binance_provider.Client")
+@patch("src.data_providers.binance_provider.get_config")
+def test_get_account_equity_spot_uses_usdt_total(mock_config, mock_client_class):
+    from src.data_providers.binance_provider import BinanceProvider
+
+    mock_config.return_value = Mock(get_required=Mock(return_value="fake_key"))
+    mock_client_class.return_value = Mock()
+
+    provider = BinanceProvider()
+    provider._use_margin = False
+    provider.get_balance = Mock(return_value=Mock(total=84.5))
+
+    assert provider.get_account_equity() == pytest.approx(84.5)
+
+
+def _make_sync(equity, db_balance, open_positions):
+    exchange = Mock()
+    exchange.get_account_equity.return_value = equity
+    db = Mock()
+    db.get_current_balance.return_value = db_balance
+    db.get_active_positions.return_value = open_positions
+    sync = AccountSynchronizer(
+        exchange=exchange, db_manager=db, session_id=1, use_margin=True
+    )
+    return sync, db
+
+
+def test_margin_equity_corrects_when_flat_and_divergent():
+    """Flat + >1% divergence -> correct tracked balance down to true equity."""
+    sync, db = _make_sync(equity=84.22, db_balance=99.89, open_positions=[])
+
+    res = sync._sync_margin_equity()
+
+    assert res["corrected"] is True
+    assert res["new_balance"] == pytest.approx(84.22)
+    assert res["old_balance"] == pytest.approx(99.89)
+    db.update_balance.assert_called_once()
+
+
+def test_margin_equity_no_correct_within_threshold():
+    """Divergence under the 1% threshold -> no correction."""
+    sync, db = _make_sync(equity=99.50, db_balance=99.89, open_positions=[])
+
+    res = sync._sync_margin_equity()
+
+    assert res["corrected"] is False
+    db.update_balance.assert_not_called()
+
+
+def test_margin_equity_no_correct_when_positions_open():
+    """Divergent but a position is open -> warn, do NOT correct (avoids double-count)."""
+    sync, db = _make_sync(equity=84.22, db_balance=99.89, open_positions=[{"id": 1}])
+
+    res = sync._sync_margin_equity()
+
+    assert res.get("corrected") is not True
+    assert res["reason"] == "positions open"
+    db.update_balance.assert_not_called()
+
+
+def test_margin_equity_no_sync_when_equity_unavailable():
+    """Equity unreadable -> no sync, no correction (fail safe)."""
+    sync, db = _make_sync(equity=None, db_balance=99.89, open_positions=[])
+
+    res = sync._sync_margin_equity()
+
+    assert res["synced"] is False
+    db.update_balance.assert_not_called()

--- a/tests/unit/engines/live/test_account_sync_margin.py
+++ b/tests/unit/engines/live/test_account_sync_margin.py
@@ -49,12 +49,14 @@ def test_get_account_equity_spot_uses_usdt_total(mock_config, mock_client_class)
     assert provider.get_account_equity() == pytest.approx(84.5)
 
 
-def _make_sync(equity, db_balance, open_positions):
+def _make_sync(equity, db_balance, usdt_total):
     exchange = Mock()
     exchange.get_account_equity.return_value = equity
+    exchange.get_balance.return_value = (
+        Mock(total=usdt_total) if usdt_total is not None else None
+    )
     db = Mock()
     db.get_current_balance.return_value = db_balance
-    db.get_active_positions.return_value = open_positions
     sync = AccountSynchronizer(
         exchange=exchange, db_manager=db, session_id=1, use_margin=True
     )
@@ -62,8 +64,8 @@ def _make_sync(equity, db_balance, open_positions):
 
 
 def test_margin_equity_corrects_when_flat_and_divergent():
-    """Flat + >1% divergence -> correct tracked balance down to true equity."""
-    sync, db = _make_sync(equity=84.22, db_balance=99.89, open_positions=[])
+    """Flat (equity == USDT cash) + >1% divergence -> correct down to true equity."""
+    sync, db = _make_sync(equity=84.22, db_balance=99.89, usdt_total=84.22)
 
     res = sync._sync_margin_equity()
 
@@ -74,8 +76,8 @@ def test_margin_equity_corrects_when_flat_and_divergent():
 
 
 def test_margin_equity_no_correct_within_threshold():
-    """Divergence under the 1% threshold -> no correction."""
-    sync, db = _make_sync(equity=99.50, db_balance=99.89, open_positions=[])
+    """Flat but divergence under the 1% threshold -> no correction."""
+    sync, db = _make_sync(equity=99.50, db_balance=99.89, usdt_total=99.50)
 
     res = sync._sync_margin_equity()
 
@@ -83,20 +85,33 @@ def test_margin_equity_no_correct_within_threshold():
     db.update_balance.assert_not_called()
 
 
-def test_margin_equity_no_correct_when_positions_open():
-    """Divergent but a position is open -> warn, do NOT correct (avoids double-count)."""
-    sync, db = _make_sync(equity=84.22, db_balance=99.89, open_positions=[{"id": 1}])
+def test_margin_equity_no_correct_when_position_held():
+    """Divergent AND a position is held (equity != USDT) -> warn, do NOT correct.
+
+    Guards against an open/unreconciled position folding its value into cash.
+    """
+    sync, db = _make_sync(equity=84.22, db_balance=99.89, usdt_total=65.41)
 
     res = sync._sync_margin_equity()
 
     assert res.get("corrected") is not True
-    assert res["reason"] == "positions open"
+    assert res["reason"] == "position held"
     db.update_balance.assert_not_called()
 
 
 def test_margin_equity_no_sync_when_equity_unavailable():
     """Equity unreadable -> no sync, no correction (fail safe)."""
-    sync, db = _make_sync(equity=None, db_balance=99.89, open_positions=[])
+    sync, db = _make_sync(equity=None, db_balance=99.89, usdt_total=99.89)
+
+    res = sync._sync_margin_equity()
+
+    assert res["synced"] is False
+    db.update_balance.assert_not_called()
+
+
+def test_margin_equity_no_correct_when_equity_zero_or_negative():
+    """Non-positive equity is treated as unavailable -> no correction."""
+    sync, db = _make_sync(equity=0.0, db_balance=99.89, usdt_total=99.89)
 
     res = sync._sync_margin_equity()
 

--- a/tests/unit/engines/live/test_margin_side_effect.py
+++ b/tests/unit/engines/live/test_margin_side_effect.py
@@ -175,11 +175,11 @@ def test_account_sync_reconciles_balance_skips_position_in_margin_mode():
         "positions": [],
         "open_orders": [],
     }
-    # True equity equals tracked balance -> reconcile runs but makes no correction.
+    # Equity == tracked balance == USDT cash (flat) -> reconcile runs, no correction.
     mock_exchange.get_account_equity.return_value = 100.0
+    mock_exchange.get_balance.return_value = MagicMock(total=100.0)
     mock_db = MagicMock()
     mock_db.get_current_balance.return_value = 100.0
-    mock_db.get_active_positions.return_value = []
 
     syncer = AccountSynchronizer(
         exchange=mock_exchange,

--- a/tests/unit/engines/live/test_margin_side_effect.py
+++ b/tests/unit/engines/live/test_margin_side_effect.py
@@ -162,11 +162,9 @@ def test_trading_engine_stop_loss_auto_repay():
 
 
 @pytest.mark.fast
-def test_account_sync_skips_balance_and_position_in_margin_mode():
-    """AccountSynchronizer skips both balance and position sync in margin mode.
-
-    USDT netAsset excludes cross-asset liabilities (borrowed ETH from shorts),
-    so syncing USDT alone would inflate capital and oversize the next trade.
+def test_account_sync_reconciles_balance_skips_position_in_margin_mode():
+    """In margin mode, balance is reconciled against true equity (prevention
+    layer 2); position sync stays skipped (USDT netAsset excludes liabilities).
     """
     from src.engines.live.account_sync import AccountSynchronizer
 
@@ -177,7 +175,11 @@ def test_account_sync_skips_balance_and_position_in_margin_mode():
         "positions": [],
         "open_orders": [],
     }
+    # True equity equals tracked balance -> reconcile runs but makes no correction.
+    mock_exchange.get_account_equity.return_value = 100.0
     mock_db = MagicMock()
+    mock_db.get_current_balance.return_value = 100.0
+    mock_db.get_active_positions.return_value = []
 
     syncer = AccountSynchronizer(
         exchange=mock_exchange,
@@ -189,8 +191,10 @@ def test_account_sync_skips_balance_and_position_in_margin_mode():
     result = syncer.sync_account_data(force=True)
 
     assert result.success is True
-    assert result.data["balance_sync"]["synced"] is False
-    assert "margin" in result.data["balance_sync"]["reason"]
+    # Balance is now reconciled (not skipped) in margin mode.
+    assert result.data["balance_sync"]["synced"] is True
+    assert result.data["balance_sync"]["corrected"] is False
+    # Position sync remains skipped in margin mode.
     assert result.data["position_sync"]["synced"] is False
     assert "margin" in result.data["position_sync"]["reason"]
 


### PR DESCRIPTION
## Problem (the $15 silent drain)

In production the bot's tracked balance read **\$99.89** while true equity was **\$84.47** — a ~15% gap. Root cause: margin mode **skips balance sync entirely** (USDT alone overstates equity: sale proceeds inflate USDT while a borrowed-asset liability sits on a separate row). So realized losses from the SL-failure → emergency-close cascade that were never booked to the tracked balance drifted from reality **unnoticed**, and the bot over-sized on a phantom balance.

The existing skip even documents the fix: *"Proper margin equity requires account-level `totalNetAssetOfBtc`, which is a future enhancement."* This implements it.

## Change
- **`get_account_equity()`** on `ExchangeInterface` (default `None`) + `BinanceProvider` (margin: `totalNetAssetOfBtc` × BTC price, net of liabilities; spot: USDT total).
- **`_sync_margin_equity()`** in `account_sync`: reconcile tracked balance vs true equity; correct (via existing `update_balance` + engine's `balance_sync.corrected` path) only while **FLAT** — equity == cash only with no open-position value, else it double-counts. Material divergence (>1%) is **always logged**. Position sync stays skipped.

This is layer 2 of the prevention series (root causes #648 cap, #653 Decimal coerce already shipped). It also **self-corrects the current \$99.89 → ~\$84 on the next restart** while flat.

## Testing
- 6 new unit tests (`test_account_sync_margin.py`): equity calc (margin/spot); reconcile corrects when flat+divergent, no-op within 1%, refuses while positions open, fails safe when equity unavailable.
- Updated `test_account_sync_*_margin_mode` to the new behavior. `data_providers/` + `engines/live/` units: **215 passed**.

## Post-deploy verification
Watch for `Margin equity reconcile: tracked balance \$99.89 vs true equity \$84… — correcting`, and confirm sizing uses the corrected balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)