### PR TITLE
fix(db): coerce position and trade numeric fields to float at source

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Live position/trade recovery no longer crashes on `Decimal`-vs-`float`
+  arithmetic. `DatabaseManager.get_active_positions` and `get_recent_trades`
+  now coerce SQLAlchemy `Numeric(18,8)` columns (which read back from
+  PostgreSQL as `Decimal`) to `float` at the source — `float()` for
+  non-nullable columns, `_to_optional_float()` for nullable ones — mirroring
+  the existing `orders_data` block and `LivePositionTracker.recover_positions`.
+  Previously these raw `Decimal`s flowed through `_recover_active_positions`
+  into recovered `Position` objects and raised `unsupported operand type(s)
+  for *: 'decimal.Decimal' and 'float'` in reconciliation's default
+  stop-loss branches (`entry_price * (1.0 ± DEFAULT_STOP_LOSS_PCT)`), which
+  run *before* the `place_stop_loss_order` boundary that PR #653 had patched.
+  Also keeps dashboard consumers JSON-serializable (`json.dumps` raises on
+  `Decimal`).
 - Backtest-live engine parity: closed nine silent divergences. Backtest now
   propagates `TimeExitPolicy`-specific exit reasons (`"Max holding period"`,
   `"Weekend flat"`, etc.) instead of hardcoding `"Time limit"`; gained an

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -1581,35 +1581,47 @@ class DatabaseManager:
                         "id": p.id,
                         "symbol": p.symbol,
                         "side": p.side.value,
-                        "entry_price": p.entry_price,
-                        "current_price": p.current_price,
-                        "size": p.size,
-                        "quantity": p.quantity,
+                        # Numeric(18, 8) columns read back as Decimal. Coerce to float
+                        # at the source (mirroring orders_data above and
+                        # LivePositionTracker.recover_positions) so recovered Position
+                        # objects never mix Decimal with the float constants used in
+                        # downstream arithmetic (e.g. reconciliation's default stop-loss
+                        # branches: entry_price * (1.0 ± DEFAULT_STOP_LOSS_PCT)).
+                        "entry_price": float(p.entry_price),
+                        "current_price": self._to_optional_float(p.current_price),
+                        "size": float(p.size),
+                        "quantity": self._to_optional_float(p.quantity),
                         "entry_balance": self._to_optional_float(getattr(p, "entry_balance", None)),
-                        "unrealized_pnl": p.unrealized_pnl,
-                        "unrealized_pnl_percent": p.unrealized_pnl_percent,
-                        "stop_loss": p.stop_loss,
-                        "take_profit": p.take_profit,
+                        "unrealized_pnl": self._to_optional_float(p.unrealized_pnl, 0.0),
+                        "unrealized_pnl_percent": self._to_optional_float(
+                            p.unrealized_pnl_percent, 0.0
+                        ),
+                        "stop_loss": self._to_optional_float(p.stop_loss),
+                        "take_profit": self._to_optional_float(p.take_profit),
                         "entry_time": p.entry_time,
                         "strategy": p.strategy_name,
                         "trailing_stop_activated": getattr(p, "trailing_stop_activated", False),
-                        "trailing_stop_price": getattr(p, "trailing_stop_price", None),
+                        "trailing_stop_price": self._to_optional_float(
+                            getattr(p, "trailing_stop_price", None)
+                        ),
                         "breakeven_triggered": getattr(p, "breakeven_triggered", False),
-                        "mfe": p.mfe,
-                        "mae": p.mae,
-                        "mfe_price": p.mfe_price,
-                        "mae_price": p.mae_price,
+                        "mfe": self._to_optional_float(p.mfe, 0.0),
+                        "mae": self._to_optional_float(p.mae, 0.0),
+                        "mfe_price": self._to_optional_float(p.mfe_price),
+                        "mae_price": self._to_optional_float(p.mae_price),
                         "mfe_time": p.mfe_time,
                         "mae_time": p.mae_time,
                         # * Include order information for consistency with dashboard
                         "orders": orders_data,
                         # * Include partial operations tracking
-                        "original_size": p.original_size,
-                        "current_size": p.current_size,
+                        "original_size": self._to_optional_float(p.original_size),
+                        "current_size": self._to_optional_float(p.current_size),
                         "partial_exits_taken": p.partial_exits_taken,
                         "scale_ins_taken": p.scale_ins_taken,
-                        "last_partial_exit_price": p.last_partial_exit_price,
-                        "last_scale_in_price": p.last_scale_in_price,
+                        "last_partial_exit_price": self._to_optional_float(
+                            p.last_partial_exit_price
+                        ),
+                        "last_scale_in_price": self._to_optional_float(p.last_scale_in_price),
                         # * Include exchange order IDs for live trading recovery
                         "entry_order_id": getattr(p, "entry_order_id", None),
                         "stop_loss_order_id": getattr(p, "stop_loss_order_id", None),
@@ -1635,19 +1647,22 @@ class DatabaseManager:
                     "id": t.id,
                     "symbol": t.symbol,
                     "side": t.side.value,
-                    "entry_price": t.entry_price,
-                    "exit_price": t.exit_price,
-                    "size": t.size,
-                    "pnl": t.pnl,
-                    "pnl_percent": t.pnl_percent,
+                    # Numeric(18, 8) columns read back as Decimal. Coerce to float at
+                    # the source (mirroring get_active_positions) so dashboard consumers
+                    # stay JSON-serializable and downstream float arithmetic is safe.
+                    "entry_price": float(t.entry_price),
+                    "exit_price": float(t.exit_price),
+                    "size": float(t.size),
+                    "pnl": float(t.pnl),
+                    "pnl_percent": float(t.pnl_percent),
                     "entry_time": t.entry_time,
                     "exit_time": t.exit_time,
                     "exit_reason": t.exit_reason,
                     "strategy": t.strategy_name,
-                    "mfe": t.mfe,
-                    "mae": t.mae,
-                    "mfe_price": t.mfe_price,
-                    "mae_price": t.mae_price,
+                    "mfe": self._to_optional_float(t.mfe, 0.0),
+                    "mae": self._to_optional_float(t.mae, 0.0),
+                    "mfe_price": self._to_optional_float(t.mfe_price),
+                    "mae_price": self._to_optional_float(t.mae_price),
                     "mfe_time": t.mfe_time,
                     "mae_time": t.mae_time,
                 }

--- a/tests/unit/database/test_data_retrieval.py
+++ b/tests/unit/database/test_data_retrieval.py
@@ -148,6 +148,81 @@ class TestDataRetrieval:
         # The Decimal * float bug must no longer reproduce on the recovered field.
         assert position["entry_price"] * (1.0 - 0.02) == pytest.approx(44100.12098765)
 
+    def test_get_active_positions_null_numeric_fields_use_defaults(self, mock_postgresql_db):
+        """Nullable numeric columns read back as NULL must surface as None (not a
+        Decimal, and not a crash from a bare float(None)), while default=0.0 columns
+        must surface as 0.0. Guards the nullable branch of the source coercion.
+        """
+        mock_position = Mock()
+        mock_position.id = 7
+        mock_position.symbol = "ETHUSDT"
+        mock_position.side.value = "LONG"
+        mock_position.strategy_name = "TestStrategy"
+        mock_position.entry_time = datetime.now(UTC)
+        # Required (nullable=False) columns are always present.
+        mock_position.entry_price = Decimal("2500.0")
+        mock_position.size = Decimal("0.25")
+        # Nullable numeric columns are NULL in the DB.
+        mock_position.current_price = None
+        mock_position.quantity = None
+        mock_position.entry_balance = None
+        mock_position.stop_loss = None
+        mock_position.take_profit = None
+        mock_position.trailing_stop_price = None
+        mock_position.mfe_price = None
+        mock_position.mae_price = None
+        mock_position.original_size = None
+        mock_position.current_size = None
+        mock_position.last_partial_exit_price = None
+        mock_position.last_scale_in_price = None
+        # default=0.0 columns are NULL (the default should apply).
+        mock_position.unrealized_pnl = None
+        mock_position.unrealized_pnl_percent = None
+        mock_position.mfe = None
+        mock_position.mae = None
+
+        def mock_query_side_effect(model):
+            if model.__name__ == "Position":
+                q = Mock()
+                q.filter.return_value.all.return_value = [mock_position]
+                return q
+            if model.__name__ == "Order":
+                q = Mock()
+                q.filter.return_value.order_by.return_value.all.return_value = []
+                return q
+            return Mock()
+
+        mock_postgresql_db._mock_session.query.side_effect = mock_query_side_effect
+
+        position = mock_postgresql_db.get_active_positions()[0]
+
+        # Required fields still coerce to float.
+        assert isinstance(position["entry_price"], float)
+        assert isinstance(position["size"], float)
+
+        # Nullable fields surface as None (not Decimal, not a crash).
+        nullable_fields = [
+            "current_price",
+            "quantity",
+            "entry_balance",
+            "stop_loss",
+            "take_profit",
+            "trailing_stop_price",
+            "mfe_price",
+            "mae_price",
+            "original_size",
+            "current_size",
+            "last_partial_exit_price",
+            "last_scale_in_price",
+        ]
+        for field in nullable_fields:
+            assert position[field] is None, f"{field} should be None, got {position[field]!r}"
+
+        # default=0.0 columns fall back to 0.0 (float), never None.
+        for field in ["unrealized_pnl", "unrealized_pnl_percent", "mfe", "mae"]:
+            assert position[field] == 0.0
+            assert isinstance(position[field], float)
+
     def test_get_recent_trades(self, mock_postgresql_db):
         """Test getting recent trades"""
         mock_trade = Mock()
@@ -226,6 +301,43 @@ class TestDataRetrieval:
         assert trade["entry_price"] == pytest.approx(45000.12345678)
         assert trade["pnl"] == pytest.approx(100.0)
         assert trade["mae_price"] == pytest.approx(44500.0)
+
+    def test_get_recent_trades_null_numeric_fields_use_defaults(self, mock_postgresql_db):
+        """Nullable trade numeric columns surface as None; default=0.0 columns as 0.0."""
+        mock_trade = Mock()
+        mock_trade.id = 9
+        mock_trade.symbol = "ETHUSDT"
+        mock_trade.side.value = "LONG"
+        mock_trade.strategy_name = "TestStrategy"
+        mock_trade.entry_time = datetime.now(UTC)
+        mock_trade.exit_time = datetime.now(UTC)
+        mock_trade.exit_reason = "Stop loss"
+        # Required (nullable=False) columns are always present.
+        mock_trade.entry_price = Decimal("2500.0")
+        mock_trade.exit_price = Decimal("2400.0")
+        mock_trade.size = Decimal("0.25")
+        mock_trade.pnl = Decimal("-25.0")
+        mock_trade.pnl_percent = Decimal("-1.0")
+        # Nullable numeric columns are NULL.
+        mock_trade.mfe_price = None
+        mock_trade.mae_price = None
+        # default=0.0 columns are NULL (the default should apply).
+        mock_trade.mfe = None
+        mock_trade.mae = None
+
+        mock_query = Mock()
+        mock_query.order_by.return_value.limit.return_value.all.return_value = [mock_trade]
+        mock_postgresql_db._mock_session.query.return_value = mock_query
+
+        trade = mock_postgresql_db.get_recent_trades(limit=5)[0]
+
+        for field in ["entry_price", "exit_price", "size", "pnl", "pnl_percent"]:
+            assert isinstance(trade[field], float)
+        assert trade["mfe_price"] is None
+        assert trade["mae_price"] is None
+        for field in ["mfe", "mae"]:
+            assert trade[field] == 0.0
+            assert isinstance(trade[field], float)
 
     def test_get_performance_metrics(self, mock_postgresql_db):
         """Test getting performance metrics"""

--- a/tests/unit/database/test_data_retrieval.py
+++ b/tests/unit/database/test_data_retrieval.py
@@ -1,6 +1,7 @@
 """Data retrieval tests for DatabaseManager."""
 
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from unittest.mock import Mock
 
 import pytest
@@ -66,6 +67,87 @@ class TestDataRetrieval:
         assert len(positions) == 1
         assert positions[0]["symbol"] == "BTCUSDT"
 
+    def test_get_active_positions_coerces_numeric_fields_to_float(self, mock_postgresql_db):
+        """Numeric columns come back from PostgreSQL as Decimal; get_active_positions
+        must coerce them to float so downstream float arithmetic (e.g. the default
+        stop-loss branches in reconciliation: entry_price * (1.0 ± DEFAULT_STOP_LOSS_PCT))
+        never raises ``unsupported operand type(s) for *: 'Decimal' and 'float'``.
+        """
+        # Mirror real SQLAlchemy Numeric(18, 8) reads: every numeric field is a Decimal.
+        mock_position = Mock()
+        mock_position.id = 1
+        mock_position.symbol = "BTCUSDT"
+        mock_position.side.value = "LONG"
+        mock_position.entry_price = Decimal("45000.12345678")
+        mock_position.current_price = Decimal("46000.0")
+        mock_position.size = Decimal("0.10000000")
+        mock_position.quantity = Decimal("0.00500000")
+        mock_position.entry_balance = Decimal("1000.0")
+        mock_position.unrealized_pnl = Decimal("100.0")
+        mock_position.unrealized_pnl_percent = Decimal("2.22")
+        mock_position.stop_loss = Decimal("43000.0")
+        mock_position.take_profit = Decimal("47000.0")
+        mock_position.trailing_stop_price = Decimal("44000.0")
+        mock_position.mfe = Decimal("0.03")
+        mock_position.mae = Decimal("0.01")
+        mock_position.mfe_price = Decimal("46500.0")
+        mock_position.mae_price = Decimal("44500.0")
+        mock_position.original_size = Decimal("1.0")
+        mock_position.current_size = Decimal("0.5")
+        mock_position.last_partial_exit_price = Decimal("46200.0")
+        mock_position.last_scale_in_price = Decimal("44800.0")
+        mock_position.entry_time = datetime.now(UTC)
+        mock_position.strategy_name = "TestStrategy"
+
+        def mock_query_side_effect(model):
+            if model.__name__ == "Position":
+                mock_positions_query = Mock()
+                mock_positions_query.filter.return_value.all.return_value = [mock_position]
+                return mock_positions_query
+            if model.__name__ == "Order":
+                mock_orders_query = Mock()
+                mock_orders_query.filter.return_value.order_by.return_value.all.return_value = []
+                return mock_orders_query
+            return Mock()
+
+        mock_postgresql_db._mock_session.query.side_effect = mock_query_side_effect
+
+        positions = mock_postgresql_db.get_active_positions()
+        position = positions[0]
+
+        numeric_fields = [
+            "entry_price",
+            "current_price",
+            "size",
+            "quantity",
+            "entry_balance",
+            "unrealized_pnl",
+            "unrealized_pnl_percent",
+            "stop_loss",
+            "take_profit",
+            "trailing_stop_price",
+            "mfe",
+            "mae",
+            "mfe_price",
+            "mae_price",
+            "original_size",
+            "current_size",
+            "last_partial_exit_price",
+            "last_scale_in_price",
+        ]
+        for field in numeric_fields:
+            value = position[field]
+            assert not isinstance(value, Decimal), f"{field} leaked a Decimal: {value!r}"
+            assert isinstance(value, float), f"{field} should be float, got {type(value).__name__}"
+
+        # Values must be preserved through coercion, not just type-changed.
+        assert position["entry_price"] == pytest.approx(45000.12345678)
+        assert position["stop_loss"] == pytest.approx(43000.0)
+        assert position["quantity"] == pytest.approx(0.005)
+
+        # The Decimal * float bug must no longer reproduce on the recovered field.
+        assert position["entry_price"] * (1.0 - 0.02) == pytest.approx(44100.12098765)
+
     def test_get_recent_trades(self, mock_postgresql_db):
         """Test getting recent trades"""
         mock_trade = Mock()
@@ -91,6 +173,59 @@ class TestDataRetrieval:
         assert isinstance(trades, list)
         assert len(trades) == 1
         assert trades[0]["symbol"] == "BTCUSDT"
+
+    def test_get_recent_trades_coerces_numeric_fields_to_float(self, mock_postgresql_db):
+        """Numeric columns come back from PostgreSQL as Decimal; get_recent_trades
+        must coerce them to float so dashboard consumers stay JSON-serializable
+        (json.dumps raises on Decimal) and any downstream float arithmetic is safe.
+        Mirrors the coercion applied in get_active_positions.
+        """
+        # Mirror real SQLAlchemy Numeric(18, 8) reads: every numeric field is a Decimal.
+        mock_trade = Mock()
+        mock_trade.id = 1
+        mock_trade.symbol = "BTCUSDT"
+        mock_trade.side.value = "LONG"
+        mock_trade.entry_price = Decimal("45000.12345678")
+        mock_trade.exit_price = Decimal("46000.0")
+        mock_trade.size = Decimal("0.10000000")
+        mock_trade.pnl = Decimal("100.0")
+        mock_trade.pnl_percent = Decimal("2.22")
+        mock_trade.mfe = Decimal("0.03")
+        mock_trade.mae = Decimal("0.01")
+        mock_trade.mfe_price = Decimal("46500.0")
+        mock_trade.mae_price = Decimal("44500.0")
+        mock_trade.entry_time = datetime.now(UTC)
+        mock_trade.exit_time = datetime.now(UTC)
+        mock_trade.exit_reason = "Take profit"
+        mock_trade.strategy_name = "TestStrategy"
+
+        mock_query = Mock()
+        mock_query.order_by.return_value.limit.return_value.all.return_value = [mock_trade]
+        mock_postgresql_db._mock_session.query.return_value = mock_query
+
+        trades = mock_postgresql_db.get_recent_trades(limit=10)
+        trade = trades[0]
+
+        numeric_fields = [
+            "entry_price",
+            "exit_price",
+            "size",
+            "pnl",
+            "pnl_percent",
+            "mfe",
+            "mae",
+            "mfe_price",
+            "mae_price",
+        ]
+        for field in numeric_fields:
+            value = trade[field]
+            assert not isinstance(value, Decimal), f"{field} leaked a Decimal: {value!r}"
+            assert isinstance(value, float), f"{field} should be float, got {type(value).__name__}"
+
+        # Values must be preserved through coercion, not just type-changed.
+        assert trade["entry_price"] == pytest.approx(45000.12345678)
+        assert trade["pnl"] == pytest.approx(100.0)
+        assert trade["mae_price"] == pytest.approx(44500.0)
 
     def test_get_performance_metrics(self, mock_postgresql_db):
         """Test getting performance metrics"""


### PR DESCRIPTION
## Summary

`DatabaseManager.get_active_positions` and `get_recent_trades` returned SQLAlchemy `Numeric(18,8)` columns as raw `Decimal`. Only `entry_balance` was coerced, while the sibling `orders_data` block in the same method already floated every numeric field — an inconsistency that leaked `Decimal` values into the live engine.

The position values flow through `_recover_active_positions` (`src/engines/live/trading_engine.py`) into recovered `Position` objects. Mixing those `Decimal`s with `float` constants raised:

```
unsupported operand type(s) for *: 'decimal.Decimal' and 'float'
```

in reconciliation's **default stop-loss** branches (`src/engines/live/reconciliation.py` ~561, ~1147, ~2959), which compute `entry_price * (1.0 ± DEFAULT_STOP_LOSS_PCT)` **before** calling `place_stop_loss_order`. PR #653 only patched the `place_stop_loss_order` boundary, so those default-stop branches (hit when a recovered position has no stop-loss price) still raised.

## Changes

- `get_active_positions`: coerce all position numeric fields to `float` at the source — `float()` for non-nullable columns (`entry_price`, `size`), `_to_optional_float()` for nullable ones, `_to_optional_float(..., 0.0)` for `default=0.0` columns (`unrealized_pnl`, `unrealized_pnl_percent`, `mfe`, `mae`).
- `get_recent_trades`: same coercion (dashboard-only consumer, but keeps it JSON-serializable since `json.dumps` raises on `Decimal`, and consistent with the position path).

Both mirror the existing `orders_data` block and `LivePositionTracker.recover_positions`. This eliminates the `Decimal * float` class of bug **at the source** rather than patching each arithmetic site.

## User-facing impact

Recovered positions with no stored stop-loss (e.g. after a crash/restart) no longer crash reconciliation when applying the conservative default stop — closing a gap in the post-crash capital-protection path.

## Testing performed

- TDD: added `test_get_active_positions_coerces_numeric_fields_to_float` and `test_get_recent_trades_coerces_numeric_fields_to_float` (`tests/unit/database/test_data_retrieval.py`) — each builds a mock row with `Decimal` values and asserts the returned dict fields are `float`, not `Decimal` (incl. an explicit `entry_price * (1.0 - 0.02)` arithmetic assertion). Both failed before the fix (`entry_price leaked a Decimal`), pass after.
- `pytest tests/unit/ -k "reconcil or recover or position or trade"` → **687 passed**.
- Consumer suites (`tests/unit/database/`, `tests/unit/dashboards/`, `tests/unit/position_management/`, `tests/unit/live/`, `tests/unit/engines/`) all green.
- `black`/`ruff` clean on changed regions (pre-existing deviations elsewhere left untouched).

## Related

- Follows up PR #653 (which patched the `place_stop_loss_order` symptom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)