### PR TITLE
Promote to production: bind kline/user WS socket to the manager loop (#661)

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -1990,6 +1990,34 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             self._twm = ThreadedWebsocketManager(**twm_kwargs)
             self._twm.start()
 
+    def _socket_on_twm_loop(self, start_fn: Callable[[], Any]) -> Any:
+        """Invoke a TWM ``start_*_socket`` call with the manager's own loop installed
+        as this thread's current loop, then restore the previous loop.
+
+        python-binance builds each socket's ReconnectingWebsocket SYNCHRONOUSLY on the
+        calling thread and binds it to ``get_loop()`` (the current thread's loop). The
+        manager thread runs ``self._twm_loop``, so the socket must bind to THAT loop —
+        otherwise its read-loop is scheduled onto a loop nothing runs and zero events
+        are ever delivered (the #650 regression: kline went dark after the first
+        reconnect). Restoring the previous loop afterwards means we never permanently
+        hijack the main thread's loop (which is what caused the #646 collision).
+        """
+        if self._twm_loop is None:
+            return start_fn()
+        try:
+            prev = asyncio.get_event_loop()
+        except RuntimeError:
+            prev = None
+        asyncio.set_event_loop(self._twm_loop)
+        try:
+            return start_fn()
+        finally:
+            # prev is only a thread-local reference we restore — it is never *run* on
+            # this thread (set_event_loop just sets the pointer), so a stale/closed prev
+            # is harmless. Restoring it (incl. on exception) avoids leaving the caller's
+            # loop hijacked, which is what caused the #646 collision.
+            asyncio.set_event_loop(prev)
+
     def start_kline_stream(
         self, symbol: str, timeframe: str, on_kline: Callable[[dict], None]
     ) -> bool:
@@ -2020,8 +2048,10 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 on_kline(msg)
 
             self._kline_event_received = False  # Reset until first event confirms
-            self._kline_socket_key = self._twm.start_kline_socket(
-                callback=_kline_callback, symbol=symbol, interval=timeframe
+            self._kline_socket_key = self._socket_on_twm_loop(
+                lambda: self._twm.start_kline_socket(
+                    callback=_kline_callback, symbol=symbol, interval=timeframe
+                )
             )
             self._kline_ws_state = WebSocketState.PRIMARY
             self._last_kline_event_time = datetime.now(UTC)
@@ -2054,9 +2084,13 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 on_user_event(msg)
 
             if self._use_margin:
-                self._user_socket_key = self._twm.start_margin_socket(callback=_user_callback)
+                self._user_socket_key = self._socket_on_twm_loop(
+                    lambda: self._twm.start_margin_socket(callback=_user_callback)
+                )
             else:
-                self._user_socket_key = self._twm.start_user_socket(callback=_user_callback)
+                self._user_socket_key = self._socket_on_twm_loop(
+                    lambda: self._twm.start_user_socket(callback=_user_callback)
+                )
             self._last_user_event_time = datetime.now(UTC)
             self._user_ws_state = WebSocketState.PRIMARY
             return True

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -97,6 +97,121 @@ def test_stop_streams_closes_twm_event_loop(mock_config, mock_client):
 
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.Client")
+@patch("src.data_providers.binance_provider.get_config")
+def test_kline_socket_starts_bound_to_twm_loop(mock_config, mock_client):
+    """The kline socket is built synchronously on the calling thread and binds to the
+    CURRENT loop; start_kline_stream must install the manager's own loop for the call
+    (so the socket binds to the loop the TWM thread runs, not a loop nothing runs) and
+    restore the previous loop afterwards. Regression guard for #650 — passing a per-
+    manager loop without making it current bound the socket to the wrong loop and zero
+    kline events were ever delivered.
+    """
+    import asyncio
+
+    mock_config_obj = Mock()
+    mock_config_obj.get_required.return_value = "fake_key"
+    mock_config.return_value = mock_config_obj
+
+    provider = BinanceProvider()
+    twm_loop = asyncio.new_event_loop()
+    provider._twm_loop = twm_loop
+    provider._twm = Mock()
+    seen = {}
+
+    def fake_start_kline_socket(**kwargs):
+        seen["loop_during"] = asyncio.get_event_loop()
+        return "kline-key"
+
+    provider._twm.start_kline_socket = fake_start_kline_socket
+
+    main_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(main_loop)
+    try:
+        ok = provider.start_kline_stream("ETHUSDT", "1h", lambda m: None)
+        assert ok is True
+        # Socket constructed while the MANAGER loop was current (not main_loop), so
+        # python-binance binds it to the loop the TWM thread actually runs.
+        assert seen["loop_during"] is twm_loop
+        # Caller's previous loop is restored (no permanent main-thread hijack).
+        assert asyncio.get_event_loop() is main_loop
+    finally:
+        asyncio.set_event_loop(None)
+        main_loop.close()
+        twm_loop.close()
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.Client")
+@patch("src.data_providers.binance_provider.get_config")
+def test_socket_on_twm_loop_restores_previous_loop_on_exception(mock_config, mock_client):
+    """The previous loop must be restored even when start_fn raises — otherwise a
+    failed socket start would leave the caller's loop hijacked (the #646 regression).
+    """
+    import asyncio
+
+    mock_config_obj = Mock()
+    mock_config_obj.get_required.return_value = "fake_key"
+    mock_config.return_value = mock_config_obj
+
+    provider = BinanceProvider()
+    twm_loop = asyncio.new_event_loop()
+    provider._twm_loop = twm_loop
+    main_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(main_loop)
+
+    def boom():
+        assert asyncio.get_event_loop() is twm_loop  # manager loop installed during call
+        raise RuntimeError("socket start failed")
+
+    try:
+        with pytest.raises(RuntimeError):
+            provider._socket_on_twm_loop(boom)
+        assert asyncio.get_event_loop() is main_loop  # restored despite the exception
+    finally:
+        asyncio.set_event_loop(None)
+        main_loop.close()
+        twm_loop.close()
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.Client")
+@patch("src.data_providers.binance_provider.get_config")
+def test_user_socket_starts_bound_to_twm_loop(mock_config, mock_client):
+    """The margin/user socket must bind to the manager loop too (same #650 mechanism)."""
+    import asyncio
+
+    mock_config_obj = Mock()
+    mock_config_obj.get_required.return_value = "fake_key"
+    mock_config.return_value = mock_config_obj
+
+    provider = BinanceProvider()
+    provider._use_margin = True
+    twm_loop = asyncio.new_event_loop()
+    provider._twm_loop = twm_loop
+    provider._twm = Mock()
+    seen = {}
+
+    def fake_start_margin_socket(**kwargs):
+        seen["loop_during"] = asyncio.get_event_loop()
+        return "user-key"
+
+    provider._twm.start_margin_socket = fake_start_margin_socket
+
+    main_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(main_loop)
+    try:
+        ok = provider.start_user_stream(lambda m: None)
+        assert ok is True
+        assert seen["loop_during"] is twm_loop
+        assert asyncio.get_event_loop() is main_loop
+    finally:
+        asyncio.set_event_loop(None)
+        main_loop.close()
+        twm_loop.close()
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
 class TestBinanceDataProvider:
     @pytest.mark.data_provider
     def test_binance_provider_initialization(self):


### PR DESCRIPTION
Surgical promote of **#661** only (patch-id-verified). Fixes the #650 regression that left the kline WS bound to the wrong event loop → 0 events delivered after a reconnect → trading loop stalled (the overnight outage). Verified 3 ways (prod container, local integration 5 events/12s, unit tests) + architecture review **APPROVE**. **This is degraded in prod now — restores the live kline feed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)