### PR TITLE
Promote to production: recovering REST fallback for kline WS (#662)

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -351,7 +351,9 @@ DEFAULT_PENDING_SUBMIT_EXPIRY_MINUTES = 60
 
 # WebSocket Stream Constants
 DEFAULT_WS_KLINE_STALENESS_THRESHOLD = 120  # Seconds before kline stream considered stale
-DEFAULT_WS_USER_STALENESS_THRESHOLD = 120  # Seconds before user stream considered stale (only when orders tracked)
+DEFAULT_WS_USER_STALENESS_THRESHOLD = (
+    120  # Seconds before user stream considered stale (only when orders tracked)
+)
 DEFAULT_WS_HEALTH_CHECK_INTERVAL = 30  # Seconds between health monitor checks
 DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_DEGRADED
 # Consecutive unproductive user-stream reconnects (stale again with no real event)
@@ -360,6 +362,16 @@ DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_D
 # and reports success even on a dead multiplexed ws_api socket, so reconnects never
 # self-terminate and churn forever (#616).
 DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT = 3
+# Kline watchdog (#662): a *recovering* REST fallback, unlike the user-stream
+# breaker above. After this many consecutive unproductive kline reconnects
+# (socket re-opened but no real event confirms it — ws_healthy requires
+# _kline_event_received), the engine drops to momentary REST polling but KEEPS
+# probing the WS and returns to WS-primary the instant a real event resumes.
+DEFAULT_WS_KLINE_RECONNECT_CIRCUIT_LIMIT = 3
+# Once past that limit, attempt a kline reconnect only every Nth health cycle
+# (≈ N × DEFAULT_WS_HEALTH_CHECK_INTERVAL seconds) so a persistently dead socket
+# doesn't busy-loop — but never stop, so a return to WS is always possible (#662).
+DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY = 10
 DEFAULT_STARTUP_BAN_MAX_WAIT = 600  # Max seconds to wait for an IP ban to lift during startup
 DEFAULT_STARTUP_BAN_MAX_RETRIES = 3  # Max retry attempts for ban-related startup failures
 

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -498,6 +498,10 @@ class LiveTradingEngine:
         # Consecutive unproductive user-stream reconnects; trips a circuit breaker
         # that stops the futile reconnect loop and runs REST-only (#616).
         self._user_reconnect_failures = 0
+        # Consecutive unproductive kline reconnects; drives the *recovering* REST
+        # fallback (#662) — momentary REST while reconnecting, auto-return to
+        # WS-primary the instant a real kline event resumes (never REST-until-restart).
+        self._kline_reconnect_failures = 0
         # Stop-loss fills are detected on the OrderTracker poll thread but their
         # bookkeeping exit is deferred to the trading loop so a slow/failing close
         # can't block order polling or force-remove a filled order (#631).
@@ -1531,8 +1535,11 @@ class LiveTradingEngine:
         (the monitor's grace-period wait) so a thread that re-dies immediately
         can't busy-respawn.
         """
-        # Only relevant once a stream the monitor watches has been started.
-        if not (self._ws_kline_active or self._user_data_processor):
+        # Only relevant once a stream the monitor watches has been started. Gate on
+        # the provider's existence, not _ws_kline_active — the latter is toggled off
+        # during a momentary kline REST fallback (#662), and the monitor must stay
+        # supervised then too (it is what detects the WS recovering).
+        if self._ws_kline_provider is None and not self._user_data_processor:
             return
         if not self.is_running or self.stop_event.is_set():
             return
@@ -1609,12 +1616,79 @@ class LiveTradingEngine:
             self.stop_event.wait(DEFAULT_WS_HEALTH_CHECK_INTERVAL)
 
     def _check_kline_health(self) -> None:
-        """Check kline stream health and reconnect if stale."""
-        if not self._ws_kline_provider or not self._ws_kline_active:
+        """Kline stream health with a *recovering* REST fallback (#662).
+
+        REST is only ever a momentary fallback while the WS is down. The instant a
+        real kline event resumes (``ws_healthy`` requires ``_kline_event_received``)
+        we return to WS-primary and clear the breaker, so the bot can never get
+        stuck on REST after a disconnect. Unlike the user-stream breaker (#616),
+        this one keeps probing forever (throttled) rather than staying degraded
+        until restart.
+
+        Runs only on the WS health-monitor thread (the single writer of
+        ``_ws_kline_active`` / ``_kline_reconnect_failures``), matching the existing
+        lock-free convention; main-loop reads of the flag are GIL-atomic.
+        """
+        provider = self._ws_kline_provider
+        if not provider:
             return
-        if not getattr(self._ws_kline_provider, "ws_healthy", True):
-            logger.warning("Kline stream unhealthy — attempting reconnect")
-            self._handle_kline_disconnect()
+
+        # Recovery: a real kline event arrived since the last reconnect, so the WS
+        # is delivering again — return to WS-primary and reset the breaker.
+        if getattr(provider, "ws_healthy", False):
+            if not self._ws_kline_active:
+                logger.info(
+                    "Kline WebSocket recovered after %d health cycle(s) on REST — "
+                    "REST polling disabled, WS primary again (#662)",
+                    self._kline_reconnect_failures,
+                )
+            self._ws_kline_active = True
+            self._kline_reconnect_failures = 0
+            return
+
+        # Unhealthy. Drop to REST immediately so the trading loop keeps trading
+        # while we work to restore the WS. The data-fetch path already prefers REST
+        # whenever the WS is not healthy, so this flips off the WS cache-warming
+        # shortcut and records the degraded state (logged once per outage).
+        if self._ws_kline_active:
+            self._ws_kline_active = False
+            provider.mark_kline_degraded()
+            logger.warning(
+                "Kline stream unhealthy — falling back to REST polling while reconnecting (#662)"
+            )
+
+        self._kline_reconnect_failures += 1
+        if not self._should_probe_kline_reconnect(self._kline_reconnect_failures):
+            return
+
+        logger.warning(
+            "Kline stream stale — attempting WS reconnect (failure #%d)",
+            self._kline_reconnect_failures,
+        )
+        self._handle_kline_disconnect()
+
+    def _should_probe_kline_reconnect(self, failures: int) -> bool:
+        """Whether to attempt a kline WS reconnect on this health cycle (#662).
+
+        Fast phase (``failures`` <= circuit limit): probe every cycle for quick
+        recovery. Throttled phase: probe only every Nth cycle so a persistently
+        dead socket doesn't busy-loop on needless socket churn + REST resyncs.
+
+        NEVER returns permanently False — past the limit it still returns True at
+        every multiple of ``DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY``, so the WS
+        always retains a path back to primary (the owner's "never REST-forever"
+        requirement). Recovery itself is independent of this predicate: the
+        ``ws_healthy`` branch in ``_check_kline_health`` restores WS-primary the
+        instant a real event resumes, even on a throttled (non-probing) cycle.
+        """
+        from src.config.constants import (
+            DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY,
+            DEFAULT_WS_KLINE_RECONNECT_CIRCUIT_LIMIT,
+        )
+
+        if failures <= DEFAULT_WS_KLINE_RECONNECT_CIRCUIT_LIMIT:
+            return True
+        return failures % DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY == 0
 
     def _check_user_stream_health(self) -> None:
         """Check user data stream health and reconnect if needed."""
@@ -1689,10 +1763,19 @@ class LiveTradingEngine:
         self._handle_user_stream_disconnect()
 
     def _handle_kline_disconnect(self) -> None:
-        """Handle kline stream failure. Resync from REST and attempt reconnect."""
-        if not self._ws_kline_provider:
+        """Resync kline history from REST and attempt one WS reconnect.
+
+        Does NOT decide WS-primary vs REST — that belongs to ``_check_kline_health``,
+        which returns to WS-primary only once a real event confirms ``ws_healthy``
+        (#662). ``reconnect_kline`` returning True only means a socket was *opened*,
+        not that it delivers data (the #650/#663 failure signature), so trusting it
+        here is exactly what caused the 30s "reconnected" churn.
+        """
+        provider = self._ws_kline_provider
+        if not provider:
             return
-        # Resync kline history from REST
+        # Resync kline history from REST so the buffer has no gap, whether we end up
+        # recovering the WS or keep serving the loop from REST in the meantime.
         if self._kline_buffer:
             try:
                 self._kline_buffer.resync_from_rest(
@@ -1700,24 +1783,14 @@ class LiveTradingEngine:
                 )
             except Exception as e:
                 logger.error("Kline REST resync failed: %s", e)
-        # Attempt reconnect. The call is bounded by the REST socket timeout
-        # (#631); treat any failure as "stay on REST polling" rather than letting
-        # it abort recovery / propagate into the WS health thread.
-        reconnected = False
+        # Attempt reconnect (bounded internally by the REST socket timeout, #631).
+        # Whether it actually restored event flow is confirmed next health cycle via
+        # ws_healthy; we deliberately do not treat the return value as "healthy".
         try:
-            reconnected = bool(
-                hasattr(self._ws_kline_provider, "reconnect_kline")
-                and self._ws_kline_provider.reconnect_kline()
-            )
+            if hasattr(provider, "reconnect_kline"):
+                provider.reconnect_kline()
         except Exception as e:
             logger.error("Kline reconnect attempt failed: %s", e)
-        if reconnected:
-            self._ws_kline_active = True
-            logger.info("Kline WebSocket reconnected")
-        else:
-            self._ws_kline_provider.mark_kline_degraded()
-            self._ws_kline_active = False
-            logger.warning("Kline reconnect failed — REST polling resumed")
 
     def _handle_user_stream_disconnect(self) -> None:
         """Handle user data stream failure. Resync orders and attempt reconnect."""

--- a/tests/unit/test_db_resilience.py
+++ b/tests/unit/test_db_resilience.py
@@ -296,6 +296,7 @@ def test_watchdog_respawns_dead_ws_thread() -> None:
     engine = _make_engine()
     engine.is_running = True
     engine._ws_kline_active = True
+    engine._ws_kline_provider = Mock()  # a kline stream exists → monitor is supervised (#662)
     engine._ws_health_thread = _dead_thread()
     engine._start_ws_health_monitor = Mock()
 
@@ -309,6 +310,9 @@ def test_watchdog_noop_when_thread_alive() -> None:
     engine = _make_engine()
     engine.is_running = True
     engine._ws_kline_active = True
+    engine._ws_kline_provider = (
+        Mock()
+    )  # kline stream exists → guard passes, reach alive-check (#662)
     alive = Mock()
     alive.is_alive.return_value = True
     engine._ws_health_thread = alive
@@ -340,6 +344,9 @@ def test_watchdog_noop_when_stopping() -> None:
     engine = _make_engine()
     engine.is_running = True
     engine._ws_kline_active = True
+    engine._ws_kline_provider = (
+        Mock()
+    )  # kline stream exists → guard passes, reach stopping-check (#662)
     engine.stop_event.set()
     engine._ws_health_thread = _dead_thread()
     engine._start_ws_health_monitor = Mock()
@@ -448,19 +455,24 @@ def test_drain_failure_is_isolated_and_logged(caplog) -> None:
 
 
 @pytest.mark.fast
-def test_kline_disconnect_degrades_when_reconnect_raises() -> None:
-    """A raising kline reconnect (e.g. REST timeout) degrades to polling, not crash."""
+def test_kline_disconnect_survives_reconnect_timeout() -> None:
+    """A raising kline reconnect (e.g. REST timeout) must not propagate (#631).
+
+    Post-#662 _handle_kline_disconnect is state-free — dropping to REST is owned by
+    _check_kline_health (which already did so before calling here). This pins only
+    the exception-safety guarantee: a timing-out reconnect can't crash the WS
+    health thread.
+    """
     engine = _make_engine()
     engine._kline_buffer = None  # skip REST resync
     provider = Mock()
     provider.reconnect_kline.side_effect = TimeoutError("rest socket hung")
     engine._ws_kline_provider = provider
-    engine._ws_kline_active = True
 
     engine._handle_kline_disconnect()  # must not propagate
 
-    provider.mark_kline_degraded.assert_called_once()
-    assert engine._ws_kline_active is False
+    provider.reconnect_kline.assert_called_once()
+    provider.mark_kline_degraded.assert_not_called()  # not this function's job anymore
 
 
 @pytest.mark.fast

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -58,15 +58,19 @@ class TestCheckKlineHealth:
 
     @pytest.mark.fast
     def test_triggers_disconnect_when_unhealthy(self, mock_engine):
-        """Should call _handle_kline_disconnect when ws_healthy is False."""
+        """Unhealthy first cycle: drop to REST (flag off + degrade once) and reconnect."""
         mock_provider = MagicMock()
         mock_provider.ws_healthy = False
         mock_engine._ws_kline_provider = mock_provider
         mock_engine._ws_kline_active = True
+        mock_engine._kline_reconnect_failures = 0
 
         with patch.object(mock_engine, "_handle_kline_disconnect") as mock_disconnect:
             mock_engine._check_kline_health()
             mock_disconnect.assert_called_once()
+            # The degrade-on-first-unhealthy step must not regress silently.
+            assert mock_engine._ws_kline_active is False
+            mock_provider.mark_kline_degraded.assert_called_once()
 
     @pytest.mark.fast
     def test_does_nothing_when_healthy(self, mock_engine):
@@ -165,7 +169,9 @@ class TestCheckUserStreamHealth:
             tracker.enable_polling.assert_called()
             # Teardown must happen BEFORE degrade, else the terminal state is
             # DISCONNECTED instead of REST_DEGRADED and the one-shot guard breaks.
-            ordered = [c[0] for c in ex.mock_calls if c[0] in ("stop_user_stream", "mark_user_degraded")]
+            ordered = [
+                c[0] for c in ex.mock_calls if c[0] in ("stop_user_stream", "mark_user_degraded")
+            ]
             assert ordered == ["stop_user_stream", "mark_user_degraded"]
 
     @pytest.mark.fast
@@ -260,11 +266,19 @@ class TestCheckUserStreamHealth:
 
 
 class TestHandleKlineDisconnect:
-    """Tests for _handle_kline_disconnect()."""
+    """Tests for _handle_kline_disconnect().
+
+    Post-#662 the handler is *state-free*: it resyncs from REST and fires one
+    reconnect attempt, but it does NOT decide WS-primary vs REST or mark the
+    stream degraded — that is owned by _check_kline_health, which returns to
+    WS-primary only once a real event confirms ws_healthy. Trusting
+    reconnect_kline's return value (a socket opened, not events flowing) here is
+    exactly what caused the 30s reconnect churn.
+    """
 
     @pytest.mark.fast
-    def test_resyncs_buffer_and_reconnects(self, mock_engine):
-        """Should resync from REST and reconnect kline stream."""
+    def test_resyncs_buffer_and_attempts_reconnect(self, mock_engine):
+        """Resyncs from REST and calls reconnect_kline, without owning WS state."""
         mock_provider = MagicMock()
         mock_provider.reconnect_kline.return_value = True
         mock_engine._ws_kline_provider = mock_provider
@@ -279,23 +293,183 @@ class TestHandleKlineDisconnect:
             mock_engine.data_provider, "BTCUSDT", "1h"
         )
         mock_provider.reconnect_kline.assert_called_once()
-        assert mock_engine._ws_kline_active is True
+        # Does NOT flip the flag — even on a "successful" reconnect, only a real
+        # event (checked next health cycle) may restore WS-primary (#662).
+        assert mock_engine._ws_kline_active is False
 
     @pytest.mark.fast
-    def test_sets_rest_degraded_on_reconnect_failure(self, mock_engine):
-        """Should fall back to REST_DEGRADED when reconnect fails."""
+    def test_does_not_mark_degraded_or_flip_state_on_failure(self, mock_engine):
+        """A failed reconnect does NOT degrade here — _check_kline_health owns that
+        (it already dropped to REST before calling us). The handler just returns."""
         mock_provider = MagicMock()
         mock_provider.reconnect_kline.return_value = False
         mock_engine._ws_kline_provider = mock_provider
-        mock_engine._ws_kline_active = True
+        mock_engine._ws_kline_active = True  # caller's state; handler must not change it
 
         mock_buffer = MagicMock()
         mock_engine._kline_buffer = mock_buffer
 
         mock_engine._handle_kline_disconnect()
 
-        mock_provider.mark_kline_degraded.assert_called_once()
+        mock_provider.mark_kline_degraded.assert_not_called()
+        assert mock_engine._ws_kline_active is True  # unchanged by the handler
+
+    @pytest.mark.fast
+    def test_reconnect_exception_does_not_propagate(self, mock_engine):
+        """A raising reconnect (e.g. REST timeout) is swallowed, not a crash (#631)."""
+        mock_provider = MagicMock()
+        mock_provider.reconnect_kline.side_effect = TimeoutError("rest socket hung")
+        mock_engine._ws_kline_provider = mock_provider
+        mock_engine._kline_buffer = None  # skip resync
+
+        mock_engine._handle_kline_disconnect()  # must not raise
+        mock_provider.reconnect_kline.assert_called_once()
+
+
+class TestKlineRecoveringRestFallback:
+    """#662: the kline WS uses a *recovering* REST fallback — momentary REST while
+    the WS is down, auto-return to WS-primary the instant real events resume, and
+    it never stops trying (so it can never get stuck on REST until restart)."""
+
+    @staticmethod
+    def _dead_kline_engine(mock_engine):
+        """Engine whose kline socket is dead-but-'started': start_kline_socket
+        returned True but no event ever arrives → ws_healthy stays False."""
+        provider = MagicMock()
+        provider.ws_healthy = False
+        mock_engine._ws_kline_provider = provider
+        mock_engine._ws_kline_active = True
+        mock_engine._kline_reconnect_failures = 0
+        return provider
+
+    @pytest.mark.fast
+    def test_should_probe_predicate_never_permanently_false(self, mock_engine):
+        """The throttle predicate probes every cycle up to the limit, then every
+        Nth cycle — and is never permanently False, so the WS always has a path
+        back to primary (#662)."""
+        from src.config.constants import (
+            DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY as PROBE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_KLINE_RECONNECT_CIRCUIT_LIMIT as LIMIT,
+        )
+
+        # Fast phase: probe on every cycle up to the limit.
+        assert all(mock_engine._should_probe_kline_reconnect(n) for n in range(1, LIMIT + 1))
+        # Throttled phase: only multiples of PROBE probe.
+        assert mock_engine._should_probe_kline_reconnect(LIMIT + 1) is False
+        assert mock_engine._should_probe_kline_reconnect(PROBE) is True
+        # Never permanently false: a probe always recurs within every PROBE-cycle window.
+        for start in range(LIMIT + 1, 5 * PROBE, PROBE):
+            assert any(
+                mock_engine._should_probe_kline_reconnect(n) for n in range(start, start + PROBE)
+            )
+
+    @pytest.mark.fast
+    def test_unhealthy_drops_to_momentary_rest_and_reconnects(self, mock_engine):
+        """First unhealthy cycle: flip to REST (loop keeps trading), degrade once,
+        and attempt a reconnect."""
+        provider = self._dead_kline_engine(mock_engine)
+        with patch.object(mock_engine, "_handle_kline_disconnect") as disc:
+            mock_engine._check_kline_health()
+        assert mock_engine._ws_kline_active is False  # on REST now
+        provider.mark_kline_degraded.assert_called_once()
+        disc.assert_called_once()
+        assert mock_engine._kline_reconnect_failures == 1
+
+    @pytest.mark.fast
+    def test_returns_to_ws_primary_when_events_resume(self, mock_engine):
+        """The instant a real kline event resumes (ws_healthy True), return to
+        WS-primary and reset the breaker — the recovery the user-stream lacks."""
+        provider = MagicMock()
+        provider.ws_healthy = True  # real event arrived
+        mock_engine._ws_kline_provider = provider
+        mock_engine._ws_kline_active = False  # had dropped to REST
+        mock_engine._kline_reconnect_failures = 5
+
+        with patch.object(mock_engine, "_handle_kline_disconnect") as disc:
+            mock_engine._check_kline_health()
+        assert mock_engine._ws_kline_active is True  # WS primary again
+        assert mock_engine._kline_reconnect_failures == 0  # breaker reset
+        disc.assert_not_called()
+        provider.mark_kline_degraded.assert_not_called()
+
+    @pytest.mark.fast
+    def test_degrades_exactly_once_across_many_dead_cycles(self, mock_engine):
+        """mark_kline_degraded fires once per outage (no per-cycle log spam) and the
+        engine stays on REST throughout."""
+        provider = self._dead_kline_engine(mock_engine)
+        with patch.object(mock_engine, "_handle_kline_disconnect"):
+            for _ in range(25):
+                mock_engine._check_kline_health()
+        provider.mark_kline_degraded.assert_called_once()
         assert mock_engine._ws_kline_active is False
+
+    @pytest.mark.fast
+    def test_reconnect_attempts_throttle_but_never_stop(self, mock_engine):
+        """Regression vs BOTH the 30s churn and REST-until-restart: a persistently
+        dead socket gets fast reconnects up to the limit, then throttled probes
+        every Nth cycle — bounded, but NEVER zero (always a path back to WS)."""
+        from src.config.constants import (
+            DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY as PROBE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_KLINE_RECONNECT_CIRCUIT_LIMIT as LIMIT,
+        )
+
+        provider = self._dead_kline_engine(mock_engine)
+        attempt_cycles: list[int] = []
+
+        def _record():
+            # _handle_kline_disconnect is called after the failure counter is bumped,
+            # so the counter == the cycle index at each attempt.
+            attempt_cycles.append(mock_engine._kline_reconnect_failures)
+
+        with patch.object(mock_engine, "_handle_kline_disconnect", side_effect=_record):
+            for _ in range(5 * PROBE):  # 50 cycles
+                mock_engine._check_kline_health()
+
+        expected = [n for n in range(1, 5 * PROBE + 1) if n <= LIMIT or n % PROBE == 0]
+        assert attempt_cycles == expected
+        # Never stops: probes continue into the final stretch of cycles.
+        assert any(c > 5 * PROBE - PROBE for c in attempt_cycles)
+        provider.mark_kline_degraded.assert_called_once()
+
+    @pytest.mark.fast
+    def test_recovers_after_long_degradation(self, mock_engine):
+        """Even after a long dead-socket stretch, a real event returns to WS-primary
+        — proving REST is never permanent (#662)."""
+        provider = self._dead_kline_engine(mock_engine)
+        with patch.object(mock_engine, "_handle_kline_disconnect"):
+            for _ in range(30):
+                mock_engine._check_kline_health()
+        assert mock_engine._ws_kline_active is False
+        assert mock_engine._kline_reconnect_failures >= 30
+
+        provider.ws_healthy = True  # events resume
+        with patch.object(mock_engine, "_handle_kline_disconnect") as disc:
+            mock_engine._check_kline_health()
+        assert mock_engine._ws_kline_active is True
+        assert mock_engine._kline_reconnect_failures == 0
+        disc.assert_not_called()
+
+    @pytest.mark.fast
+    def test_no_spurious_recovery_log_when_healthy_at_startup(self, mock_engine, caplog):
+        """A normally-healthy stream logs no 'recovered' message and stays primary."""
+        import logging
+
+        provider = MagicMock()
+        provider.ws_healthy = True
+        mock_engine._ws_kline_provider = provider
+        mock_engine._ws_kline_active = True  # already primary
+        mock_engine._kline_reconnect_failures = 0
+
+        with caplog.at_level(logging.INFO):
+            with patch.object(mock_engine, "_handle_kline_disconnect") as disc:
+                mock_engine._check_kline_health()
+        assert mock_engine._ws_kline_active is True
+        assert "recovered" not in caplog.text.lower()
+        disc.assert_not_called()
 
 
 class TestHandleUserStreamDisconnect:


### PR DESCRIPTION
Surgical production promote of **#662** (merged to develop as `28a93a2e`, PR #664).

**Patch-id verified** identical to the develop commit (`4337a2ee…`) — carries *only* #662, no unpromoted develop backlog.

## What ships
A *recovering* REST fallback for the kline WebSocket: gate WS-primary on real events (`ws_healthy`/`_kline_event_received`), momentary REST on staleness, throttled-but-never-stop reconnects (`_should_probe_kline_reconnect`), auto-return to WS-primary the instant events resume. Completes the kline-WS hardening from #663 (which fixed the common 24h reconnect; this covers the residual python-binance `MAX_RECONNECTS=5` silent-death zombie).

## Vetting
- 70 unit tests (8 new #662 cases incl. never-permanent-REST); 500+ in the broader sweep.
- architecture-reviewer + code-reviewer: **both APPROVE** (single-writer thread model, no stale/dup candles, CODE.md 210/272/207 compliant).
- Feat-branch CI green (unit 1–4 + integration); patch-id-identical code here.

## Risk
Low — confined to the WS health-monitor thread; new logic is dormant unless a WS stall occurs; REST fallback path already exists. Bot is flat (no capital at risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)