### PR TITLE
chore(live): remove TRADING_FRESH_START recovery-bypass flag (#668)

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4434,15 +4434,15 @@ class LiveTradingEngine:
     def _recover_existing_session(self) -> float | None:
         """Try to recover balance from an existing session.
 
-        Checks for an active session first (crash recovery). If none exists —
-        clean restart after graceful shutdown — falls back to the most recent
-        matching session within 24 hours. Skipped entirely when
-        TRADING_FRESH_START=true is set in the environment.
+        Prefers an active session (crash recovery); otherwise falls back to the
+        most recent matching session within 7 days (clean-restart path). When
+        there is genuinely no recent session to recover (new symbol/strategy,
+        fresh DB, or older than the window), returns None and the engine starts
+        fresh. Recovery runs unconditionally in every environment so staging
+        mirrors production — there is intentionally no bypass flag. (A
+        recovery-bypass env var silently orphaned open positions and reset to a
+        phantom balance; removed — see #668.)
         """
-        if os.environ.get("TRADING_FRESH_START", "").lower() == "true":
-            logger.info("TRADING_FRESH_START=true — skipping session recovery")
-            return None
-
         try:
             # Prefer an active session (crash recovery path).
             session_id = self.db_manager.get_active_session_id()

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4448,7 +4448,7 @@ class LiveTradingEngine:
             session_id = self.db_manager.get_active_session_id()
             source = "active"
 
-            # Fallback: most recent matching session within 24h (clean-restart path).
+            # Fallback: most recent matching session within 7 days (clean-restart path).
             if session_id is None:
                 strategy = self._strategy_name()
                 session_id = self.db_manager.get_last_session_id(

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -62,7 +62,7 @@ def make_engine(enable_live_trading: bool = False) -> LiveTradingEngine:
 
 @pytest.mark.fast
 def test_recovery_falls_back_to_recent_inactive_session():
-    """No active session → falls back to most-recent session within 24 hours.
+    """No active session → falls back to most-recent session within 7 days.
 
     Critically: trading_session_id must remain None so start() creates a
     fresh session. Reusing the closed session ID would cause every balance

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -30,10 +30,14 @@ def make_engine(enable_live_trading: bool = False) -> LiveTradingEngine:
     db_patch = patch("src.engines.live.trading_engine.DatabaseManager")
     config_patch = patch("src.engines.live.trading_engine.get_config", return_value={})
     # Live trading mode requires an exchange interface and provider setup
-    exchange_patch = patch(
-        "src.engines.live.trading_engine._create_exchange_provider",
-        return_value=(MagicMock(), "mock"),
-    ) if enable_live_trading else patch("builtins.id", side_effect=id)  # no-op patch
+    exchange_patch = (
+        patch(
+            "src.engines.live.trading_engine._create_exchange_provider",
+            return_value=(MagicMock(), "mock"),
+        )
+        if enable_live_trading
+        else patch("builtins.id", side_effect=id)
+    )  # no-op patch
 
     with db_patch, config_patch, exchange_patch:
         engine = LiveTradingEngine(
@@ -123,20 +127,6 @@ def test_recovery_prefers_active_session_over_recent():
 
     assert result == 999.0
     engine.db_manager.get_last_session_id.assert_not_called()
-
-
-@pytest.mark.fast
-def test_fresh_start_env_var_bypasses_recovery(monkeypatch):
-    """TRADING_FRESH_START=true skips all session recovery."""
-    monkeypatch.setenv("TRADING_FRESH_START", "true")
-    engine = make_engine()
-    engine.db_manager.get_active_session_id = MagicMock(return_value=10)
-    engine.db_manager.recover_last_balance = MagicMock(return_value=999.0)
-
-    result = engine._recover_existing_session()
-
-    assert result is None
-    engine.db_manager.get_active_session_id.assert_not_called()
 
 
 @pytest.mark.fast


### PR DESCRIPTION
## Why
`TRADING_FRESH_START=true` made `_recover_existing_session` skip balance/session recovery and start at `INITIAL_BALANCE`. Staging forensics (2026-06-04) showed this is a **footgun**: in live/margin while holding open positions it silently **orphans the real positions** and **resets to a phantom balance** — the capital-erosion failure mode (#668). It also made **staging diverge from production** (paper could reset; prod never would), violating the "every environment mirrors prod" principle.

## Analysis (why removal is safe)
- **Used by nothing automated** — not `railway.json`, `Dockerfile`, CI, or scripts. Only the code guard, one unit test, and the original design doc.
- **Not currently set** on staging (the Jun-1 use was ephemeral) or prod (proven by behaviour: prod carries balance forward across restarts).
- **Prod behaviour unchanged** — prod never sets it, so it already always recovers.
- **Staging now always recovers = mirrors prod.**
- **Genuine clean start still works** — with no recent matching session (new symbol/strategy, fresh DB, >7 days) `_recover_existing_session` already returns `None` → starts fresh. Only the *force-ignore-a-recent-session* footgun is removed; a safe, dev-marked reset can be added later if a real need surfaces.

## Changes
- Remove the `os.environ["TRADING_FRESH_START"]` guard in `_recover_existing_session`.
- Refresh the docstring (also fixes a stale "24 hours" → the actual 7-day window).
- Drop `test_fresh_start_env_var_bypasses_recovery`.

## Testing
`tests/unit/engines/live/test_session_recovery.py` — **13 passed**. ruff clean; black (repo pin 24.8.0) clean.

Resolves the footgun half of **#668**; the `_sync_margin_equity` defer-when-positions-held gap remains tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)