### PR TITLE
Promote to production: capital-safety fixes — remove FRESH_START (#668) + atomic position-close (#657)

### DIFF
--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -644,9 +644,7 @@ class DatabaseManager:
                 trading_session.win_rate = (
                     (len(winning_trades) / len(trades) * 100) if trades else 0
                 )
-                trading_session.total_pnl = sum(
-                    _trade_net_pnl(t) for t in trades
-                )
+                trading_session.total_pnl = sum(_trade_net_pnl(t) for t in trades)
 
                 # Calculate max drawdown from account history
                 account_history = (
@@ -717,6 +715,7 @@ class DatabaseManager:
         mfe_time: datetime | None = None,
         mae_time: datetime | None = None,
         margin_interest_cost: float | None = None,
+        position_id: int | None = None,
     ) -> int:
         """Logs a completed trade to the database.
 
@@ -746,6 +745,15 @@ class DatabaseManager:
             mae_price: Price at MAE
             mfe_time: Timestamp of MFE
             mae_time: Timestamp of MAE
+            position_id: Database ID of the Position this trade closes. When
+                provided, the matching Position row is flipped to CLOSED in the
+                SAME transaction as the Trade insert (atomic close). The new
+                Trade's ``position_id`` FK is also set. When None (the default),
+                behaviour is unchanged: only the Trade is inserted and no
+                position status is touched. This keyword keeps every existing
+                caller backward-compatible while letting the live/paper exit path
+                close the position atomically (fixes #657: positions left OPEN in
+                paper mode, causing phantom duplicate trades on restart).
 
         Returns:
             Trade ID
@@ -793,17 +801,48 @@ class DatabaseManager:
                 confidence_score=confidence_score,
                 strategy_config=strategy_config,
                 session_id=session_id or self._current_session_id,
+                position_id=position_id,
                 mfe=mfe,
                 mae=mae,
                 mfe_price=mfe_price,
                 mae_price=mae_price,
                 mfe_time=mfe_time,
                 mae_time=mae_time,
-                margin_interest_cost=margin_interest_cost if margin_interest_cost is not None else 0.0,
+                margin_interest_cost=(
+                    margin_interest_cost if margin_interest_cost is not None else 0.0
+                ),
             )
 
             session.add(trade)
             try:
+                # When closing a tracked position, flip its status to CLOSED in
+                # the SAME transaction as the Trade insert so the two coupled
+                # writes commit together or not at all (CODE.md "Database &
+                # Transactions": coupled fields in a single transaction). This
+                # mirrors the atomic Trade-insert + Position-close block in
+                # atomic_position_reconciliation, minus the balance update (the
+                # caller owns balance via atomic_balance_update). Runs in BOTH
+                # paper and live mode — the #657 bug was that closing was
+                # paper-blind, so positions accumulated as permanently OPEN.
+                if position_id is not None:
+                    position = session.query(Position).filter(Position.id == position_id).first()
+                    if position is not None:
+                        position.status = PositionStatus.CLOSED
+                        position.current_price = exit_price
+                        position.last_update = exit_time
+                        position.unrealized_pnl = pnl
+                        position.unrealized_pnl_percent = pnl_percent
+                    else:
+                        # Position vanished (e.g. already purged). Keep the
+                        # trade — losing the audit row is worse than a missing
+                        # status flip — but record the inconsistency loudly.
+                        logger.warning(
+                            "log_trade: position_id=%s not found for %s; "
+                            "trade inserted without atomic status flip.",
+                            position_id,
+                            symbol,
+                        )
+
                 session.commit()
             except IntegrityError as ie:
                 # Rollback on integrity errors (duplicate keys, constraint violations)
@@ -813,7 +852,10 @@ class DatabaseManager:
                 )
                 raise
             except Exception as e:
-                # Rollback on any other database errors
+                # Rollback on any other database errors. Because the Trade insert
+                # and the Position status flip share this session, the rollback
+                # discards BOTH — neither the orphaned trade nor a half-closed
+                # position can survive a failure (atomic both-or-neither).
                 session.rollback()
                 logger.error(
                     f"Failed to log trade for {symbol}: {e}. Transaction rolled back.",
@@ -1298,6 +1340,75 @@ class DatabaseManager:
                 )
 
             return fixes_applied
+
+    def heal_positions_with_terminal_trades(self, session_id: int | None = None) -> int:
+        """Close OPEN positions that already have a matching terminal Trade.
+
+        Self-heals the #657 inconsistency: a position whose exit Trade was logged
+        but whose ``status`` was never flipped to CLOSED (the historical paper-mode
+        bug). Such a row, if left OPEN, is reloaded by ``_recover_active_positions``
+        on restart and re-closed — producing a phantom duplicate trade. This closes
+        any OPEN position that is the FK target of at least one Trade.
+
+        Paper-safe: pure DB reconciliation, no exchange calls and no
+        ``enable_live_trading`` gating, so it runs identically in paper and live
+        mode. Idempotent — a second call finds nothing left to close.
+
+        Args:
+            session_id: Restrict the heal to one trading session. When None, uses
+                the current session if set, otherwise heals across all sessions.
+
+        Returns:
+            Number of positions transitioned OPEN -> CLOSED.
+        """
+        effective_session_id = session_id or self._current_session_id
+
+        with self.get_session() as session:
+            # Subquery: position IDs that are the FK target of any Trade. A Trade
+            # row only exists for a completed (terminal) exit, so its presence is
+            # proof the position should be CLOSED.
+            closed_position_ids = (
+                session.query(Trade.position_id)
+                .filter(Trade.position_id.isnot(None))
+                .distinct()
+                .subquery()
+            )
+
+            query = session.query(Position).filter(
+                Position.status == PositionStatus.OPEN,
+                Position.id.in_(session.query(closed_position_ids.c.position_id)),
+            )
+            if effective_session_id is not None:
+                query = query.filter(Position.session_id == effective_session_id)
+
+            stale_positions = query.all()
+            healed = 0
+            now = datetime.now(UTC)
+            for position in stale_positions:
+                position.status = PositionStatus.CLOSED
+                position.last_update = now
+                healed += 1
+
+            if healed == 0:
+                return 0
+
+            try:
+                session.commit()
+            except Exception as e:
+                session.rollback()
+                logger.error(
+                    f"Failed to heal positions with terminal trades: {e}. "
+                    "Transaction rolled back.",
+                    exc_info=True,
+                )
+                raise
+
+            logger.info(
+                "Startup self-heal: closed %d OPEN position(s) that already had a "
+                "terminal trade (prevents phantom duplicate trades on recovery).",
+                healed,
+            )
+            return healed
 
     def get_trades_by_symbol_and_date(
         self, symbol: str, start_date: datetime, session_id: int | None = None
@@ -2003,9 +2114,7 @@ class DatabaseManager:
             trades = session.query(Trade).filter(Trade.session_id == session_id).all()
 
             # Calculate current balance from initial balance + net PnL
-            total_pnl = sum(
-                _trade_net_pnl(trade) for trade in trades
-            )
+            total_pnl = sum(_trade_net_pnl(trade) for trade in trades)
             current_balance = trading_session.initial_balance + total_pnl
 
             # Update the balance tracking and warn if persistence fails

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1322,6 +1322,28 @@ class LiveTradingEngine:
             self.live_execution_engine.session_id = self.trading_session_id
             self.live_execution_engine.strategy_name = self._strategy_name()
 
+        # Startup self-heal (#657): close any OPEN position in this session that
+        # already has a terminal Trade. Deliberately NOT gated behind
+        # enable_live_trading/exchange — the whole bug was that closing was
+        # paper-blind, so this must run in paper mode too. Pure DB reconciliation
+        # (no exchange calls), idempotent, and complements the atomic status flip
+        # now performed inside log_trade. Placed before account sync so the books
+        # are consistent before any exchange reconciliation reads them.
+        if self.trading_session_id is not None:
+            try:
+                healed = self.db_manager.heal_positions_with_terminal_trades(
+                    self.trading_session_id
+                )
+                if healed:
+                    logger.info(
+                        "🩹 Startup self-heal closed %d stale-OPEN position(s) with "
+                        "terminal trades (session #%s)",
+                        healed,
+                        self.trading_session_id,
+                    )
+            except Exception as heal_err:
+                logger.warning("Startup position self-heal failed (continuing): %s", heal_err)
+
         # Perform account synchronization if available
         self._pending_balance_correction = False
         self._pending_corrected_balance = None
@@ -3948,6 +3970,29 @@ class LiveTradingEngine:
                 self._log_trade(trade)
 
             if self.trading_session_id is not None:
+                # Pass the position's DB row id so log_trade flips the Position
+                # to CLOSED in the SAME transaction as the Trade insert. This is
+                # the single fix for #657: previously the closed Trade row was
+                # written but positions.status stayed OPEN (the dedicated CLOSED
+                # setters are all gated on enable_live_trading+exchange, so they
+                # were dead in paper mode), leaving positions permanently OPEN
+                # and re-closed on restart as phantom duplicate trades.
+                #
+                # db_position_id is set on the position object at open time
+                # (LivePositionTracker.open_position) and on recovery
+                # (_recover_active_positions). It may legitimately be None for a
+                # position that was never persisted (e.g. db logging failed, or
+                # tests without a DB); in that case log_trade falls back to its
+                # original behaviour (insert trade only, no status flip).
+                close_position_id = getattr(position, "db_position_id", None)
+                if close_position_id is None:
+                    logger.warning(
+                        "Closing %s (%s) without db_position_id — position row "
+                        "status will not be flipped to CLOSED; relying on startup "
+                        "self-heal to reconcile.",
+                        position.symbol,
+                        position.order_id,
+                    )
                 self.db_manager.log_trade(
                     symbol=position.symbol,
                     side=position.side.value,
@@ -3964,6 +4009,7 @@ class LiveTradingEngine:
                     entry_time=position.entry_time,
                     exit_time=datetime.now(UTC),
                     session_id=self.trading_session_id,
+                    position_id=close_position_id,
                     mfe=(metrics.mfe if metrics else None),
                     mae=(metrics.mae if metrics else None),
                     mfe_price=(metrics.mfe_price if metrics else None),
@@ -4564,6 +4610,33 @@ class LiveTradingEngine:
         try:
             if not self.trading_session_id:
                 return
+
+            # Self-heal BEFORE reloading (works in paper too, no exchange calls):
+            # close any OPEN position in this session that already has a terminal
+            # Trade. Such rows are the #657 footgun — historically a closed Trade
+            # was logged without flipping positions.status, so the stale-OPEN row
+            # gets reloaded here with its old stop_loss and re-closed, producing a
+            # phantom duplicate trade. Healing first means get_active_positions
+            # below cannot return them. Belt-and-suspenders alongside the atomic
+            # status flip now done in log_trade.
+            try:
+                healed = self.db_manager.heal_positions_with_terminal_trades(
+                    self.trading_session_id
+                )
+                if healed:
+                    logger.info(
+                        "🩹 Self-healed %d stale-OPEN position(s) with terminal trades "
+                        "before recovery (session #%s)",
+                        healed,
+                        self.trading_session_id,
+                    )
+            except Exception as heal_err:
+                # Never let a heal failure block recovery; the atomic log_trade
+                # flip remains the primary defense going forward.
+                logger.warning(
+                    "Position self-heal failed before recovery (continuing): %s",
+                    heal_err,
+                )
 
             # Get active positions from database
             db_positions = self.db_manager.get_active_positions(self.trading_session_id)

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4434,21 +4434,21 @@ class LiveTradingEngine:
     def _recover_existing_session(self) -> float | None:
         """Try to recover balance from an existing session.
 
-        Checks for an active session first (crash recovery). If none exists —
-        clean restart after graceful shutdown — falls back to the most recent
-        matching session within 24 hours. Skipped entirely when
-        TRADING_FRESH_START=true is set in the environment.
+        Prefers an active session (crash recovery); otherwise falls back to the
+        most recent matching session within 7 days (clean-restart path). When
+        there is genuinely no recent session to recover (new symbol/strategy,
+        fresh DB, or older than the window), returns None and the engine starts
+        fresh. Recovery runs unconditionally in every environment so staging
+        mirrors production — there is intentionally no bypass flag. (A
+        recovery-bypass env var silently orphaned open positions and reset to a
+        phantom balance; removed — see #668.)
         """
-        if os.environ.get("TRADING_FRESH_START", "").lower() == "true":
-            logger.info("TRADING_FRESH_START=true — skipping session recovery")
-            return None
-
         try:
             # Prefer an active session (crash recovery path).
             session_id = self.db_manager.get_active_session_id()
             source = "active"
 
-            # Fallback: most recent matching session within 24h (clean-restart path).
+            # Fallback: most recent matching session within 7 days (clean-restart path).
             if session_id is None:
                 strategy = self._strategy_name()
                 session_id = self.db_manager.get_last_session_id(

--- a/tests/unit/database/test_position_close_atomic.py
+++ b/tests/unit/database/test_position_close_atomic.py
@@ -1,0 +1,333 @@
+"""Atomic position-close tests for ``DatabaseManager.log_trade`` (#657).
+
+Regression coverage for the capital-critical bug where a normal live/paper exit
+wrote the closed Trade row but never flipped ``positions.status`` to CLOSED. The
+stale-OPEN row was then reloaded on restart and re-closed, producing phantom
+duplicate trades.
+
+These use a real in-memory SQLite database (the same lightweight pattern as
+``test_mfe_mae_database.py``) so the transaction semantics — and the atomic
+both-or-neither guarantee — are exercised end to end rather than mocked.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from src.database.manager import DatabaseManager
+from src.database.models import Position, PositionStatus, Trade, TradeSource
+
+pytestmark = pytest.mark.unit
+
+
+def _make_db() -> DatabaseManager:
+    """Fresh isolated in-memory DB with schema created."""
+    return DatabaseManager("sqlite:///:memory:")
+
+
+def _new_session(db: DatabaseManager) -> int:
+    return db.create_trading_session(
+        strategy_name="TestStrategy",
+        symbol="BTCUSDT",
+        timeframe="1h",
+        mode=TradeSource.PAPER,
+        initial_balance=1000.0,
+    )
+
+
+def _open_position(db: DatabaseManager, session_id: int, order_id: str = "order-1") -> int:
+    """Log a fresh OPEN position and return its DB id."""
+    return db.log_position(
+        symbol="BTCUSDT",
+        side="long",
+        entry_price=100.0,
+        size=0.1,
+        strategy_name="TestStrategy",
+        entry_order_id=order_id,
+        quantity=1.0,
+        entry_balance=1000.0,
+        session_id=session_id,
+    )
+
+
+def _position_status(db: DatabaseManager, position_id: int) -> PositionStatus:
+    with db.get_session() as session:
+        pos = session.query(Position).filter(Position.id == position_id).first()
+        assert pos is not None
+        return pos.status
+
+
+def _count_trades(db: DatabaseManager, session_id: int) -> int:
+    with db.get_session() as session:
+        return session.query(Trade).filter(Trade.session_id == session_id).count()
+
+
+class TestAtomicPositionClose:
+    """log_trade(position_id=...) flips the position CLOSED in one transaction."""
+
+    def test_exit_flips_status_and_links_position_id(self):
+        """A normal (paper) exit closes the position AND links trades.position_id."""
+        db = _make_db()
+        session_id = _new_session(db)
+        position_id = _open_position(db, session_id)
+
+        assert _position_status(db, position_id) == PositionStatus.OPEN
+
+        trade_id = db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="take_profit",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=session_id,
+            position_id=position_id,
+        )
+
+        # Return type unchanged: still the trade id int.
+        assert isinstance(trade_id, int)
+
+        # Position flipped to CLOSED in the same call.
+        assert _position_status(db, position_id) == PositionStatus.CLOSED
+
+        # Trade row links back to the position and carries final exit state.
+        with db.get_session() as session:
+            trade = session.query(Trade).filter(Trade.id == trade_id).first()
+            assert trade is not None
+            assert trade.position_id == position_id
+            pos = session.query(Position).filter(Position.id == position_id).first()
+            assert float(pos.current_price) == pytest.approx(110.0)
+            assert float(pos.unrealized_pnl) == pytest.approx(10.0)
+
+    def test_closed_position_not_returned_by_get_active_positions(self):
+        """After an atomic close, the position drops out of the active set so it
+        cannot be reloaded by recovery."""
+        db = _make_db()
+        session_id = _new_session(db)
+        position_id = _open_position(db, session_id)
+
+        assert any(p["id"] == position_id for p in db.get_active_positions(session_id))
+
+        db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="take_profit",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=session_id,
+            position_id=position_id,
+        )
+
+        active_ids = [p["id"] for p in db.get_active_positions(session_id)]
+        assert position_id not in active_ids
+
+
+class TestLogTradeBackwardCompatibility:
+    """log_trade without position_id must behave exactly as before."""
+
+    def test_without_position_id_inserts_trade_and_leaves_status(self):
+        db = _make_db()
+        session_id = _new_session(db)
+        position_id = _open_position(db, session_id)
+
+        trade_id = db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="take_profit",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=session_id,
+            # No position_id passed.
+        )
+
+        # Trade still inserted, return type unchanged.
+        assert isinstance(trade_id, int)
+        assert _count_trades(db, session_id) == 1
+
+        # Position status untouched (still OPEN) and trade has no FK link.
+        assert _position_status(db, position_id) == PositionStatus.OPEN
+        with db.get_session() as session:
+            trade = session.query(Trade).filter(Trade.id == trade_id).first()
+            assert trade.position_id is None
+
+    def test_unknown_position_id_still_inserts_trade(self):
+        """A position_id that no longer exists must not crash or lose the trade —
+        the trade is the durable audit record."""
+        db = _make_db()
+        session_id = _new_session(db)
+
+        trade_id = db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="take_profit",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=session_id,
+            position_id=999_999,  # does not exist
+        )
+
+        assert isinstance(trade_id, int)
+        assert _count_trades(db, session_id) == 1
+
+
+class TestAtomicRollback:
+    """If the transaction fails, the Trade insert and the status flip both roll
+    back — neither an orphaned trade nor a half-closed position survives."""
+
+    def test_commit_failure_rolls_back_both_trade_and_status(self):
+        db = _make_db()
+        session_id = _new_session(db)
+        position_id = _open_position(db, session_id)
+
+        # First trade claims a specific exit_order_id within the session.
+        db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="take_profit",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=session_id,
+            exit_order_id="dup-exit-1",
+        )
+        trades_before = _count_trades(db, session_id)
+
+        # Second trade reuses the SAME exit_order_id + session, violating
+        # uq_trade_order_session at commit — AFTER the position flip line has run
+        # inside the transaction. The rollback must revert BOTH the trade insert
+        # and the in-session status flip.
+        with pytest.raises(IntegrityError):  # uq_trade_order_session violation
+            db.log_trade(
+                symbol="BTCUSDT",
+                side="long",
+                entry_price=100.0,
+                exit_price=120.0,
+                size=0.1,
+                entry_time=datetime.now(UTC) - timedelta(hours=1),
+                exit_time=datetime.now(UTC),
+                pnl=20.0,
+                exit_reason="take_profit",
+                strategy_name="TestStrategy",
+                source=TradeSource.PAPER,
+                session_id=session_id,
+                exit_order_id="dup-exit-1",  # duplicate -> commit fails
+                position_id=position_id,
+            )
+
+        # Neither side persisted: no extra trade row, position still OPEN.
+        assert _count_trades(db, session_id) == trades_before
+        assert _position_status(db, position_id) == PositionStatus.OPEN
+
+
+class TestStartupHeal:
+    """heal_positions_with_terminal_trades closes stale-OPEN rows that already
+    have a terminal Trade — the paper-safe startup self-heal."""
+
+    def test_heal_closes_stale_open_with_terminal_trade(self):
+        db = _make_db()
+        session_id = _new_session(db)
+        position_id = _open_position(db, session_id)
+
+        # Simulate the historical bug: a terminal trade exists for the position
+        # but its status was never flipped (insert trade WITHOUT position_id, then
+        # manually link the FK so the heal can match it — mimicking a legacy row
+        # whose status flip was skipped).
+        trade_id = db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="take_profit",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=session_id,
+        )
+        with db.get_session() as session:
+            trade = session.query(Trade).filter(Trade.id == trade_id).first()
+            trade.position_id = position_id
+            session.commit()
+
+        # Pre-condition: position is wrongly OPEN.
+        assert _position_status(db, position_id) == PositionStatus.OPEN
+
+        healed = db.heal_positions_with_terminal_trades(session_id)
+        assert healed == 1
+        assert _position_status(db, position_id) == PositionStatus.CLOSED
+
+        # Idempotent: a second run finds nothing left to close.
+        assert db.heal_positions_with_terminal_trades(session_id) == 0
+
+    def test_heal_leaves_genuinely_open_positions_untouched(self):
+        """A position with NO terminal trade must stay OPEN."""
+        db = _make_db()
+        session_id = _new_session(db)
+        position_id = _open_position(db, session_id)
+
+        healed = db.heal_positions_with_terminal_trades(session_id)
+
+        assert healed == 0
+        assert _position_status(db, position_id) == PositionStatus.OPEN
+
+    def test_recovery_does_not_reload_position_with_terminal_trade(self):
+        """End-to-end: a position closed atomically (status CLOSED + linked trade)
+        is not returned by get_active_positions, so recovery cannot reload it and
+        produce a phantom duplicate trade."""
+        db = _make_db()
+        session_id = _new_session(db)
+        position_id = _open_position(db, session_id)
+
+        db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="stop_loss",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=session_id,
+            position_id=position_id,
+        )
+
+        # Recovery reads get_active_positions(status==OPEN); the closed position
+        # must be absent so no second (phantom) close can occur.
+        recovered = db.get_active_positions(session_id)
+        assert all(p["id"] != position_id for p in recovered)
+        # And only the single, legitimate trade exists.
+        assert _count_trades(db, session_id) == 1

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -30,10 +30,14 @@ def make_engine(enable_live_trading: bool = False) -> LiveTradingEngine:
     db_patch = patch("src.engines.live.trading_engine.DatabaseManager")
     config_patch = patch("src.engines.live.trading_engine.get_config", return_value={})
     # Live trading mode requires an exchange interface and provider setup
-    exchange_patch = patch(
-        "src.engines.live.trading_engine._create_exchange_provider",
-        return_value=(MagicMock(), "mock"),
-    ) if enable_live_trading else patch("builtins.id", side_effect=id)  # no-op patch
+    exchange_patch = (
+        patch(
+            "src.engines.live.trading_engine._create_exchange_provider",
+            return_value=(MagicMock(), "mock"),
+        )
+        if enable_live_trading
+        else patch("builtins.id", side_effect=id)
+    )  # no-op patch
 
     with db_patch, config_patch, exchange_patch:
         engine = LiveTradingEngine(
@@ -58,7 +62,7 @@ def make_engine(enable_live_trading: bool = False) -> LiveTradingEngine:
 
 @pytest.mark.fast
 def test_recovery_falls_back_to_recent_inactive_session():
-    """No active session → falls back to most-recent session within 24 hours.
+    """No active session → falls back to most-recent session within 7 days.
 
     Critically: trading_session_id must remain None so start() creates a
     fresh session. Reusing the closed session ID would cause every balance
@@ -123,20 +127,6 @@ def test_recovery_prefers_active_session_over_recent():
 
     assert result == 999.0
     engine.db_manager.get_last_session_id.assert_not_called()
-
-
-@pytest.mark.fast
-def test_fresh_start_env_var_bypasses_recovery(monkeypatch):
-    """TRADING_FRESH_START=true skips all session recovery."""
-    monkeypatch.setenv("TRADING_FRESH_START", "true")
-    engine = make_engine()
-    engine.db_manager.get_active_session_id = MagicMock(return_value=10)
-    engine.db_manager.recover_last_balance = MagicMock(return_value=999.0)
-
-    result = engine._recover_existing_session()
-
-    assert result is None
-    engine.db_manager.get_active_session_id.assert_not_called()
 
 
 @pytest.mark.fast


### PR DESCRIPTION
Bundled surgical promote of two capital-safety fixes (one prod restart for both). **Patch-id verified** identical to their develop commits — carries ONLY these two changes, no other develop backlog:
- **#670 / #668** — remove the `TRADING_FRESH_START` recovery-bypass footgun (`f7395b5a`, patch-id `3b96eb24`). Prod behaviour unchanged (prod never set the flag).
- **#671 / #657** — atomic position-close: `_execute_exit`→`log_trade` now flips `positions.status=CLOSED` + links `trades.position_id` in one transaction; paper-safe startup self-heal (`3e946b1f`, patch-id `df93db8b`). Stops the phantom-duplicate-trade class (was active on develop).

## Vetting
- Both fixes: architecture-reviewer + code-reviewer **APPROVE**; develop CI green.
- #27 verified independently: 8/8 atomic-close tests (incl. mutation-tested both-or-neither rollback) + 968 in the broad sweep; reviewers proved the heal cannot false-close a real position.

## Prod safety
Prod holds one small SL-protected LONG (0.0033 ETH, ~$0.6 max risk). The restart re-adopts it from the exchange (server-side SL persists). #27's startup heal finds nothing to heal in prod (reset state, 0 closed trades, no orphans). Promoting *before* the position closes means its eventual close is atomic/clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)