### PR TITLE
Promote to production: fix Decimal*float in margin reconciliation (#674)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1829,12 +1829,15 @@ class PositionReconciler:
             # get_balance returns AccountBalance with total=netAsset in margin mode
             balance = self.exchange.get_balance(base_asset)
 
-            # Scale tracked quantity by partial exit ratio
-            qty = getattr(position, "quantity", 0) or 0.0
+            # Scale tracked quantity by partial exit ratio. Coerce to float —
+            # DB-loaded positions carry Decimal (Numeric) fields, and the
+            # "position_qty * 0.5" comparisons below raise "Decimal * float"
+            # otherwise (#653 class; broke startup margin reconciliation).
+            qty = float(getattr(position, "quantity", 0) or 0.0)
             current_size = getattr(position, "current_size", None)
             original_size = getattr(position, "original_size", None)
-            if current_size is not None and original_size is not None and original_size > 0:
-                position_qty = qty * (current_size / original_size)
+            if current_size is not None and original_size is not None and float(original_size) > 0:
+                position_qty = qty * (float(current_size) / float(original_size))
             else:
                 position_qty = qty
 
@@ -1947,15 +1950,18 @@ class PositionReconciler:
         total = 0.0
         positions = self.position_tracker.positions
         for position in positions.values():
-            # Use quantity (actual asset amount), not size (balance fraction)
-            qty = getattr(position, "quantity", None) or 0.0
-            price = getattr(position, "entry_price", 0)
+            # Use quantity (actual asset amount), not size (balance fraction).
+            # Coerce to float — DB-loaded positions carry Decimal (Numeric)
+            # fields, and mixing Decimal with the float `total`/price below
+            # raises "unsupported operand type(s) for *" (#653 class).
+            qty = float(getattr(position, "quantity", None) or 0.0)
+            price = float(getattr(position, "entry_price", 0) or 0.0)
             if qty > 0 and price > 0:
                 # Scale by current_size/original_size to account for partial exits
                 current = getattr(position, "current_size", None)
                 original = getattr(position, "original_size", None)
-                if current is not None and original is not None and original > 0:
-                    qty = qty * (current / original)
+                if current is not None and original is not None and float(original) > 0:
+                    qty = qty * (float(current) / float(original))
                 total += qty * price
         return total
 
@@ -2077,8 +2083,12 @@ class PositionReconciler:
         if exit_price is None or exit_price <= 0:
             return
 
-        entry_price = getattr(position, "entry_price", 0)
-        qty = getattr(position, "quantity", 0) or 0.0
+        # Coerce to float — DB-loaded positions carry Decimal (Numeric) fields,
+        # and "(entry_price - exit_price) * qty" below raises "Decimal - float"
+        # otherwise (#653 class), silently failing to realize P&L on a margin
+        # close so the session balance drifts.
+        entry_price = float(getattr(position, "entry_price", 0) or 0.0)
+        qty = float(getattr(position, "quantity", 0) or 0.0)
         if entry_price <= 0 or qty <= 0:
             return
 
@@ -2087,8 +2097,8 @@ class PositionReconciler:
         # P&L on the full original quantity, doubling the realized amount.
         current = getattr(position, "current_size", None)
         original = getattr(position, "original_size", None)
-        if current is not None and original is not None and original > 0:
-            qty = qty * (current / original)
+        if current is not None and original is not None and float(original) > 0:
+            qty = qty * (float(current) / float(original))
 
         # Calculate realized P&L (long: sell higher = profit)
         side = getattr(position, "side", "long")
@@ -2469,12 +2479,15 @@ class PeriodicReconciler:
                     balance = self.exchange.get_balance(base_asset)
                     position_gone = False
 
-                    # Scale tracked quantity by partial exit ratio
-                    qty = getattr(position, "quantity", None) or 0.0
+                    # Scale tracked quantity by partial exit ratio. Coerce to
+                    # float — DB-loaded positions carry Decimal (Numeric) fields,
+                    # and "pos_qty * 0.5" below raises "Decimal * float" otherwise
+                    # (#653 class; broke margin position reconciliation in prod).
+                    qty = float(getattr(position, "quantity", None) or 0.0)
                     cur = getattr(position, "current_size", None)
                     orig = getattr(position, "original_size", None)
-                    if cur is not None and orig is not None and orig > 0:
-                        pos_qty = qty * (cur / orig)
+                    if cur is not None and orig is not None and float(orig) > 0:
+                        pos_qty = qty * (float(cur) / float(orig))
                     else:
                         pos_qty = qty
 

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -114,6 +114,62 @@ def reconciler(mock_exchange, mock_position_tracker, mock_db):
     )
 
 
+def test_estimate_position_notional_handles_decimal_fields(reconciler, mock_position_tracker):
+    """DB-loaded positions carry Decimal quantity/price/size; the notional
+    estimate (and the margin position check, same pattern) must coerce to
+    float, not raise 'unsupported operand type(s) for *: Decimal and float'
+    (#653 class — broke margin position reconciliation in prod)."""
+    from decimal import Decimal
+    from types import SimpleNamespace
+
+    mock_position_tracker.positions = {
+        "ETHUSDT:long": SimpleNamespace(
+            quantity=Decimal("0.5"),
+            entry_price=Decimal("2000"),
+            current_size=Decimal("0.5"),
+            original_size=Decimal("1.0"),
+        )
+    }
+
+    notional = reconciler._estimate_position_notional()  # must not raise
+
+    assert isinstance(notional, float)
+    # qty 0.5 * (current 0.5 / original 1.0) = 0.25; * price 2000 = 500.0
+    assert notional == pytest.approx(500.0)
+
+
+def test_verify_margin_position_handles_decimal_quantity(
+    mock_exchange, mock_position_tracker, mock_db
+):
+    """Startup margin position check on a DB-loaded (Decimal) short position must
+    not raise 'Decimal * float' on the `position_qty * 0.5` threshold (#653)."""
+    from decimal import Decimal
+    from types import SimpleNamespace
+
+    reconciler = PositionReconciler(
+        exchange_interface=mock_exchange,
+        position_tracker=mock_position_tracker,
+        db_manager=mock_db,
+        session_id=1,
+        use_margin=True,
+    )
+    reconciler._remove_phantom_position = MagicMock()
+    position = SimpleNamespace(
+        symbol="ETHUSDT",
+        side="short",
+        quantity=Decimal("1.0"),
+        current_size=Decimal("1.0"),
+        original_size=Decimal("1.0"),
+    )
+    # borrowed (float) 0.1 < position_qty 1.0 * 0.5 → external-partial-close branch
+    mock_exchange.get_margin_borrowed = MagicMock(return_value=0.1)
+    mock_exchange.get_balance.return_value = SimpleNamespace(total=0.1)
+
+    reconciler._verify_margin_position_exists(position, MagicMock())  # must not raise
+
+    reconciler._remove_phantom_position.assert_called_once()
+
+
 # ---------- Startup Reconciliation Tests ----------
 
 


### PR DESCRIPTION
Surgical promote of **#674** (develop `52e958a2`, patch-id `970828f5` — matches exactly; only `reconciliation.py` + its test).

## What ships
Coerce DB-loaded `Decimal` position fields to `float` at three margin-reconcile sites that raise `unsupported operand type(s) for *: 'decimal.Decimal' and 'float'`:
- periodic margin position check (`_reconcile_cycle`) — **firing every cycle in prod now**;
- startup twin (`_verify_margin_position_exists`) — fires on every margin restart;
- `_realize_pnl_on_close` (`Decimal - float`) — silently dropped realized P&L on a margin close → balance drift.

## Vetting
architecture-reviewer **APPROVE** (after its completeness sweep found the 2 extra sites — all now fixed); 2 regression tests; develop CI green; #653-class, established `float()` pattern. Follow-up #675 tracks the structural "coerce-at-load" bug-class killer.

Prod is holding one small SL-protected LONG; restart re-adopts it (proven on the #672 deploy). Expected post-deploy: the `Margin position check failed` WARN disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)