### PR TITLE
fix(live): carry OPEN positions forward on clean restart — stop orphaning live positions (#668)

### DIFF
--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -1741,6 +1741,150 @@ class DatabaseManager:
 
             return result
 
+    def reassign_open_positions_to_session(
+        self,
+        old_session_id: int,
+        new_session_id: int,
+        symbol: str | None = None,
+        strategy_name: str | None = None,
+    ) -> list[int]:
+        """Carry OPEN positions forward from a closed session to a new one (#668).
+
+        On a graceful restart the engine creates a NEW trading session but only
+        recovers the *balance* from the most recent inactive session. OPEN
+        positions stay bound to the OLD session via ``Position.session_id``, so
+        ``get_active_positions(new_session_id)`` filters them out and the
+        position is orphaned (still OPEN in the DB, invisible to the live
+        tracker). This re-points genuinely-OPEN positions — and their linked
+        orders — onto the new session so recovery can reload them.
+
+        Only ``PositionStatus.OPEN`` rows move. Positions closed atomically by
+        ``log_trade`` (#671) are already CLOSED and are left behind, so a
+        genuinely-closed position is never resurrected. The move is idempotent:
+        a second call finds nothing under ``old_session_id``.
+
+        Linked ``Order`` rows are re-pointed to ``new_session_id`` for journal
+        consistency, but the ``uq_order_internal_session`` unique constraint
+        (``internal_order_id`` + ``session_id``) is respected: if an order with
+        the same ``internal_order_id`` already exists under the new session,
+        that order is left under the old session. Position↔order linkage still
+        works via ``Order.position_id`` (the join ``get_active_positions`` uses),
+        so leaving the order behind does not strand the position.
+
+        Args:
+            old_session_id: Session the orphaned positions are currently bound to.
+            new_session_id: Active session to carry them forward onto.
+            symbol: Restrict the move to this symbol (avoids pulling positions
+                for a different symbol that shares the DB). When None, moves all.
+            strategy_name: Restrict the move to this strategy (avoids pulling a
+                different strategy's positions). When None, ignores strategy.
+
+        Returns:
+            The DB ids of the positions that were moved (empty if none matched).
+        """
+        if old_session_id == new_session_id:
+            # No-op: nothing to carry forward onto the same session.
+            return []
+
+        # Single WRITE-timeout transaction: position re-point, order re-point,
+        # and audit rows commit together (atomic — CODE.md Database & Transactions).
+        with self.get_session_with_timeout(QueryTimeout.WRITE) as session:
+            query = session.query(Position).filter(
+                Position.status == PositionStatus.OPEN,
+                Position.session_id == old_session_id,
+            )
+            if symbol is not None:
+                query = query.filter(Position.symbol == symbol)
+            if strategy_name is not None:
+                query = query.filter(Position.strategy_name == strategy_name)
+
+            # Row-level lock so a concurrent reconciler cannot mutate these
+            # positions mid-move (CODE.md: for_update in reconciliation queries).
+            # SQLite ignores FOR UPDATE (single-writer), Postgres honours it.
+            positions = query.with_for_update().all()
+
+            if not positions:
+                return []
+
+            moved_ids: list[int] = []
+            now = datetime.now(UTC)
+            for position in positions:
+                # Re-point linked orders first, skipping any that would collide
+                # with an existing (internal_order_id, new_session_id) row.
+                orders = session.query(Order).filter(Order.position_id == position.id).all()
+                for order in orders:
+                    collision = (
+                        session.query(Order.id)
+                        .filter(
+                            Order.internal_order_id == order.internal_order_id,
+                            Order.session_id == new_session_id,
+                            Order.id != order.id,
+                        )
+                        .first()
+                    )
+                    if collision is not None:
+                        # Leave this order under the old session — re-pointing it
+                        # would violate uq_order_internal_session. Linkage to the
+                        # position survives via Order.position_id.
+                        logger.warning(
+                            "Order #%s (internal_id=%s) for position #%s left under "
+                            "session #%s: re-point would collide with uq_order_internal_session "
+                            "in session #%s",
+                            order.id,
+                            order.internal_order_id,
+                            position.id,
+                            old_session_id,
+                            new_session_id,
+                        )
+                        continue
+                    order.session_id = new_session_id
+                    order.last_update = now
+
+                position.session_id = new_session_id
+                position.last_update = now
+                moved_ids.append(position.id)
+
+                # Immutable audit trail under the NEW session (where it now lives).
+                session.add(
+                    ReconciliationAuditEvent(
+                        session_id=new_session_id,
+                        entity_type="position",
+                        entity_id=position.id,
+                        field="session_id",
+                        old_value=str(old_session_id),
+                        new_value=str(new_session_id),
+                        reason=(
+                            f"Carried OPEN {position.symbol} position forward from "
+                            f"inactive session #{old_session_id} on clean restart (#668)"
+                        ),
+                        severity="HIGH",
+                    )
+                )
+
+            try:
+                session.commit()
+            except Exception as e:
+                session.rollback()
+                logger.error(
+                    "Failed to reassign OPEN positions from session #%s to #%s: %s. "
+                    "Transaction rolled back.",
+                    old_session_id,
+                    new_session_id,
+                    e,
+                    exc_info=True,
+                )
+                raise
+
+            logger.info(
+                "Carried %d OPEN position(s) forward from inactive session #%s to "
+                "active session #%s (#668): %s",
+                len(moved_ids),
+                old_session_id,
+                new_session_id,
+                moved_ids,
+            )
+            return moved_ids
+
     def get_recent_trades(self, limit: int = 50, session_id: int | None = None) -> list[dict]:
         """Get recent trades."""
         with self.get_session() as session:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1367,6 +1367,10 @@ class LiveTradingEngine:
                     reassign_err,
                     exc_info=True,
                 )
+            finally:
+                # Clear so a later start()/stop()/start() re-entry cannot re-trigger a
+                # stale-session reassign (#668, P3).
+                self._recovered_inactive_session_id = None
 
         # Startup self-heal (#657): close any OPEN position in this session that
         # already has a terminal Trade. Deliberately NOT gated behind
@@ -4555,23 +4559,27 @@ class LiveTradingEngine:
                 return None
 
             logger.info("🔍 Found %s session #%s", source, session_id)
+
+            # Clean restart (inactive session): remember it so start() can carry its
+            # OPEN positions forward into the new session — INDEPENDENT of whether a
+            # positive balance was recovered. A fully-liquidated session (balance 0)
+            # can still hold an OPEN position; gating this on balance > 0 would
+            # re-orphan it (#668, P2). The active/crash path reuses the session
+            # directly below and never needs this.
+            if source != "active":
+                self._recovered_inactive_session_id = session_id
+
             recovered_balance = self.db_manager.recover_last_balance(session_id)
             if recovered_balance and recovered_balance > 0:
-                # For crash recovery (active session), reuse the existing session ID so
-                # trades continue to be attributed to the same session row.
-                # For clean restarts (inactive session), only recover the balance — a new
-                # session will be created below, preventing writes to a closed session.
+                # Crash recovery (active session): reuse the existing session ID so
+                # trades stay attributed to the same session row. Clean restarts create
+                # a new session below; their OPEN positions are carried forward via
+                # _recovered_inactive_session_id (set above).
                 if source == "active":
                     self.trading_session_id = session_id
                     # Wire session context to execution engine so journaling works
                     self.live_execution_engine.session_id = session_id
                     self.live_execution_engine.strategy_name = self._strategy_name()
-                else:
-                    # Clean restart: remember the inactive session so start() can
-                    # carry its OPEN positions forward into the new session once
-                    # the new session id exists. Without this the OPEN position
-                    # stays bound to this closed session and is orphaned (#668).
-                    self._recovered_inactive_session_id = session_id
                 logger.info(
                     "💾 Recovered balance $%.2f from %s session #%s",
                     recovered_balance,

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -381,6 +381,12 @@ class LiveTradingEngine:
             )
             raise RuntimeError("Database connection required. Service stopped.") from e
         self.trading_session_id: int | None = None
+        # On a clean restart the engine recovers balance from the most recent
+        # inactive session but creates a NEW session. This holds that old
+        # session id so start() can carry its OPEN positions forward into the
+        # new session (#668); None when recovery took the active/crash path or
+        # found no recent session.
+        self._recovered_inactive_session_id: int | None = None
 
         # Initialize dynamic risk manager after database is available
         if self.enable_dynamic_risk:
@@ -1321,6 +1327,46 @@ class LiveTradingEngine:
             # Wire session_id and strategy_name to execution engine for order journaling
             self.live_execution_engine.session_id = self.trading_session_id
             self.live_execution_engine.strategy_name = self._strategy_name()
+
+        # Carry OPEN positions forward on a clean restart (#668). The inactive
+        # session recovered above (balance only) still owns any OPEN position via
+        # Position.session_id, so _recover_active_positions() at line ~1281 saw a
+        # None session id and loaded nothing — the position would be orphaned.
+        # Re-point those positions onto the new session, then reload them into the
+        # live tracker. Ordering: reassign → recover-into-tracker (which self-heals
+        # first) → the heal + exchange reconciliation below re-verify the position
+        # and its server-side stop-loss against the exchange.
+        if self._recovered_inactive_session_id is not None and self.trading_session_id is not None:
+            try:
+                moved_ids = self.db_manager.reassign_open_positions_to_session(
+                    old_session_id=self._recovered_inactive_session_id,
+                    new_session_id=self.trading_session_id,
+                    symbol=self._active_symbol,
+                    strategy_name=self._strategy_name(),
+                )
+                if moved_ids:
+                    logger.info(
+                        "🔁 Carried %d OPEN position(s) forward from inactive session "
+                        "#%s into new session #%s; reloading into tracker",
+                        len(moved_ids),
+                        self._recovered_inactive_session_id,
+                        self.trading_session_id,
+                    )
+                    # Reload now that the rows belong to the new session. Safe and
+                    # idempotent if it already ran (empty session ⇒ no-op).
+                    self._recover_active_positions()
+            except Exception as reassign_err:
+                # A failure here must not abort startup, but it is capital-critical
+                # (an OPEN position stays orphaned), so log loudly for alerting.
+                logger.critical(
+                    "Failed to carry OPEN positions forward from inactive session "
+                    "#%s into session #%s (positions may be orphaned — MANUAL "
+                    "RECONCILIATION REQUIRED): %s",
+                    self._recovered_inactive_session_id,
+                    self.trading_session_id,
+                    reassign_err,
+                    exc_info=True,
+                )
 
         # Startup self-heal (#657): close any OPEN position in this session that
         # already has a terminal Trade. Deliberately NOT gated behind
@@ -4520,6 +4566,12 @@ class LiveTradingEngine:
                     # Wire session context to execution engine so journaling works
                     self.live_execution_engine.session_id = session_id
                     self.live_execution_engine.strategy_name = self._strategy_name()
+                else:
+                    # Clean restart: remember the inactive session so start() can
+                    # carry its OPEN positions forward into the new session once
+                    # the new session id exists. Without this the OPEN position
+                    # stays bound to this closed session and is orphaned (#668).
+                    self._recovered_inactive_session_id = session_id
                 logger.info(
                     "💾 Recovered balance $%.2f from %s session #%s",
                     recovered_balance,

--- a/tests/unit/database/test_reassign_open_positions.py
+++ b/tests/unit/database/test_reassign_open_positions.py
@@ -1,0 +1,344 @@
+"""Tests for ``DatabaseManager.reassign_open_positions_to_session`` (#668).
+
+Regression coverage for the capital-critical clean-restart bug where a graceful
+restart created a NEW trading session but left OPEN positions bound to the OLD
+(now-inactive) session. ``get_active_positions(new_session_id)`` filters by
+session, so the OPEN position was orphaned (still OPEN in the DB, invisible to
+the live tracker). This reassigns genuinely-OPEN positions — and their linked
+orders — onto the new session so recovery can carry them forward.
+
+Uses a real in-memory SQLite database (the same lightweight pattern as
+``test_position_close_atomic.py``) so the transaction semantics and the
+``uq_order_internal_session`` collision handling are exercised end to end.
+"""
+
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.database.models import (
+    Order,
+    OrderStatus,
+    OrderType,
+    Position,
+    PositionSide,
+    PositionStatus,
+    ReconciliationAuditEvent,
+    TradeSource,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_db() -> DatabaseManager:
+    """Fresh isolated in-memory DB with schema created."""
+    return DatabaseManager("sqlite:///:memory:")
+
+
+def _new_session(
+    db: DatabaseManager, symbol: str = "BTCUSDT", strategy: str = "TestStrategy"
+) -> int:
+    return db.create_trading_session(
+        strategy_name=strategy,
+        symbol=symbol,
+        timeframe="1h",
+        mode=TradeSource.PAPER,
+        initial_balance=1000.0,
+    )
+
+
+def _open_position(
+    db: DatabaseManager,
+    session_id: int,
+    *,
+    symbol: str = "BTCUSDT",
+    strategy: str = "TestStrategy",
+    entry_order_id: str = "order-1",
+    stop_loss_order_id: str | None = None,
+) -> int:
+    """Log a fresh OPEN position (with a linked ENTRY order) and return its id."""
+    return db.log_position(
+        symbol=symbol,
+        side="long",
+        entry_price=100.0,
+        size=0.1,
+        strategy_name=strategy,
+        entry_order_id=entry_order_id,
+        quantity=1.0,
+        entry_balance=1000.0,
+        session_id=session_id,
+        stop_loss_order_id=stop_loss_order_id,
+    )
+
+
+def _close_position(db: DatabaseManager, position_id: int) -> None:
+    with db.get_session() as session:
+        pos = session.query(Position).filter(Position.id == position_id).first()
+        pos.status = PositionStatus.CLOSED
+        session.commit()
+
+
+def _position_session(db: DatabaseManager, position_id: int) -> int:
+    with db.get_session() as session:
+        return session.query(Position).filter(Position.id == position_id).first().session_id
+
+
+def _order_session_for_position(db: DatabaseManager, position_id: int) -> int:
+    with db.get_session() as session:
+        return (
+            session.query(Order)
+            .filter(Order.position_id == position_id)
+            .order_by(Order.id.asc())
+            .first()
+            .session_id
+        )
+
+
+class TestReassignOpenPositions:
+    """Only genuinely-OPEN, matching positions move; closed/other rows stay put."""
+
+    def test_moves_only_open_position_for_matching_session(self):
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        position_id = _open_position(db, old, entry_order_id="exch-1")
+
+        moved = db.reassign_open_positions_to_session(old, new)
+
+        assert moved == [position_id]
+        assert _position_session(db, position_id) == new
+        # And it now surfaces under the new session's active set.
+        assert any(p["id"] == position_id for p in db.get_active_positions(new))
+        # ...and no longer under the old one.
+        assert all(p["id"] != position_id for p in db.get_active_positions(old))
+
+    def test_closed_position_is_not_carried_forward(self):
+        """A position CLOSED under the old session (e.g. by #671's atomic close)
+        must NOT be resurrected onto the new session."""
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        open_id = _open_position(db, old, entry_order_id="exch-open")
+        closed_id = _open_position(db, old, entry_order_id="exch-closed")
+        _close_position(db, closed_id)
+
+        moved = db.reassign_open_positions_to_session(old, new)
+
+        assert moved == [open_id]
+        assert _position_session(db, closed_id) == old  # stayed behind
+        assert _position_session(db, open_id) == new
+
+    def test_other_symbol_position_is_left_behind(self):
+        """With a symbol filter, a different symbol's OPEN position must not move."""
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        btc_id = _open_position(db, old, symbol="BTCUSDT", entry_order_id="exch-btc")
+        eth_id = _open_position(db, old, symbol="ETHUSDT", entry_order_id="exch-eth")
+
+        moved = db.reassign_open_positions_to_session(old, new, symbol="BTCUSDT")
+
+        assert moved == [btc_id]
+        assert _position_session(db, eth_id) == old
+
+    def test_other_strategy_position_is_left_behind(self):
+        """With a strategy filter, a different strategy's OPEN position must not move."""
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        a_id = _open_position(db, old, strategy="StratA", entry_order_id="exch-a")
+        b_id = _open_position(db, old, strategy="StratB", entry_order_id="exch-b")
+
+        moved = db.reassign_open_positions_to_session(old, new, strategy_name="StratA")
+
+        assert moved == [a_id]
+        assert _position_session(db, b_id) == old
+
+    def test_linked_order_is_repointed_to_new_session(self):
+        """The position's linked ENTRY order moves to the new session too."""
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        position_id = _open_position(db, old, entry_order_id="exch-1")
+
+        # Pre-condition: the ENTRY order lives under the old session.
+        assert _order_session_for_position(db, position_id) == old
+
+        db.reassign_open_positions_to_session(old, new)
+
+        assert _order_session_for_position(db, position_id) == new
+
+    def test_audit_event_recorded_under_new_session(self):
+        """Each move records an immutable audit row under the new session."""
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        position_id = _open_position(db, old, entry_order_id="exch-1")
+
+        db.reassign_open_positions_to_session(old, new)
+
+        with db.get_session() as session:
+            event = (
+                session.query(ReconciliationAuditEvent)
+                .filter(
+                    ReconciliationAuditEvent.entity_id == position_id,
+                    ReconciliationAuditEvent.field == "session_id",
+                )
+                .first()
+            )
+        assert event is not None
+        assert event.entity_type == "position"
+        assert event.session_id == new
+        assert event.old_value == str(old)
+        assert event.new_value == str(new)
+        assert event.severity == "HIGH"
+
+    def test_idempotent_second_call_moves_nothing(self):
+        """A second call finds nothing under the old session — no double-adopt."""
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        position_id = _open_position(db, old, entry_order_id="exch-1")
+
+        first = db.reassign_open_positions_to_session(old, new)
+        second = db.reassign_open_positions_to_session(old, new)
+
+        assert first == [position_id]
+        assert second == []
+
+    def test_same_session_is_noop(self):
+        """Passing old == new is a guarded no-op (cannot carry onto itself)."""
+        db = _make_db()
+        session_id = _new_session(db)
+        _open_position(db, session_id, entry_order_id="exch-1")
+
+        assert db.reassign_open_positions_to_session(session_id, session_id) == []
+
+    def test_no_matching_positions_returns_empty(self):
+        """Empty old session ⇒ empty result, no error."""
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+
+        assert db.reassign_open_positions_to_session(old, new) == []
+
+
+class TestReassignUniqueConstraintCollision:
+    """``uq_order_internal_session`` (internal_order_id + session_id) is respected:
+    a colliding order is left under the old session; the position still moves and
+    stays linked via ``Order.position_id``."""
+
+    def test_colliding_order_left_behind_position_still_moves(self):
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        position_id = _open_position(db, old, entry_order_id=None)
+
+        # Give the position's linked order a known internal_order_id.
+        with db.get_session() as session:
+            order = session.query(Order).filter(Order.position_id == position_id).first()
+            order.internal_order_id = "shared-iid"
+            session.commit()
+            old_order_id = order.id
+
+        # Pre-existing order under the NEW session with the SAME internal_order_id.
+        with db.get_session() as session:
+            clash = Order(
+                position_id=None,
+                order_type=OrderType.ENTRY,
+                status=OrderStatus.FILLED,
+                internal_order_id="shared-iid",
+                symbol="BTCUSDT",
+                side=PositionSide.LONG,
+                quantity=Decimal("1.0"),
+                strategy_name="TestStrategy",
+                session_id=new,
+            )
+            session.add(clash)
+            session.commit()
+
+        moved = db.reassign_open_positions_to_session(old, new)
+
+        # Position moves; the colliding order stays under the old session.
+        assert moved == [position_id]
+        assert _position_session(db, position_id) == new
+        with db.get_session() as session:
+            order = session.query(Order).filter(Order.id == old_order_id).first()
+            assert order.session_id == old  # not re-pointed (would violate uq)
+            assert order.position_id == position_id  # linkage intact
+
+        # The position still surfaces under the new session (join is on position_id).
+        assert any(p["id"] == position_id for p in db.get_active_positions(new))
+
+
+class TestReassignPreservesPartialExitState:
+    """Sizing fields are untouched by the move — a partially-exited position keeps
+    its current_size/original_size so risk accounting stays correct."""
+
+    def test_partial_exit_sizes_preserved_across_move(self):
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        full_id = _open_position(db, old, entry_order_id="exch-full")
+        partial_id = _open_position(db, old, entry_order_id="exch-partial")
+
+        # Simulate a partial exit on the second position: half remains.
+        with db.get_session() as session:
+            partial = session.query(Position).filter(Position.id == partial_id).first()
+            partial.original_size = Decimal("0.1")
+            partial.current_size = Decimal("0.05")
+            partial.partial_exits_taken = 1
+            session.commit()
+
+        moved = db.reassign_open_positions_to_session(old, new)
+
+        # Both OPEN positions move.
+        assert sorted(moved) == sorted([full_id, partial_id])
+        assert _position_session(db, full_id) == new
+        assert _position_session(db, partial_id) == new
+
+        # The partially-exited position keeps its sizing fields unchanged.
+        with db.get_session() as session:
+            partial = session.query(Position).filter(Position.id == partial_id).first()
+            assert float(partial.original_size) == pytest.approx(0.1)
+            assert float(partial.current_size) == pytest.approx(0.05)
+            assert partial.partial_exits_taken == 1
+
+
+class TestReassignAtomicCloseInterplay:
+    """End-to-end interplay with #671's atomic close: a position closed via
+    log_trade(position_id=...) under the old session is NOT carried forward."""
+
+    def test_position_closed_via_log_trade_not_carried_forward(self):
+        db = _make_db()
+        old = _new_session(db)
+        new = _new_session(db)
+        kept_open_id = _open_position(db, old, entry_order_id="exch-keep")
+        closed_id = _open_position(db, old, entry_order_id="exch-close")
+
+        # Close one position atomically via log_trade (#671): status flips to CLOSED
+        # in the same transaction as the Trade insert.
+        db.log_trade(
+            symbol="BTCUSDT",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            size=0.1,
+            entry_time=datetime.now(UTC) - timedelta(hours=1),
+            exit_time=datetime.now(UTC),
+            pnl=10.0,
+            exit_reason="take_profit",
+            strategy_name="TestStrategy",
+            source=TradeSource.PAPER,
+            session_id=old,
+            position_id=closed_id,
+        )
+
+        moved = db.reassign_open_positions_to_session(old, new)
+
+        # Only the still-open position carries forward; the closed one stays put.
+        assert moved == [kept_open_id]
+        assert _position_session(db, closed_id) == old
+        assert all(p["id"] != closed_id for p in db.get_active_positions(new))

--- a/tests/unit/engines/live/test_clean_restart_readoption.py
+++ b/tests/unit/engines/live/test_clean_restart_readoption.py
@@ -1,0 +1,305 @@
+"""Engine-level tests for clean-restart position re-adoption (#668).
+
+On a graceful restart the engine recovers BALANCE from the most recent inactive
+session but creates a NEW session. Before this fix, OPEN positions stayed bound
+to the OLD session (``Position.session_id``) and ``get_active_positions`` —
+filtered by the new session — returned nothing, orphaning the position (still
+OPEN in the DB, invisible to the live tracker / risk manager / reconciler).
+
+These tests drive ``LiveTradingEngine.start()`` with a REAL in-memory database
+(so the carry-forward DB transaction runs for real) while the heavy runtime I/O
+(trading loop, websocket streams, account sync, periodic reconciler) is mocked
+out so ``start()`` returns promptly. They assert the previously-orphaned OPEN
+position is carried forward: present in ``live_position_tracker``, registered
+with the risk manager, its server-side stop-loss tracked by ``OrderTracker``,
+and that startup reconciliation takes the non-empty ``reconcile_startup`` branch
+rather than the "No local positions to reconcile" path.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.database.models import Position, PositionStatus, TradeSource
+from src.engines.live.trading_engine import LiveTradingEngine
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = pytest.mark.fast
+
+# Must match create_ml_basic_strategy().name (the value _strategy_name() returns),
+# since get_last_session_id() filters the recovery candidate by strategy name.
+STRATEGY_NAME = "MlBasic"
+SYMBOL = "BTCUSDT"
+
+
+def _seed_inactive_session_with_open_position(
+    db: DatabaseManager,
+    *,
+    symbol: str = SYMBOL,
+    strategy: str = STRATEGY_NAME,
+    stop_loss_order_id: str | None = "sl-exch-1",
+    entry_order_id: str = "entry-exch-1",
+) -> tuple[int, int]:
+    """Create an ENDED session that still owns an OPEN position.
+
+    Returns (session_id, position_id).
+    """
+    session_id = db.create_trading_session(
+        strategy_name=strategy,
+        symbol=symbol,
+        timeframe="1h",
+        mode=TradeSource.PAPER,
+        initial_balance=1000.0,
+    )
+    position_id = db.log_position(
+        symbol=symbol,
+        side="long",
+        entry_price=100.0,
+        size=0.1,
+        strategy_name=strategy,
+        entry_order_id=entry_order_id,
+        quantity=1.0,
+        entry_balance=1000.0,
+        session_id=session_id,
+        stop_loss_order_id=stop_loss_order_id,
+    )
+    # Gracefully end the session (mirrors a clean shutdown): is_active -> False.
+    db.end_trading_session(session_id=session_id, final_balance=1000.0)
+    return session_id, position_id
+
+
+def _make_live_engine_with_real_db(db: DatabaseManager) -> LiveTradingEngine:
+    """Build a live-mode engine wired to a real in-memory DB.
+
+    The exchange provider is mocked (so live mode initializes its account
+    synchronizer + order tracker) but the DB is real so the carry-forward
+    transaction executes end to end.
+    """
+    strategy = create_ml_basic_strategy()
+    mock_data_provider = MagicMock()
+
+    with (
+        patch("src.engines.live.trading_engine.DatabaseManager"),
+        patch("src.engines.live.trading_engine.get_config", return_value={}),
+        patch(
+            "src.engines.live.trading_engine._create_exchange_provider",
+            return_value=(MagicMock(), "mock"),
+        ),
+    ):
+        engine = LiveTradingEngine(
+            strategy=strategy,
+            data_provider=mock_data_provider,
+            initial_balance=1000.0,
+            enable_live_trading=True,
+            resume_from_last_balance=True,
+        )
+
+    # Swap in the real database used to seed the orphan.
+    engine.db_manager = db
+    return engine
+
+
+def _run_start_with_mocked_runtime(
+    engine: LiveTradingEngine,
+    reconciler_cls: MagicMock,
+) -> None:
+    """Drive start() to completion with heavy runtime I/O neutralized."""
+    # Make the trading loop a no-op so the worker thread dies immediately and
+    # start()'s keep-alive loop exits and calls stop().
+    engine._run_trading_loop = MagicMock()
+    engine._start_websocket_streams = MagicMock()
+    engine._exit_if_loop_crashed = MagicMock()
+    # Display-only; mocked to avoid Decimal/float arithmetic in the final-stats
+    # banner when balance is recovered from the DB as a Decimal (orthogonal to
+    # the position carry-forward under test).
+    engine._print_final_stats = MagicMock()
+
+    # Account sync: report success with no balance correction so start() proceeds
+    # to position reconciliation using the real recovered state.
+    sync_result = MagicMock()
+    sync_result.success = True
+    sync_result.data = {"balance_sync": {"corrected": False}}
+    engine.account_synchronizer.sync_account_data = MagicMock(return_value=sync_result)
+
+    with patch("src.engines.live.reconciliation.PositionReconciler", reconciler_cls):
+        engine.start(symbol=SYMBOL, timeframe="1h", max_steps=0)
+
+
+@pytest.fixture
+def reconciler_cls():
+    """A PositionReconciler stand-in that records how it was invoked.
+
+    Crucially, ``reconcile_startup`` runs AFTER recovery has loaded positions
+    into the tracker but BEFORE ``stop()`` (which, in live mode, closes and
+    drains them). So the snapshot it receives is the right place to observe the
+    carried-forward tracker state — capture it for assertions.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture_startup(positions_snapshot):
+        # Copy keys/values so later draining can't mutate what we asserted on.
+        captured["startup_snapshot"] = dict(positions_snapshot)
+        return []
+
+    instance = MagicMock()
+    instance.reconcile_startup.side_effect = _capture_startup
+    instance.resolve_pending_orders.return_value = []
+    cls = MagicMock(return_value=instance)
+    cls.instance = instance
+    cls.captured = captured
+    return cls
+
+
+class TestCleanRestartCarriesOpenPositionForward:
+    """The OPEN orphan under the old session is carried into the new session and
+    loaded into the live tracker on start()."""
+
+    def test_open_position_loaded_into_tracker(self, reconciler_cls):
+        db = DatabaseManager("sqlite:///:memory:")
+        old_session_id, position_id = _seed_inactive_session_with_open_position(db)
+        engine = _make_live_engine_with_real_db(db)
+
+        _run_start_with_mocked_runtime(engine, reconciler_cls)
+
+        # A brand-new session was created (clean-restart semantics preserved).
+        assert engine.trading_session_id is not None
+        assert engine.trading_session_id != old_session_id
+        # The previously-orphaned position was loaded into the live tracker
+        # before reconciliation (snapshot captured at reconcile_startup time,
+        # ahead of the live-mode stop() that drains the tracker).
+        tracked = reconciler_cls.captured["startup_snapshot"]
+        assert len(tracked) == 1
+        position = next(iter(tracked.values()))
+        assert position.symbol == SYMBOL
+        assert position.db_position_id == position_id
+
+    def test_position_carried_to_new_session_in_db(self, reconciler_cls):
+        db = DatabaseManager("sqlite:///:memory:")
+        old_session_id, position_id = _seed_inactive_session_with_open_position(db)
+        engine = _make_live_engine_with_real_db(db)
+
+        _run_start_with_mocked_runtime(engine, reconciler_cls)
+
+        # The DB row is now bound to the new session and surfaces under it.
+        with db.get_session() as s:
+            pos = s.query(Position).filter(Position.id == position_id).first()
+            assert pos.session_id == engine.trading_session_id
+            assert pos.status == PositionStatus.OPEN
+        active_ids = [p["id"] for p in db.get_active_positions(engine.trading_session_id)]
+        assert position_id in active_ids
+
+    def test_recovered_stop_loss_tracked_by_order_tracker(self, reconciler_cls):
+        db = DatabaseManager("sqlite:///:memory:")
+        _seed_inactive_session_with_open_position(db, stop_loss_order_id="sl-exch-1")
+        engine = _make_live_engine_with_real_db(db)
+
+        _run_start_with_mocked_runtime(engine, reconciler_cls)
+
+        assert engine.order_tracker is not None
+        # The recovered position's server-side SL order is being monitored.
+        assert "sl-exch-1" in engine.order_tracker._pending_orders
+
+    def test_recovered_position_registered_with_risk_manager(self, reconciler_cls):
+        db = DatabaseManager("sqlite:///:memory:")
+        _seed_inactive_session_with_open_position(db)
+        engine = _make_live_engine_with_real_db(db)
+        # Spy on the real risk manager.
+        engine.risk_manager.update_position = MagicMock(wraps=engine.risk_manager.update_position)
+
+        _run_start_with_mocked_runtime(engine, reconciler_cls)
+
+        assert engine.risk_manager.update_position.called
+        symbols = {
+            c.kwargs.get("symbol") for c in engine.risk_manager.update_position.call_args_list
+        }
+        assert SYMBOL in symbols
+
+    def test_reconciler_takes_nonempty_startup_branch(self, reconciler_cls):
+        """With the orphan carried forward, the tracker is non-empty, so startup
+        reconciliation re-verifies the position via reconcile_startup() rather
+        than falling through to the empty 'No local positions to reconcile' path
+        (resolve_pending_orders)."""
+        db = DatabaseManager("sqlite:///:memory:")
+        _seed_inactive_session_with_open_position(db)
+        engine = _make_live_engine_with_real_db(db)
+
+        _run_start_with_mocked_runtime(engine, reconciler_cls)
+
+        reconciler_cls.instance.reconcile_startup.assert_called_once()
+        # The empty-tracker branch must NOT have been taken.
+        reconciler_cls.instance.resolve_pending_orders.assert_not_called()
+
+    def test_reassign_called_with_symbol_and_strategy(self, reconciler_cls):
+        """The carry-forward is scoped to the active symbol + strategy so a
+        co-tenant symbol/strategy in the same DB is not pulled in."""
+        db = DatabaseManager("sqlite:///:memory:")
+        old_session_id, _ = _seed_inactive_session_with_open_position(db)
+        engine = _make_live_engine_with_real_db(db)
+        engine.db_manager.reassign_open_positions_to_session = MagicMock(
+            wraps=engine.db_manager.reassign_open_positions_to_session
+        )
+
+        _run_start_with_mocked_runtime(engine, reconciler_cls)
+
+        engine.db_manager.reassign_open_positions_to_session.assert_called_once()
+        kwargs = engine.db_manager.reassign_open_positions_to_session.call_args.kwargs
+        assert kwargs["old_session_id"] == old_session_id
+        assert kwargs["new_session_id"] == engine.trading_session_id
+        assert kwargs["symbol"] == SYMBOL
+        assert kwargs["strategy_name"] == STRATEGY_NAME
+
+
+class TestCleanRestartNoOrphan:
+    """When there is no inactive session to recover, the new code is inert and the
+    normal boot path is unchanged (regression guard)."""
+
+    def test_no_recovery_does_not_call_reassign(self, reconciler_cls):
+        db = DatabaseManager("sqlite:///:memory:")  # empty DB, nothing to recover
+        engine = _make_live_engine_with_real_db(db)
+        engine.db_manager.reassign_open_positions_to_session = MagicMock(
+            wraps=engine.db_manager.reassign_open_positions_to_session
+        )
+
+        _run_start_with_mocked_runtime(engine, reconciler_cls)
+
+        assert engine._recovered_inactive_session_id is None
+        engine.db_manager.reassign_open_positions_to_session.assert_not_called()
+        # No positions, so reconciliation takes the empty branch.
+        reconciler_cls.instance.resolve_pending_orders.assert_called_once()
+        reconciler_cls.instance.reconcile_startup.assert_not_called()
+
+
+class TestRecoverExistingSessionRemembersInactiveId:
+    """Unit-level: _recover_existing_session captures the inactive session id on
+    the clean-restart branch (and only there)."""
+
+    def test_inactive_branch_sets_recovered_id(self):
+        db = DatabaseManager("sqlite:///:memory:")
+        old_session_id, _ = _seed_inactive_session_with_open_position(db)
+        engine = _make_live_engine_with_real_db(db)
+        engine._active_symbol = SYMBOL
+
+        recovered = engine._recover_existing_session()
+
+        assert recovered is not None
+        # New-session semantics preserved: trading_session_id stays unset...
+        assert engine.trading_session_id is None
+        # ...but the old session id is remembered for carry-forward.
+        assert engine._recovered_inactive_session_id == old_session_id
+
+    def test_active_branch_does_not_set_recovered_id(self):
+        db = DatabaseManager("sqlite:///:memory:")
+        engine = _make_live_engine_with_real_db(db)
+        engine._active_symbol = SYMBOL
+        # Force the active (crash-recovery) path.
+        engine.db_manager.get_active_session_id = MagicMock(return_value=55)
+        engine.db_manager.recover_last_balance = MagicMock(return_value=900.0)
+
+        recovered = engine._recover_existing_session()
+
+        assert recovered == 900.0
+        assert engine.trading_session_id == 55
+        assert engine._recovered_inactive_session_id is None

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -142,6 +142,36 @@ def test_recovery_returns_none_when_session_found_but_no_balance():
 
 
 @pytest.mark.fast
+def test_inactive_session_remembered_even_when_balance_zero():
+    """#668 P2: a fully-liquidated inactive session (balance 0) still gets its id
+    remembered so start() carries its OPEN positions forward — gating the
+    remember on balance > 0 would re-orphan them."""
+    engine = make_engine()
+    engine.db_manager.get_active_session_id = MagicMock(return_value=None)
+    engine.db_manager.get_last_session_id = MagicMock(return_value=42)
+    engine.db_manager.recover_last_balance = MagicMock(return_value=0.0)
+
+    result = engine._recover_existing_session()
+
+    assert result is None  # no positive balance recovered
+    assert engine._recovered_inactive_session_id == 42  # but the session is remembered
+
+
+@pytest.mark.fast
+def test_active_session_does_not_set_recovered_inactive_id():
+    """The active/crash-recovery path reuses the session directly and must NOT set
+    _recovered_inactive_session_id (#668 selectivity)."""
+    engine = make_engine()
+    engine.db_manager.get_active_session_id = MagicMock(return_value=77)
+    engine.db_manager.recover_last_balance = MagicMock(return_value=850.0)
+
+    engine._recover_existing_session()
+
+    assert engine._recovered_inactive_session_id is None
+    assert engine.trading_session_id == 77
+
+
+@pytest.mark.fast
 def test_paper_mode_stop_preserves_open_positions():
     """In paper trading, stop() must NOT force-close positions."""
     engine = make_engine(enable_live_trading=False)


### PR DESCRIPTION
## Why
A graceful restart **orphaned a live ETH LONG in production** (2026-06-04 19:12): the clean-restart (recent-inactive) recovery path restores balance but creates a NEW session, while OPEN positions stay bound to the OLD session (`Position.session_id`), so `get_active_positions(new_session)` can't see them (`manager.py:1648` is the pin). Every exchange-side backstop misses it (empty tracker → no `reconcile_position`; margin mode skips `_sync_positions`; the SL-order sync is a stub). This is #668's failure mode, only half-closed by #670.

## Fix (Option A — carry positions forward)
- **New** `DatabaseManager.reassign_open_positions_to_session(old, new, symbol, strategy)` — re-points genuinely-OPEN positions (+ their linked orders) onto the new session in one `FOR UPDATE` write transaction, with a `ReconciliationAuditEvent` per move. Respects `uq_order_internal_session` (leaves a colliding order behind; linkage survives via `Order.position_id`). Idempotent; only `status=OPEN` rows move (a #671 atomically-closed position is never resurrected).
- **Engine**: `_recover_existing_session` remembers the inactive old-session id (independent of the recovered balance — P2); `start()` reassigns then reloads via `_recover_active_positions()`, after which the existing `reconcile_startup` path re-verifies the position + re-attaches its server-side SL. Resets the id in `finally` (P3).
- **Reconciles the current prod orphan** automatically on the post-deploy restart (re-adopt, not flatten — the position is intact + SL-protected).

## Vetting
- architecture-reviewer **APPROVE** (P2/P3 applied) + code-reviewer **APPROVE** (no blocking).
- Tests: 21 (#668) + 2 (P2) new; recovery/reconcile/position sweep **690+ passed**; ruff/black clean.
- Option B (exchange-side adoption for the no-DB-row case) is a deferred follow-up (#675-adjacent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)