### PR TITLE
fix(live): re-adopt ALL orphaned OPEN positions on clean restart (#668 follow-up)

### DIFF
--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -1743,7 +1743,7 @@ class DatabaseManager:
 
     def reassign_open_positions_to_session(
         self,
-        old_session_id: int,
+        old_session_id: int | None,
         new_session_id: int,
         symbol: str | None = None,
         strategy_name: str | None = None,
@@ -1782,17 +1782,30 @@ class DatabaseManager:
         Returns:
             The DB ids of the positions that were moved (empty if none matched).
         """
-        if old_session_id == new_session_id:
+        if old_session_id is not None and old_session_id == new_session_id:
             # No-op: nothing to carry forward onto the same session.
             return []
 
         # Single WRITE-timeout transaction: position re-point, order re-point,
         # and audit rows commit together (atomic — CODE.md Database & Transactions).
         with self.get_session_with_timeout(QueryTimeout.WRITE) as session:
-            query = session.query(Position).filter(
-                Position.status == PositionStatus.OPEN,
-                Position.session_id == old_session_id,
-            )
+            query = session.query(Position).filter(Position.status == PositionStatus.OPEN)
+            if old_session_id is None:
+                # Adopt EVERY orphaned OPEN position for this symbol/strategy: any
+                # not already under the new session — INCLUDING positions stranded
+                # under an OLDER inactive session than the one whose balance we
+                # recovered (e.g. an intervening flat restart left the position
+                # behind two sessions back). Phantom-safe: the startup heal (#657)
+                # closes any carried-forward position that has a terminal Trade, and
+                # reconcile_startup exchange-verifies the rest (#668).
+                query = query.filter(
+                    sa.or_(
+                        Position.session_id != new_session_id,
+                        Position.session_id.is_(None),
+                    )
+                )
+            else:
+                query = query.filter(Position.session_id == old_session_id)
             if symbol is not None:
                 query = query.filter(Position.symbol == symbol)
             if strategy_name is not None:
@@ -1809,6 +1822,10 @@ class DatabaseManager:
             moved_ids: list[int] = []
             now = datetime.now(UTC)
             for position in positions:
+                # Capture the original session BEFORE re-pointing — old_session_id
+                # may be None (adopting all orphans), so the position's own
+                # session_id is the source of truth for the audit + logs.
+                original_session_id = position.session_id
                 # Re-point linked orders first, skipping any that would collide
                 # with an existing (internal_order_id, new_session_id) row.
                 orders = session.query(Order).filter(Order.position_id == position.id).all()
@@ -1833,7 +1850,7 @@ class DatabaseManager:
                             order.id,
                             order.internal_order_id,
                             position.id,
-                            old_session_id,
+                            original_session_id,
                             new_session_id,
                         )
                         continue
@@ -1851,11 +1868,11 @@ class DatabaseManager:
                         entity_type="position",
                         entity_id=position.id,
                         field="session_id",
-                        old_value=str(old_session_id),
+                        old_value=str(original_session_id),
                         new_value=str(new_session_id),
                         reason=(
                             f"Carried OPEN {position.symbol} position forward from "
-                            f"inactive session #{old_session_id} on clean restart (#668)"
+                            f"inactive session #{original_session_id} on clean restart (#668)"
                         ),
                         severity="HIGH",
                     )

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1328,28 +1328,30 @@ class LiveTradingEngine:
             self.live_execution_engine.session_id = self.trading_session_id
             self.live_execution_engine.strategy_name = self._strategy_name()
 
-        # Carry OPEN positions forward on a clean restart (#668). The inactive
-        # session recovered above (balance only) still owns any OPEN position via
-        # Position.session_id, so _recover_active_positions() at line ~1281 saw a
-        # None session id and loaded nothing — the position would be orphaned.
-        # Re-point those positions onto the new session, then reload them into the
-        # live tracker. Ordering: reassign → recover-into-tracker (which self-heals
-        # first) → the heal + exchange reconciliation below re-verify the position
-        # and its server-side stop-loss against the exchange.
+        # Re-adopt orphaned OPEN positions on a clean restart (#668). A graceful
+        # restart recovers balance but creates a NEW session; any OPEN position
+        # still bound to a PRIOR session is invisible to get_active_positions(new)
+        # and would be orphaned. We adopt EVERY such position for this
+        # symbol/strategy — not just the single recovered session's — because an
+        # intervening flat restart can leave the position stranded two sessions
+        # back. Ordering: reassign → recover-into-tracker → the heal (#657, closes
+        # any phantom with a terminal trade) + exchange reconciliation below
+        # re-verify each position and its server-side stop-loss against Binance.
         if self._recovered_inactive_session_id is not None and self.trading_session_id is not None:
             try:
                 moved_ids = self.db_manager.reassign_open_positions_to_session(
-                    old_session_id=self._recovered_inactive_session_id,
+                    # None ⇒ adopt ALL orphaned OPEN positions (any session != new),
+                    # scoped to this symbol/strategy.
+                    old_session_id=None,
                     new_session_id=self.trading_session_id,
                     symbol=self._active_symbol,
                     strategy_name=self._strategy_name(),
                 )
                 if moved_ids:
                     logger.info(
-                        "🔁 Carried %d OPEN position(s) forward from inactive session "
-                        "#%s into new session #%s; reloading into tracker",
+                        "🔁 Re-adopted %d orphaned OPEN position(s) into new session "
+                        "#%s; reloading into tracker",
                         len(moved_ids),
-                        self._recovered_inactive_session_id,
                         self.trading_session_id,
                     )
                     # Reload now that the rows belong to the new session. Safe and
@@ -1359,10 +1361,8 @@ class LiveTradingEngine:
                 # A failure here must not abort startup, but it is capital-critical
                 # (an OPEN position stays orphaned), so log loudly for alerting.
                 logger.critical(
-                    "Failed to carry OPEN positions forward from inactive session "
-                    "#%s into session #%s (positions may be orphaned — MANUAL "
-                    "RECONCILIATION REQUIRED): %s",
-                    self._recovered_inactive_session_id,
+                    "Failed to re-adopt orphaned OPEN positions into session #%s "
+                    "(positions may be orphaned — MANUAL RECONCILIATION REQUIRED): %s",
                     self.trading_session_id,
                     reassign_err,
                     exc_info=True,

--- a/tests/unit/database/test_reassign_open_positions.py
+++ b/tests/unit/database/test_reassign_open_positions.py
@@ -145,6 +145,31 @@ class TestReassignOpenPositions:
         assert _position_session(db, already_new) == new  # already-current untouched
         assert _position_session(db, other_symbol) == oldest  # co-tenant symbol not pulled in
 
+    def test_old_session_none_adopts_null_session_orphan(self):
+        """old=None must also adopt an OPEN position whose session_id is NULL
+        (the column is nullable). `session_id != new` ALONE drops NULL rows
+        (NULL <> x → UNKNOWN → excluded), so the explicit `IS NULL` in the
+        filter is load-bearing — this guards against a future "simplification"
+        that would silently re-orphan a NULL-session position (#668)."""
+        db = _make_db()
+        new = _new_session(db)
+        orphan = _open_position(db, new, entry_order_id="exch-null")
+        # Strand it: NULL session_id (no owning session).
+        with db.get_session() as session:
+            session.query(Position).filter(Position.id == orphan).first().session_id = None
+            session.commit()
+        assert _position_session(db, orphan) is None
+
+        moved = db.reassign_open_positions_to_session(
+            old_session_id=None,
+            new_session_id=new,
+            symbol="BTCUSDT",
+            strategy_name="TestStrategy",
+        )
+
+        assert moved == [orphan]
+        assert _position_session(db, orphan) == new
+
     def test_closed_position_is_not_carried_forward(self):
         """A position CLOSED under the old session (e.g. by #671's atomic close)
         must NOT be resurrected onto the new session."""

--- a/tests/unit/database/test_reassign_open_positions.py
+++ b/tests/unit/database/test_reassign_open_positions.py
@@ -114,6 +114,37 @@ class TestReassignOpenPositions:
         # ...and no longer under the old one.
         assert all(p["id"] != position_id for p in db.get_active_positions(old))
 
+    def test_old_session_none_adopts_all_orphaned_positions(self):
+        """old_session_id=None adopts EVERY orphaned OPEN position for the
+        symbol/strategy (any session != new) — including one stranded under an
+        OLDER session than the most-recent (an intervening flat restart left it
+        two sessions back: the live-prod-orphan case, #668)."""
+        db = _make_db()
+        oldest = _new_session(db)  # holds the real orphan
+        intervening = _new_session(db)  # a later, flat session
+        new = _new_session(db)  # the current active session
+
+        orphan_oldest = _open_position(db, oldest, entry_order_id="exch-oldest")
+        orphan_mid = _open_position(db, intervening, entry_order_id="exch-mid")
+        closed = _open_position(db, oldest, entry_order_id="exch-closed")
+        _close_position(db, closed)
+        already_new = _open_position(db, new, entry_order_id="exch-new")
+        other_symbol = _open_position(db, oldest, symbol="ETHUSDT", entry_order_id="exch-eth")
+
+        moved = db.reassign_open_positions_to_session(
+            old_session_id=None,
+            new_session_id=new,
+            symbol="BTCUSDT",
+            strategy_name="TestStrategy",
+        )
+
+        assert set(moved) == {orphan_oldest, orphan_mid}  # both orphans, across two sessions
+        assert _position_session(db, orphan_oldest) == new
+        assert _position_session(db, orphan_mid) == new
+        assert _position_session(db, closed) == oldest  # CLOSED not resurrected
+        assert _position_session(db, already_new) == new  # already-current untouched
+        assert _position_session(db, other_symbol) == oldest  # co-tenant symbol not pulled in
+
     def test_closed_position_is_not_carried_forward(self):
         """A position CLOSED under the old session (e.g. by #671's atomic close)
         must NOT be resurrected onto the new session."""

--- a/tests/unit/engines/live/test_clean_restart_readoption.py
+++ b/tests/unit/engines/live/test_clean_restart_readoption.py
@@ -236,7 +236,7 @@ class TestCleanRestartCarriesOpenPositionForward:
         """The carry-forward is scoped to the active symbol + strategy so a
         co-tenant symbol/strategy in the same DB is not pulled in."""
         db = DatabaseManager("sqlite:///:memory:")
-        old_session_id, _ = _seed_inactive_session_with_open_position(db)
+        _seed_inactive_session_with_open_position(db)
         engine = _make_live_engine_with_real_db(db)
         engine.db_manager.reassign_open_positions_to_session = MagicMock(
             wraps=engine.db_manager.reassign_open_positions_to_session
@@ -246,7 +246,10 @@ class TestCleanRestartCarriesOpenPositionForward:
 
         engine.db_manager.reassign_open_positions_to_session.assert_called_once()
         kwargs = engine.db_manager.reassign_open_positions_to_session.call_args.kwargs
-        assert kwargs["old_session_id"] == old_session_id
+        # old_session_id=None ⇒ adopt ALL orphaned OPEN positions (any session != new),
+        # not just the recovered session — catches a position stranded under an OLDER
+        # session by an intervening flat restart (the live-prod-orphan case, #668).
+        assert kwargs["old_session_id"] is None
         assert kwargs["new_session_id"] == engine.trading_session_id
         assert kwargs["symbol"] == SYMBOL
         assert kwargs["strategy_name"] == STRATEGY_NAME


### PR DESCRIPTION
## Why (caught pre-deploy)
The merged #668 fix (PR #677) carries forward only the **most-recent inactive session's** positions. But the **live prod orphan** is stranded under an **older session**: an intervening flat restart (the #676 deploy booted an empty new session) left the ETH LONG two sessions back. So #677 alone prevents *future* orphans but wouldn't reconcile the *current* one — the code reviewer flagged exactly this ("only the single most-recent inactive session is drained").

## Change
`reassign_open_positions_to_session(old_session_id=None, …)` ⇒ adopt **every** orphaned OPEN position for the symbol/strategy (`session_id != new_session_id`, incl. NULL). The engine passes `None` on the clean-restart path. Phantom-safe by construction: the startup heal (#657) closes any carried-forward position that has a terminal Trade, and `reconcile_startup` exchange-verifies the rest (removing any not actually on Binance — now that #674 fixed the margin check). Scoped to the bot's symbol+strategy, so co-tenant rows are never pulled in.

## Result
The post-deploy restart now **re-adopts the live prod orphan** regardless of which session it's under. Backward-compatible (passing a concrete `old_session_id` still works for the original path).

## Testing
- New `test_old_session_none_adopts_all_orphaned_positions` (adopts across two older sessions; leaves CLOSED / already-current / co-tenant-symbol untouched); updated engine call test. **37 reassign/recovery tests pass**; ruff/black clean (the 6 ruff errors are pre-existing UP038 in manager.py).

Stacks on #677 (already in develop). 🤖 Generated with [Claude Code](https://claude.com/claude-code)