### PR TITLE
Revert #679 (clean-restart adopt-all resurrects phantoms); keep #677-only

### DIFF
--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -8,3 +8,18 @@ See `README.md` for format.
 
 ## 1970-01-01 00:00 · note · system
 Log initialized.
+
+---
+
+## 2026-06-05 · incident-resolve · daemon(PM)
+**Prod "orphan" was a PHANTOM, not double-exposure.** Halted the approved #677+#679 promote after prod logs showed the bot was no longer flat (opened new pos #13 at 20:07 UTC) with the old orphan SL still referenced. With explicit human approval, ran a strictly read-only reconciliation inside the prod container (`railway ssh`, SELECT + GET only):
+- DB had 2 OPEN ETHUSDT rows: **#12** (0.0033 ETH, session 17, SL `47100334866`) and **#13** (0.0037 ETH, session 18, SL `47181104013`).
+- Exchange truth: only **0.00378 ETH** held (= #13's 0.0037 + dust); only **one** live ETH order (`47181104013`); account equity **$83.28** vs tracked $84.13.
+- ⇒ **#12 is a phantom** (stale pre-#671 close-gap row; its ETH + SL already gone). No double-exposure. Only #13 is real and SL-protected.
+
+**Actions (human-approved):**
+1. Closed phantom #12 in prod DB (guarded status-only write; re-verified exchange showed no second holding before writing). Balance NOT manually poked — layer-2 `_sync_margin_equity` books the $0.85 (1%) overstatement to true equity at the next FLAT moment (race-free).
+2. Pivoted the prod promote from #677+#679 → **#677-only** (PR #682; closed #680). #677 is phantom-safe (re-adopts only most-recent inactive session; `old_session_id=self._recovered_inactive_session_id`). #679's `adopt-all` would resurrect phantoms because the margin-LONG reconcile check (`reconciliation.py:1885`) reads AGGREGATE balance — a phantom borrows the real position's holdings and survives.
+3. Filed **#683** to redesign #679 as exchange-verified-before-adopt; #679 to be reverted on develop (interim parity with prod = #677-only).
+
+Refs: #668, #677, #679, #671, #648/#15, #28 (booking-while-held), #674 (margin Decimal, in prod).

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -1743,7 +1743,7 @@ class DatabaseManager:
 
     def reassign_open_positions_to_session(
         self,
-        old_session_id: int | None,
+        old_session_id: int,
         new_session_id: int,
         symbol: str | None = None,
         strategy_name: str | None = None,
@@ -1782,30 +1782,17 @@ class DatabaseManager:
         Returns:
             The DB ids of the positions that were moved (empty if none matched).
         """
-        if old_session_id is not None and old_session_id == new_session_id:
+        if old_session_id == new_session_id:
             # No-op: nothing to carry forward onto the same session.
             return []
 
         # Single WRITE-timeout transaction: position re-point, order re-point,
         # and audit rows commit together (atomic — CODE.md Database & Transactions).
         with self.get_session_with_timeout(QueryTimeout.WRITE) as session:
-            query = session.query(Position).filter(Position.status == PositionStatus.OPEN)
-            if old_session_id is None:
-                # Adopt EVERY orphaned OPEN position for this symbol/strategy: any
-                # not already under the new session — INCLUDING positions stranded
-                # under an OLDER inactive session than the one whose balance we
-                # recovered (e.g. an intervening flat restart left the position
-                # behind two sessions back). Phantom-safe: the startup heal (#657)
-                # closes any carried-forward position that has a terminal Trade, and
-                # reconcile_startup exchange-verifies the rest (#668).
-                query = query.filter(
-                    sa.or_(
-                        Position.session_id != new_session_id,
-                        Position.session_id.is_(None),
-                    )
-                )
-            else:
-                query = query.filter(Position.session_id == old_session_id)
+            query = session.query(Position).filter(
+                Position.status == PositionStatus.OPEN,
+                Position.session_id == old_session_id,
+            )
             if symbol is not None:
                 query = query.filter(Position.symbol == symbol)
             if strategy_name is not None:
@@ -1822,10 +1809,6 @@ class DatabaseManager:
             moved_ids: list[int] = []
             now = datetime.now(UTC)
             for position in positions:
-                # Capture the original session BEFORE re-pointing — old_session_id
-                # may be None (adopting all orphans), so the position's own
-                # session_id is the source of truth for the audit + logs.
-                original_session_id = position.session_id
                 # Re-point linked orders first, skipping any that would collide
                 # with an existing (internal_order_id, new_session_id) row.
                 orders = session.query(Order).filter(Order.position_id == position.id).all()
@@ -1850,7 +1833,7 @@ class DatabaseManager:
                             order.id,
                             order.internal_order_id,
                             position.id,
-                            original_session_id,
+                            old_session_id,
                             new_session_id,
                         )
                         continue
@@ -1868,11 +1851,11 @@ class DatabaseManager:
                         entity_type="position",
                         entity_id=position.id,
                         field="session_id",
-                        old_value=str(original_session_id),
+                        old_value=str(old_session_id),
                         new_value=str(new_session_id),
                         reason=(
                             f"Carried OPEN {position.symbol} position forward from "
-                            f"inactive session #{original_session_id} on clean restart (#668)"
+                            f"inactive session #{old_session_id} on clean restart (#668)"
                         ),
                         severity="HIGH",
                     )

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1333,30 +1333,28 @@ class LiveTradingEngine:
             self.live_execution_engine.session_id = self.trading_session_id
             self.live_execution_engine.strategy_name = self._strategy_name()
 
-        # Re-adopt orphaned OPEN positions on a clean restart (#668). A graceful
-        # restart recovers balance but creates a NEW session; any OPEN position
-        # still bound to a PRIOR session is invisible to get_active_positions(new)
-        # and would be orphaned. We adopt EVERY such position for this
-        # symbol/strategy — not just the single recovered session's — because an
-        # intervening flat restart can leave the position stranded two sessions
-        # back. Ordering: reassign → recover-into-tracker → the heal (#657, closes
-        # any phantom with a terminal trade) + exchange reconciliation below
-        # re-verify each position and its server-side stop-loss against Binance.
+        # Carry OPEN positions forward on a clean restart (#668). The inactive
+        # session recovered above (balance only) still owns any OPEN position via
+        # Position.session_id, so _recover_active_positions() at line ~1281 saw a
+        # None session id and loaded nothing — the position would be orphaned.
+        # Re-point those positions onto the new session, then reload them into the
+        # live tracker. Ordering: reassign → recover-into-tracker (which self-heals
+        # first) → the heal + exchange reconciliation below re-verify the position
+        # and its server-side stop-loss against the exchange.
         if self._recovered_inactive_session_id is not None and self.trading_session_id is not None:
             try:
                 moved_ids = self.db_manager.reassign_open_positions_to_session(
-                    # None ⇒ adopt ALL orphaned OPEN positions (any session != new),
-                    # scoped to this symbol/strategy.
-                    old_session_id=None,
+                    old_session_id=self._recovered_inactive_session_id,
                     new_session_id=self.trading_session_id,
                     symbol=self._active_symbol,
                     strategy_name=self._strategy_name(),
                 )
                 if moved_ids:
                     logger.info(
-                        "🔁 Re-adopted %d orphaned OPEN position(s) into new session "
-                        "#%s; reloading into tracker",
+                        "🔁 Carried %d OPEN position(s) forward from inactive session "
+                        "#%s into new session #%s; reloading into tracker",
                         len(moved_ids),
+                        self._recovered_inactive_session_id,
                         self.trading_session_id,
                     )
                     # Reload now that the rows belong to the new session. Safe and
@@ -1366,8 +1364,10 @@ class LiveTradingEngine:
                 # A failure here must not abort startup, but it is capital-critical
                 # (an OPEN position stays orphaned), so log loudly for alerting.
                 logger.critical(
-                    "Failed to re-adopt orphaned OPEN positions into session #%s "
-                    "(positions may be orphaned — MANUAL RECONCILIATION REQUIRED): %s",
+                    "Failed to carry OPEN positions forward from inactive session "
+                    "#%s into session #%s (positions may be orphaned — MANUAL "
+                    "RECONCILIATION REQUIRED): %s",
+                    self._recovered_inactive_session_id,
                     self.trading_session_id,
                     reassign_err,
                     exc_info=True,

--- a/tests/unit/database/test_reassign_open_positions.py
+++ b/tests/unit/database/test_reassign_open_positions.py
@@ -114,62 +114,6 @@ class TestReassignOpenPositions:
         # ...and no longer under the old one.
         assert all(p["id"] != position_id for p in db.get_active_positions(old))
 
-    def test_old_session_none_adopts_all_orphaned_positions(self):
-        """old_session_id=None adopts EVERY orphaned OPEN position for the
-        symbol/strategy (any session != new) — including one stranded under an
-        OLDER session than the most-recent (an intervening flat restart left it
-        two sessions back: the live-prod-orphan case, #668)."""
-        db = _make_db()
-        oldest = _new_session(db)  # holds the real orphan
-        intervening = _new_session(db)  # a later, flat session
-        new = _new_session(db)  # the current active session
-
-        orphan_oldest = _open_position(db, oldest, entry_order_id="exch-oldest")
-        orphan_mid = _open_position(db, intervening, entry_order_id="exch-mid")
-        closed = _open_position(db, oldest, entry_order_id="exch-closed")
-        _close_position(db, closed)
-        already_new = _open_position(db, new, entry_order_id="exch-new")
-        other_symbol = _open_position(db, oldest, symbol="ETHUSDT", entry_order_id="exch-eth")
-
-        moved = db.reassign_open_positions_to_session(
-            old_session_id=None,
-            new_session_id=new,
-            symbol="BTCUSDT",
-            strategy_name="TestStrategy",
-        )
-
-        assert set(moved) == {orphan_oldest, orphan_mid}  # both orphans, across two sessions
-        assert _position_session(db, orphan_oldest) == new
-        assert _position_session(db, orphan_mid) == new
-        assert _position_session(db, closed) == oldest  # CLOSED not resurrected
-        assert _position_session(db, already_new) == new  # already-current untouched
-        assert _position_session(db, other_symbol) == oldest  # co-tenant symbol not pulled in
-
-    def test_old_session_none_adopts_null_session_orphan(self):
-        """old=None must also adopt an OPEN position whose session_id is NULL
-        (the column is nullable). `session_id != new` ALONE drops NULL rows
-        (NULL <> x → UNKNOWN → excluded), so the explicit `IS NULL` in the
-        filter is load-bearing — this guards against a future "simplification"
-        that would silently re-orphan a NULL-session position (#668)."""
-        db = _make_db()
-        new = _new_session(db)
-        orphan = _open_position(db, new, entry_order_id="exch-null")
-        # Strand it: NULL session_id (no owning session).
-        with db.get_session() as session:
-            session.query(Position).filter(Position.id == orphan).first().session_id = None
-            session.commit()
-        assert _position_session(db, orphan) is None
-
-        moved = db.reassign_open_positions_to_session(
-            old_session_id=None,
-            new_session_id=new,
-            symbol="BTCUSDT",
-            strategy_name="TestStrategy",
-        )
-
-        assert moved == [orphan]
-        assert _position_session(db, orphan) == new
-
     def test_closed_position_is_not_carried_forward(self):
         """A position CLOSED under the old session (e.g. by #671's atomic close)
         must NOT be resurrected onto the new session."""

--- a/tests/unit/engines/live/test_clean_restart_readoption.py
+++ b/tests/unit/engines/live/test_clean_restart_readoption.py
@@ -236,7 +236,7 @@ class TestCleanRestartCarriesOpenPositionForward:
         """The carry-forward is scoped to the active symbol + strategy so a
         co-tenant symbol/strategy in the same DB is not pulled in."""
         db = DatabaseManager("sqlite:///:memory:")
-        _seed_inactive_session_with_open_position(db)
+        old_session_id, _ = _seed_inactive_session_with_open_position(db)
         engine = _make_live_engine_with_real_db(db)
         engine.db_manager.reassign_open_positions_to_session = MagicMock(
             wraps=engine.db_manager.reassign_open_positions_to_session
@@ -246,10 +246,7 @@ class TestCleanRestartCarriesOpenPositionForward:
 
         engine.db_manager.reassign_open_positions_to_session.assert_called_once()
         kwargs = engine.db_manager.reassign_open_positions_to_session.call_args.kwargs
-        # old_session_id=None ⇒ adopt ALL orphaned OPEN positions (any session != new),
-        # not just the recovered session — catches a position stranded under an OLDER
-        # session by an intervening flat restart (the live-prod-orphan case, #668).
-        assert kwargs["old_session_id"] is None
+        assert kwargs["old_session_id"] == old_session_id
         assert kwargs["new_session_id"] == engine.trading_session_id
         assert kwargs["symbol"] == SYMBOL
         assert kwargs["strategy_name"] == STRATEGY_NAME


### PR DESCRIPTION
Reverts #679 (`a0c2c55a`) on develop so develop matches the **#677-only** state now in production (PR #682).

## Why
`#679` made clean-restart re-adoption `old_session_id=None` ("adopt ALL orphaned OPEN positions"). Production reconciliation proved this **resurrects phantom DB rows**: the margin-LONG existence check (`reconciliation._verify_margin_position_exists`, ~line 1885) reads the *aggregate* asset balance, so a stale phantom borrows a real position's holdings, survives reconcile, and then gets a default SL placed for inventory that isn't there → `-2010` churn.

`#677` alone is phantom-safe — it re-adopts only the most-recent inactive session's positions (`old_session_id=self._recovered_inactive_session_id`). This revert restores that behavior + its original tests.

The proper fix (adopt across sessions but **exchange-verify each candidate** before adopting) is tracked in **#683** and will land as new work — not by re-applying #679 as-is.

Also includes a `.claude/state/log.md` entry recording the prod phantom incident + the #677-only promote.

## Parity
develop + production now both run #677-only for the #668 clean-restart path, per the "every environment mirrors production" principle.

Refs: #668, #677 (prod 28c340ce), #679 (reverted here), #683 (redesign).