### PR TITLE
Promote to production: coerce recovered balance to float, reject non-finite (#681)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Live restart balance recovery no longer crashes or silently resets on
+  `Decimal`-vs-`float` arithmetic. `DatabaseManager.recover_last_balance`'s trades
+  fallback computed `initial_balance + net PnL`, raising `TypeError` on
+  `Decimal + float` — swallowed by `_recover_existing_session`, which then returned
+  `None` and reset the engine to its default balance on restart. With no trades it
+  returned a raw `Decimal` that later broke `_print_final_stats`' float arithmetic
+  on shutdown (`unsupported operand -: Decimal and float`). The fallback now coerces
+  `float(initial_balance)`; `_recover_existing_session` coerces the recovered value
+  to `float` and fails fast (raises) on a non-finite balance *before* its `> 0`
+  positivity filter, so corrupt persisted state can never reach position sizing or
+  silently fall back to the default balance.
 - Backtest-live engine parity: closed nine silent divergences. Backtest now
   propagates `TimeExitPolicy`-specific exit reasons (`"Max holding period"`,
   `"Weekend flat"`, etc.) instead of hardcoding `"Time limit"`; gained an

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -2257,9 +2257,13 @@ class DatabaseManager:
             # Get all trades for this session
             trades = session.query(Trade).filter(Trade.session_id == session_id).all()
 
-            # Calculate current balance from initial balance + net PnL
+            # Calculate current balance from initial balance + net PnL.
+            # Coerce the Numeric initial_balance to float at the DB read boundary:
+            # _trade_net_pnl() returns float, and Decimal + float raises TypeError,
+            # which the caller swallows -> None -> the balance is silently lost and
+            # the session resets (CODE.md "Arithmetic & Financial Calculations").
             total_pnl = sum(_trade_net_pnl(trade) for trade in trades)
-            current_balance = trading_session.initial_balance + total_pnl
+            current_balance = float(trading_session.initial_balance) + total_pnl
 
             # Update the balance tracking and warn if persistence fails
             success = self.update_balance(

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1272,7 +1272,12 @@ class LiveTradingEngine:
         if self.resume_from_last_balance:
             recovered_balance = self._recover_existing_session()
             if recovered_balance is not None:
-                self.current_balance = recovered_balance
+                # _recover_existing_session() already coerced this to a finite float
+                # and rejected corrupt (non-finite) state. The float() here is a
+                # cheap defensive invariant so current_balance never becomes a
+                # Decimal — which would break downstream float arithmetic such as
+                # _print_final_stats (CODE.md "Arithmetic & Financial Calculations").
+                self.current_balance = float(recovered_balance)
                 logger.info(
                     "💾 Recovered balance from previous session: $%.2f",
                     recovered_balance,
@@ -4570,6 +4575,21 @@ class LiveTradingEngine:
                 self._recovered_inactive_session_id = session_id
 
             recovered_balance = self.db_manager.recover_last_balance(session_id)
+            # Sanitize BEFORE the positivity filter below. recover_last_balance()
+            # can return a Decimal (Numeric column), and corrupt state can be
+            # non-finite — float(Decimal('Infinity'))/NaN -> inf/nan. The `> 0`
+            # check would otherwise silently drop -inf/NaN to None (engine starts
+            # on the default balance and may trade) or raise on Decimal('NaN').
+            # Coerce to a float invariant and fail fast on non-finite: a corrupt
+            # persisted balance must halt startup, never feed position sizing
+            # (CODE.md "Arithmetic & Financial Calculations").
+            if recovered_balance is not None:
+                recovered_balance = float(recovered_balance)
+                if not math.isfinite(recovered_balance):
+                    raise ValueError(
+                        f"Recovered balance is not finite ({recovered_balance!r}); "
+                        "refusing to start on corrupt persisted state."
+                    )
             if recovered_balance and recovered_balance > 0:
                 # Crash recovery (active session): reuse the existing session ID so
                 # trades stay attributed to the same session row. Clean restarts create
@@ -4590,6 +4610,11 @@ class LiveTradingEngine:
 
             logger.warning("⚠️  Session #%s found but no balance to recover", session_id)
             return None
+        except ValueError:
+            # Corrupt-balance invariant violation — must not be swallowed by the
+            # broad handler below (that would silently fall back to the default
+            # balance). Propagate so startup fails fast.
+            raise
         except Exception as e:
             logger.error("❌ Error recovering session: %s", e, exc_info=True)
             return None

--- a/tests/unit/engines/live/test_recovered_balance_float_coercion.py
+++ b/tests/unit/engines/live/test_recovered_balance_float_coercion.py
@@ -1,0 +1,234 @@
+"""Regression: a balance recovered from the DB as a Decimal must be coerced to
+float at the engine recovery boundary (discovered while building #668).
+
+``DatabaseManager.recover_last_balance`` can return a ``decimal.Decimal``: when no
+``account_balances`` row exists it falls back to ``TradingSession.initial_balance``
+(a ``Numeric(18, 8)`` column) plus net trade PnL, and SQLAlchemy hands ``Numeric``
+back as ``Decimal``. ``start()`` stored that straight into ``self.current_balance``,
+so the shutdown banner's float arithmetic in ``_print_final_stats()`` —
+``(self.current_balance - self.initial_balance) / self.initial_balance`` — raised
+``TypeError: unsupported operand type(s) for -: 'decimal.Decimal' and 'float'``.
+
+``start()`` must coerce the recovered balance to ``float`` so ``current_balance``
+stays a float invariant (CODE.md "Arithmetic & Financial Calculations": coerce
+``Numeric`` reads to ``float`` at the boundary, as ``get_active_positions`` does).
+
+These drive ``LiveTradingEngine.start()`` in PAPER mode against a REAL in-memory DB
+(so the Decimal-producing recovery transaction runs for real) with only the
+trading loop / websocket I/O mocked, so ``start()`` returns promptly and runs
+``stop()`` -> ``_print_final_stats()`` end to end. Paper mode skips all live-only
+machinery (account sync, reconcilers, order tracker), keeping the repro minimal.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.database.models import TradeSource
+from src.engines.live.trading_engine import LiveTradingEngine
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = pytest.mark.fast
+
+# Must equal create_ml_basic_strategy().name — get_last_session_id() filters the
+# recovery candidate by strategy name.
+STRATEGY_NAME = "MlBasic"
+SYMBOL = "BTCUSDT"
+
+
+def _seed_inactive_session(db: DatabaseManager) -> int:
+    """Create an ENDED session with NO account_balances row.
+
+    With no persisted balance row, recover_last_balance() takes its trades
+    fallback and returns ``initial_balance`` (a Numeric column) as a Decimal —
+    the exact value that used to corrupt the engine's current_balance.
+    """
+    session_id = db.create_trading_session(
+        strategy_name=STRATEGY_NAME,
+        symbol=SYMBOL,
+        timeframe="1h",
+        mode=TradeSource.PAPER,
+        initial_balance=1000.0,
+    )
+    # Gracefully end the session (mirrors a clean shutdown): is_active -> False.
+    db.end_trading_session(session_id=session_id, final_balance=1000.0)
+    return session_id
+
+
+def _log_closed_trade(db: DatabaseManager, session_id: int, *, pnl: float) -> None:
+    """Log one CLOSED trade with a known net PnL and NO account_balances row.
+
+    This forces recover_last_balance() down its trades fallback with a non-zero
+    float ``total_pnl`` — the branch that did ``Decimal(initial_balance) + float``
+    and raised TypeError.
+    """
+    now = datetime.now(UTC)
+    db.log_trade(
+        symbol=SYMBOL,
+        side="long",
+        entry_price=100.0,
+        exit_price=100.0 + pnl,
+        size=0.1,
+        entry_time=now,
+        exit_time=now,
+        pnl=pnl,
+        exit_reason="take_profit",
+        strategy_name=STRATEGY_NAME,
+        source=TradeSource.PAPER,
+        session_id=session_id,
+        quantity=1.0,
+    )
+
+
+def _make_paper_engine_with_real_db(db: DatabaseManager) -> LiveTradingEngine:
+    """Build a paper-mode engine wired to a real in-memory DB.
+
+    Paper mode needs no exchange provider, so the recovery transaction is the
+    only thing touching the (real) database.
+    """
+    strategy = create_ml_basic_strategy()
+    with (
+        patch("src.engines.live.trading_engine.DatabaseManager"),
+        patch("src.engines.live.trading_engine.get_config", return_value={}),
+    ):
+        engine = LiveTradingEngine(
+            strategy=strategy,
+            data_provider=MagicMock(),
+            initial_balance=1000.0,
+            enable_live_trading=False,
+            resume_from_last_balance=True,
+        )
+
+    # Swap in the real database holding the prior ended session.
+    engine.db_manager = db
+    return engine
+
+
+def _drive_start(engine: LiveTradingEngine, *, mock_final_stats: bool) -> None:
+    """Run start() to completion with runtime I/O neutralized.
+
+    The trading loop is a no-op so its worker thread dies immediately and
+    start()'s keep-alive loop exits and calls stop(). When ``mock_final_stats``
+    is False the real ``_print_final_stats`` runs inside stop(), exercising the
+    Decimal/float banner arithmetic end to end.
+    """
+    engine._run_trading_loop = MagicMock()
+    engine._start_websocket_streams = MagicMock()
+    engine._exit_if_loop_crashed = MagicMock()
+    if mock_final_stats:
+        engine._print_final_stats = MagicMock()
+    engine.start(symbol=SYMBOL, timeframe="1h", max_steps=0)
+
+
+class TestRecoveredDecimalBalanceCoercedToFloat:
+    def test_current_balance_is_float_after_recovery(self):
+        db = DatabaseManager("sqlite:///:memory:")
+        _seed_inactive_session(db)
+        engine = _make_paper_engine_with_real_db(db)
+
+        # Mock the banner here so start() completes and we can inspect the stored
+        # balance directly (the no-raise behaviour is covered by the test below).
+        _drive_start(engine, mock_final_stats=True)
+
+        # Recovered from a Numeric column via the trades fallback; the engine must
+        # store it as float, not decimal.Decimal.
+        assert isinstance(engine.current_balance, float)
+
+    def test_print_final_stats_does_not_raise_on_recovered_balance(self):
+        db = DatabaseManager("sqlite:///:memory:")
+        _seed_inactive_session(db)
+        engine = _make_paper_engine_with_real_db(db)
+
+        # Real _print_final_stats runs inside stop(): it mixes current_balance
+        # with the float initial_balance, so a Decimal current_balance would
+        # raise "unsupported operand -: Decimal and float" here.
+        _drive_start(engine, mock_final_stats=False)
+
+
+class TestRecoverLastBalanceTradesFallback:
+    """recover_last_balance's trades fallback adds net PnL (always float, via
+    _trade_net_pnl) to TradingSession.initial_balance (Numeric -> Decimal).
+    ``Decimal + float`` raises TypeError, which _recover_existing_session swallows
+    -> None -> the balance is silently lost and the session resets. The DB read
+    boundary must coerce to a finite float."""
+
+    def test_recover_last_balance_with_trades_returns_finite_float(self):
+        db = DatabaseManager("sqlite:///:memory:")
+        session_id = db.create_trading_session(
+            strategy_name=STRATEGY_NAME,
+            symbol=SYMBOL,
+            timeframe="1h",
+            mode=TradeSource.PAPER,
+            initial_balance=1000.0,
+        )
+        _log_closed_trade(db, session_id, pnl=250.0)
+        db.end_trading_session(session_id=session_id, final_balance=1250.0)
+
+        balance = db.recover_last_balance(session_id)
+
+        assert isinstance(balance, float)
+        assert math.isfinite(balance)
+        assert balance == pytest.approx(1250.0)
+
+    def test_engine_recovers_balance_with_trades_not_reset(self):
+        db = DatabaseManager("sqlite:///:memory:")
+        session_id = db.create_trading_session(
+            strategy_name=STRATEGY_NAME,
+            symbol=SYMBOL,
+            timeframe="1h",
+            mode=TradeSource.PAPER,
+            initial_balance=1000.0,
+        )
+        _log_closed_trade(db, session_id, pnl=250.0)
+        db.end_trading_session(session_id=session_id, final_balance=1250.0)
+        engine = _make_paper_engine_with_real_db(db)
+
+        _drive_start(engine, mock_final_stats=True)
+
+        # Recovered as a float, and actually carried forward (initial 1000 + 250
+        # PnL) rather than silently reset to the constructor default by a
+        # swallowed TypeError.
+        assert isinstance(engine.current_balance, float)
+        assert engine.current_balance == pytest.approx(1250.0)
+
+
+class TestNonFiniteRecoveredBalanceRejected:
+    """A non-finite recovered balance (corrupt persisted state; float() happily
+    turns Decimal('Infinity')/NaN into inf/nan) must never reach position sizing.
+    _recover_existing_session() rejects it BEFORE its own `> 0` positivity filter —
+    that filter would otherwise drop -inf/NaN to None (engine starts on the default
+    balance) or raise on Decimal('NaN'). The engine fails fast instead (CODE.md
+    "Arithmetic & Financial Calculations": math.isfinite() on trading inputs).
+
+    The DB layer (recover_last_balance) is mocked so the REAL _recover_existing_session
+    path — filter and guard — actually runs; mocking _recover_existing_session itself
+    would bypass the very code under test.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            float("inf"),
+            float("-inf"),
+            float("nan"),
+            Decimal("Infinity"),
+            Decimal("-Infinity"),
+            Decimal("NaN"),
+        ],
+    )
+    def test_non_finite_recovered_balance_refuses_to_start(self, bad_value):
+        db = DatabaseManager("sqlite:///:memory:")
+        engine = _make_paper_engine_with_real_db(db)
+        # Drive the active (crash-recovery) branch deterministically, then have the
+        # DB hand back a corrupt non-finite balance.
+        engine.db_manager.get_active_session_id = MagicMock(return_value=42)
+        engine.db_manager.recover_last_balance = MagicMock(return_value=bad_value)
+
+        with pytest.raises(ValueError, match="Recovered balance is not finite"):
+            _drive_start(engine, mock_final_stats=True)


### PR DESCRIPTION
Surgical prod promote of #681 (merged to develop). Cherry-pick of `157cabc2` onto current `main` — `manager.py` and `trading_engine.py` auto-merged cleanly on top of #677; only `docs/changelog.md` needed resolution (kept the single #681 entry).

## Why this is prod-urgent

`origin/main` is vulnerable today:
- `manager.py` `recover_last_balance` trades-fallback does `Decimal + float` (`initial_balance + net PnL`) → `TypeError`, swallowed by `_recover_existing_session` → returns `None` → **the engine silently resets to its default balance on restart**.
- A `Decimal` recovered balance then breaks `_print_final_stats`' float subtraction on shutdown (`unsupported operand -: Decimal and float`).

## Change (identical to the #681 commit reviewed on develop)

- `manager.py` — `float(trading_session.initial_balance) + total_pnl` at the DB read boundary.
- `trading_engine.py::_recover_existing_session` — coerce recovered value to `float` and fail fast (raise, re-raised past the broad `except`) on a non-finite balance **before** the `> 0` positivity filter (which previously dropped `-inf`/`NaN` to `None` or raised `InvalidOperation` on `Decimal('NaN')`).
- `trading_engine.py::start()` — defensive `float()` at the assignment.

## Testing

- Regression suite `tests/unit/engines/live/test_recovered_balance_float_coercion.py` (10 tests) **passes on this `main`-based branch**, alongside the #677 carry-forward + session-recovery suites: **34 passed**.
- Codex-reviewed to no blocking findings on develop (3 rounds).

## Provenance

- develop PR: #681 (merged, CI-green).
- Builds on #677 (already promoted to prod via #682). Does **not** pull in the rest of the unpromoted develop backlog (Dashboard V2 #612, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)