### PR TITLE
fix(live): coerce float-Decimal in PositionReconciler entry-order verify (#673 Bug 2)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1231,10 +1231,14 @@ class PositionReconciler:
         from src.data_providers.exchange_interface import OrderStatus as ExOrderStatus
 
         if exchange_order.status == ExOrderStatus.FILLED:
-            # Check fill price matches entry_price
-            if exchange_order.average_price and position.entry_price > 0:
+            # Check fill price matches entry_price. Coerce to float — DB-loaded
+            # positions carry Decimal (Numeric) fields; "float - Decimal" below
+            # raises TypeError (#673 Bug 2: silently disabled PositionReconciler
+            # in prod, falling back to legacy reconciliation every startup).
+            entry_price_f = float(position.entry_price or 0.0)
+            if exchange_order.average_price and entry_price_f > 0:
                 price_diff_pct = (
-                    abs(exchange_order.average_price - position.entry_price) / position.entry_price
+                    abs(float(exchange_order.average_price) - entry_price_f) / entry_price_f
                 )
                 if price_diff_pct > 0.001:  # >0.1% difference
                     audit = AuditEvent(
@@ -1272,9 +1276,11 @@ class PositionReconciler:
                         )
                         raise
 
-            # Check fill quantity matches position quantity
+            # Check fill quantity matches position quantity. Coerce to float —
+            # same Decimal/float mismatch as the price check above (#673 Bug 2).
             filled_qty = getattr(exchange_order, "filled_quantity", None)
-            position_qty = getattr(position, "quantity", None) or 0.0
+            filled_qty = float(filled_qty) if filled_qty is not None else None
+            position_qty = float(getattr(position, "quantity", None) or 0.0)
             if filled_qty and filled_qty > 0 and position_qty > 0:
                 qty_diff_pct = abs(filled_qty - position_qty) / position_qty
                 # Correct if >1% difference — significant enough to affect P&L

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -138,6 +138,36 @@ def test_estimate_position_notional_handles_decimal_fields(reconciler, mock_posi
     assert notional == pytest.approx(500.0)
 
 
+def test_verify_entry_order_handles_decimal_position_fields(reconciler):
+    """_verify_entry_order subtracts the exchange fill (float) from DB position
+    fields (Decimal entry_price / quantity). Both diff subtractions must coerce
+    to float — otherwise 'unsupported operand type(s) for -: float and Decimal'
+    raises and silently disables the primary PositionReconciler in prod, forcing
+    the legacy fallback every startup reconcile (#673 Bug 2)."""
+    from decimal import Decimal
+    from types import SimpleNamespace
+
+    from src.data_providers.exchange_interface import OrderStatus as ExOS
+    from src.engines.live.reconciliation import ReconciliationResult
+
+    position = SimpleNamespace(
+        symbol="ETHUSDT",
+        db_position_id=1,
+        entry_price=Decimal("2000"),
+        quantity=Decimal("0.5"),
+        current_size=Decimal("0.5"),
+        original_size=Decimal("1.0"),
+    )
+    # FILLED order; price/qty within correction thresholds so no DB write is
+    # attempted — the bug is in the diff subtraction itself, which runs first.
+    order = MockExchangeOrder(status=ExOS.FILLED, average_price=2000.5, filled_quantity=0.5)
+    result = ReconciliationResult(entity_type="position", entity_id=1, status="verified")
+
+    # Pre-fix this raised TypeError (float - Decimal); must complete cleanly now.
+    out = reconciler._verify_entry_order(position, order, result)
+    assert out is result
+
+
 def test_verify_margin_position_handles_decimal_quantity(
     mock_exchange, mock_position_tracker, mock_db
 ):


### PR DESCRIPTION
## Problem (live in prod)
`PositionReconciler._verify_entry_order` compares the exchange fill against the DB position. Two diff computations subtracted a **float** (exchange `average_price` / `filled_quantity`) from a **Decimal** (DB `entry_price` / `quantity`):
```python
abs(exchange_order.average_price - position.entry_price) / position.entry_price   # float - Decimal
abs(filled_qty - position_qty) / position_qty                                     # float - Decimal
```
Both raise `TypeError: unsupported operand type(s) for -: 'float' and 'decimal.Decimal'`. The exception propagates to `trading_engine` (caught), which then **falls back to legacy reconciliation on every startup reconcile** — the primary reconciler is effectively dead code in prod. Confirmed live 2026-06-05 (1× `PositionReconciler failed, falling back to legacy reconciliation: ...` at the 08:24 UTC boot).

This is **#673 Bug 2**. Bug 1 (margin external-closure check, `pos_qty * 0.5`) was already fixed by #674 — verified 0 occurrences in prod.

## Fix
Coerce the DB Decimal fields to `float` at both diff sites (same `float()`-at-use pattern established in #674/#653, and already used elsewhere in this module at `reconciliation.py:1169-1175`). Minimal, localized, no behavior change beyond not raising.

## Test
Adds `test_verify_entry_order_handles_decimal_position_fields` — constructs a Decimal-typed position + a FILLED exchange order and calls `_verify_entry_order`. **Verified it fails without the fix** (reproduces the exact prod `TypeError`) and passes with it. Full reconciliation suite: 108 passed.

Closes #673.

🤖 Generated with [Claude Code](https://claude.com/claude-code)