### PR TITLE
fix(infra): raise Railway healthcheckTimeout 10s → 300s (intermittent deploy failures)

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
     "preDeployCommand": "atb db verify --apply-migrations",
     "startCommand": "atb live-health hyper_growth --max-position 0.5",
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 10,
+    "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
## Problem
Railway deploys have failed intermittently — most recently **development 2026-06-01 and 2026-06-02** (also sporadic in staging/prod history). Every failure shows the identical signature in the deploy log:
```
... db verify --apply-migrations  → ✅ Alembic consistent / schema matches
Starting Container
Stopping Container
```
No application error, no crash — the **preDeploy `db verify` succeeds** (so the DB is reachable), then Railway **aborts the deploy** because `/health` did not return success within the **10-second** `healthcheckTimeout`.

## Root cause
`railway.json` set `"healthcheckTimeout": 10`. That window races the container cold-start:
- `/health` already has a startup grace — it returns **200** while the loop is still starting (`live_health.py:38-40`, `age is None → "starting"`), and the health-server thread starts **before** the heavy engine import (`live_health.py:167` vs `:187`).
- So the only thing gating `/health` reachability is the **Python interpreter + atb/ML import chain** to reach and bind the port. On a slower cold boot that exceeds 10s → `/health` is unreachable → deploy FAILED → the previous deployment stays up.

10s is far below Railway's own **300s** default for a service that loads ML models on startup; deploys passed only when the boot happened to come in under the wire.

## Fix
Raise `healthcheckTimeout` to **300** (Railway default).
- **Zero runtime impact**: during the healthcheck window the *previous* deployment keeps serving (rolling deploy), so a longer window only gives a healthy-but-slow boot more room to pass before cutover.
- Genuine post-start crashes are still handled by `restartPolicyType: ON_FAILURE` (10 retries).

## Rollout note
`railway.json` is per-branch. This PR fixes the **development** environment. The same one-line change should be promoted to **`main` (production)** and **`staging`** to fix those environments too — flagging for a follow-up promote rather than bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)