### PR TITLE
feat(observability): structured error/event emission + alerting (#669, part 1)

### DIFF
--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -1510,9 +1510,17 @@ class DatabaseManager:
         component: str | None = None,
         details: dict | None = None,
         session_id: int | None = None,
+        error_code: str | None = None,
+        stack_trace: str | None = None,
+        alert_sent: bool = False,
+        alert_method: str | None = None,
     ) -> int:
         """
         Log a system event.
+
+        The ``error_code``, ``stack_trace``, ``alert_sent`` and ``alert_method``
+        fields populate the long-existing observability columns on
+        ``SystemEvent`` so operators can triage incidents from ``system_events``.
 
         Returns:
             Event ID
@@ -1543,6 +1551,10 @@ class DatabaseManager:
                 severity=severity,
                 component=component,
                 details=details,
+                error_code=error_code,
+                stack_trace=stack_trace,
+                alert_sent=alert_sent,
+                alert_method=alert_method,
                 session_id=session_id or self._current_session_id,
                 timestamp=datetime.now(UTC),
             )

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -9,6 +9,7 @@ import signal
 import sys
 import threading
 import time
+import traceback
 from dataclasses import asdict
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -50,7 +51,7 @@ from src.data_providers.exchange_interface import (
 )
 from src.data_providers.sentiment_provider import SentimentDataProvider
 from src.database.manager import DatabaseManager
-from src.database.models import TradeSource
+from src.database.models import EventType, TradeSource
 
 # Modular handlers (optional injection for testability)
 from src.engines.live.data.market_data_handler import MarketDataHandler
@@ -1416,6 +1417,7 @@ class LiveTradingEngine:
                     # Check if balance was corrected
                     balance_sync = sync_result.data.get("balance_sync", {})
                     if balance_sync.get("corrected", False):
+                        previous_balance = balance_sync.get("old_balance", self.current_balance)
                         corrected_balance = balance_sync.get("new_balance", self.current_balance)
                         # Atomic balance update with lock to prevent race conditions
                         with self._balance_lock:
@@ -1425,6 +1427,18 @@ class LiveTradingEngine:
                         logger.info(
                             "💰 Balance corrected from exchange: $%.2f",
                             corrected_balance,
+                        )
+                        # A silent balance overwrite masked a real capital-erosion
+                        # incident before — make every correction auditable.
+                        self._record_event(
+                            EventType.WARNING,
+                            (
+                                "Balance overwritten from exchange: "
+                                f"{previous_balance} -> {corrected_balance}"
+                            ),
+                            severity="warning",
+                            component="balance",
+                            error_code="BALANCE_OVERWRITE",
                         )
                 else:
                     logger.warning("⚠️ Account synchronization failed: %s", sync_result.message)
@@ -1495,6 +1509,16 @@ class LiveTradingEngine:
                 logger.info("🔄 Periodic reconciler started")
             except Exception as e:
                 logger.warning("Failed to start periodic reconciler: %s", e)
+                # A silently-disabled reconciler is exactly the kind of failure
+                # that ran invisible for months — surface it in system_events.
+                self._record_event(
+                    EventType.ERROR,
+                    f"Periodic reconciler failed to start: {e}",
+                    severity="error",
+                    component="reconciler",
+                    error_code="RECONCILER_START_FAILED",
+                    exc=e,
+                )
 
         # Try to start WebSocket streams for reduced API weight
         self._start_websocket_streams(symbol, timeframe)
@@ -1525,6 +1549,16 @@ class LiveTradingEngine:
         if not self._close_only_mode:
             self._close_only_mode = True
             logger.critical("🚨 CLOSE-ONLY MODE ACTIVATED — no new entries until manual review")
+            # Emit once on transition (guarded above) so the kill-switch is
+            # visible in system_events and pages an operator.
+            self._record_event(
+                EventType.ALERT,
+                "Close-only mode activated — no new entries until manual review",
+                severity="critical",
+                component="risk",
+                error_code="CLOSE_ONLY",
+                alert=True,
+            )
 
     def resume_trading(self) -> None:
         """Resume normal trading after close-only mode review."""
@@ -3614,8 +3648,16 @@ class LiveTradingEngine:
                         max_retries,
                         symbol,
                     )
-                    self._send_alert(
-                        f"⚠️ EMERGENCY: Closing {symbol} position - stop-loss placement failed"
+                    # Record the structured event and fire the alert in one call
+                    # (alert=True dispatches the webhook, so no separate
+                    # _send_alert is needed here).
+                    self._record_event(
+                        EventType.ALERT,
+                        f"EMERGENCY: Closing {symbol} position - stop-loss placement failed",
+                        severity="critical",
+                        component="execution",
+                        error_code="EMERGENCY_CLOSE",
+                        alert=True,
                     )
                     # Fetch current market price for accurate exit pricing.
                     # The position is still open on the exchange without a stop loss,
@@ -4356,6 +4398,58 @@ class LiveTradingEngine:
         except Exception as e:
             logger.error("Failed to log trade: %s", e, exc_info=True)
 
+    def _record_event(
+        self,
+        event_type: EventType,
+        message: str,
+        *,
+        severity: str = "error",
+        component: str | None = None,
+        error_code: str | None = None,
+        exc: BaseException | None = None,
+        alert: bool = False,
+    ) -> None:
+        """Emit a structured ``system_events`` row (and optionally an alert).
+
+        Populates the long-dormant observability columns (``component``,
+        ``error_code``, ``stack_trace``, ``alert_sent``, ``alert_method``) so
+        operators can triage incidents from ``system_events`` instead of grepping
+        application logs. A stack trace is captured only when ``exc`` is supplied
+        and an exception is currently being handled.
+
+        Entirely fault-isolated: any logging, DB, or alert failure is swallowed so
+        observability can never break the trading loop.
+        """
+        try:
+            # Capture the active traceback only when an exception is in flight;
+            # format_exc() returns the literal string "NoneType: None\n" outside
+            # an except block, which would be noise in the audit trail.
+            stack_trace = traceback.format_exc() if exc is not None else None
+            if stack_trace is not None and stack_trace.startswith("NoneType: None"):
+                stack_trace = None
+
+            alert_sent = False
+            alert_method: str | None = None
+            if alert:
+                self._send_alert(message)
+                alert_sent = True
+                alert_method = "webhook"
+
+            self.db_manager.log_event(
+                event_type=event_type,
+                message=message,
+                severity=severity,
+                component=component,
+                error_code=error_code,
+                stack_trace=stack_trace,
+                session_id=self.trading_session_id,
+                alert_sent=alert_sent,
+                alert_method=alert_method,
+            )
+        except Exception as e:
+            # Observability must never propagate into the trading loop.
+            logger.warning("observability event failed: %s", e)
+
     def _send_alert(self, message: str):
         """Send trading alert (webhook, email, etc.)"""
         if not self.alert_webhook_url:
@@ -4912,7 +5006,9 @@ class LiveTradingEngine:
                         "🚨 %d CRITICAL reconciliation issues — entering close-only mode",
                         critical_count,
                     )
-                    self._close_only_mode = True
+                    # Route through the guarded helper so the CLOSE_ONLY event is
+                    # emitted on this startup-critical path too, not just runtime.
+                    self._enter_close_only_mode()
 
                 # Log HIGH severity auto-corrections (cancelled entries, SL fills)
                 for r in results:
@@ -4936,6 +5032,14 @@ class LiveTradingEngine:
             except Exception as e:
                 logger.warning(
                     "PositionReconciler failed, falling back to legacy reconciliation: %s", e
+                )
+                self._record_event(
+                    EventType.ERROR,
+                    f"PositionReconciler failed, falling back to legacy reconciliation: {e}",
+                    severity="error",
+                    component="reconciler",
+                    error_code="RECONCILER_FALLBACK",
+                    exc=e,
                 )
 
         # Legacy fallback: SL-based reconciliation (requires positions)

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4431,9 +4431,11 @@ class LiveTradingEngine:
             alert_sent = False
             alert_method: str | None = None
             if alert:
-                self._send_alert(message)
-                alert_sent = True
-                alert_method = "webhook"
+                # Record the real OUTCOME, not just intent: _send_alert returns
+                # False when no webhook is configured or the POST fails, so
+                # alert_sent reflects whether an operator was actually paged.
+                alert_sent = bool(self._send_alert(message))
+                alert_method = "webhook" if alert_sent else None
 
             self.db_manager.log_event(
                 event_type=event_type,
@@ -4450,10 +4452,17 @@ class LiveTradingEngine:
             # Observability must never propagate into the trading loop.
             logger.warning("observability event failed: %s", e)
 
-    def _send_alert(self, message: str):
-        """Send trading alert (webhook, email, etc.)"""
+    def _send_alert(self, message: str) -> bool:
+        """Send a trading alert (webhook).
+
+        Returns True only if an alert was actually dispatched (a webhook POST
+        was attempted without raising); False when no webhook is configured or
+        the POST failed. Callers persist this as the real ``alert_sent`` so
+        operators aren't misled into thinking a critical event paged them when
+        it didn't.
+        """
         if not self.alert_webhook_url:
-            return
+            return False
 
         try:
             import requests
@@ -4463,8 +4472,10 @@ class LiveTradingEngine:
                 "timestamp": datetime.now(UTC).isoformat(),
             }
             requests.post(self.alert_webhook_url, json=payload, timeout=10)
+            return True
         except Exception as e:
             logger.error("Failed to send alert: %s", e, exc_info=True)
+            return False
 
     def _sleep_with_interrupt(self, seconds: float):
         """Sleep in small increments to allow for interrupt and float seconds"""

--- a/tests/unit/database/test_event_logging.py
+++ b/tests/unit/database/test_event_logging.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
 class TestEventLogging:

--- a/tests/unit/database/test_event_logging.py
+++ b/tests/unit/database/test_event_logging.py
@@ -26,6 +26,52 @@ class TestEventLogging:
             mock_postgresql_db._mock_session.add.assert_called()
             mock_postgresql_db._mock_session.commit.assert_called()
 
+    def test_log_event_persists_observability_fields(self, mock_postgresql_db):
+        """log_event forwards error_code/stack_trace/alert_sent/alert_method."""
+        mock_event_obj = Mock()
+        mock_event_obj.id = 202
+
+        with patch("database.manager.SystemEvent") as mock_event_class:
+            mock_event_class.return_value = mock_event_obj
+
+            event_id = mock_postgresql_db.log_event(
+                event_type="ERROR",
+                message="Reconciler fell back to legacy path",
+                severity="error",
+                component="reconciler",
+                error_code="RECONCILER_FALLBACK",
+                stack_trace="Traceback (most recent call last): boom",
+                alert_sent=True,
+                alert_method="webhook",
+            )
+
+            assert event_id == 202
+            _, kwargs = mock_event_class.call_args
+            assert kwargs["error_code"] == "RECONCILER_FALLBACK"
+            assert kwargs["stack_trace"] == "Traceback (most recent call last): boom"
+            assert kwargs["alert_sent"] is True
+            assert kwargs["alert_method"] == "webhook"
+            assert kwargs["component"] == "reconciler"
+            assert kwargs["severity"] == "error"
+
+    def test_log_event_observability_fields_default_safely(self, mock_postgresql_db):
+        """Existing callers get backward-compatible defaults for the new fields."""
+        mock_event_obj = Mock()
+        mock_event_obj.id = 303
+
+        with patch("database.manager.SystemEvent") as mock_event_class:
+            mock_event_class.return_value = mock_event_obj
+
+            mock_postgresql_db.log_event(
+                event_type="TEST", message="Legacy caller", severity="info"
+            )
+
+            _, kwargs = mock_event_class.call_args
+            assert kwargs["error_code"] is None
+            assert kwargs["stack_trace"] is None
+            assert kwargs["alert_sent"] is False
+            assert kwargs["alert_method"] is None
+
     def test_log_account_snapshot(self, mock_postgresql_db):
         """Test logging account snapshot"""
         with patch("database.manager.AccountHistory"):

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -76,6 +76,7 @@ class TestRecordEvent:
     def test_alert_true_sends_alert_and_sets_flags(self):
         """alert=True dispatches the webhook and records alert_sent/alert_method."""
         engine = _make_engine()
+        engine._send_alert = MagicMock(return_value=True)  # webhook delivered
 
         engine._record_event(
             EventType.ALERT,
@@ -91,6 +92,27 @@ class TestRecordEvent:
         assert kwargs["alert_sent"] is True
         assert kwargs["alert_method"] == "webhook"
         assert kwargs["severity"] == "critical"
+
+    def test_alert_not_dispatched_records_alert_sent_false(self):
+        """When _send_alert returns False (no webhook configured / POST failed),
+        alert_sent is recorded as False and alert_method as None — operators must
+        not be misled into believing a critical event paged them when it didn't."""
+        engine = _make_engine()
+        engine._send_alert = MagicMock(return_value=False)  # nothing delivered
+
+        engine._record_event(
+            EventType.ALERT,
+            "Emergency close",
+            severity="critical",
+            component="execution",
+            error_code="EMERGENCY_CLOSE",
+            alert=True,
+        )
+
+        engine._send_alert.assert_called_once_with("Emergency close")
+        _, kwargs = engine.db_manager.log_event.call_args
+        assert kwargs["alert_sent"] is False
+        assert kwargs["alert_method"] is None
 
     def test_swallows_log_event_failure(self):
         """A db_manager.log_event failure must never propagate to the caller."""

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -1,0 +1,125 @@
+"""Unit tests for LiveTradingEngine._record_event structured observability.
+
+The emitter only depends on three attributes (``db_manager``,
+``trading_session_id`` and ``_send_alert``), so the engine is instantiated via
+``__new__`` to keep these tests fast, deterministic and free of the heavy
+strategy/data-provider wiring required by the real constructor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.database.models import EventType
+from src.engines.live.trading_engine import LiveTradingEngine
+
+pytestmark = pytest.mark.unit
+
+
+def _make_engine() -> LiveTradingEngine:
+    """Build a bare engine with just the collaborators _record_event touches."""
+    engine = LiveTradingEngine.__new__(LiveTradingEngine)
+    engine.db_manager = MagicMock()
+    engine.trading_session_id = 42
+    engine._send_alert = MagicMock()
+    return engine
+
+
+class TestRecordEvent:
+    def test_captures_stack_trace_when_exc_supplied(self):
+        """With an active exception, the formatted traceback reaches log_event."""
+        engine = _make_engine()
+
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            engine._record_event(
+                EventType.ERROR,
+                "Reconciler fell back",
+                severity="error",
+                component="reconciler",
+                error_code="RECONCILER_FALLBACK",
+                exc=exc,
+            )
+
+        engine.db_manager.log_event.assert_called_once()
+        _, kwargs = engine.db_manager.log_event.call_args
+        assert kwargs["event_type"] == EventType.ERROR
+        assert kwargs["component"] == "reconciler"
+        assert kwargs["error_code"] == "RECONCILER_FALLBACK"
+        assert kwargs["severity"] == "error"
+        assert kwargs["session_id"] == 42
+        assert "ValueError: boom" in kwargs["stack_trace"]
+        assert "Traceback" in kwargs["stack_trace"]
+        # No alert requested -> not sent, columns reflect that.
+        assert kwargs["alert_sent"] is False
+        assert kwargs["alert_method"] is None
+        engine._send_alert.assert_not_called()
+
+    def test_no_stack_trace_without_exc(self):
+        """Without exc, stack_trace is None (never the 'NoneType: None' sentinel)."""
+        engine = _make_engine()
+
+        engine._record_event(
+            EventType.WARNING,
+            "Balance overwritten",
+            severity="warning",
+            component="balance",
+            error_code="BALANCE_OVERWRITE",
+        )
+
+        _, kwargs = engine.db_manager.log_event.call_args
+        assert kwargs["stack_trace"] is None
+
+    def test_alert_true_sends_alert_and_sets_flags(self):
+        """alert=True dispatches the webhook and records alert_sent/alert_method."""
+        engine = _make_engine()
+
+        engine._record_event(
+            EventType.ALERT,
+            "Close-only mode activated",
+            severity="critical",
+            component="risk",
+            error_code="CLOSE_ONLY",
+            alert=True,
+        )
+
+        engine._send_alert.assert_called_once_with("Close-only mode activated")
+        _, kwargs = engine.db_manager.log_event.call_args
+        assert kwargs["alert_sent"] is True
+        assert kwargs["alert_method"] == "webhook"
+        assert kwargs["severity"] == "critical"
+
+    def test_swallows_log_event_failure(self):
+        """A db_manager.log_event failure must never propagate to the caller."""
+        engine = _make_engine()
+        engine.db_manager.log_event.side_effect = RuntimeError("db down")
+
+        # Must not raise.
+        engine._record_event(
+            EventType.ERROR,
+            "Reconciler start failed",
+            severity="error",
+            component="reconciler",
+            error_code="RECONCILER_START_FAILED",
+        )
+
+        engine.db_manager.log_event.assert_called_once()
+
+    def test_swallows_send_alert_failure(self):
+        """An alert dispatch failure is also swallowed (still never raises)."""
+        engine = _make_engine()
+        engine._send_alert.side_effect = RuntimeError("webhook down")
+
+        engine._record_event(
+            EventType.ALERT,
+            "Emergency close",
+            severity="critical",
+            component="execution",
+            error_code="EMERGENCY_CLOSE",
+            alert=True,
+        )
+
+        engine._send_alert.assert_called_once()

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -15,7 +15,7 @@ import pytest
 from src.database.models import EventType
 from src.engines.live.trading_engine import LiveTradingEngine
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
 def _make_engine() -> LiveTradingEngine:


### PR DESCRIPTION
## Scope (part 1 of #669)

`system_events` only ever recorded `ENGINE_START`/`ENGINE_STOP`, so every serious incident — the 12.8-day outage, the phantom-trade emergency closes, orphaned positions, balance resets, a silently-disabled reconciler — was completely invisible to an operator watching the table. This PR makes the engine emit structured `ERROR`/`WARNING`/`ALERT` events with `component` / `error_code` / `stack_trace` / `alert_sent` / `alert_method`, and wires the kill-switch and emergency-close paths to the existing alert webhook.

**Tight scope:** engine-level structured event emission + alerting only. No behavioural change to trading logic — every existing log line is preserved; emits are added beside them and only on the state-change/error path (never per-candle).

## No migration needed (columns pre-exist)

The `SystemEvent` model already has `component`, `error_code`, `stack_trace`, `alert_sent`, `alert_method` (migration `0001`, lines 472-476) — they were simply never populated. `EventType` is stored as `VARCHAR` (`native_enum=False`), so reusing `ERROR`/`WARNING`/`ALERT` needs no migration either. **No alembic migration is added in this PR.**

## Changes

**`src/database/manager.py`**
- `log_event` (line 1505): adds optional `error_code` / `stack_trace` / `alert_sent` / `alert_method` kwargs, forwarded into the `SystemEvent(...)` constructor. Fully backward-compatible — all new params are optional and existing callers are unaffected.

**`src/engines/live/trading_engine.py`**
- `_record_event` (line 4401): new fault-isolated emitter. Captures `traceback.format_exc()` only when `exc` is supplied and an exception is in flight (drops the `NoneType: None` sentinel); sends an alert via `_send_alert` when `alert=True` (recording `alert_sent=True`, `alert_method="webhook"`); passes `session_id=self.trading_session_id`. The whole body is wrapped in try/except — a logging/DB/alert failure can never propagate into the trading loop (logs `"observability event failed: %s"` only).

### Instrumented sites (final line numbers)

| Site | Call line | event_type | severity | component | error_code | alert |
|------|-----------|-----------|----------|-----------|-----------|-------|
| Balance overwrite from exchange (`"Balance corrected from exchange"`) | **1433** | `WARNING` | warning | `balance` | `BALANCE_OVERWRITE` | – |
| PeriodicReconciler fails to **start** | **1514** | `ERROR` | error | `reconciler` | `RECONCILER_START_FAILED` | – |
| Close-only / kill-switch activation (`_enter_close_only_mode`, def @ 1547) | **1554** | `ALERT` | critical | `risk` | `CLOSE_ONLY` | ✅ |
| Stop-loss-failure → emergency close | **3654** | `ALERT` | critical | `execution` | `EMERGENCY_CLOSE` | ✅ |
| PositionReconciler legacy fallback (`"falling back to legacy reconciliation"`) | **5036** | `ERROR` | error | `reconciler` | `RECONCILER_FALLBACK` | ✅ exc |

Notes:
- **Close-only emits exactly once on entry**: the emit lives inside the existing `if not self._close_only_mode:` guard in `_enter_close_only_mode()`, so all callers (DB-outage loop, ambiguous-entry phantom, startup-critical reconciliation) get one event on transition and none on re-entry. The startup-critical reconciliation path (`_reconcile_positions_with_exchange`) was changed from setting `self._close_only_mode = True` directly to calling `_enter_close_only_mode()` so it is covered too.
- The emergency-close and close-only sites previously called `_send_alert` directly; that call is now folded into `_record_event(..., alert=True)` so the webhook still fires exactly once and the event is recorded alongside it (no double-send).
- `RECONCILER_FALLBACK` and `RECONCILER_START_FAILED` pass `exc=e` so the stack trace is persisted to `stack_trace`.

## Deferred (follow-up PRs)

- **Write-gap dead-man's-switch** — detect an `account_history`/heartbeat write gap over threshold and raise an incident (would have caught the 12.8-day outage). Not in this PR.
- **Reconciler-internal emission sites** — making `PositionReconciler` / `PeriodicReconciler` write `reconciliation_audit_events` and emit on internal discrepancies needs a callback/handle into the engine's emitter; deferred to keep this PR engine-scoped.

## Tests

- `tests/unit/database/test_event_logging.py`: extends the `log_event` coverage — asserts the new fields are persisted to `SystemEvent` and that existing callers still get safe defaults (`error_code=None`, `stack_trace=None`, `alert_sent=False`, `alert_method=None`).
- `tests/unit/engines/live/test_record_event.py` (new): `_record_event` captures a stack trace when `exc` is set and omits it otherwise; `alert=True` calls `_send_alert` and sets `alert_sent=True` / `alert_method="webhook"`; **a `db_manager.log_event` failure does not raise** (swallowed); an alert-dispatch failure is likewise swallowed.

Verification: `pytest tests/unit/ -k "event or system_event or observability or log_event or record_event"` → 75 passed; live-engine + reconciliation + db-resilience suites (incl. `test_prolonged_db_outage_enters_close_only`) → 185 passed. `ruff check` clean on all changed lines (the 6 pre-existing `UP038` notes in `manager.py` are outside the changed ranges). `black --check` clean. `mypy` reports 0 errors in both changed source files. No alembic migration added.

Closes part 1 of #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)