### PR TITLE
Promote to production: reconciler float-Decimal fix (#673) + Railway healthcheck (#687)

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -6,7 +6,7 @@
     "preDeployCommand": "atb db verify --apply-migrations",
     "startCommand": "atb live-health hyper_growth --max-position 0.5",
     "healthcheckPath": "/health",
-    "healthcheckTimeout": 10,
+    "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1231,10 +1231,14 @@ class PositionReconciler:
         from src.data_providers.exchange_interface import OrderStatus as ExOrderStatus
 
         if exchange_order.status == ExOrderStatus.FILLED:
-            # Check fill price matches entry_price
-            if exchange_order.average_price and position.entry_price > 0:
+            # Check fill price matches entry_price. Coerce to float — DB-loaded
+            # positions carry Decimal (Numeric) fields; "float - Decimal" below
+            # raises TypeError (#673 Bug 2: silently disabled PositionReconciler
+            # in prod, falling back to legacy reconciliation every startup).
+            entry_price_f = float(position.entry_price or 0.0)
+            if exchange_order.average_price and entry_price_f > 0:
                 price_diff_pct = (
-                    abs(exchange_order.average_price - position.entry_price) / position.entry_price
+                    abs(float(exchange_order.average_price) - entry_price_f) / entry_price_f
                 )
                 if price_diff_pct > 0.001:  # >0.1% difference
                     audit = AuditEvent(
@@ -1272,9 +1276,11 @@ class PositionReconciler:
                         )
                         raise
 
-            # Check fill quantity matches position quantity
+            # Check fill quantity matches position quantity. Coerce to float —
+            # same Decimal/float mismatch as the price check above (#673 Bug 2).
             filled_qty = getattr(exchange_order, "filled_quantity", None)
-            position_qty = getattr(position, "quantity", None) or 0.0
+            filled_qty = float(filled_qty) if filled_qty is not None else None
+            position_qty = float(getattr(position, "quantity", None) or 0.0)
             if filled_qty and filled_qty > 0 and position_qty > 0:
                 qty_diff_pct = abs(filled_qty - position_qty) / position_qty
                 # Correct if >1% difference — significant enough to affect P&L

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -138,6 +138,36 @@ def test_estimate_position_notional_handles_decimal_fields(reconciler, mock_posi
     assert notional == pytest.approx(500.0)
 
 
+def test_verify_entry_order_handles_decimal_position_fields(reconciler):
+    """_verify_entry_order subtracts the exchange fill (float) from DB position
+    fields (Decimal entry_price / quantity). Both diff subtractions must coerce
+    to float — otherwise 'unsupported operand type(s) for -: float and Decimal'
+    raises and silently disables the primary PositionReconciler in prod, forcing
+    the legacy fallback every startup reconcile (#673 Bug 2)."""
+    from decimal import Decimal
+    from types import SimpleNamespace
+
+    from src.data_providers.exchange_interface import OrderStatus as ExOS
+    from src.engines.live.reconciliation import ReconciliationResult
+
+    position = SimpleNamespace(
+        symbol="ETHUSDT",
+        db_position_id=1,
+        entry_price=Decimal("2000"),
+        quantity=Decimal("0.5"),
+        current_size=Decimal("0.5"),
+        original_size=Decimal("1.0"),
+    )
+    # FILLED order; price/qty within correction thresholds so no DB write is
+    # attempted — the bug is in the diff subtraction itself, which runs first.
+    order = MockExchangeOrder(status=ExOS.FILLED, average_price=2000.5, filled_quantity=0.5)
+    result = ReconciliationResult(entity_type="position", entity_id=1, status="verified")
+
+    # Pre-fix this raised TypeError (float - Decimal); must complete cleanly now.
+    out = reconciler._verify_entry_order(position, order, result)
+    assert out is result
+
+
 def test_verify_margin_position_handles_decimal_quantity(
     mock_exchange, mock_position_tracker, mock_db
 ):


### PR DESCRIPTION
Surgical promote of two codex-APPROVED, gate-complete fixes (patch-id verified identical to develop):

- **#686** (`1e058c18`, patch-id `a9898e9f`) — coerce `float - Decimal` in `PositionReconciler._verify_entry_order`. Fixes the `TypeError` that **silently disabled the primary reconciler in prod** (it falls back to legacy reconciliation on every restart — observed live each boot). Closes #673.
- **#687** (`b41cd3b4`, patch-id `10610182`) — raise Railway `healthcheckTimeout` 10s → 300s. Fixes intermittent deploy failures (the 10s window raced the ML-import cold start). Validated: the development env deployed SUCCESS with 300s.

## Review gate (per session policy)
Both: CI green on develop, claude-review pass, review threads resolved, and **`/codex-code-review` → APPROVE** (run scoped on the diffs). #688 (observability) is held back — codex requested a `raise_for_status()` change; it'll promote separately once fixed + re-reviewed.

## Post-deploy
The deploy restarts the bot; I verify #13 (the live ETH LONG) re-adopts with SL `47181104013` intact, balance reconciles, and that the reconciler-fallback `float-Decimal` WARN **no longer fires** (the #686 proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)