### PR TITLE
fix(observability): _send_alert checks HTTP status for accurate alert_sent (#688 follow-up)

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4455,11 +4455,11 @@ class LiveTradingEngine:
     def _send_alert(self, message: str) -> bool:
         """Send a trading alert (webhook).
 
-        Returns True only if an alert was actually dispatched (a webhook POST
-        was attempted without raising); False when no webhook is configured or
-        the POST failed. Callers persist this as the real ``alert_sent`` so
-        operators aren't misled into thinking a critical event paged them when
-        it didn't.
+        Returns True only if an alert was actually delivered (a webhook POST
+        returned a 2xx status); False when no webhook is configured, the POST
+        raised, or the endpoint returned a non-2xx status (4xx/5xx). Callers
+        persist this as the real ``alert_sent`` so operators aren't misled into
+        thinking a critical event paged them when it didn't.
         """
         if not self.alert_webhook_url:
             return False
@@ -4471,7 +4471,11 @@ class LiveTradingEngine:
                 "text": f"🤖 Trading Bot: {message}",
                 "timestamp": datetime.now(UTC).isoformat(),
             }
-            requests.post(self.alert_webhook_url, json=payload, timeout=10)
+            resp = requests.post(self.alert_webhook_url, json=payload, timeout=10)
+            # A 4xx/5xx response means the alert was NOT delivered — requests
+            # does not raise on HTTP error status by default, so check it
+            # explicitly or alert_sent would falsely read True (#688 review).
+            resp.raise_for_status()
             return True
         except Exception as e:
             logger.error("Failed to send alert: %s", e, exc_info=True)

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -160,9 +160,11 @@ class TestSendAlert:
         return engine
 
     def test_no_webhook_returns_false(self):
+        """No webhook configured -> not delivered (False); no POST attempted."""
         assert self._engine(None)._send_alert("hi") is False
 
     def test_2xx_returns_true(self):
+        """A 2xx webhook response -> alert delivered (True)."""
         engine = self._engine("http://hook.test")
         with patch("requests.post", autospec=True) as post:
             post.return_value.raise_for_status.return_value = None  # 2xx
@@ -177,6 +179,7 @@ class TestSendAlert:
             assert engine._send_alert("hi") is False
 
     def test_post_exception_returns_false(self):
+        """A network exception during the POST -> not delivered (False)."""
         engine = self._engine("http://hook.test")
         with patch("requests.post", autospec=True, side_effect=ConnectionError("network down")):
             assert engine._send_alert("hi") is False

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -8,7 +8,7 @@ strategy/data-provider wiring required by the real constructor.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -145,3 +145,37 @@ class TestRecordEvent:
         )
 
         engine._send_alert.assert_called_once()
+
+
+class TestSendAlert:
+    """_send_alert must report the REAL delivery outcome so alert_sent is honest:
+    True only on a 2xx webhook response; False when unconfigured, on a non-2xx
+    status (requests does not raise on those), or on a network exception."""
+
+    @staticmethod
+    def _engine(webhook: str | None) -> LiveTradingEngine:
+        engine = LiveTradingEngine.__new__(LiveTradingEngine)
+        engine.alert_webhook_url = webhook
+        return engine
+
+    def test_no_webhook_returns_false(self):
+        assert self._engine(None)._send_alert("hi") is False
+
+    def test_2xx_returns_true(self):
+        engine = self._engine("http://hook.test")
+        with patch("requests.post") as post:
+            post.return_value.raise_for_status.return_value = None  # 2xx
+            assert engine._send_alert("hi") is True
+            post.assert_called_once()
+
+    def test_non_2xx_returns_false(self):
+        """A 4xx/5xx response (raise_for_status raises) means NOT delivered."""
+        engine = self._engine("http://hook.test")
+        with patch("requests.post") as post:
+            post.return_value.raise_for_status.side_effect = RuntimeError("500")
+            assert engine._send_alert("hi") is False
+
+    def test_post_exception_returns_false(self):
+        engine = self._engine("http://hook.test")
+        with patch("requests.post", side_effect=RuntimeError("network down")):
+            assert engine._send_alert("hi") is False

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from src.database.models import EventType
 from src.engines.live.trading_engine import LiveTradingEngine
@@ -163,7 +164,7 @@ class TestSendAlert:
 
     def test_2xx_returns_true(self):
         engine = self._engine("http://hook.test")
-        with patch("requests.post") as post:
+        with patch("requests.post", autospec=True) as post:
             post.return_value.raise_for_status.return_value = None  # 2xx
             assert engine._send_alert("hi") is True
             post.assert_called_once()
@@ -171,11 +172,11 @@ class TestSendAlert:
     def test_non_2xx_returns_false(self):
         """A 4xx/5xx response (raise_for_status raises) means NOT delivered."""
         engine = self._engine("http://hook.test")
-        with patch("requests.post") as post:
-            post.return_value.raise_for_status.side_effect = RuntimeError("500")
+        with patch("requests.post", autospec=True) as post:
+            post.return_value.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
             assert engine._send_alert("hi") is False
 
     def test_post_exception_returns_false(self):
         engine = self._engine("http://hook.test")
-        with patch("requests.post", side_effect=RuntimeError("network down")):
+        with patch("requests.post", autospec=True, side_effect=ConnectionError("network down")):
             assert engine._send_alert("hi") is False


### PR DESCRIPTION
Follow-up to #688, addressing the `/codex-code-review` finding.

## Problem
`_send_alert` returned `True` whenever `requests.post(...)` did not raise — but `requests` does **not** raise on HTTP error status (4xx/5xx). So a webhook returning 404/429/500 would still persist `alert_sent=True`, falsely telling an operator triaging a CLOSE_ONLY/EMERGENCY_CLOSE that they were paged when the alert never landed.

## Fix
Add `resp.raise_for_status()` after the POST. `alert_sent` is now `True` only on a **2xx** response; `False` on no-webhook, non-2xx status, or network exception. One-line change + comment.

## Tests
New `TestSendAlert`: 2xx→True, non-2xx→False, no-webhook→False, exception→False.

Once green + codex-APPROVE, this promotes to prod together with #688 (observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)