### PR TITLE
fix(live): register reused session with db_manager on active recovery (P0 #41)

### DIFF
--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -615,6 +615,18 @@ class DatabaseManager:
             logger.info(f"Created trading session #{trading_session.id}: {session_name}")
             return trading_session.id
 
+    def set_current_session(self, session_id: int) -> None:
+        """Bind this manager to an already-existing trading session.
+
+        ``create_trading_session`` sets ``_current_session_id`` for new sessions,
+        but the live engine's crash-recovery path REUSES an existing active
+        session instead of creating one. Without registering it here, every
+        session-scoped write that falls back to ``_current_session_id`` (balance
+        updates, position reconciliation, account history, ...) fails with
+        "No active trading session" on the first trade after recovery (#41).
+        """
+        self._current_session_id = session_id
+
     def end_trading_session(
         self, session_id: int | None = None, final_balance: float | None = None
     ) -> None:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4706,6 +4706,12 @@ class LiveTradingEngine:
                 # _recovered_inactive_session_id (set above).
                 if source == "active":
                     self.trading_session_id = session_id
+                    # Register the reused session with the DB manager. create_trading_session
+                    # sets _current_session_id for NEW sessions, but this active-recovery path
+                    # reuses an existing one — without this, every session-scoped write that
+                    # falls back to _current_session_id (balance updates, etc.) fails with
+                    # "No active trading session" on the first trade after recovery (#41).
+                    self.db_manager.set_current_session(session_id)
                     # Wire session context to execution engine so journaling works
                     self.live_execution_engine.session_id = session_id
                     self.live_execution_engine.strategy_name = self._strategy_name()

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -96,6 +96,10 @@ def test_active_session_recovery_reuses_session_id():
 
     assert result == 850.0
     assert engine.trading_session_id == 77
+    # Reused session MUST be registered with the DB manager, or session-scoped
+    # writes (balance updates, etc.) fail with "No active trading session" on the
+    # first trade after recovery (#41).
+    engine.db_manager.set_current_session.assert_called_once_with(77)
 
 
 @pytest.mark.fast

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -4,10 +4,11 @@ Covers the _recover_existing_session() method which restores balance across
 both crash restarts (active session) and clean restarts (recent inactive session).
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+from src.database.manager import DatabaseManager
 from src.engines.live.trading_engine import LiveTradingEngine
 from src.strategies.ml_basic import create_ml_basic_strategy
 
@@ -47,9 +48,10 @@ def make_engine(enable_live_trading: bool = False) -> LiveTradingEngine:
             enable_live_trading=enable_live_trading,
         )
 
-    # Replace the db_manager created during __init__ with a fresh MagicMock
-    # so each test gets a clean, unconfigured mock to assert against.
-    engine.db_manager = MagicMock()
+    # Replace the db_manager created during __init__ with a fresh autospec'd
+    # mock so each test gets a clean instance to assert against AND signature
+    # mismatches on real DatabaseManager methods are caught (CODE.md).
+    engine.db_manager = create_autospec(DatabaseManager, instance=True)
     # Simulate what start() sets before calling _recover_existing_session().
     engine._active_symbol = "BTCUSDT"
     return engine


### PR DESCRIPTION
## P0 production incident (2026-06-05 15:01)
When #13's stop-loss closed, the realized-P&L balance update failed:
`Failed to update balance for realized P&L ETHUSDT: No active trading session for balance update.`
Then a new entry was aborted, an emergency-close fired, and the bot went degraded (Status logging stopped, entries failing). Bot is **flat and not bleeding**, but frozen.

## Root cause
`atomic_balance_update` (manager.py:2407) raises when `session_id or self._current_session_id` is falsy. `_current_session_id` is **only set when *creating* a session** (manager.py:600). The engine's **active-session recovery** path (`_recover_existing_session`, trading_engine.py:4708) reuses an existing session and sets `self.trading_session_id` — but **never registers it with the DB manager**. So after every active-recovery boot, `_current_session_id` stays `None`, and the *first* balance write (a trade) fails. Latent for ~2.5h because #13 was just held.

**A plain restart would reuse the still-active session and hit the same bug** — which is why this fix (not just a restart) is the recovery.

## Fix
Add `DatabaseManager.set_current_session()` and call it from the active-recovery path so the reused session id is registered. Deploying this restarts the bot, which recovers the (now-flat) session correctly and resumes trading.

## Test
`test_active_session_recovery_reuses_session_id` now asserts active recovery calls `set_current_session(<id>)` — **verified it fails without the fix**, passes with (15 passed).

Once green + codex APPROVE, auto-promote to prod to recover the live bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)