### PR TITLE
Promote P0: register reused session on active recovery (#41) — recovers degraded prod bot

### DIFF
--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -615,6 +615,18 @@ class DatabaseManager:
             logger.info(f"Created trading session #{trading_session.id}: {session_name}")
             return trading_session.id
 
+    def set_current_session(self, session_id: int) -> None:
+        """Bind this manager to an already-existing trading session.
+
+        ``create_trading_session`` sets ``_current_session_id`` for new sessions,
+        but the live engine's crash-recovery path REUSES an existing active
+        session instead of creating one. Without registering it here, every
+        session-scoped write that falls back to ``_current_session_id`` (balance
+        updates, position reconciliation, account history, ...) fails with
+        "No active trading session" on the first trade after recovery (#41).
+        """
+        self._current_session_id = session_id
+
     def end_trading_session(
         self, session_id: int | None = None, final_balance: float | None = None
     ) -> None:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4706,6 +4706,12 @@ class LiveTradingEngine:
                 # _recovered_inactive_session_id (set above).
                 if source == "active":
                     self.trading_session_id = session_id
+                    # Register the reused session with the DB manager. create_trading_session
+                    # sets _current_session_id for NEW sessions, but this active-recovery path
+                    # reuses an existing one — without this, every session-scoped write that
+                    # falls back to _current_session_id (balance updates, etc.) fails with
+                    # "No active trading session" on the first trade after recovery (#41).
+                    self.db_manager.set_current_session(session_id)
                     # Wire session context to execution engine so journaling works
                     self.live_execution_engine.session_id = session_id
                     self.live_execution_engine.strategy_name = self._strategy_name()

--- a/tests/unit/engines/live/test_session_recovery.py
+++ b/tests/unit/engines/live/test_session_recovery.py
@@ -4,10 +4,11 @@ Covers the _recover_existing_session() method which restores balance across
 both crash restarts (active session) and clean restarts (recent inactive session).
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+from src.database.manager import DatabaseManager
 from src.engines.live.trading_engine import LiveTradingEngine
 from src.strategies.ml_basic import create_ml_basic_strategy
 
@@ -47,9 +48,10 @@ def make_engine(enable_live_trading: bool = False) -> LiveTradingEngine:
             enable_live_trading=enable_live_trading,
         )
 
-    # Replace the db_manager created during __init__ with a fresh MagicMock
-    # so each test gets a clean, unconfigured mock to assert against.
-    engine.db_manager = MagicMock()
+    # Replace the db_manager created during __init__ with a fresh autospec'd
+    # mock so each test gets a clean instance to assert against AND signature
+    # mismatches on real DatabaseManager methods are caught (CODE.md).
+    engine.db_manager = create_autospec(DatabaseManager, instance=True)
     # Simulate what start() sets before calling _recover_existing_session().
     engine._active_symbol = "BTCUSDT"
     return engine
@@ -96,6 +98,10 @@ def test_active_session_recovery_reuses_session_id():
 
     assert result == 850.0
     assert engine.trading_session_id == 77
+    # Reused session MUST be registered with the DB manager, or session-scoped
+    # writes (balance updates, etc.) fail with "No active trading session" on the
+    # first trade after recovery (#41).
+    engine.db_manager.set_current_session.assert_called_once_with(77)
 
 
 @pytest.mark.fast


### PR DESCRIPTION
Surgical promote of the P0 fix #693 (`352c3647`, patch-id `1d3b573b` — identical to develop). **This deploy recovers the live bot**, which has been degraded since 15:01 UTC.

## Incident
After #13's SL closed, balance updates failed with `No active trading session` → entry aborted, emergency-close fired, bot degraded (Status logging dead, entries failing). Bot is flat / not bleeding but frozen.

## Root cause + fix
The active-session recovery path set `trading_session_id` but never registered it with the DB manager, so `_current_session_id` stayed `None` and the first balance write failed. Fix adds `DatabaseManager.set_current_session()` and calls it on active recovery. **A plain restart would not have fixed this** (it reuses the active session → same bug); this code change is the recovery.

## Gate
CI green, claude-review pass, threads resolved, **codex APPROVE**. Regression test verified (fails without the fix).

## Post-deploy verification
The deploy restarts the bot → active-recovery now registers the session → I verify: `_current_session_id` set, no `No active trading session`, Status logging resumes (Positions/Balance), balance reconciles, and a clean trade can book P&L.

🤖 Generated with [Claude Code](https://claude.com/claude-code)