### PR TITLE
fix(exchange): quantize order quantity to step-size precision to avoid 51077 (#42)

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -17,7 +17,6 @@ import threading
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from decimal import Decimal
 from enum import Enum
 from functools import wraps
 from typing import Any, TypeVar
@@ -36,6 +35,7 @@ from src.config.constants import (
 )
 from src.infrastructure.timeout import TimeoutError as InfraTimeoutError
 from src.infrastructure.timeout import run_with_timeout
+from src.trading.precision import quantize_to_step
 from src.trading.symbols.factory import SymbolFactory
 
 from .data_provider import DataProvider
@@ -1743,13 +1743,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             # 40 * 0.0001 = 0.004000000000000001) that exceed the asset's max
             # precision, so Binance rejects with code 51077. Quantize to the
             # step's decimal count so the value sent has no excess decimals.
-            if step_size > 0:
-                # .exponent is a negative int for any finite Decimal (str of a real
-                # step_size); the isinstance guard satisfies the type checker and
-                # safely defaults to 0 decimals for the impossible non-finite case.
-                exponent = Decimal(str(step_size)).as_tuple().exponent
-                step_decimals = max(0, -exponent) if isinstance(exponent, int) else 0
-                quantity = round(quantity, step_decimals)
+            quantity = quantize_to_step(quantity, step_size)
 
             if quantity <= 0:
                 logger.error(

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -17,6 +17,7 @@ import threading
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from enum import Enum
 from functools import wraps
 from typing import Any, TypeVar
@@ -1737,6 +1738,14 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                     quantity = math.floor(quantity / step_size + 1e-9) * step_size
             elif step_size > 0:
                 quantity = round(quantity / step_size) * step_size
+
+            # `(integer) * step_size` in float math leaves artifacts (e.g.
+            # 40 * 0.0001 = 0.004000000000000001) that exceed the asset's max
+            # precision, so Binance rejects with code 51077. Quantize to the
+            # step's decimal count so the value sent has no excess decimals.
+            if step_size > 0:
+                step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
+                quantity = round(quantity, step_decimals)
 
             if quantity <= 0:
                 logger.error(

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -1744,7 +1744,11 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             # precision, so Binance rejects with code 51077. Quantize to the
             # step's decimal count so the value sent has no excess decimals.
             if step_size > 0:
-                step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
+                # .exponent is a negative int for any finite Decimal (str of a real
+                # step_size); the isinstance guard satisfies the type checker and
+                # safely defaults to 0 decimals for the impossible non-finite case.
+                exponent = Decimal(str(step_size)).as_tuple().exponent
+                step_decimals = max(0, -exponent) if isinstance(exponent, int) else 0
                 quantity = round(quantity, step_decimals)
 
             if quantity <= 0:

--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -14,7 +14,6 @@ import math
 import time
 import uuid
 from dataclasses import dataclass
-from decimal import Decimal
 from typing import Any
 
 from src.config.constants import (
@@ -29,6 +28,7 @@ from src.data_providers.exchange_interface import (
 )
 from src.engines.shared.cost_calculator import CostCalculator
 from src.engines.shared.models import PositionSide
+from src.trading.precision import quantize_to_step
 
 logger = logging.getLogger(__name__)
 
@@ -967,11 +967,11 @@ class LiveExecutionEngine:
                     # 40 * 0.0001 = 0.004000000000000001) that exceed the asset's max
                     # precision; sent verbatim Binance rejects with code 51077. Quantize
                     # to the step's decimal count so the sent value has no excess decimals.
-                    exponent = Decimal(str(step_size)).as_tuple().exponent
-                    step_decimals = max(0, -exponent) if isinstance(exponent, int) else 0
-                    quantity = round(normalized, step_decimals)
+                    quantity = quantize_to_step(normalized, step_size)
             except (ArithmeticError, ValueError) as e:
-                logger.error("Step_size normalization failed for %s: %s", symbol, e)
+                logger.error(
+                    "Step_size normalization failed for %s: %s", symbol, e, exc_info=True
+                )
 
         # Validate min_qty constraint
         min_qty = symbol_info.get("min_qty")

--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -14,6 +14,7 @@ import math
 import time
 import uuid
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any
 
 from src.config.constants import (
@@ -962,7 +963,12 @@ class LiveExecutionEngine:
                         symbol,
                     )
                 else:
-                    quantity = normalized
+                    # `(integer) * step_size` in float math leaves artifacts (e.g.
+                    # 40 * 0.0001 = 0.004000000000000001) that exceed the asset's max
+                    # precision; sent verbatim Binance rejects with code 51077. Quantize
+                    # to the step's decimal count so the sent value has no excess decimals.
+                    step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
+                    quantity = round(normalized, step_decimals)
             except (ArithmeticError, ValueError) as e:
                 logger.error("Step_size normalization failed for %s: %s", symbol, e)
 

--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -967,7 +967,8 @@ class LiveExecutionEngine:
                     # 40 * 0.0001 = 0.004000000000000001) that exceed the asset's max
                     # precision; sent verbatim Binance rejects with code 51077. Quantize
                     # to the step's decimal count so the sent value has no excess decimals.
-                    step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
+                    exponent = Decimal(str(step_size)).as_tuple().exponent
+                    step_decimals = max(0, -exponent) if isinstance(exponent, int) else 0
                     quantity = round(normalized, step_decimals)
             except (ArithmeticError, ValueError) as e:
                 logger.error("Step_size normalization failed for %s: %s", symbol, e)

--- a/src/trading/precision.py
+++ b/src/trading/precision.py
@@ -1,0 +1,22 @@
+"""Order-quantity precision helpers shared by the exchange + execution layers."""
+
+from decimal import Decimal
+
+
+def quantize_to_step(value: float, step_size: float) -> float:
+    """Clamp ``value`` to the decimal precision implied by ``step_size``.
+
+    After rounding a quantity to a LOT_SIZE step via float multiplication
+    (``round(value / step) * step``), the result can carry float artifacts like
+    ``0.004000000000000001`` that exceed an asset's max precision, so Binance
+    rejects the order with code 51077. This strips them by rounding to the number
+    of decimal places ``step_size`` implies. A no-op for already-clean values;
+    returns ``value`` unchanged when ``step_size`` is non-positive.
+    """
+    if step_size <= 0:
+        return value
+    # .exponent is a negative int for any finite Decimal (str of a real step);
+    # the isinstance guard defaults to 0 decimals for the impossible non-finite case.
+    exponent = Decimal(str(step_size)).as_tuple().exponent
+    decimals = max(0, -exponent) if isinstance(exponent, int) else 0
+    return round(value, decimals)

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import Mock, patch
 
 import pandas as pd
@@ -923,6 +924,119 @@ class TestPlaceStopLossOrder:
 
         # Assert
         assert result is None
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
+class TestStopLossQuantityStepPrecision:
+    """The quantity sent to Binance must carry no more decimals than LOT_SIZE allows.
+
+    `(integer) * step_size` in float math leaves artifacts (e.g.
+    round(0.0003 / 0.0001) * 0.0001 == 0.00030000000000000003). Sent verbatim, that
+    over-precise value is rejected with code 51077 ("Precision is over the maximum
+    defined for this asset"), which in prod made the SL submission ambiguous and left
+    a position unprotected in close-only mode. The quantize step must clamp the value
+    to the step's decimal count. Without the fix these assertions FAIL (the raw float
+    has exponent -17 to -20); with it the exponent never goes below what the step allows.
+    """
+
+    @staticmethod
+    def _make_provider(mock_config, mock_client_class, step_size, base_asset="ETH"):
+        """Build a provider whose symbol_info reports `step_size` and has free balance."""
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "slp"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(
+            return_value={
+                "step_size": step_size,
+                "tick_size": 0.01,
+                "base_asset": base_asset,
+            }
+        )
+        # Free balance comfortably covers the quantity so the SELL cap never trims it.
+        provider.get_balance = Mock(return_value=Mock(free=1_000_000.0))
+        return provider, mock_client
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize(
+        ("step_size", "quantity"),
+        [
+            # step -> a clean lot-multiple qty whose float round-trip is over-precise.
+            (0.0001, 0.0003),  # reproduces the 51077 incident case; raw exp == -20
+            (0.001, 0.009),  # raw exp == -18
+            (0.01, 0.35),  # raw exp == -17
+            (1.0, 40.0),  # integer step: must stay whole, no artifact introduced
+        ],
+    )
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_buy_branch_quantity_quantized_to_step(
+        self, mock_config, mock_client_class, step_size, quantity
+    ):
+        """BUY/other branch: round(qty/step)*step is quantized to the step's precision."""
+        provider, mock_client = self._make_provider(mock_config, mock_client_class, step_size)
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.BUY, quantity=quantity, stop_price=2100.0
+        )
+
+        assert result == "slp"
+        sent_qty = mock_client.create_order.call_args.kwargs["quantity"]
+        step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
+        # No more decimal places than the step implies (exponent not below -step_decimals).
+        assert Decimal(str(sent_qty)).as_tuple().exponent >= -step_decimals
+        # The quantize preserves the intended quantity (rounding artifact only).
+        assert sent_qty == pytest.approx(quantity, abs=step_size / 2)
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize(
+        ("step_size", "quantity"),
+        [
+            (0.0001, 0.0003),
+            (0.001, 0.009),
+            (0.01, 0.35),
+            (1.0, 40.0),
+        ],
+    )
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_branch_quantity_quantized_to_step(
+        self, mock_config, mock_client_class, step_size, quantity
+    ):
+        """SELL branch: floor(qty/step)*step is quantized to the step's precision too."""
+        provider, mock_client = self._make_provider(mock_config, mock_client_class, step_size)
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=quantity, stop_price=1900.0
+        )
+
+        assert result == "slp"
+        sent_qty = mock_client.create_order.call_args.kwargs["quantity"]
+        step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
+        assert Decimal(str(sent_qty)).as_tuple().exponent >= -step_decimals
+        assert sent_qty == pytest.approx(quantity, abs=step_size / 2)
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_reproduces_51077_case_exponent_within_four_decimals(
+        self, mock_config, mock_client_class
+    ):
+        """Explicit 51077 reproduction: step 0.0001, qty 0.0003 -> exponent >= -4."""
+        provider, mock_client = self._make_provider(mock_config, mock_client_class, 0.0001)
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.BUY, quantity=0.0003, stop_price=2100.0
+        )
+
+        assert result == "slp"
+        sent_qty = mock_client.create_order.call_args.kwargs["quantity"]
+        assert Decimal(str(sent_qty)).as_tuple().exponent >= -4
+        assert sent_qty == pytest.approx(0.0003, abs=1e-9)
 
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")

--- a/tests/unit/live/test_order_execution.py
+++ b/tests/unit/live/test_order_execution.py
@@ -291,6 +291,68 @@ class TestExecuteEntry:
 
 
 # ============================================================================
+# Tests for _normalize_quantity step-size precision (51077 guard)
+# ============================================================================
+
+
+class TestNormalizeQuantityPrecision:
+    """The entry quantity from _normalize_quantity must respect LOT_SIZE precision.
+
+    `round(qty / step_size) * step_size` in float math leaves artifacts (e.g.
+    round(0.0003 / 0.0001) * 0.0001 == 0.00030000000000000003). That over-precise
+    value is what reaches place_order -> create_order for entries, and Binance
+    rejects it with code 51077. Without the quantize these assertions FAIL (the raw
+    float has exponent -17 to -20); with it the exponent never goes below the step.
+    """
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize(
+        ("step_size", "quantity"),
+        [
+            (0.0001, 0.0003),  # reproduces the 51077 incident case; raw exp == -20
+            (0.001, 0.009),  # raw exp == -18
+            (0.01, 0.35),  # raw exp == -17
+            (1.0, 40.0),  # integer step: stays whole, no artifact introduced
+        ],
+    )
+    def test_normalized_quantity_quantized_to_step(
+        self, execution_engine_with_exchange, mock_exchange, step_size, quantity
+    ):
+        """Normalized quantity carries no more decimals than the step implies."""
+        mock_exchange.get_symbol_info.return_value = {
+            "step_size": step_size,
+            "min_qty": 0.0,
+            "min_notional": 0.0,
+        }
+
+        result = execution_engine_with_exchange._normalize_quantity(
+            "BTCUSDT", quantity, value=1_000.0
+        )
+
+        step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
+        assert Decimal(str(result)).as_tuple().exponent >= -step_decimals
+        assert result == pytest.approx(quantity, abs=step_size / 2)
+
+    @pytest.mark.fast
+    def test_reproduces_51077_case_exponent_within_four_decimals(
+        self, execution_engine_with_exchange, mock_exchange
+    ):
+        """Explicit 51077 reproduction: step 0.0001, qty 0.0003 -> exponent >= -4."""
+        mock_exchange.get_symbol_info.return_value = {
+            "step_size": 0.0001,
+            "min_qty": 0.0,
+            "min_notional": 0.0,
+        }
+
+        result = execution_engine_with_exchange._normalize_quantity(
+            "BTCUSDT", 0.0003, value=1_000.0
+        )
+
+        assert Decimal(str(result)).as_tuple().exponent >= -4
+        assert result == pytest.approx(0.0003, abs=1e-9)
+
+
+# ============================================================================
 # Tests for LiveExecutionEngine exit execution
 # ============================================================================
 

--- a/tests/unit/live/test_order_execution.py
+++ b/tests/unit/live/test_order_execution.py
@@ -295,6 +295,7 @@ class TestExecuteEntry:
 # ============================================================================
 
 
+@pytest.mark.unit
 class TestNormalizeQuantityPrecision:
     """The entry quantity from _normalize_quantity must respect LOT_SIZE precision.
 

--- a/tests/unit/trading/test_precision.py
+++ b/tests/unit/trading/test_precision.py
@@ -1,0 +1,39 @@
+"""Tests for src/trading/precision.quantize_to_step."""
+
+from decimal import Decimal
+
+import pytest
+
+from src.trading.precision import quantize_to_step
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.mark.parametrize(
+    "value,step,max_decimals",
+    [
+        (0.00030000000000000003, 0.0001, 4),  # the exact 51077 artifact
+        (0.004000000000000001, 0.0001, 4),
+        (1.2300000000001, 0.01, 2),
+        (0.123456789, 0.001, 3),
+        (5.0000000001, 1.0, 1),  # integer-ish step: value already clean
+    ],
+)
+def test_quantize_strips_float_artifacts(value, step, max_decimals):
+    """Result carries no more decimals than step_size implies (avoids Binance 51077)."""
+    result = quantize_to_step(value, step)
+    exponent = Decimal(str(result)).as_tuple().exponent
+    assert isinstance(exponent, int)
+    assert exponent >= -max_decimals
+
+
+def test_quantize_preserves_value_within_step_precision():
+    """The quantize is a value-preserving clamp, not a re-round of the lot multiple."""
+    assert quantize_to_step(0.004000000000000001, 0.0001) == pytest.approx(0.004)
+    assert quantize_to_step(1.23, 0.01) == pytest.approx(1.23)
+
+
+def test_quantize_noop_for_nonpositive_step():
+    """step_size <= 0 returns the value unchanged (no precision info to apply)."""
+    assert quantize_to_step(1.2345, 0) == 1.2345
+    assert quantize_to_step(1.2345, -1.0) == 1.2345


### PR DESCRIPTION
## Root cause

Order quantity is rounded to the symbol's `LOT_SIZE` `step_size` via float multiplication:

- SELL / stop-loss: `quantity = math.floor(quantity / step_size + 1e-9) * step_size`
- BUY / other:      `quantity = round(quantity / step_size) * step_size`

`(integer) * step_size` in float math leaves artifacts. For example:

```
round(0.0003 / 0.0001) * 0.0001  ==  0.00030000000000000003   # exponent -20
```

That over-precise value exceeds the asset's max precision, so Binance rejects the order with **code 51077** ("Precision is over the maximum defined for this asset").

In the 2026-06-05 prod incident this made an SL submission ambiguous, tipped the engine into **close-only mode**, and left a position **without a stop-loss**. It is intermittent — only quantities whose float product carries an artifact trip it (e.g. #13's qty was clean, #14's wasn't).

## The fix

After the existing step-size rounding, quantize the result to the step's decimal precision so no float artifacts remain. Guarded on `step_size > 0`:

```python
from decimal import Decimal
step_decimals = max(0, -Decimal(str(step_size)).as_tuple().exponent)
quantity = round(quantity, step_decimals)
```

Applied at **both** quantity send-sites:

**1. `src/data_providers/binance_provider.py` — `place_stop_loss_order`** (the site in the report)
- Added import `from decimal import Decimal` (line 20).
- Added the quantize once **after both** the SELL floor branch and the BUY/other round branch, before the `quantity <= 0` guard (lines **1742–1749**; the active statements are at 1747–1748). The quantity is sent to `_call_create_order` as a raw float (`"quantity": quantity`) — not via `str()` — so quantizing the float value is exactly what reaches `client.create_order` / `client.create_margin_order`.

**2. `src/engines/live/execution/execution_engine.py` — `LiveExecutionEngine._normalize_quantity`** (separate send-site found during the scan)
- Added import `from decimal import Decimal` (line 17).
- This method has the identical defect at the entry/BUY path: `normalized = round(quantity / step_size) * step_size`, and its result is passed straight to `place_order` → `create_order` (entries do **no** further rounding). Replaced the bare `quantity = normalized` with the quantize (lines **969–971**).

### Separate send-site formatting issue?

Scanned for `str(quantity)`, f-strings, and `_format_quantity`-style helpers reaching the Binance client. Findings:
- `place_stop_loss_order` and `place_order` pass `quantity` as a **raw float** (not stringified) — quantizing the float value is the correct fix; `stopPrice`/`price` use `str(...)` but quantity does not.
- The only repo-wide quantity normalizer that feeds an order send is `LiveExecutionEngine._normalize_quantity` — same bug class, **fixed here** (item 2 above).
- `coinbase_provider.py` uses `str(quantity)` for Coinbase orders — out of scope (not Binance, not the 51077 path).
- `database/manager.py` / `reconciliation.py` wrap quantity in `Decimal(str(...))` for DB persistence only — not exchange sends, no precision risk.

No other Binance send-site stringifies or re-rounds quantity after the fixed points.

## What is NOT changed

- The `math.floor(... + 1e-9) * step_size` (SELL) and `round(...) * step_size` (BUY) lot logic — preserved.
- The SELL free-base-balance cap (avoids -2010) — preserved.
- The `+1e-9` epsilon that stops an exact-lot multiple stored a hair low from truncating a whole step — preserved.

The quantize is a pure precision clamp; for already-clean values (e.g. the existing `0.0049` cap test) it is a no-op.

## Test coverage

All new tests are marked `@pytest.mark.fast`.

- `tests/unit/data_providers/test_binance_provider.py::TestStopLossQuantityStepPrecision` (line 931) — parametrized over `step_size` 0.0001 / 0.001 / 0.01 / 1.0, for **both** the SELL (floor) and BUY (round) branches, plus an explicit 51077 reproduction asserting `Decimal(str(result)).as_tuple().exponent >= -4` for step 0.0001 / qty 0.0003.
- `tests/unit/live/test_order_execution.py::TestNormalizeQuantityPrecision` (line 298) — same step-size matrix against `_normalize_quantity`, plus the explicit 51077 case.

Each test asserts the sent/returned quantity has no more decimals than the step implies (`exponent >= -step_decimals`) and that the quantize preserves the intended value (`pytest.approx`). The integer-step `1.0` case proves the fix does not break whole-number lots.

**Regression verified**: with the fix reverted, the artifact cases FAIL with exactly `assert -20 >= -4`, `assert -18 >= -3`, `assert -17 >= -2` (raw float exponents -17 to -20) on both send-sites; the integer-step case still passes. With the fix, all pass.

### Verification

- `pytest` green: 134 tests across `test_binance_provider.py`, `test_order_execution.py`, `test_margin_side_effect.py`; plus 111 in adjacent live/reconciliation suites.
- `ruff` / `black` clean on the changed lines (remaining repo findings are pre-existing noise on untouched lines).
- No Alembic migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
