### PR TITLE
fix(exchange): quantize stop-loss price to tick precision — avoid -1111 (#698)

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -1701,8 +1701,17 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 tick_size_raw = symbol_info.get("tick_size", 0.01)
                 tick_size = float(tick_size_raw) if isinstance(tick_size_raw, int | float) else 0.01
                 if tick_size > 0:
-                    stop_price = round(stop_price / tick_size) * tick_size
-                    limit_price = round(limit_price / tick_size) * tick_size
+                    # `round(x / tick) * tick` in float math leaves artifacts (e.g.
+                    # round(1648.82 / 0.01) * 0.01 = 1648.8200000000001) that exceed the
+                    # asset's price precision, so Binance rejects the stop-loss with code
+                    # -1111 ("price has too much precision"). Quantize to the tick's decimal
+                    # count, mirroring the quantity quantize at the LOT_SIZE step below.
+                    stop_price = quantize_to_step(
+                        round(stop_price / tick_size) * tick_size, tick_size
+                    )
+                    limit_price = quantize_to_step(
+                        round(limit_price / tick_size) * tick_size, tick_size
+                    )
 
                 # Validate step_size is numeric before division to prevent TypeError
                 step_size_raw = symbol_info.get("step_size", 0.00001)

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -1078,6 +1078,7 @@ class TestStopLossPriceTickPrecision:
 
     @staticmethod
     def _tick_decimals(tick_size):
+        """Number of decimal places the tick size implies (e.g. 0.01 -> 2, 1.0 -> 1)."""
         return max(0, -Decimal(str(tick_size)).as_tuple().exponent)
 
     @pytest.mark.fast

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -1039,6 +1039,8 @@ class TestStopLossQuantityStepPrecision:
         assert sent_qty == pytest.approx(0.0003, abs=1e-9)
 
 
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
 class TestStopLossPriceTickPrecision:
     """The stopPrice/price sent to Binance must carry no more decimals than PRICE_FILTER allows.
 

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -1039,6 +1039,127 @@ class TestStopLossQuantityStepPrecision:
         assert sent_qty == pytest.approx(0.0003, abs=1e-9)
 
 
+class TestStopLossPriceTickPrecision:
+    """The stopPrice/price sent to Binance must carry no more decimals than PRICE_FILTER allows.
+
+    `round(price / tick) * tick` in float math leaves artifacts (e.g.
+    round(1648.82 / 0.01) * 0.01 == 1648.8200000000001). Sent verbatim, that
+    over-precise value is rejected with code -1111 ("Parameter 'price' has too much
+    precision"), which in prod made every stop-loss placement fail and forced an
+    emergency close of the just-opened position. The quantize step must clamp both the
+    stopPrice and the derived limit price to the tick's decimal count. Without the fix
+    these assertions FAIL (the raw float exponent is far below the tick precision); with
+    it the exponent never goes below what the tick allows. Mirror of the quantity 51077
+    guard in TestStopLossQuantityStepPrecision, for the price side (#698).
+    """
+
+    @staticmethod
+    def _make_provider(mock_config, mock_client_class, tick_size, base_asset="ETH"):
+        """Build a provider whose symbol_info reports `tick_size` and has free balance."""
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        mock_client.create_order.return_value = {"orderId": "slp"}
+        provider = BinanceProvider()
+        provider.get_symbol_info = Mock(
+            return_value={
+                "step_size": 0.0001,
+                "tick_size": tick_size,
+                "base_asset": base_asset,
+            }
+        )
+        # Free balance comfortably covers the quantity so the SELL cap never trims it.
+        provider.get_balance = Mock(return_value=Mock(free=1_000_000.0))
+        return provider, mock_client
+
+    @staticmethod
+    def _tick_decimals(tick_size):
+        return max(0, -Decimal(str(tick_size)).as_tuple().exponent)
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize(
+        ("tick_size", "stop_price"),
+        [
+            # tick -> a price whose round(price/tick)*tick float round-trip is over-precise.
+            (0.01, 1648.82),  # reproduces the live -1111 case; raw exp far below -2
+            (0.1, 1648.8),
+            (0.01, 2100.07),
+            (1.0, 2100.0),  # integer tick: must stay whole, no artifact introduced
+        ],
+    )
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_buy_branch_prices_quantized_to_tick(
+        self, mock_config, mock_client_class, tick_size, stop_price
+    ):
+        """BUY branch: stopPrice and the derived limit price carry no excess decimals."""
+        provider, mock_client = self._make_provider(mock_config, mock_client_class, tick_size)
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.BUY, quantity=0.05, stop_price=stop_price
+        )
+
+        assert result == "slp"
+        tick_decimals = self._tick_decimals(tick_size)
+        sent_stop = mock_client.create_order.call_args.kwargs["stopPrice"]
+        sent_price = mock_client.create_order.call_args.kwargs["price"]
+        # Sent as strings; neither may have more decimals than the tick implies.
+        assert Decimal(sent_stop).as_tuple().exponent >= -tick_decimals
+        assert Decimal(sent_price).as_tuple().exponent >= -tick_decimals
+        # stopPrice preserves the intended level (within one tick).
+        assert float(sent_stop) == pytest.approx(stop_price, abs=tick_size)
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize(
+        ("tick_size", "stop_price"),
+        [
+            (0.01, 1899.93),
+            (0.1, 1899.9),
+            (0.01, 1648.82),
+            (1.0, 1900.0),
+        ],
+    )
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_sell_branch_prices_quantized_to_tick(
+        self, mock_config, mock_client_class, tick_size, stop_price
+    ):
+        """SELL branch: stopPrice and the derived limit price carry no excess decimals."""
+        provider, mock_client = self._make_provider(mock_config, mock_client_class, tick_size)
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.SELL, quantity=0.05, stop_price=stop_price
+        )
+
+        assert result == "slp"
+        tick_decimals = self._tick_decimals(tick_size)
+        sent_stop = mock_client.create_order.call_args.kwargs["stopPrice"]
+        sent_price = mock_client.create_order.call_args.kwargs["price"]
+        assert Decimal(sent_stop).as_tuple().exponent >= -tick_decimals
+        assert Decimal(sent_price).as_tuple().exponent >= -tick_decimals
+        assert float(sent_stop) == pytest.approx(stop_price, abs=tick_size)
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_reproduces_1111_case_exponent_within_two_decimals(
+        self, mock_config, mock_client_class
+    ):
+        """Explicit -1111 reproduction: tick 0.01, stop 1648.82 -> exponent >= -2."""
+        provider, mock_client = self._make_provider(mock_config, mock_client_class, 0.01)
+
+        result = provider.place_stop_loss_order(
+            symbol="ETHUSDT", side=OrderSide.BUY, quantity=0.05, stop_price=1648.82
+        )
+
+        assert result == "slp"
+        sent_stop = mock_client.create_order.call_args.kwargs["stopPrice"]
+        assert Decimal(sent_stop).as_tuple().exponent >= -2
+        assert float(sent_stop) == pytest.approx(1648.82, abs=1e-9)
+
+
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
 @patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
 class TestGetOrderIdRouting:


### PR DESCRIPTION
## What
Quantize the stop-loss `stop_price` and `limit_price` to the PRICE_FILTER tick precision in `place_stop_loss_order`, mirroring the quantity quantize that fixed 51077 (#695).

## Why
The 51077 fix covered order **quantity** (LOT_SIZE step) but not the stop-loss **price** (PRICE_FILTER tick). `round(price / tick) * tick` leaves float artifacts (e.g. `round(1648.82 / 0.01) * 0.01 == 1648.8200000000001`), which Binance rejects with **code -1111** ("Parameter 'price' has too much precision").

**Observed live in prod** (2026-06-05 21:04 UTC, session #20): short #15 opened cleanly (quantity fix working), then the stop-loss failed -1111 ×3 → position emergency-closed → PnL −$0.02. **Every position the bot opens emergency-closes until this lands.** See #698.

## Fix
```python
stop_price = quantize_to_step(round(stop_price / tick_size) * tick_size, tick_size)
limit_price = quantize_to_step(round(limit_price / tick_size) * tick_size, tick_size)
```
`quantize_to_step` already imported. Low-risk: snaps to the tick multiple then strips the float artifact — can only make the price *more* valid. Completeness scan confirms these are the only `round(price/tick)*tick` sites in `src/`; entry orders are market orders (no price param), so only the SL carries a price.

## Tests
`TestStopLossPriceTickPrecision` — buy + sell branches across tick sizes (0.01 / 0.1 / 1.0) and an explicit 1648.82 → exponent ≥ -2 reproduction. Asserts the sent `stopPrice`/`price` strings carry no more decimals than the tick allows. Mirrors the proven `TestStopLossQuantityStepPrecision`.

## Sequencing
Must land **before** #697 (dust blocks shorts) is cleared — otherwise unblocked entries open positions that immediately emergency-close. Bot is currently flat & safe, so no rush, but this is the prerequisite for restoring functional trading.

Closes #698. Relates #695/#696 (51077), #697 (dust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)