### PR TITLE
Promote: orphaned-borrow repay sweep (dry-run default) — #702

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -76,6 +76,17 @@ DEFAULT_HEALTH_LOOP_MAX_SILENCE_SECONDS = 900  # 15 minutes
 DEFAULT_HEALTH_MIN_CHECK_INTERVAL = 10  # Minimum health check interval (aggressive recovery)
 DEFAULT_HEALTH_MAX_CHECK_INTERVAL = 300  # Maximum health check interval
 
+# Orphaned Margin Borrow Sweep (reconciler auto-repay)
+# A cross-margin borrow with no tracked position behind it (e.g. an un-repaid short
+# remnant) blocks new shorts (#697) and accrues interest. The reconciler sweep repays
+# such an orphaned borrow ONLY when the base asset is provably flat and fully covered.
+DEFAULT_ORPHANED_BORROW_REPAY_CAP_USD = (
+    50.0  # Max USD value of a borrow to auto-repay; above → alert only
+)
+NET_FLAT_DUST_USD = 1.0  # |netAsset| * price below this counts as flat (no real position)
+BORROW_DUST_EPSILON = 1e-8  # Borrowed amounts at/below this are treated as zero
+ORPHANED_BORROW_SWEEP_COOLDOWN_SECONDS = 300  # Min seconds between sweep attempts per base asset
+
 # Core Trading Defaults (used across backtest and live engines)
 DEFAULT_STOP_LOSS_PCT = 0.05  # 5% stop loss
 DEFAULT_MIN_STOP_LOSS_PCT = 0.01  # 1% minimum stop loss

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -17,6 +17,7 @@ import threading
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from enum import Enum
 from functools import wraps
 from typing import Any, TypeVar
@@ -47,20 +48,18 @@ from .exchange_interface import (
     OrderStatus,
     OrderType,
     Position,
-    SideEffectType,
     Trade,
 )
 
 logger = logging.getLogger(__name__)
 
 try:
+    # Ensure ws.protocol.State is accessible (not auto-loaded in websockets 13+)
+    import websockets.protocol  # noqa: F401
     from binance import ThreadedWebsocketManager
     from binance.client import Client
     from binance.enums import SIDE_BUY, SIDE_SELL
     from binance.exceptions import BinanceAPIException, BinanceOrderException
-
-    # Ensure ws.protocol.State is accessible (not auto-loaded in websockets 13+)
-    import websockets.protocol  # noqa: F401
 
     BINANCE_AVAILABLE = True
 except ImportError:
@@ -1085,6 +1084,84 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             logger.warning("Failed to get borrowed amount for %s: %s", asset, e)
             return None  # Unknown — caller must not assume position is closed
 
+    def get_margin_account_asset(self, asset: str) -> dict | None:
+        """Raw cross-margin wallet fields for ``asset`` as strings, or None on error.
+
+        Returns a dict with ``free``/``locked``/``borrowed``/``interest``/``netAsset``
+        (Binance's raw string values) so callers can build exact ``Decimal``s rather
+        than float-rounding a loan amount. ``None`` means the lookup could not be
+        confirmed (transient error) — callers making a safety decision must treat
+        ``None`` as "unknown" and NOT act. An asset absent from the account returns
+        zeros.
+        """
+        if not self._use_margin or not BINANCE_AVAILABLE or not self._client:
+            return None
+        try:
+            account = self._call_get_account()
+            for bal in account.get("balances", []):
+                if bal["asset"] == asset:
+                    return {
+                        "asset": asset,
+                        "free": str(bal.get("free", "0")),
+                        "locked": str(bal.get("locked", "0")),
+                        "borrowed": str(bal.get("borrowed", "0")),
+                        "interest": str(bal.get("interest", "0")),
+                        "netAsset": str(bal.get("netAsset", bal.get("free", "0"))),
+                    }
+            return {
+                "asset": asset,
+                "free": "0",
+                "locked": "0",
+                "borrowed": "0",
+                "interest": "0",
+                "netAsset": "0",
+            }
+        except Exception as e:
+            logger.warning("Failed to read margin account asset %s: %s", asset, e)
+            return None
+
+    def has_open_orders(self, symbol: str) -> bool | None:
+        """Whether ``symbol`` has any open order — fail-CLOSED.
+
+        Unlike :meth:`get_open_orders` (which returns ``[]`` on failure), this returns
+        ``None`` when the lookup cannot be confirmed (transient error), so a caller
+        making a safety decision can treat ``None`` as "an order may exist" and skip.
+        ``True`` if one or more open orders, ``False`` if confirmed none.
+        """
+        if not BINANCE_AVAILABLE or not self._client:
+            return None
+        try:
+            orders_data = self._call_get_open_orders(symbol=symbol)
+            return len(orders_data) > 0
+        except Exception as e:
+            logger.warning("Open-orders lookup failed for %s: %s", symbol, e)
+            return None
+
+    def repay_margin_loan(self, asset: str, amount: Decimal) -> bool:
+        """Repay a cross-margin loan for ``asset`` via the modern borrow-repay endpoint.
+
+        Uses ``POST /sapi/v1/margin/borrow-repay`` (``type=REPAY``); the legacy
+        ``/sapi/v1/margin/repay`` endpoint is deprecated by Binance. Cross margin only
+        — no ``symbol`` (that parameter is for isolated margin). Returns ``True`` on
+        success. Never raises: any failure (e.g. ``-3015`` repay-exceeds-liability,
+        ``-3007`` HAS_PENDING_TRANSACTION, network) returns ``False`` so the caller
+        re-evaluates on the next cycle. Success is confirmed by the caller re-reading
+        the account, not by this return value alone.
+        """
+        if not self._use_margin or not BINANCE_AVAILABLE or not self._client:
+            return False
+        if amount <= 0:
+            return False
+        try:
+            self._client.margin_borrow_repay(
+                asset=asset, amount=str(amount), type="REPAY", isIsolated="FALSE"
+            )
+            logger.info("Margin repay submitted: %s %s", amount, asset)
+            return True
+        except Exception as e:
+            logger.warning("Margin repay failed for %s amount %s: %s", asset, amount, e)
+            return False
+
     def get_margin_interest_history(
         self,
         asset: str,
@@ -1634,9 +1711,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             bal = self.get_balance(base_asset)
             return float(bal.free) if bal is not None else None
         except Exception as e:
-            logger.warning(
-                "Could not read free %s balance for stop-loss sizing: %s", base_asset, e
-            )
+            logger.warning("Could not read free %s balance for stop-loss sizing: %s", base_asset, e)
             return None
 
     # Only retry transient -1015 (too many orders), NOT -1003 (IP ban).

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -15,20 +15,25 @@ import threading
 import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from src.config.constants import (
+    BORROW_DUST_EPSILON,
     DEFAULT_MAX_PENDING_ORDERS_PER_RECONCILE,
+    DEFAULT_ORPHANED_BORROW_REPAY_CAP_USD,
     DEFAULT_PENDING_SUBMIT_EXPIRY_MINUTES,
     DEFAULT_RECONCILE_TIME_BUDGET_SECONDS,
     DEFAULT_RECONCILIATION_BALANCE_THRESHOLD_PCT,
-    DEFAULT_RECONCILIATION_DUST_THRESHOLD,
     DEFAULT_RECONCILIATION_INTERVAL_SECONDS,
     DEFAULT_RECONCILIATION_ORDER_MATCH_TIME_WINDOW_MIN,
     DEFAULT_RECONCILIATION_ORDER_MATCH_TOLERANCE_PCT,
     DEFAULT_STOP_LOSS_PCT,
+    NET_FLAT_DUST_USD,
+    ORPHANED_BORROW_SWEEP_COOLDOWN_SECONDS,
 )
+from src.config.feature_flags import get_flag
 from src.data_providers.exchange_interface import SideEffectType
 from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.shared.models import PositionSide
@@ -420,7 +425,6 @@ class PositionReconciler:
         Defensive: catches all exceptions since the position may already be
         in the correct state.
         """
-        from src.engines.live.execution.position_tracker import LivePosition
 
         order_type = order_data.get("order_type", "")
         symbol = order_data.get("symbol", "")
@@ -448,7 +452,7 @@ class PositionReconciler:
         fill_qty: float,
     ) -> None:
         """Create position if an ENTRY order filled but was never persisted."""
-        from datetime import UTC, datetime
+        from datetime import UTC
 
         from src.engines.live.execution.position_tracker import LivePosition
 
@@ -547,8 +551,7 @@ class PositionReconciler:
                     )
                 except Exception as e:
                     logger.warning(
-                        "Failed to deduct entry fee $%.4f for recovered "
-                        "position %s: %s",
+                        "Failed to deduct entry fee $%.4f for recovered " "position %s: %s",
                         entry_fee,
                         client_order_id,
                         e,
@@ -1688,10 +1691,14 @@ class PositionReconciler:
     def _extract_base_asset(symbol: str) -> str:
         """Extract the base asset from a trading pair symbol.
 
-        Strips common quote currencies (USDT, BUSD, USD) from the end
-        of the symbol to get the base asset (e.g., "BTC" from "BTCUSDT").
+        Strips common quote currencies (USDT, BUSD, USDC, USD) from the end of
+        the symbol to get the base asset (e.g., "BTC" from "BTCUSDT", "ETH" from
+        "ETHUSDC"). Longest-first so 4-char quotes match before "USD". Single
+        source of truth for base-asset resolution (incl. the orphaned-borrow sweep,
+        which groups symbols by base asset — a missed quote would split a base into
+        two groups and weaken Gate 2).
         """
-        for quote in ("USDT", "BUSD", "USD"):
+        for quote in ("USDT", "BUSD", "USDC", "USD"):
             if symbol.endswith(quote) and len(symbol) > len(quote):
                 return symbol[: -len(quote)]
         return symbol
@@ -1817,9 +1824,7 @@ class PositionReconciler:
         except Exception as e:
             logger.warning("Asset holdings check failed for %s: %s", base_asset, e)
 
-    def _verify_margin_position_exists(
-        self, position: Any, result: ReconciliationResult
-    ) -> None:
+    def _verify_margin_position_exists(self, position: Any, result: ReconciliationResult) -> None:
         """Verify a margin position still exists by checking borrowed balance.
 
         For short positions, checks if the base asset has borrowed > 0.
@@ -1909,13 +1914,9 @@ class PositionReconciler:
                         self._remove_phantom_position(position, result)
 
         except Exception as e:
-            logger.warning(
-                "Margin position check failed for %s: %s — position retained", symbol, e
-            )
+            logger.warning("Margin position check failed for %s: %s — position retained", symbol, e)
 
-    def _remove_phantom_position(
-        self, position: Any, result: ReconciliationResult
-    ) -> None:
+    def _remove_phantom_position(self, position: Any, result: ReconciliationResult) -> None:
         """Remove a phantom position from tracker and DB, cancel its exchange SL."""
         # Cancel the server-side stop-loss before removing from tracker.
         # Leaving an orphaned SL on the exchange is a fund-loss path —
@@ -1926,12 +1927,15 @@ class PositionReconciler:
                 self.exchange.cancel_order(sl_order_id, position.symbol)
                 logger.info(
                     "Cancelled orphaned SL %s for removed position %s",
-                    sl_order_id, position.symbol,
+                    sl_order_id,
+                    position.symbol,
                 )
             except Exception as e:
                 logger.warning(
                     "Failed to cancel SL %s for removed position %s: %s",
-                    sl_order_id, position.symbol, e,
+                    sl_order_id,
+                    position.symbol,
+                    e,
                 )
 
         self.position_tracker.remove_position(position.order_id)
@@ -2313,6 +2317,8 @@ class PeriodicReconciler:
         interval: float = DEFAULT_RECONCILIATION_INTERVAL_SECONDS,
         on_critical: Any = None,
         use_margin: bool = False,
+        symbols: list[str] | None = None,
+        sweep_cooldown: dict[str, float] | None = None,
     ) -> None:
         """Initialize periodic reconciler.
 
@@ -2326,6 +2332,8 @@ class PeriodicReconciler:
             use_margin: Whether margin trading mode is active. When True,
                 skip spot-specific checks (asset holdings) that don't apply
                 to cross-margin accounts.
+            symbols: Configured trading symbols, used by the orphaned-borrow sweep
+                to know which base assets it may repay.
         """
         self.exchange = exchange_interface
         self.position_tracker = position_tracker
@@ -2334,6 +2342,7 @@ class PeriodicReconciler:
         self._use_margin = use_margin
         self.interval = interval
         self.on_critical = on_critical
+        self._symbols = symbols or []
 
         self._running = False
         self._thread: threading.Thread | None = None
@@ -2343,6 +2352,12 @@ class PeriodicReconciler:
         self._locks_lock = threading.Lock()  # Protects _position_mutation_locks dict
         # Cache for margin interest queries (5-min TTL per position)
         self._interest_cache: dict[str, tuple[float, float]] = {}
+        # Per-base-asset cooldown timestamps for the orphaned-borrow sweep. Shared
+        # with the engine's startup sweep when provided, so the two paths don't both
+        # act within one cooldown window.
+        self._sweep_cooldown: dict[str, float] = (
+            sweep_cooldown if sweep_cooldown is not None else {}
+        )
 
     def start(self) -> None:
         """Start the periodic reconciliation daemon thread."""
@@ -2400,6 +2415,20 @@ class PeriodicReconciler:
 
     def _reconcile_cycle(self) -> None:
         """Execute one reconciliation cycle."""
+        # Orphaned-borrow sweep runs every cycle — INCLUDING when flat — because an
+        # orphaned borrow exists precisely when there is no tracked position. Must
+        # run before the flat early-return below. No-op unless margin + flag enabled.
+        if self._use_margin and self._symbols:
+            run_orphaned_borrow_sweep(
+                exchange=self.exchange,
+                position_tracker=self.position_tracker,
+                db_manager=self.db_manager,
+                session_id=self.session_id,
+                use_margin=self._use_margin,
+                symbols=self._symbols,
+                cooldown_state=self._sweep_cooldown,
+            )
+
         # Snapshot positions (release lock before API calls)
         positions_snapshot = self.position_tracker.positions
         if not positions_snapshot:
@@ -2478,9 +2507,7 @@ class PeriodicReconciler:
                     symbol = position.symbol
                     base_asset = PositionReconciler._extract_base_asset(symbol)
                     side = getattr(position, "side", None)
-                    is_short = (
-                        side == PositionSide.SHORT or str(side).lower() == "short"
-                    )
+                    is_short = side == PositionSide.SHORT or str(side).lower() == "short"
 
                     balance = self.exchange.get_balance(base_asset)
                     position_gone = False
@@ -2539,9 +2566,7 @@ class PeriodicReconciler:
                             try:
                                 self.db_manager.close_position(db_pos_id)
                             except Exception as e:
-                                logger.warning(
-                                    "Failed to close DB position %s: %s", db_pos_id, e
-                                )
+                                logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
                 except Exception as e:
                     logger.warning(
                         "Margin position check failed for %s: %s",
@@ -2560,18 +2585,14 @@ class PeriodicReconciler:
             for _key, position in list(positions_snapshot.items()):
                 try:
                     side = getattr(position, "side", None)
-                    is_short = (
-                        side == PositionSide.SHORT or str(side).lower() == "short"
-                    )
+                    is_short = side == PositionSide.SHORT or str(side).lower() == "short"
                     if not is_short:
                         continue
                     entry_time = getattr(position, "entry_time", None)
                     if entry_time is None:
                         continue
 
-                    base_asset = PositionReconciler._extract_base_asset(
-                        position.symbol
-                    )
+                    base_asset = PositionReconciler._extract_base_asset(position.symbol)
                     cache_key = f"{position.symbol}_{_key}"
                     cached = self._interest_cache.get(cache_key)
                     if cached and (now - cached[1]) < interest_cache_ttl:
@@ -2608,9 +2629,7 @@ class PeriodicReconciler:
                     )
 
             # Evict stale cache entries for positions no longer tracked
-            active_keys = {
-                f"{pos.symbol}_{k}" for k, pos in positions_snapshot.items()
-            }
+            active_keys = {f"{pos.symbol}_{k}" for k, pos in positions_snapshot.items()}
             stale = [k for k in self._interest_cache if k not in active_keys]
             for k in stale:
                 del self._interest_cache[k]
@@ -2630,11 +2649,7 @@ class PeriodicReconciler:
 
                 current_size = getattr(position, "current_size", None)
                 original_size = getattr(position, "original_size", None)
-                if (
-                    current_size is not None
-                    and original_size is not None
-                    and original_size > 0
-                ):
+                if current_size is not None and original_size is not None and original_size > 0:
                     position_qty = qty * (current_size / original_size)
                 else:
                     position_qty = qty
@@ -2754,7 +2769,12 @@ class PeriodicReconciler:
                             pos_qty = getattr(position, "quantity", 0) or 0.0
                             current = getattr(position, "current_size", None)
                             original = getattr(position, "original_size", None)
-                            if current is not None and original is not None and original > 0 and pos_qty > 0:
+                            if (
+                                current is not None
+                                and original is not None
+                                and original > 0
+                                and pos_qty > 0
+                            ):
                                 held = pos_qty * (current / original)
                                 remaining = max(held - partial_fill, 0.0)
                                 position.current_size = original * (remaining / max(pos_qty, 1e-9))
@@ -3093,3 +3113,270 @@ def classify_severity(
             return Severity.LOW
 
     return Severity.LOW
+
+
+# --------------------------------------------------------------------------- #
+# Orphaned-margin-borrow sweep
+# --------------------------------------------------------------------------- #
+# A cross-margin borrow with no tracked position behind it (e.g. a short whose
+# cover never repaid the loan) blocks new shorts (#697) and accrues interest.
+# Closing repays via AUTO_REPAY on the order, but a flat bot fires no close, so an
+# orphaned borrow is never repaid. This sweep repays it — strictly guarded, per
+# BASE ASSET (a borrow is asset-scoped, not tied to one symbol). Default mode is
+# dry-run (detect + log only). See docs/plan and ORPHANED_BORROW_* constants.
+#
+# NOTE: active mode requires the shared base-asset exchange-mutation lock that
+# serialises this sweep against entry/exit (a focused follow-up). Until that lands
+# keep the flag at "off" or "dry_run" in production.
+
+
+def _base_asset_of(symbol: str) -> str:
+    """Base asset of a pair (delegates to the canonical reconciler implementation).
+
+    Single source of truth — avoids a divergent copy of the quote-stripping logic.
+    """
+    return PositionReconciler._extract_base_asset(symbol)
+
+
+def run_orphaned_borrow_sweep(
+    *,
+    exchange: Any,
+    position_tracker: Any,
+    db_manager: Any,
+    session_id: int,
+    use_margin: bool,
+    symbols: list[str],
+    cooldown_state: dict[str, float],
+) -> list[ReconciliationResult]:
+    """Repay cross-margin borrows that have no tracked position (orphaned).
+
+    Groups ``symbols`` by base asset and, for each base asset, repays its borrow
+    ONLY when every configured symbol sharing that base is provably flat and
+    order-free, the held balance fully covers the borrow, net exposure is ~flat,
+    and the value is under a hard USD cap. Mode comes from the
+    ``orphaned_borrow_sweep_mode`` feature flag: ``off`` (no-op), ``dry_run``
+    (detect + log, default) or ``active`` (repay). Never raises; a per-asset error
+    is isolated. ``cooldown_state`` is mutated to throttle attempts per base asset.
+    """
+    results: list[ReconciliationResult] = []
+    if not use_margin or not symbols:
+        return results
+    mode = get_flag("orphaned_borrow_sweep_mode", "off")
+    if mode not in ("dry_run", "active"):
+        return results
+    if not all(
+        hasattr(exchange, m)
+        for m in ("get_margin_account_asset", "repay_margin_loan", "has_open_orders")
+    ):
+        return results
+
+    by_base: dict[str, list[str]] = {}
+    for sym in symbols:
+        by_base.setdefault(_base_asset_of(sym), []).append(sym)
+
+    for base_asset, base_symbols in by_base.items():
+        try:
+            result = _sweep_one_base_asset(
+                exchange=exchange,
+                position_tracker=position_tracker,
+                db_manager=db_manager,
+                session_id=session_id,
+                base_asset=base_asset,
+                base_symbols=base_symbols,
+                mode=mode,
+                cooldown_state=cooldown_state,
+            )
+            if result is not None:
+                results.append(result)
+        except Exception as e:  # never let a sweep error break the caller
+            logger.warning("Orphaned-borrow sweep failed for %s: %s — skipped", base_asset, e)
+    return results
+
+
+def _sweep_one_base_asset(
+    *,
+    exchange: Any,
+    position_tracker: Any,
+    db_manager: Any,
+    session_id: int,
+    base_asset: str,
+    base_symbols: list[str],
+    mode: str,
+    cooldown_state: dict[str, float],
+) -> ReconciliationResult | None:
+    """Evaluate the gate chain for one base asset and repay/alert/dry-run."""
+    now = time.time()
+    if now - cooldown_state.get(base_asset, 0.0) < ORPHANED_BORROW_SWEEP_COOLDOWN_SECONDS:
+        return None
+
+    # Gate 2: no tracked position for ANY symbol sharing the base asset.
+    for sym in base_symbols:
+        if position_tracker.has_position_for_symbol(sym):
+            return None
+
+    # Gate 3 (fail-closed): no in-flight order (journal rows or open exchange orders)
+    # for any symbol sharing the base asset. Unknown == "an order may exist" -> skip.
+    try:
+        unresolved = db_manager.get_unresolved_orders(session_id)
+    except Exception as e:
+        logger.warning(
+            "Orphaned-borrow sweep: unresolved-orders lookup failed for %s — skipping (fail-closed): %s",
+            base_asset,
+            e,
+        )
+        return None
+    if unresolved is None:
+        return None
+    base_set = set(base_symbols)
+    for order in unresolved:
+        osym = order.get("symbol") if isinstance(order, dict) else getattr(order, "symbol", None)
+        if osym in base_set:
+            return None
+    for sym in base_symbols:
+        has_orders = exchange.has_open_orders(sym)
+        if has_orders is None or has_orders:  # fail-closed on None
+            return None
+
+    # Gate 5: provably flat & covered, from a single Decimal snapshot.
+    snap = exchange.get_margin_account_asset(base_asset)
+    if snap is None:
+        return None
+    try:
+        borrowed = Decimal(snap["borrowed"])
+        interest = Decimal(snap["interest"])
+        free = Decimal(snap["free"])
+        locked = Decimal(snap["locked"])
+        net = Decimal(snap["netAsset"])
+    except (KeyError, ArithmeticError, TypeError, ValueError):
+        return None
+    owed = borrowed + interest
+    if owed <= Decimal(str(BORROW_DUST_EPSILON)):
+        return None  # nothing to repay
+    if locked != 0:
+        return None  # base asset reserved by an order
+    if free < owed:
+        logger.warning(
+            "Orphaned-borrow sweep: %s free %s < owed %s — skipping (possible real short)",
+            base_asset,
+            free,
+            owed,
+        )
+        return None
+
+    # Gate 6: valid price + value cap.
+    try:
+        price = exchange.get_current_price(base_symbols[0])
+    except Exception as e:
+        logger.warning(
+            "Orphaned-borrow sweep: price lookup failed for %s — skipping: %s",
+            base_symbols[0],
+            e,
+        )
+        price = None
+    if price is None or not math.isfinite(float(price)) or float(price) <= 0:
+        return None
+    price_d = Decimal(str(price))
+    if abs(net) * price_d > Decimal(str(NET_FLAT_DUST_USD)):
+        return None  # net exposure not flat — a real position exists
+    owed_value = owed * price_d
+
+    def _audit(old: str, new: str, reason: str, severity: Severity) -> None:
+        try:
+            db_manager.log_audit_event(
+                session_id=session_id,
+                entity_type="balance",
+                entity_id=None,
+                field="borrowed",
+                old_value=old,
+                new_value=new,
+                reason=reason,
+                severity=severity.value,
+            )
+        except Exception as e:
+            logger.error("Failed to persist orphaned-borrow audit: %s", e, exc_info=True)
+
+    # Any decision (alert/dry-run/active) starts the cooldown.
+    cooldown_state[base_asset] = now
+
+    if owed_value > Decimal(str(DEFAULT_ORPHANED_BORROW_REPAY_CAP_USD)):
+        logger.critical(
+            "🚨 Orphaned %s borrow %s (~$%.2f) exceeds auto-repay cap $%.0f — manual review required",
+            base_asset,
+            owed,
+            float(owed_value),
+            DEFAULT_ORPHANED_BORROW_REPAY_CAP_USD,
+        )
+        _audit(
+            str(owed),
+            str(owed),
+            f"Orphaned margin borrow {base_asset} ~${float(owed_value):.2f} exceeds cap — manual review",
+            Severity.CRITICAL,
+        )
+        return ReconciliationResult(
+            entity_type="balance",
+            entity_id=base_asset,
+            status="unresolved",
+            severity=Severity.CRITICAL,
+        )
+
+    if mode == "dry_run":
+        logger.warning(
+            "🔍 DRY-RUN orphaned-borrow sweep: would repay %s %s (~$%.2f) — all gates passed",
+            owed,
+            base_asset,
+            float(owed_value),
+        )
+        _audit(
+            str(owed),
+            str(owed),
+            f"DRY-RUN: would repay orphaned margin borrow {owed} {base_asset}",
+            Severity.MEDIUM,
+        )
+        return ReconciliationResult(
+            entity_type="balance", entity_id=base_asset, status="skipped", severity=Severity.MEDIUM
+        )
+
+    # mode == "active": repay, then re-query to confirm the loan is cleared.
+    if not exchange.repay_margin_loan(base_asset, owed):
+        logger.warning("Orphaned-borrow repay returned False for %s %s", owed, base_asset)
+        return ReconciliationResult(
+            entity_type="balance",
+            entity_id=base_asset,
+            status="unresolved",
+            severity=Severity.MEDIUM,
+        )
+    verify = exchange.get_margin_account_asset(base_asset)
+    if verify is None:
+        logger.warning(
+            "Orphaned-borrow repay submitted for %s but post-repay re-query failed — re-verify next cycle",
+            base_asset,
+        )
+        return ReconciliationResult(
+            entity_type="balance",
+            entity_id=base_asset,
+            status="unresolved",
+            severity=Severity.MEDIUM,
+        )
+    try:
+        remaining = Decimal(verify["borrowed"]) + Decimal(verify["interest"])
+    except (KeyError, ArithmeticError, TypeError, ValueError):
+        remaining = owed  # cannot confirm -> treat as not-cleared
+    if remaining > Decimal(str(BORROW_DUST_EPSILON)):
+        logger.warning(
+            "Orphaned-borrow partial repay for %s — %s still owed; re-evaluate next cycle",
+            base_asset,
+            remaining,
+        )
+        return ReconciliationResult(
+            entity_type="balance",
+            entity_id=base_asset,
+            status="unresolved",
+            severity=Severity.MEDIUM,
+        )
+    logger.info(
+        "✅ Repaid orphaned margin borrow %s %s (~$%.2f)", owed, base_asset, float(owed_value)
+    )
+    _audit(str(owed), "0", f"Repaid orphaned margin borrow {owed} {base_asset}", Severity.HIGH)
+    return ReconciliationResult(
+        entity_type="balance", entity_id=base_asset, status="corrected", severity=Severity.HIGH
+    )

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -490,6 +490,9 @@ class LiveTradingEngine:
         self.is_running = False
         self._close_only_mode = False  # No new entries when True; exits still run
         self._periodic_reconciler = None  # Set during start() for live trading
+        # Shared per-base-asset cooldown for the orphaned-borrow sweep, so the
+        # startup sweep and the periodic reconciler don't both act in one window.
+        self._orphan_sweep_cooldown: dict[str, float] = {}
         self.completed_trades: list[Trade] = []
         self.last_data_update = None
         self.last_account_snapshot = None  # Track when we last logged account state
@@ -1504,6 +1507,8 @@ class LiveTradingEngine:
                     session_id=self.trading_session_id,
                     on_critical=self._enter_close_only_mode,
                     use_margin=use_margin,
+                    symbols=[self._active_symbol] if self._active_symbol else [],
+                    sweep_cooldown=self._orphan_sweep_cooldown,
                 )
                 self._periodic_reconciler.start()
                 logger.info("🔄 Periodic reconciler started")
@@ -4970,6 +4975,7 @@ class LiveTradingEngine:
                 from src.engines.live.reconciliation import (
                     PositionReconciler,
                     Severity,
+                    run_orphaned_borrow_sweep,
                 )
 
                 use_margin = getattr(self.exchange_interface, "is_margin_mode", False)
@@ -4985,6 +4991,20 @@ class LiveTradingEngine:
                 if not positions_snapshot:
                     logger.info("📊 No local positions to reconcile — checking pending orders")
                     results = reconciler.resolve_pending_orders()
+
+                    # After pending orders are resolved (so a fill that becomes a
+                    # position is adopted first), sweep any orphaned margin borrow.
+                    # No-op unless margin + flag enabled; safe when flat.
+                    if use_margin and self._active_symbol:
+                        run_orphaned_borrow_sweep(
+                            exchange=self.exchange_interface,
+                            position_tracker=self.live_position_tracker,
+                            db_manager=self.db_manager,
+                            session_id=self.trading_session_id,
+                            use_margin=use_margin,
+                            symbols=[self._active_symbol],
+                            cooldown_state=self._orphan_sweep_cooldown,
+                        )
 
                     # Process results even with no positions — a filled entry
                     # order may create a position, and critical issues must

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -1165,6 +1165,99 @@ class TestStopLossPriceTickPrecision:
 
 @pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
 @patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
+class TestOrphanedBorrowExchangeHelpers:
+    """repay_margin_loan / get_margin_account_asset / has_open_orders for the sweep."""
+
+    @staticmethod
+    def _provider(mock_config, mock_client_class):
+        cfg = Mock()
+        cfg.get_required.return_value = "fake_key"
+        mock_config.return_value = cfg
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        provider = BinanceProvider()
+        provider._use_margin = True
+        provider._client = mock_client
+        return provider, mock_client
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_repay_uses_modern_borrow_repay_endpoint(self, mock_config, mock_client_class):
+        provider, client = self._provider(mock_config, mock_client_class)
+        ok = provider.repay_margin_loan("ETH", Decimal("0.00282625"))
+        assert ok is True
+        client.margin_borrow_repay.assert_called_once_with(
+            asset="ETH", amount="0.00282625", type="REPAY", isIsolated="FALSE"
+        )
+        # The deprecated /sapi/v1/margin/repay endpoint must NOT be used.
+        client.repay_margin_loan.assert_not_called()
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_repay_returns_false_on_error(self, mock_config, mock_client_class):
+        provider, client = self._provider(mock_config, mock_client_class)
+        client.margin_borrow_repay.side_effect = Exception("APIError(code=-3015) exceeds liability")
+        assert provider.repay_margin_loan("ETH", Decimal("0.003")) is False
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_repay_noop_when_not_margin_or_nonpositive(self, mock_config, mock_client_class):
+        provider, client = self._provider(mock_config, mock_client_class)
+        provider._use_margin = False
+        assert provider.repay_margin_loan("ETH", Decimal("0.003")) is False
+        provider._use_margin = True
+        assert provider.repay_margin_loan("ETH", Decimal("0")) is False
+        client.margin_borrow_repay.assert_not_called()
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_has_open_orders_fail_closed_on_error(self, mock_config, mock_client_class):
+        provider, _ = self._provider(mock_config, mock_client_class)
+        with patch.object(provider, "_call_get_open_orders", side_effect=Exception("boom")):
+            assert provider.has_open_orders("ETHUSDT") is None  # fail-closed, not []
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_has_open_orders_true_and_false(self, mock_config, mock_client_class):
+        provider, _ = self._provider(mock_config, mock_client_class)
+        with patch.object(provider, "_call_get_open_orders", return_value=[{"orderId": 1}]):
+            assert provider.has_open_orders("ETHUSDT") is True
+        with patch.object(provider, "_call_get_open_orders", return_value=[]):
+            assert provider.has_open_orders("ETHUSDT") is False
+
+    @pytest.mark.fast
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_get_margin_account_asset_returns_raw_strings(self, mock_config, mock_client_class):
+        provider, _ = self._provider(mock_config, mock_client_class)
+        account = {
+            "balances": [
+                {
+                    "asset": "ETH",
+                    "free": "0.0029",
+                    "locked": "0",
+                    "borrowed": "0.00282625",
+                    "interest": "0.0000001",
+                    "netAsset": "0.00007",
+                }
+            ]
+        }
+        with patch.object(provider, "_call_get_account", return_value=account):
+            snap = provider.get_margin_account_asset("ETH")
+        assert snap is not None
+        assert snap["borrowed"] == "0.00282625"
+        assert snap["free"] == "0.0029"
+        assert snap["interest"] == "0.0000001"
+        assert snap["netAsset"] == "0.00007"
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
 class TestGetOrderIdRouting:
     """Tests for get_order() routing between orderId and origClientOrderId."""
 
@@ -1357,10 +1450,12 @@ class TestMarginFlag:
     @patch("src.data_providers.binance_provider.get_config")
     def test_is_live_flag(self, mock_config, mock_client_class):
         """Verify _is_live=True when TRADING_MODE=live."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "spot",
-            "TRADING_MODE": "live",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "spot",
+                "TRADING_MODE": "live",
+            }
+        )
         mock_client = Mock()
         mock_client_class.return_value = mock_client
 
@@ -1387,10 +1482,12 @@ class TestMarginFailFast:
     @patch("src.data_providers.binance_provider.get_config")
     def test_margin_live_mode_no_offline_fallback(self, mock_config, mock_client_class):
         """Live+margin raises RuntimeError instead of falling back to offline stub."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "live",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "live",
+            }
+        )
         mock_client_class.side_effect = Exception("Connection refused")
 
         with pytest.raises(RuntimeError, match="FATAL.*live margin mode"):
@@ -1400,10 +1497,12 @@ class TestMarginFailFast:
     @patch("src.data_providers.binance_provider.get_config")
     def test_margin_paper_mode_allows_offline_fallback(self, mock_config, mock_client_class):
         """Paper+margin falls back to offline stub (no RuntimeError)."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "paper",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "paper",
+            }
+        )
         mock_client_class.side_effect = Exception("Connection refused")
 
         provider = BinanceProvider()
@@ -1413,10 +1512,12 @@ class TestMarginFailFast:
     @patch("src.data_providers.binance_provider.get_config")
     def test_margin_live_no_sdk_fails_fast(self, mock_config):
         """Live+margin raises RuntimeError when SDK is not installed."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "live",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "live",
+            }
+        )
 
         with pytest.raises(RuntimeError, match="Binance library not available"):
             BinanceProvider()
@@ -1479,10 +1580,12 @@ class TestMarginStartupChecks:
     @patch("src.data_providers.binance_provider.get_config")
     def test_margin_startup_api_error_live_raises(self, mock_config, mock_client_class):
         """API error during margin verification in live mode raises RuntimeError."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "live",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "live",
+            }
+        )
         mock_client = Mock()
         mock_client_class.return_value = mock_client
         mock_client.get_margin_account.side_effect = Exception("API timeout")
@@ -1494,10 +1597,12 @@ class TestMarginStartupChecks:
     @patch("src.data_providers.binance_provider.get_config")
     def test_margin_startup_api_error_paper_warns(self, mock_config, mock_client_class):
         """API error during margin verification in paper mode logs warning, no raise."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "paper",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "paper",
+            }
+        )
         mock_client = Mock()
         mock_client_class.return_value = mock_client
         mock_client.get_margin_account.side_effect = Exception("API timeout")
@@ -1515,10 +1620,12 @@ class TestMarginBaseAssetGuard:
     @patch("src.data_providers.binance_provider.get_config")
     def test_warns_non_usdt_holdings_in_live_mode(self, mock_config, mock_client_class):
         """Live margin mode warns (not raises) for non-USDT assets — could be a recovering long."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "live",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "live",
+            }
+        )
         mock_client = Mock()
         mock_client_class.return_value = mock_client
         mock_client.get_margin_account.return_value = {
@@ -1542,10 +1649,12 @@ class TestMarginBaseAssetGuard:
     @patch("src.data_providers.binance_provider.get_config")
     def test_allows_dust_holdings(self, mock_config, mock_client_class):
         """Dust amounts (< $1) are ignored."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "live",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "live",
+            }
+        )
         mock_client = Mock()
         mock_client_class.return_value = mock_client
         mock_client.get_margin_account.return_value = {
@@ -1567,10 +1676,12 @@ class TestMarginBaseAssetGuard:
     @patch("src.data_providers.binance_provider.get_config")
     def test_warns_in_paper_mode(self, mock_config, mock_client_class):
         """Paper mode warns but doesn't raise for non-USDT holdings."""
-        mock_config.return_value = _make_config_mock({
-            "BINANCE_ACCOUNT_TYPE": "margin",
-            "TRADING_MODE": "paper",
-        })
+        mock_config.return_value = _make_config_mock(
+            {
+                "BINANCE_ACCOUNT_TYPE": "margin",
+                "TRADING_MODE": "paper",
+            }
+        )
         mock_client = Mock()
         mock_client_class.return_value = mock_client
         mock_client.get_margin_account.return_value = {
@@ -1661,7 +1772,9 @@ class TestMarginDispatch:
     @patch("src.data_providers.binance_provider.get_config")
     def test_spot_dispatch_routes_to_spot_methods(self, mock_config, mock_client_class):
         """Dispatch methods call spot client methods when _use_margin=False."""
-        provider, mock_client = self._make_provider(mock_config, mock_client_class, use_margin=False)
+        provider, mock_client = self._make_provider(
+            mock_config, mock_client_class, use_margin=False
+        )
 
         # _call_get_account
         mock_client.get_account.return_value = {"balances": [], "canTrade": True}
@@ -1711,11 +1824,16 @@ class TestMarginDispatch:
     @patch("src.data_providers.binance_provider.get_config")
     def test_spot_dispatch_strips_sideEffectType(self, mock_config, mock_client_class):
         """Spot dispatch removes sideEffectType param to avoid Binance error."""
-        provider, mock_client = self._make_provider(mock_config, mock_client_class, use_margin=False)
+        provider, mock_client = self._make_provider(
+            mock_config, mock_client_class, use_margin=False
+        )
 
         mock_client.create_order.return_value = {"orderId": "123"}
         provider._call_create_order(
-            symbol="BTCUSDT", side="BUY", type="MARKET", quantity=0.1,
+            symbol="BTCUSDT",
+            side="BUY",
+            type="MARKET",
+            quantity=0.1,
             sideEffectType="MARGIN_BUY",
         )
         call_kwargs = mock_client.create_order.call_args.kwargs
@@ -1988,27 +2106,37 @@ class TestMarginErrorCodes:
     def test_margin_insufficient_balance_raises(self, mock_config, mock_client_class):
         """Error -3041 (insufficient margin balance) raises ValueError, not None."""
         from binance.exceptions import BinanceAPIException
+
         from src.data_providers.exchange_interface import OrderType
 
         mock_config.return_value = _make_config_mock({"BINANCE_ACCOUNT_TYPE": "margin"})
         mock_client = Mock()
         mock_client_class.return_value = mock_client
         mock_client.get_margin_account.return_value = {
-            "tradeEnabled": True, "borrowEnabled": True,
-            "marginLevel": "2.5", "userAssets": [],
+            "tradeEnabled": True,
+            "borrowEnabled": True,
+            "marginLevel": "2.5",
+            "userAssets": [],
         }
         mock_client.get_margin_symbol.return_value = {
-            "isMarginTrade": True, "isBuyAllowed": True, "isSellAllowed": True,
+            "isMarginTrade": True,
+            "isBuyAllowed": True,
+            "isSellAllowed": True,
         }
         mock_client.get_exchange_info.return_value = {
-            "symbols": [{
-                "symbol": "ETHUSDT", "baseAsset": "ETH", "quoteAsset": "USDT",
-                "status": "TRADING", "filters": [
-                    {"filterType": "LOT_SIZE", "minQty": "0.001", "stepSize": "0.001"},
-                    {"filterType": "PRICE_FILTER", "minPrice": "0.01", "tickSize": "0.01"},
-                    {"filterType": "MIN_NOTIONAL", "minNotional": "10"},
-                ],
-            }],
+            "symbols": [
+                {
+                    "symbol": "ETHUSDT",
+                    "baseAsset": "ETH",
+                    "quoteAsset": "USDT",
+                    "status": "TRADING",
+                    "filters": [
+                        {"filterType": "LOT_SIZE", "minQty": "0.001", "stepSize": "0.001"},
+                        {"filterType": "PRICE_FILTER", "minPrice": "0.01", "tickSize": "0.01"},
+                        {"filterType": "MIN_NOTIONAL", "minNotional": "10"},
+                    ],
+                }
+            ],
         }
 
         # Simulate Binance margin error -3041

--- a/tests/unit/live/test_orphaned_borrow_sweep.py
+++ b/tests/unit/live/test_orphaned_borrow_sweep.py
@@ -1,0 +1,268 @@
+"""Unit tests for the orphaned-margin-borrow sweep (reconciliation.run_orphaned_borrow_sweep).
+
+The sweep repays a cross-margin borrow that has no tracked position behind it, but ONLY
+when a strict gate chain proves the base asset is flat, order-free, fully covered, and
+under a value cap. These tests exercise each gate plus the dry-run/active/over-cap paths.
+Money never moves unless every gate passes AND the flag is "active".
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.engines.live import reconciliation
+from src.engines.live.reconciliation import run_orphaned_borrow_sweep
+
+pytestmark = pytest.mark.fast
+
+SYMBOL = "ETHUSDT"
+BASE = "ETH"
+
+
+def _snapshot(borrowed="0.003", interest="0", free="0.003", locked="0", net="0.00007"):
+    return {
+        "asset": BASE,
+        "free": free,
+        "locked": locked,
+        "borrowed": borrowed,
+        "interest": interest,
+        "netAsset": net,
+    }
+
+
+def _exchange(
+    *,
+    snapshot=None,
+    verify_after=None,
+    has_orders: bool | None = False,
+    price=1600.0,
+    repay_ok=True,
+):
+    ex = MagicMock()
+    snap = snapshot if snapshot is not None else _snapshot()
+    if verify_after is None:
+        ex.get_margin_account_asset.return_value = snap
+    else:
+        ex.get_margin_account_asset.side_effect = [snap, verify_after]
+    ex.has_open_orders.return_value = has_orders
+    ex.get_current_price.return_value = price
+    ex.repay_margin_loan.return_value = repay_ok
+    return ex
+
+
+def _tracker(has_position=False):
+    t = MagicMock()
+    t.has_position_for_symbol.return_value = has_position
+    return t
+
+
+def _db(unresolved=None):
+    db = MagicMock()
+    db.get_unresolved_orders.return_value = [] if unresolved is None else unresolved
+    db.log_audit_event.return_value = 1
+    return db
+
+
+def _run(
+    exchange, tracker, db, *, mode="active", symbols=(SYMBOL,), cooldown=None, use_margin=True
+):
+    with patch.object(reconciliation, "get_flag", return_value=mode):
+        return run_orphaned_borrow_sweep(
+            exchange=exchange,
+            position_tracker=tracker,
+            db_manager=db,
+            session_id=1,
+            use_margin=use_margin,
+            symbols=list(symbols),
+            cooldown_state={} if cooldown is None else cooldown,
+        )
+
+
+# ---- happy paths ----------------------------------------------------------- #
+
+
+def test_active_repays_when_flat_covered_under_cap():
+    ex = _exchange(verify_after=_snapshot(borrowed="0", interest="0", free="0", net="0"))
+    results = _run(ex, _tracker(), _db(), mode="active")
+    # Repaid the exact Decimal liability (borrowed + interest), not a re-rounded float.
+    ex.repay_margin_loan.assert_called_once_with(BASE, Decimal("0.003"))
+    # Post-repay re-query happened (snapshot read twice: gate + verify).
+    assert ex.get_margin_account_asset.call_count == 2
+    assert results and results[0].status == "corrected"
+
+
+def test_dry_run_detects_but_never_repays():
+    ex = _exchange()
+    results = _run(ex, _tracker(), _db(), mode="dry_run")
+    ex.repay_margin_loan.assert_not_called()
+    assert results and results[0].status == "skipped"
+
+
+def test_off_mode_is_noop():
+    ex = _exchange()
+    results = _run(ex, _tracker(), _db(), mode="off")
+    ex.repay_margin_loan.assert_not_called()
+    ex.get_margin_account_asset.assert_not_called()
+    assert results == []
+
+
+def test_not_margin_is_noop():
+    ex = _exchange()
+    results = _run(ex, _tracker(), _db(), mode="active", use_margin=False)
+    ex.repay_margin_loan.assert_not_called()
+    assert results == []
+
+
+# ---- gate: no tracked position --------------------------------------------- #
+
+
+def test_skip_when_position_tracked():
+    ex = _exchange()
+    _run(ex, _tracker(has_position=True), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_skip_when_other_symbol_sharing_base_has_position():
+    # ETHUSDT and ETHUSDC share base ETH; a position on either blocks repaying the ETH borrow.
+    ex = _exchange()
+    tracker = MagicMock()
+    tracker.has_position_for_symbol.side_effect = lambda s: s == "ETHUSDC"
+    _run(ex, tracker, _db(), mode="active", symbols=("ETHUSDT", "ETHUSDC"))
+    ex.repay_margin_loan.assert_not_called()
+
+
+# ---- gate: no in-flight order (fail-closed) -------------------------------- #
+
+
+def test_skip_when_unresolved_journal_row_for_symbol():
+    ex = _exchange()
+    _run(ex, _tracker(), _db(unresolved=[{"symbol": SYMBOL}]), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_skip_when_open_orders_present():
+    ex = _exchange(has_orders=True)
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_fail_closed_when_open_orders_lookup_unconfirmed():
+    ex = _exchange(has_orders=None)  # None = lookup failed -> must skip
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_fail_closed_when_journal_lookup_raises():
+    ex = _exchange()
+    db = _db()
+    db.get_unresolved_orders.side_effect = RuntimeError("db down")
+    _run(ex, _tracker(), db, mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+# ---- gate: provably flat & covered ----------------------------------------- #
+
+
+def test_skip_when_free_below_owed():
+    ex = _exchange(snapshot=_snapshot(borrowed="0.003", free="0.001"))
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_skip_when_locked_nonzero():
+    ex = _exchange(snapshot=_snapshot(locked="0.001"))
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_skip_when_net_exposure_not_flat():
+    # netAsset 0.01 ETH * 1600 = $16 > NET_FLAT_DUST_USD ($1) -> a real position exists.
+    ex = _exchange(snapshot=_snapshot(net="0.01"))
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_skip_when_borrow_below_dust():
+    ex = _exchange(snapshot=_snapshot(borrowed="0", interest="0"))
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_skip_when_snapshot_unavailable():
+    ex = _exchange()
+    ex.get_margin_account_asset.return_value = None
+    ex.get_margin_account_asset.side_effect = None
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+# ---- gate: valid price + cap ----------------------------------------------- #
+
+
+@pytest.mark.parametrize("bad_price", [None, 0.0, -5.0, float("nan"), float("inf")])
+def test_skip_when_price_invalid(bad_price):
+    ex = _exchange(price=bad_price)
+    _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_not_called()
+
+
+def test_over_cap_alerts_and_does_not_repay():
+    # 1 ETH borrowed * 1600 = $1600 >> $50 cap. But keep it net-flat/covered so only the
+    # cap gate trips: free covers it, netAsset ~0.
+    ex = _exchange(snapshot=_snapshot(borrowed="1", free="1", net="0"))
+    db = _db()
+    results = _run(ex, _tracker(), db, mode="active")
+    ex.repay_margin_loan.assert_not_called()
+    assert results and results[0].severity.value == "CRITICAL"
+    db.log_audit_event.assert_called_once()
+
+
+# ---- active-mode post-repay verification ----------------------------------- #
+
+
+def test_partial_repay_does_not_emit_success():
+    # Repay returns ok, but the borrow is still present afterwards -> unresolved, not corrected.
+    ex = _exchange(verify_after=_snapshot(borrowed="0.0015", interest="0"))
+    results = _run(ex, _tracker(), _db(), mode="active")
+    ex.repay_margin_loan.assert_called_once()
+    assert results and results[0].status == "unresolved"
+
+
+def test_repay_call_false_is_unresolved():
+    ex = _exchange(repay_ok=False)
+    results = _run(ex, _tracker(), _db(), mode="active")
+    assert results and results[0].status == "unresolved"
+
+
+# ---- cooldown -------------------------------------------------------------- #
+
+
+def test_cooldown_blocks_second_attempt_in_window():
+    ex = _exchange(verify_after=_snapshot(borrowed="0", free="0", net="0"))
+    cooldown: dict[str, float] = {}
+    _run(ex, _tracker(), _db(), mode="active", cooldown=cooldown)
+    assert ex.repay_margin_loan.call_count == 1
+    # Second call within cooldown window must not act again.
+    ex2 = _exchange()
+    _run(ex2, _tracker(), _db(), mode="active", cooldown=cooldown)
+    ex2.repay_margin_loan.assert_not_called()
+
+
+def test_periodic_reconciler_uses_shared_cooldown_dict():
+    """The engine passes one cooldown dict to both the startup sweep and the periodic
+    reconciler, so the two paths can't both repay within one cooldown window."""
+    from src.engines.live.reconciliation import PeriodicReconciler
+
+    shared: dict[str, float] = {}
+    pr = PeriodicReconciler(
+        exchange_interface=MagicMock(),
+        position_tracker=MagicMock(),
+        db_manager=MagicMock(),
+        session_id=1,
+        symbols=["ETHUSDT"],
+        sweep_cooldown=shared,
+    )
+    assert pr._sweep_cooldown is shared


### PR DESCRIPTION
Surgical promote of develop squash `4ed1ac54` (#702), **patch-id verified identical** (`d844dd02…`).

Codex-APPROVED (3 rounds, 113 tests pass). Ships **dry-run / default-OFF** — inert until `FEATURE_ORPHANED_BORROW_SWEEP_MODE` is set. After deploy I'll set it to `dry_run` to validate the gates against the real ~0.0028 ETH orphan (detect + log only, **no money moves**). Active mode is gated on the follow-up lock (#703).

Refs #697, #702.