### PR TITLE
feat(margin): base-asset exchange-mutation lock — enables safe sweep ACTIVE mode (#703)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2319,6 +2319,7 @@ class PeriodicReconciler:
         use_margin: bool = False,
         symbols: list[str] | None = None,
         sweep_cooldown: dict[str, float] | None = None,
+        lock_registry: Any = None,
     ) -> None:
         """Initialize periodic reconciler.
 
@@ -2358,6 +2359,8 @@ class PeriodicReconciler:
         self._sweep_cooldown: dict[str, float] = (
             sweep_cooldown if sweep_cooldown is not None else {}
         )
+        # Shared per-base-asset exchange-mutation lock (serialises sweep vs entry/exit).
+        self._lock_registry = lock_registry
 
     def start(self) -> None:
         """Start the periodic reconciliation daemon thread."""
@@ -2427,6 +2430,7 @@ class PeriodicReconciler:
                 use_margin=self._use_margin,
                 symbols=self._symbols,
                 cooldown_state=self._sweep_cooldown,
+                lock_registry=self._lock_registry,
             )
 
         # Snapshot positions (release lock before API calls)
@@ -3125,9 +3129,31 @@ def classify_severity(
 # BASE ASSET (a borrow is asset-scoped, not tied to one symbol). Default mode is
 # dry-run (detect + log only). See docs/plan and ORPHANED_BORROW_* constants.
 #
-# NOTE: active mode requires the shared base-asset exchange-mutation lock that
-# serialises this sweep against entry/exit (a focused follow-up). Until that lands
-# keep the flag at "off" or "dry_run" in production.
+# Active mode serialises against entry/exit via a shared per-base-asset
+# exchange-mutation lock (BaseAssetLockRegistry), so a repay can never race a
+# just-opened short whose borrow isn't tracked yet (#703).
+
+
+class BaseAssetLockRegistry:
+    """Per-base-asset re-entrant locks shared by entry/exit execution and the sweep.
+
+    A cross-margin borrow is asset-scoped, so all order placement and the
+    orphaned-borrow repay for a given base asset (e.g. ETH) serialise on one lock.
+    Re-entrant so an entry that holds the lock can call an exit/emergency-close that
+    re-acquires it on the same thread without deadlocking.
+    """
+
+    def __init__(self) -> None:
+        self._locks: dict[str, threading.RLock] = {}
+        self._meta = threading.Lock()
+
+    def lock_for(self, base_asset: str) -> threading.RLock:
+        with self._meta:
+            lock = self._locks.get(base_asset)
+            if lock is None:
+                lock = threading.RLock()
+                self._locks[base_asset] = lock
+            return lock
 
 
 def _base_asset_of(symbol: str) -> str:
@@ -3147,6 +3173,7 @@ def run_orphaned_borrow_sweep(
     use_margin: bool,
     symbols: list[str],
     cooldown_state: dict[str, float],
+    lock_registry: Any = None,
 ) -> list[ReconciliationResult]:
     """Repay cross-margin borrows that have no tracked position (orphaned).
 
@@ -3157,6 +3184,10 @@ def run_orphaned_borrow_sweep(
     ``orphaned_borrow_sweep_mode`` feature flag: ``off`` (no-op), ``dry_run``
     (detect + log, default) or ``active`` (repay). Never raises; a per-asset error
     is isolated. ``cooldown_state`` is mutated to throttle attempts per base asset.
+
+    ``lock_registry`` (a :class:`BaseAssetLockRegistry`) serialises the gate
+    re-read + repay against entry/exit on the same base asset, so an active repay
+    can't race a just-placed borrow. Required for safe ``active`` mode.
     """
     results: list[ReconciliationResult] = []
     if not use_margin or not symbols:
@@ -3185,6 +3216,7 @@ def run_orphaned_borrow_sweep(
                 base_symbols=base_symbols,
                 mode=mode,
                 cooldown_state=cooldown_state,
+                lock_registry=lock_registry,
             )
             if result is not None:
                 results.append(result)
@@ -3194,6 +3226,40 @@ def run_orphaned_borrow_sweep(
 
 
 def _sweep_one_base_asset(
+    *,
+    exchange: Any,
+    position_tracker: Any,
+    db_manager: Any,
+    session_id: int,
+    base_asset: str,
+    base_symbols: list[str],
+    mode: str,
+    cooldown_state: dict[str, float],
+    lock_registry: Any = None,
+) -> ReconciliationResult | None:
+    """Acquire the per-base-asset mutation lock (if provided), then run the gates.
+
+    Serialises an active repay with entry/exit on the same base asset (#703), so the
+    repay can never act on a borrow a concurrent entry just created. Gates are re-read
+    under the lock.
+    """
+    kwargs = {
+        "exchange": exchange,
+        "position_tracker": position_tracker,
+        "db_manager": db_manager,
+        "session_id": session_id,
+        "base_asset": base_asset,
+        "base_symbols": base_symbols,
+        "mode": mode,
+        "cooldown_state": cooldown_state,
+    }
+    if lock_registry is None:
+        return _sweep_one_base_asset_locked(**kwargs)
+    with lock_registry.lock_for(base_asset):
+        return _sweep_one_base_asset_locked(**kwargs)
+
+
+def _sweep_one_base_asset_locked(
     *,
     exchange: Any,
     position_tracker: Any,

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -3195,6 +3195,14 @@ def run_orphaned_borrow_sweep(
     mode = get_flag("orphaned_borrow_sweep_mode", "off")
     if mode not in ("dry_run", "active"):
         return results
+    # Fail-closed: a live repay MUST be serialised against entry/exit. Never repay
+    # unlocked, even if a direct caller forgot to pass the registry (#703).
+    if mode == "active" and lock_registry is None:
+        logger.error(
+            "Orphaned-borrow sweep ACTIVE mode requires a lock_registry to serialise "
+            "against entry/exit — refusing to repay unlocked."
+        )
+        return results
     if not all(
         hasattr(exchange, m)
         for m in ("get_margin_account_asset", "repay_margin_loan", "has_open_orders")

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -493,6 +493,12 @@ class LiveTradingEngine:
         # Shared per-base-asset cooldown for the orphaned-borrow sweep, so the
         # startup sweep and the periodic reconciler don't both act in one window.
         self._orphan_sweep_cooldown: dict[str, float] = {}
+        # Shared per-base-asset exchange-mutation lock: entry/exit and the
+        # orphaned-borrow sweep serialise on it, so an active repay can never race a
+        # just-placed borrow that isn't tracked yet (#703).
+        from src.engines.live.reconciliation import BaseAssetLockRegistry
+
+        self._base_asset_locks = BaseAssetLockRegistry()
         self.completed_trades: list[Trade] = []
         self.last_data_update = None
         self.last_account_snapshot = None  # Track when we last logged account state
@@ -1509,6 +1515,7 @@ class LiveTradingEngine:
                     use_margin=use_margin,
                     symbols=[self._active_symbol] if self._active_symbol else [],
                     sweep_cooldown=self._orphan_sweep_cooldown,
+                    lock_registry=self._base_asset_locks,
                 )
                 self._periodic_reconciler.start()
                 logger.info("🔄 Periodic reconciler started")
@@ -3302,6 +3309,38 @@ class LiveTradingEngine:
         signal_strength: float,
         signal_confidence: float,
     ) -> None:
+        """Serialise the entry on the symbol's base-asset lock, then execute it.
+
+        The lock is held across order submit -> position tracking (and any
+        emergency-close fallback, which re-acquires it re-entrantly) so the
+        orphaned-borrow sweep can't repay a borrow this entry just created (#703).
+        """
+        from src.engines.live.reconciliation import PositionReconciler
+
+        base = PositionReconciler._extract_base_asset(symbol)
+        with self._base_asset_locks.lock_for(base):
+            self._execute_entry_locked(
+                symbol=symbol,
+                side=side,
+                size=size,
+                price=price,
+                stop_loss=stop_loss,
+                take_profit=take_profit,
+                signal_strength=signal_strength,
+                signal_confidence=signal_confidence,
+            )
+
+    def _execute_entry_locked(
+        self,
+        symbol: str,
+        side: PositionSide,
+        size: float,
+        price: float,
+        stop_loss: float | None,
+        take_profit: float | None,
+        signal_strength: float,
+        signal_confidence: float,
+    ) -> None:
         """Execute a new trading position using shared execution modules."""
         try:
             # Prevent duplicate positions on the same symbol (guards against multi-slot
@@ -3885,6 +3924,37 @@ class LiveTradingEngine:
                         self.current_balance += refund_amount
 
     def _execute_exit(
+        self,
+        position: Position,
+        reason: str,
+        limit_price: float | None,
+        current_price: float,
+        candle_high: float | None,
+        candle_low: float | None,
+        candle,
+        skip_live_close: bool = False,
+    ) -> None:
+        """Serialise the close on the position's base-asset lock, then execute it (#703).
+
+        Re-entrant: an entry that already holds the lock (its SL-failed emergency
+        close routes here) re-acquires it on the same thread without deadlock.
+        """
+        from src.engines.live.reconciliation import PositionReconciler
+
+        base = PositionReconciler._extract_base_asset(getattr(position, "symbol", "") or "")
+        with self._base_asset_locks.lock_for(base):
+            self._execute_exit_locked(
+                position,
+                reason,
+                limit_price,
+                current_price,
+                candle_high,
+                candle_low,
+                candle,
+                skip_live_close=skip_live_close,
+            )
+
+    def _execute_exit_locked(
         self,
         position: Position,
         reason: str,
@@ -5004,6 +5074,7 @@ class LiveTradingEngine:
                             use_margin=use_margin,
                             symbols=[self._active_symbol],
                             cooldown_state=self._orphan_sweep_cooldown,
+                            lock_registry=self._base_asset_locks,
                         )
 
                     # Process results even with no positions — a filled entry

--- a/tests/unit/engines/live/test_margin_side_effect.py
+++ b/tests/unit/engines/live/test_margin_side_effect.py
@@ -139,19 +139,21 @@ def test_execution_engine_exit_auto_repay():
 
 @pytest.mark.fast
 def test_trading_engine_stop_loss_auto_repay():
-    """Stop-loss call in trading_engine._execute_entry includes side_effect_type='AUTO_REPAY'.
+    """Stop-loss call in the entry body includes side_effect_type='AUTO_REPAY'.
 
-    The stop-loss is placed inline in _execute_entry with retry logic. Rather than
-    constructing the full entry flow (which requires extensive mocking), we verify
-    the source code contains the kwarg on the place_stop_loss_order call.
+    The stop-loss is placed inline in the entry body (``_execute_entry_locked`` — the
+    real work; ``_execute_entry`` is a thin wrapper that only takes the base-asset
+    lock, #703) with retry logic. Rather than constructing the full entry flow (which
+    requires extensive mocking), we verify the source contains the kwarg on the
+    place_stop_loss_order call.
     """
     import inspect
 
     from src.engines.live.trading_engine import LiveTradingEngine
 
-    source = inspect.getsource(LiveTradingEngine._execute_entry)
+    source = inspect.getsource(LiveTradingEngine._execute_entry_locked)
     assert "side_effect_type=SideEffectType.AUTO_REPAY" in source, (
-        "trading_engine._execute_entry must pass side_effect_type=SideEffectType.AUTO_REPAY "
+        "the entry body must pass side_effect_type=SideEffectType.AUTO_REPAY "
         "to place_stop_loss_order"
     )
 
@@ -418,8 +420,10 @@ def _make_binance_provider(*, use_margin: bool = False):
     """Create a BinanceProvider with mocked client and optional margin mode."""
     from unittest.mock import patch
 
-    with patch("src.data_providers.binance_provider.get_config") as mock_config, \
-         patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True):
+    with (
+        patch("src.data_providers.binance_provider.get_config") as mock_config,
+        patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True),
+    ):
         mock_config_obj = MagicMock()
         mock_config_obj.get.return_value = None
         mock_config_obj.get_required.return_value = "fake_key"
@@ -441,23 +445,25 @@ def _make_binance_provider(*, use_margin: bool = False):
 def test_margin_get_balances_uses_net_asset():
     """In margin mode, total should be netAsset, not free+locked."""
     provider = _make_binance_provider(use_margin=True)
-    provider._call_get_account = MagicMock(return_value={
-        "balances": [
-            {
-                "asset": "BTC",
-                "free": "1.5",
-                "locked": "0.5",
-                # netAsset = free + locked - borrowed - interest = 1.0
-                "netAsset": "1.0",
-            },
-            {
-                "asset": "USDT",
-                "free": "10000.0",
-                "locked": "0.0",
-                "netAsset": "8000.0",
-            },
-        ]
-    })
+    provider._call_get_account = MagicMock(
+        return_value={
+            "balances": [
+                {
+                    "asset": "BTC",
+                    "free": "1.5",
+                    "locked": "0.5",
+                    # netAsset = free + locked - borrowed - interest = 1.0
+                    "netAsset": "1.0",
+                },
+                {
+                    "asset": "USDT",
+                    "free": "10000.0",
+                    "locked": "0.0",
+                    "netAsset": "8000.0",
+                },
+            ]
+        }
+    )
 
     balances = provider.get_balances()
     btc = next(b for b in balances if b.asset == "BTC")
@@ -473,11 +479,13 @@ def test_margin_get_balances_uses_net_asset():
 def test_spot_get_balances_uses_free_plus_locked():
     """In spot mode, total should remain free+locked (no regression)."""
     provider = _make_binance_provider(use_margin=False)
-    provider._call_get_account = MagicMock(return_value={
-        "balances": [
-            {"asset": "BTC", "free": "1.5", "locked": "0.5", "netAsset": "1.0"},
-        ]
-    })
+    provider._call_get_account = MagicMock(
+        return_value={
+            "balances": [
+                {"asset": "BTC", "free": "1.5", "locked": "0.5", "netAsset": "1.0"},
+            ]
+        }
+    )
 
     balances = provider.get_balances()
     btc = next(b for b in balances if b.asset == "BTC")
@@ -488,11 +496,13 @@ def test_spot_get_balances_uses_free_plus_locked():
 def test_margin_get_balance_uses_net_asset():
     """In margin mode, get_balance() should use netAsset for total."""
     provider = _make_binance_provider(use_margin=True)
-    provider._call_get_account = MagicMock(return_value={
-        "balances": [
-            {"asset": "BTC", "free": "1.5", "locked": "0.5", "netAsset": "1.0"},
-        ]
-    })
+    provider._call_get_account = MagicMock(
+        return_value={
+            "balances": [
+                {"asset": "BTC", "free": "1.5", "locked": "0.5", "netAsset": "1.0"},
+            ]
+        }
+    )
 
     balance = provider.get_balance("BTC")
     assert balance is not None
@@ -503,11 +513,13 @@ def test_margin_get_balance_uses_net_asset():
 def test_spot_get_balance_uses_free_plus_locked():
     """In spot mode, get_balance() should use free+locked."""
     provider = _make_binance_provider(use_margin=False)
-    provider._call_get_account = MagicMock(return_value={
-        "balances": [
-            {"asset": "BTC", "free": "1.5", "locked": "0.5"},
-        ]
-    })
+    provider._call_get_account = MagicMock(
+        return_value={
+            "balances": [
+                {"asset": "BTC", "free": "1.5", "locked": "0.5"},
+            ]
+        }
+    )
 
     balance = provider.get_balance("BTC")
     assert balance is not None
@@ -518,11 +530,13 @@ def test_spot_get_balance_uses_free_plus_locked():
 def test_margin_get_balances_fallback_when_no_net_asset():
     """If netAsset is missing in margin mode, fall back to free+locked."""
     provider = _make_binance_provider(use_margin=True)
-    provider._call_get_account = MagicMock(return_value={
-        "balances": [
-            {"asset": "BTC", "free": "1.5", "locked": "0.5"},
-        ]
-    })
+    provider._call_get_account = MagicMock(
+        return_value={
+            "balances": [
+                {"asset": "BTC", "free": "1.5", "locked": "0.5"},
+            ]
+        }
+    )
 
     balances = provider.get_balances()
     btc = next(b for b in balances if b.asset == "BTC")

--- a/tests/unit/live/test_orphaned_borrow_sweep.py
+++ b/tests/unit/live/test_orphaned_borrow_sweep.py
@@ -8,13 +8,15 @@ Money never moves unless every gate passes AND the flag is "active".
 
 from __future__ import annotations
 
+import threading
+import time
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.engines.live import reconciliation
-from src.engines.live.reconciliation import run_orphaned_borrow_sweep
+from src.engines.live.reconciliation import BaseAssetLockRegistry, run_orphaned_borrow_sweep
 
 pytestmark = pytest.mark.fast
 
@@ -67,7 +69,15 @@ def _db(unresolved=None):
 
 
 def _run(
-    exchange, tracker, db, *, mode="active", symbols=(SYMBOL,), cooldown=None, use_margin=True
+    exchange,
+    tracker,
+    db,
+    *,
+    mode="active",
+    symbols=(SYMBOL,),
+    cooldown=None,
+    use_margin=True,
+    lock_registry=None,
 ):
     with patch.object(reconciliation, "get_flag", return_value=mode):
         return run_orphaned_borrow_sweep(
@@ -78,6 +88,7 @@ def _run(
             use_margin=use_margin,
             symbols=list(symbols),
             cooldown_state={} if cooldown is None else cooldown,
+            lock_registry=lock_registry,
         )
 
 
@@ -266,3 +277,80 @@ def test_periodic_reconciler_uses_shared_cooldown_dict():
         sweep_cooldown=shared,
     )
     assert pr._sweep_cooldown is shared
+
+
+# ---- serialization lock (#703) --------------------------------------------- #
+
+
+def test_lock_registry_shared_per_base_and_reentrant():
+    reg = BaseAssetLockRegistry()
+    assert reg.lock_for("ETH") is reg.lock_for("ETH")  # same base -> same lock
+    assert reg.lock_for("ETH") is not reg.lock_for("BTC")  # different base -> different lock
+    lock = reg.lock_for("ETH")
+    with lock:  # re-entrant: a held lock can be re-acquired on the same thread
+        with lock:
+            pass
+
+
+def test_sweep_holds_lock_across_repay():
+    """The repay happens strictly between acquiring and releasing the base-asset lock."""
+    events: list[str] = []
+
+    class _TrackingLock:
+        def __enter__(self):
+            events.append("acquire")
+            return self
+
+        def __exit__(self, *a):
+            events.append("release")
+            return False
+
+    class _Registry:
+        def lock_for(self, base):
+            return _TrackingLock()
+
+    ex = _exchange(verify_after=_snapshot(borrowed="0", interest="0", free="0", net="0"))
+    ex.repay_margin_loan.side_effect = lambda *a, **k: (events.append("repay"), True)[1]
+    _run(ex, _tracker(), _db(), mode="active", lock_registry=_Registry())
+    assert events == ["acquire", "repay", "release"]
+
+
+def test_lock_serialises_sweep_behind_an_entry_holding_the_lock():
+    """While a (simulated) entry holds the ETH lock, the sweep's repay is blocked, and
+    only proceeds once the entry releases — proving sweep-vs-entry serialization (#703)."""
+    reg = BaseAssetLockRegistry()
+    order: list[str] = []
+    holder_has_lock = threading.Event()
+    let_holder_finish = threading.Event()
+
+    def holder():  # stands in for an in-flight entry that placed a borrow but isn't tracked yet
+        with reg.lock_for("ETH"):
+            order.append("entry_acquired")
+            holder_has_lock.set()
+            let_holder_finish.wait(2.0)
+            order.append("entry_released")
+
+    ex = _exchange(verify_after=_snapshot(borrowed="0", interest="0", free="0", net="0"))
+    ex.repay_margin_loan.side_effect = lambda *a, **k: (order.append("repay"), True)[1]
+
+    t = threading.Thread(target=holder)
+    t.start()
+    assert holder_has_lock.wait(2.0)
+
+    done = threading.Event()
+
+    def sweeper():
+        _run(ex, _tracker(), _db(), mode="active", lock_registry=reg)
+        done.set()
+
+    s = threading.Thread(target=sweeper)
+    s.start()
+    time.sleep(0.2)  # give the sweeper time to reach (and block on) the lock
+    assert "repay" not in order  # blocked: the entry still holds the lock
+
+    let_holder_finish.set()
+    assert done.wait(2.0)
+    t.join(2.0)
+    s.join(2.0)
+    # The repay only happened after the entry released the lock.
+    assert order.index("entry_released") < order.index("repay")

--- a/tests/unit/live/test_orphaned_borrow_sweep.py
+++ b/tests/unit/live/test_orphaned_borrow_sweep.py
@@ -23,6 +23,10 @@ pytestmark = pytest.mark.fast
 SYMBOL = "ETHUSDT"
 BASE = "ETH"
 
+# Sentinel so _run() defaults active-mode tests to a REAL lock registry (matching
+# production), while still allowing an explicit lock_registry=None to test fail-closed.
+_DEFAULT_REGISTRY = object()
+
 
 def _snapshot(borrowed="0.003", interest="0", free="0.003", locked="0", net="0.00007"):
     return {
@@ -77,8 +81,12 @@ def _run(
     symbols=(SYMBOL,),
     cooldown=None,
     use_margin=True,
-    lock_registry=None,
+    lock_registry=_DEFAULT_REGISTRY,
 ):
+    # Default to a real registry so active-mode gate tests exercise the locked path
+    # (as production does). Pass lock_registry=None explicitly to test fail-closed.
+    if lock_registry is _DEFAULT_REGISTRY:
+        lock_registry = BaseAssetLockRegistry()
     with patch.object(reconciliation, "get_flag", return_value=mode):
         return run_orphaned_borrow_sweep(
             exchange=exchange,
@@ -354,3 +362,10 @@ def test_lock_serialises_sweep_behind_an_entry_holding_the_lock():
     s.join(2.0)
     # The repay only happened after the entry released the lock.
     assert order.index("entry_released") < order.index("repay")
+
+
+def test_active_without_lock_registry_refuses_to_repay():
+    """Fail-closed: active mode with no lock registry must NOT repay (can't serialise)."""
+    ex = _exchange()
+    _run(ex, _tracker(), _db(), mode="active", lock_registry=None)
+    ex.repay_margin_loan.assert_not_called()


### PR DESCRIPTION
## What
The shared **per-base-asset re-entrant lock** (codex critical #2) that serialises the orphaned-borrow sweep (#702) against the entry/exit hot path — the prerequisite for safely enabling `orphaned_borrow_sweep_mode=active`.

## Why
The sweep's gates re-read state, but a money repay could still race entry: `_execute_entry` journals + submits the borrow order **before** `open_position()` tracks it (and a filled MARKET entry can be CONFIRMED-but-untracked). Without serialization, the sweep could repay a borrow a just-opened short still needs.

## How
- **`BaseAssetLockRegistry`** (one `threading.RLock` per base asset) in `reconciliation.py`. A borrow is asset-scoped, so all order placement + the repay for a base asset serialise on one lock.
- The engine owns one registry. `_execute_entry` / `_execute_exit` acquire it via **thin wrappers** around the unchanged method bodies (renamed `_..._locked`) — no risky re-indent. **Re-entrant**, so an entry that holds the lock can route through its SL-failed emergency-close (which re-acquires) without deadlock.
- `run_orphaned_borrow_sweep` takes `lock_registry`; the per-base gate re-read + repay run **under the lock**. Threaded through `PeriodicReconciler` + the startup sweep, sharing the engine's one registry.
- (Pending-order recovery is already covered by the sweep's fail-closed "no unresolved journal rows" gate.)

## Tests
Registry shared-per-base + re-entrant; repay strictly within acquire→release; and a **concurrency test** proving a held lock blocks the sweep's repay until released (sweep-vs-entry serialization).

## After this
`active` mode is safe. The rollout to auto-clear the prod orphan: promote → set `FEATURE_ORPHANED_BORROW_SWEEP_MODE=active` → the next cycle repays the ~0.0028 ETH and the dry-run log goes quiet.

Refs #697, #702, #703.

🤖 Generated with [Claude Code](https://claude.com/claude-code)