### PR TITLE
chore: add bot-monitor-live skill + session-start lessons hook

### DIFF
--- a/.claude/LESSONS.md
+++ b/.claude/LESSONS.md
@@ -162,3 +162,63 @@ state (`get_open_orders`, account sync, the actual order id) before acting or al
 - **Plan-mode + multi-round codex on the plan** before coding a risk-critical feature. The
   orphaned-borrow sweep plan went 7 → 3 → 1 → 0 codex findings *before* a line was written, which
   caught the asset-vs-symbol scoping and the entry-vs-sweep TOCTOU up front.
+
+---
+
+## 5. Live-monitoring signatures (what to grep for)
+
+The `bot-monitor-live` skill is the durable *method* for watching production; **this section is the
+evolving list of *concrete* signatures it greps for.** Add new ones here as incidents teach them —
+keep the skill generic and let the specifics live here.
+
+### 5.1 Pull logs + judge liveness safely
+- `railway logs -n 400` (bounded). **Never `--since <N>m`** — it hangs. Shows ONLY the current
+  deployment, so a boot marker in your window may be an expected deploy OR a surprise restart.
+- **Clock skew** (also §3): logs are **UTC**, your wall clock / wake scheduler may be **GMT+1**.
+  Compute `date -u` minus the last log timestamp before declaring "down" — usually a 1h illusion
+  (~2 min `Decision:` cadence).
+- **Don't trust the deploy API for liveness.** Railway can show SUCCESS while the loop is dead (a
+  DB/DNS outage killed it — see `MEMORY` bots-down-railway-dns). Ground truth = a recent
+  `Decision:`/`Status:` log line **and** the hourly `account_history` heartbeat row in the DB.
+
+### 5.2 Escalate immediately (critical markers)
+- `emergency.close` / "Stop-loss placement failed" — opened a position it couldn't protect; repeated
+  = capital-bleed churn.
+- `CLOSE-ONLY MODE ACTIVATED` — entries halted (reconcile/DB problem).
+- `code=-1111` (price precision) / `code=51077` (qty precision) — order precision rejection (should
+  be fixed; recurrence = regression, see §1.1).
+- `-2010` / "insufficient balance" on a stop-loss → unprotected position.
+- "No active trading session for balance update" — balance updates silently failing (§1.3, #693).
+- `Margin position check failed` — reconciler erroring every cycle (§1.2, #674).
+- A **new** position opened while an **untracked**/orphaned position may be live → double-exposure.
+- Unexpected `AI Trading Bot Starting` (a restart you didn't cause) — may re-orphan; watch recovery.
+- kline WS churn that never returns to WS-primary; any `Traceback`; margin level drifting toward
+  ~1.0–1.1 (liquidation) or reported balance diverging from true equity (phantom balance).
+
+### 5.3 Watch / report (non-critical)
+- A growing **orphaned margin borrow** (`borrowed=` with no tracked position) — blocks shorts +
+  accrues interest (§1.4 / §1.5).
+- `Task exception was never retrieved` — a swallowed async error; benign as a one-off at boot, report
+  if it recurs / clusters.
+- Sustained idleness when the bot *should* trade (sub-minimum sizing on a small account, #700).
+
+### 5.4 Known-benign — do NOT alarm
+- A **tracked** `Positions: 1` is normal trading, **not** double-exposure — only an *untracked*
+  orphan is. A position surviving a restart (`new opens = 0`, `Positions` stays `1`) = re-adoption
+  worked (#677) — that's GOOD.
+- `🔍 DRY-RUN orphaned-borrow sweep: would repay …` ~every 5 min — expected `[WARN]`, log-only, no
+  money moved.
+- `Calculated quantity 0.00000000 below minimum` — a sizing *skip* on a small account (#700); logged
+  at ERROR but it's the bot correctly declining a sub-minimum trade.
+- `Cannot open short … margin wallet holds … ETH` (#697) — the SHORT guard refusing while base-asset
+  dust sits in margin; expected until the borrow is repaid.
+- `51077` matching a **timestamp nanosecond suffix** (`…243651077Z`) — anchor the grep (`code=51077`,
+  `(code=51077)`); don't match bare digits in UTC timestamps.
+- An expected deploy boot (one you / the operator just triggered).
+
+### 5.5 Verify before alarming (phantom premises)
+A recurring/cron prompt may assert e.g. "a real ETH LONG was ORPHANED at 19:12 → double-exposure!".
+This has repeatedly been a **phantom**: no SL order existed, account sync showed `0 open orders`, the
+held ETH was sub-threshold dust. Treat automated/stale context as a hypothesis; confirm against live
+state — `get_open_orders`, account-sync open-order count, the actual SL order id, tracked `Positions`,
+and `free` vs `borrowed` vs `netAsset` — before reporting an incident (see §2.5).

--- a/.claude/hooks/session-start-lessons.sh
+++ b/.claude/hooks/session-start-lessons.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SessionStart hook — surface .claude/LESSONS.md into every session's context.
+#
+# Claude Code injects a SessionStart hook's stdout into the agent's context, so every
+# session (local or remote, fresh / resumed / cleared / post-compact) starts already aware
+# of the hard-won, incident-derived lessons for this live-capital trading bot.
+#
+# Single responsibility: this ONLY surfaces lessons. Environment bootstrap lives in
+# session-start.sh. Keep them separate.
+set -uo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+LESSONS="${PROJECT_DIR}/.claude/LESSONS.md"
+
+# Graceful no-op if the file isn't present (e.g. a branch predating it).
+[ -f "$LESSONS" ] || exit 0
+
+cat <<'EOF'
+========================================================================
+📓 PROJECT LESSONS — .claude/LESSONS.md (auto-loaded every session)
+Hard-won, incident-derived rules for this LIVE-CAPITAL trading bot. Read
+before touching live-trading, margin, precision, prediction, reconciliation,
+or deployment code, and treat each "trap → rule" as binding. When monitoring
+production, §5 is the concrete list of log signatures to grep for.
+========================================================================
+EOF
+
+cat "$LESSONS"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-lessons.sh"
           }
         ]
       }

--- a/.claude/skills/bot-monitor-live/SKILL.md
+++ b/.claude/skills/bot-monitor-live/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: bot-monitor-live
+description: Use when monitoring the LIVE production trading bot — routine health checks, log triage, incident detection. MONITOR-ONLY: it detects, reports, and delegates fixes to another agent or the human; it never restarts, deploys, moves money, repays loans, flips flags, or modifies any state. It reads the concrete log signatures to grep from .claude/LESSONS.md (§5).
+---
+
+# bot-monitor-live
+
+You are the **eyes** on the live production trading bot. Your loop is **detect → report →
+delegate** — never **fix**. If something needs changing, you hand it to another agent or escalate
+to the human.
+
+This skill is the durable *method*. The *concrete* signatures — exact error codes, log strings, and
+known-benign patterns — evolve in **`.claude/LESSONS.md` (§5 "Live-monitoring signatures")**, which
+is auto-loaded at session start. **Read LESSONS.md §5 on every pass and treat it as the live list of
+what to grep for.** When you learn a new signature, add it there, not here.
+
+## Hard rules
+1. **Read-only.** Allowed: log reads, deploy-status reads, `gh`/DB reads, exchange `get_*` reads.
+   **Forbidden:** any deploy / restart / redeploy, any feature-flag flip, any order place / cancel,
+   any repay / transfer / money move, any merge or git mutation, any config or state edit. If you're
+   unsure whether an action mutates, treat it as forbidden.
+2. **Verify before you alarm.** Automated / cron / stale context is a *hypothesis*, not a fact.
+   Confirm against live state before reporting an incident (see "Verify, don't trust" below).
+3. **One escalation per state, not per tick.** Don't re-page the same condition every cycle.
+4. **Anything live / money / prod is the human's call** — you surface it; you don't decide it.
+
+## How to run a monitoring pass
+Pull a bounded window of the **current** deployment's logs, then scan by dimension and compare
+against the bot's own status line (positions / balance / unrealized):
+
+```bash
+railway logs -n 400 > /tmp/mon.txt 2>&1     # bounded; NEVER --since (it hangs)
+```
+
+`railway logs` shows **only the currently-active deployment** — a new deploy replaces the prior
+window, so a boot marker in your window may be an expected deploy OR a surprise restart (find out
+which via `gh` / deploy history).
+
+Scan these **dimensions** every pass. The exact marker strings for each live in **LESSONS.md §5** —
+grep for those:
+
+| Dimension | What you're asking |
+|---|---|
+| **Liveness** | Is the loop alive? Decisions flowing at the normal cadence; the hourly `account_history` heartbeat present in the DB. |
+| **Exposure / position integrity** | Did exposure change unexpectedly — a *new* position, or an *untracked* one (orphan)? (A *tracked* position count is normal trading.) |
+| **Execution / order errors** | Order rejections, failed protective (stop-loss) orders, precision rejections. |
+| **Reconciliation health** | Is the reconciler erroring each cycle? |
+| **Connectivity** | WebSocket reconnect churn, or a fallback that never returns to primary. |
+| **Capital integrity** | Reported balance vs true equity; drawdown; margin level vs liquidation. |
+| **Restarts** | An unexpected process boot (may re-orphan a position — watch the recovery). |
+
+### Tools & how to read them
+- **`railway logs -n N`** — bounded; not `--since`; current deployment only.
+- **`railway status` / the deploy dashboard — do NOT trust for liveness.** It can read SUCCESS while
+  the process loop is dead (e.g. a DB/DNS outage killed it). Liveness = a recent decision log line +
+  the DB heartbeat row, *not* the deploy API.
+- **DB reads** — `account_history` (hourly heartbeat / equity), positions, recent trades.
+- **Exchange `get_*` reads** — open orders, balances. Distinguish a *tracked position* from raw
+  wallet balance, and (on margin) `free` vs `borrowed` vs `netAsset`, before calling anything a
+  "position".
+- **`gh` reads** — open incidents/issues, recent deploys, whether a given restart was expected.
+
+### Monitoring-process gotchas (these bite the act of monitoring itself)
+- **Clock skew.** Logs are **UTC**; your wall clock / wake scheduler may be **GMT+1**. Compute
+  `date -u` minus the last log timestamp before declaring "down" — a "stale" log is often a 1-hour
+  timezone illusion.
+- **Anchor your greps.** A bare numeric error-code grep false-positives on timestamp digits. Anchor
+  codes (e.g. `code=<N>`, `(code=<N>)`) so a nanosecond suffix can't masquerade as an error.
+- **Verify, don't trust.** Before reporting an orphan / double-exposure / "bot down", confirm against
+  live state: open-order count, the actual order id, tracked positions, the DB heartbeat, and margin
+  `free`/`borrowed`/`netAsset`. Phantom premises from cron prompts have repeatedly evaporated under a
+  live-state check (LESSONS.md §5.5).
+- **Know the benign noise.** Several ERROR-level or scary-looking lines are expected behavior (sizing
+  skips, dry-run logs, guard refusals, re-adoption). LESSONS.md §5.4 is the do-NOT-alarm list — check
+  a candidate against it before paging.
+
+## Delegation & escalation model (you do NOT fix)
+| Severity | What you do |
+|---|---|
+| **Critical / capital at risk** (emergency-close cascade, close-only, double-exposure, unprotected position, bot down, liquidation risk) | **Notify the human immediately** (PushNotification) with evidence — the log lines + timestamps + current positions/balance. A fix needing live action (restart, money move, deploy, flag flip) is the **human's decision**. You may also spawn/notify a fixing agent to prepare a diagnosis — but it, not you, makes any change. |
+| **Code bug, no immediate capital risk** | **File a GitHub issue** with evidence + labels, then **delegate to a fixing agent** (spawn an `Agent`, or hand to the PM / main session). Don't fix it yourself. |
+| **Operational / product** (idle on a small account, dust, sizing) | **Report** in your summary + file/annotate an issue with a recommendation. The human/PM decides. |
+| **Green** | One or two lines: the window scanned, that all dimensions are clean, and the current positions/balance. Don't narrate every tick. |
+
+**Report format** for any finding: *what* (symptom), *where* (log + timestamp), *evidence* (the
+actual lines + counts), *severity*, and *handoff* (who you escalated / delegated to). Never include
+a fix you applied — you don't apply fixes.
+
+## Why monitor-only
+On a live-capital system, a monitor that also mutates state is the dangerous kind of automation: it
+can act on a misread. Keeping detection and remediation in separate agents means a wrong read costs
+a wasted report, not a wrong trade. **Detect, report, delegate — and stop.**


### PR DESCRIPTION
## What & why

Three coordinated additions so future agents start every session with hard-won context and have a safe, repeatable way to watch production. Follow-up to #708 (which added `LESSONS.md`).

### 1. `bot-monitor-live` skill (`.claude/skills/bot-monitor-live/SKILL.md`)
A **monitor-only** skill: its loop is **detect → report → delegate**, never *fix*. Hard rules forbid any deploy/restart, flag flip, order/money move, or git/state mutation — it escalates to the human or hands fixes to another agent. Rationale: on a live-capital system, a monitor that also mutates state can act on a misread; separating detection from remediation means a wrong read costs a wasted report, not a wrong trade.

It is deliberately **generic** — *how* to monitor, the dimensions to scan, tools, and monitoring-process gotchas (clock skew, anchored greps, don't-trust-the-deploy-API, verify-don't-trust). It **defers the concrete signatures to `LESSONS.md` §5** so the method stays stable while specifics evolve.

### 2. `LESSONS.md` §5 "Live-monitoring signatures"
The concrete grep markers — critical / watch / known-benign / phantom-premise — moved out of the skill into the living lessons doc (one source of truth for specifics).

### 3. SessionStart lessons hook (`.claude/hooks/session-start-lessons.sh` + `settings.json`)
Injects `LESSONS.md` into **every** session's context at start. Added as a **separate** hook next to the existing remote-only venv bootstrap (`session-start.sh`) — single responsibility, and it runs locally too (the bootstrap script is gated on `CLAUDE_CODE_REMOTE`). Graceful no-op when `LESSONS.md` is absent.

## User-facing impact
- Every new/resumed/cleared/post-compact session now starts with the project lessons in context.
- A reusable `bot-monitor-live` skill for read-only production health passes.
- No `src/` changes; **no live-trading impact**; fully reversible.

## Testing performed
- `python3 -m json.tool .claude/settings.json` → valid JSON.
- Ran the hook with `CLAUDE_PROJECT_DIR` set → exit 0, 231 lines (framing + full `LESSONS.md` incl. §5), no stderr.
- Ran the hook with a bogus project dir → exit 0, 0 bytes (graceful no-op).
- Grepped the skill: 0 issue refs / 0 literal error codes / 0 benign-string specifics (confirmed generic); the 17 specifics are present in `LESSONS.md` §5; skill references `LESSONS.md` 6×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)