### PR TITLE
fix(live): cancel resting stop-loss before market close (#710)

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
 
 from src.config import get_config
 from src.config.constants import (
+    BORROW_DUST_EPSILON,
     DEFAULT_ACCOUNT_SNAPSHOT_INTERVAL,
     DEFAULT_CHECK_INTERVAL,
     DEFAULT_DATA_FRESHNESS_THRESHOLD,
@@ -4012,17 +4013,33 @@ class LiveTradingEngine:
             else:
                 # #710: On margin a resting stop-loss order reserves the position's
                 # base asset, so a market close submitted while it rests is rejected
-                # by the exchange with -2010 (insufficient balance). Cancel the
-                # protective order FIRST to free the balance. If the cancel cannot be
-                # confirmed, do NOT submit the close: the stop may have just filled
-                # (closing would over-sell) or may still rest (closing would -2010) —
-                # leave the position protected and let the next cycle / reconciler act.
+                # with -2010 (insufficient balance). We must cancel the stop first to
+                # free the balance — but ONLY when it is safe to close the full size.
+                #
+                # Inventory-awareness: a stop that has ANY fill means held base !=
+                # tracked size, so a full-size close would over-sell (long) / over-buy
+                # (short). Re-query the stop's filled quantity BEFORE cancelling (no
+                # unprotected window — it stays resting) and AGAIN after the confirmed
+                # (terminal) cancel; on any fill, or any unconfirmable state, DEFER to
+                # the periodic reconciler instead of closing. Only a provably clean
+                # (zero-fill) stop is cancelled and the full size closed.
                 protective_order_cancelled = False
                 if (
                     self.enable_live_trading
                     and self.exchange_interface
                     and position.stop_loss_order_id
                 ):
+                    pre_filled = self._stop_loss_filled_quantity(position)
+                    if pre_filled is None or pre_filled > BORROW_DUST_EPSILON:
+                        logger.warning(
+                            "Deferring market close of %s: resting stop %s is mid-fill or "
+                            "its state is unconfirmable (filled=%s) — reconciler will "
+                            "adjust. Not cancelling or closing.",
+                            position.symbol,
+                            position.stop_loss_order_id,
+                            pre_filled,
+                        )
+                        return
                     if not self._cancel_stop_loss_order(position):
                         logger.warning(
                             "Skipping market close of %s: could not confirm cancel of "
@@ -4032,6 +4049,16 @@ class LiveTradingEngine:
                         )
                         return
                     protective_order_cancelled = True
+                    post_filled = self._stop_loss_filled_quantity(position)
+                    if post_filled is None or post_filled > BORROW_DUST_EPSILON:
+                        logger.warning(
+                            "Deferring market close of %s: stop %s filled during cancel "
+                            "(filled=%s) — reconciler will adjust. Not closing.",
+                            position.symbol,
+                            position.stop_loss_order_id,
+                            post_filled,
+                        )
+                        return
 
                 exit_result = self.live_exit_handler.execute_exit(
                     position=position,
@@ -4044,10 +4071,11 @@ class LiveTradingEngine:
                     data_provider=self.data_provider,
                 )
                 if not exit_result.success and protective_order_cancelled:
-                    # The close failed AFTER we freed the balance, so the position is
-                    # momentarily unprotected — re-place the stop-loss now. The
-                    # periodic reconciler (which re-places a missing stop-loss or
-                    # emergency-closes) is the ultimate backstop. (#710)
+                    # The close failed after we cancelled a clean (zero-fill) stop, so
+                    # the position is momentarily unprotected — re-protect immediately
+                    # (verifying it is still held, to avoid orphaning a stop on an
+                    # ambiguous / already-executed close). The periodic reconciler is
+                    # the ultimate backstop. (#710)
                     self._reprotect_position(position)
             if not exit_result.success:
                 logger.error(
@@ -4283,25 +4311,108 @@ class LiveTradingEngine:
             self.order_tracker.stop_tracking(position.stop_loss_order_id)
         return cancelled
 
+    def _stop_loss_filled_quantity(self, position: Position) -> float | None:
+        """Return the filled (executed) base quantity of a position's stop-loss order.
+
+        ``0.0`` for an unfilled stop, the filled base quantity for a partial/full fill,
+        or ``None`` if the order cannot be read (missing / API error). The close path
+        treats ``None`` and any non-zero fill as "unsafe to inline-close" and defers to
+        the reconciler — a partially-filled stop means held base != tracked size, so a
+        full-size close would over-sell (long) / over-buy (short). (#710)
+        """
+        if not (
+            self.enable_live_trading and self.exchange_interface and position.stop_loss_order_id
+        ):
+            return 0.0
+        try:
+            order = self.exchange_interface.get_order(position.stop_loss_order_id, position.symbol)
+        except Exception as e:
+            logger.warning(
+                "Could not read stop-loss order %s for %s: %s",
+                position.stop_loss_order_id,
+                position.symbol,
+                e,
+            )
+            return None
+        if order is None:
+            return None
+        return float(getattr(order, "filled_quantity", 0.0) or 0.0)
+
+    def _position_still_held(self, position: Position) -> bool:
+        """Whether the position's inventory is still actually held on the exchange.
+
+        Checked before an inline re-protect so a stop is not re-placed on a position an
+        ambiguous / already-executed close has actually closed (which would orphan a
+        stop). Conservative: any unreadable/uncertain state returns ``False`` (do not
+        re-place; the reconciler reconciles exchange truth). (#710)
+        """
+        if not (self.enable_live_trading and self.exchange_interface):
+            return False
+        from src.engines.live.reconciliation import PositionReconciler
+
+        base = PositionReconciler._extract_base_asset(position.symbol)
+        dust = float(BORROW_DUST_EPSILON)
+        try:
+            get_asset = getattr(self.exchange_interface, "get_margin_account_asset", None)
+            if getattr(self.exchange_interface, "is_margin_mode", False) and callable(get_asset):
+                asset = get_asset(base)
+                if not asset:
+                    return False
+                if position.side == PositionSide.SHORT:
+                    # A short is still held while base remains borrowed (owed).
+                    return float(asset.get("borrowed", 0.0) or 0.0) > dust
+                free = float(asset.get("free", 0.0) or 0.0)
+                locked = float(asset.get("locked", 0.0) or 0.0)
+                return (free + locked) > dust
+            # Spot / no margin-asset accessor: long inventory is the base balance.
+            bal = self.exchange_interface.get_balance(base)
+            if not bal:
+                return False
+            return (
+                float(getattr(bal, "free", 0.0) or 0.0) + float(getattr(bal, "locked", 0.0) or 0.0)
+            ) > dust
+        except Exception as e:
+            logger.warning("Could not confirm held inventory for %s: %s", position.symbol, e)
+            return False
+
+    def _held_protection_quantity(self, position: Position) -> float:
+        """Base quantity to protect, scaled for any prior partial exits.
+
+        Mirrors the reconciler's re-placement sizing ``quantity * current/original`` so
+        a re-protected stop covers the *remaining* held size, not the full entry size.
+        """
+        quantity = getattr(position, "quantity", None)
+        if not quantity or quantity <= 0:
+            return 0.0
+        current = getattr(position, "current_size", None)
+        original = getattr(position, "original_size", None)
+        if current is not None and original is not None and original > 0:
+            return float(quantity) * (float(current) / float(original))
+        return float(quantity)
+
     def _reprotect_position(self, position: Position) -> None:
         """Re-place a stop-loss after a failed close left a position momentarily naked.
 
-        Reached only when a market close failed *after* its resting stop was
-        cancelled to free the base balance (#710). Re-establish protection at the
-        tracked stop price so the position is not left unprotected. The periodic
-        reconciler — which re-places a missing stop-loss or emergency-closes — is the
-        ultimate backstop if this inline attempt cannot run or also fails.
+        Reached only when a market close failed *after* its clean (zero-fill) resting
+        stop was cancelled to free the base balance (#710). Re-establish protection
+        immediately rather than waiting for the ~120s reconciler — but first verify the
+        position is still actually held (the close may be ambiguous / already executed)
+        to avoid orphaning a stop, and size for any prior partial exits. The reconciler
+        is the ultimate backstop if this attempt cannot run or also fails.
         """
+        if not (self.enable_live_trading and self.exchange_interface):
+            return
+        if not self._position_still_held(position):
+            logger.warning(
+                "%s appears no longer held after a failed close — not re-placing a "
+                "stop (the reconciler will reconcile exchange state).",
+                position.symbol,
+            )
+            return
+
         stop_price = getattr(position, "stop_loss", None)
-        quantity = getattr(position, "quantity", None)
-        if (
-            not self.enable_live_trading
-            or not self.exchange_interface
-            or not stop_price
-            or stop_price <= 0
-            or not quantity
-            or quantity <= 0
-        ):
+        quantity = self._held_protection_quantity(position)
+        if not stop_price or stop_price <= 0 or quantity <= 0:
             logger.critical(
                 "CRITICAL: %s close failed after its stop-loss was cancelled and it "
                 "cannot be re-protected inline (stop_price=%s, quantity=%s) — position "
@@ -4319,20 +4430,28 @@ class LiveTradingEngine:
 
         sl_side = OrderSide.SELL if position.side == PositionSide.LONG else OrderSide.BUY
         sl_order_id = None
-        try:
-            sl_order_id = self.exchange_interface.place_stop_loss_order(
-                symbol=position.symbol,
-                side=sl_side,
-                quantity=float(quantity),
-                stop_price=float(stop_price),
-                side_effect_type=SideEffectType.AUTO_REPAY,
-            )
-        except Exception as e:
-            logger.error(
-                "Re-protect: stop-loss placement raised for %s: %s",
-                position.symbol,
-                e,
-            )
+        retry_delay = 1.0
+        for attempt in range(3):
+            try:
+                sl_order_id = self.exchange_interface.place_stop_loss_order(
+                    symbol=position.symbol,
+                    side=sl_side,
+                    quantity=float(quantity),
+                    stop_price=float(stop_price),
+                    side_effect_type=SideEffectType.AUTO_REPAY,
+                )
+                if sl_order_id:
+                    break
+            except Exception as e:
+                logger.warning(
+                    "Re-protect attempt %s/3 for %s failed: %s",
+                    attempt + 1,
+                    position.symbol,
+                    e,
+                )
+            if attempt < 2:
+                time.sleep(retry_delay)
+                retry_delay *= 2
 
         if sl_order_id:
             if position.order_id is not None:
@@ -4340,16 +4459,17 @@ class LiveTradingEngine:
             if self.order_tracker:
                 self.order_tracker.track_order(sl_order_id, position.symbol)
             logger.warning(
-                "Re-protected %s after a failed close: new stop-loss %s @ $%.2f",
+                "Re-protected %s after a failed close: new stop-loss %s @ $%.2f (qty=%.8f)",
                 position.symbol,
                 sl_order_id,
                 float(stop_price),
+                float(quantity),
             )
         else:
             logger.critical(
-                "CRITICAL: %s close failed AND re-placing its stop-loss failed — "
-                "position is UNPROTECTED pending the periodic reconciler. MANUAL "
-                "REVIEW REQUIRED.",
+                "CRITICAL: %s close failed AND re-placing its stop-loss failed after "
+                "retries — position is UNPROTECTED pending the periodic reconciler. "
+                "MANUAL REVIEW REQUIRED.",
                 position.symbol,
             )
             self._send_alert(

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4010,6 +4010,29 @@ class LiveTradingEngine:
                     current_balance=self.current_balance,
                 )
             else:
+                # #710: On margin a resting stop-loss order reserves the position's
+                # base asset, so a market close submitted while it rests is rejected
+                # by the exchange with -2010 (insufficient balance). Cancel the
+                # protective order FIRST to free the balance. If the cancel cannot be
+                # confirmed, do NOT submit the close: the stop may have just filled
+                # (closing would over-sell) or may still rest (closing would -2010) —
+                # leave the position protected and let the next cycle / reconciler act.
+                protective_order_cancelled = False
+                if (
+                    self.enable_live_trading
+                    and self.exchange_interface
+                    and position.stop_loss_order_id
+                ):
+                    if not self._cancel_stop_loss_order(position):
+                        logger.warning(
+                            "Skipping market close of %s: could not confirm cancel of "
+                            "resting stop-loss %s; position remains protected, will retry.",
+                            position.symbol,
+                            position.stop_loss_order_id,
+                        )
+                        return
+                    protective_order_cancelled = True
+
                 exit_result = self.live_exit_handler.execute_exit(
                     position=position,
                     exit_reason=reason,
@@ -4020,6 +4043,12 @@ class LiveTradingEngine:
                     candle_low=candle_low,
                     data_provider=self.data_provider,
                 )
+                if not exit_result.success and protective_order_cancelled:
+                    # The close failed AFTER we freed the balance, so the position is
+                    # momentarily unprotected — re-place the stop-loss now. The
+                    # periodic reconciler (which re-places a missing stop-loss or
+                    # emergency-closes) is the ultimate backstop. (#710)
+                    self._reprotect_position(position)
             if not exit_result.success:
                 logger.error(
                     "Failed to close position %s: %s",
@@ -4191,28 +4220,11 @@ class LiveTradingEngine:
                     margin_interest_cost=interest_cost,
                 )
 
-            if (
-                self.enable_live_trading
-                and self.exchange_interface
-                and position.stop_loss_order_id
-                and not sl_already_filled
-            ):
-                try:
-                    cancelled = self.exchange_interface.cancel_order(
-                        position.stop_loss_order_id, position.symbol
-                    )
-                    if cancelled:
-                        logger.info(
-                            "Cancelled stop-loss order %s for %s",
-                            position.stop_loss_order_id,
-                            position.symbol,
-                        )
-                except Exception as e:
-                    logger.warning("Error cancelling stop-loss order: %s", e)
-
-                if self.order_tracker:
-                    self.order_tracker.stop_tracking(position.stop_loss_order_id)
-
+            # NOTE(#710): the resting stop-loss is now cancelled BEFORE the market
+            # close (see the close path above) so it cannot reserve the base asset
+            # and trigger -2010. No post-close cancel is needed here; on a successful
+            # close the position (and its already-cancelled stop) are removed by the
+            # exit handler.
             logger.info(
                 "📈 Closed %s position for %s: PnL=$%.2f, Reason=%s, Balance=$%.2f",
                 position.side.value,
@@ -4233,6 +4245,117 @@ class LiveTradingEngine:
             )
         except Exception as e:
             logger.error("Failed to close position %s: %s", position.order_id, e, exc_info=True)
+
+    def _cancel_stop_loss_order(self, position: Position) -> bool:
+        """Cancel a position's resting stop-loss order and stop tracking it.
+
+        Returns True only when the exchange confirms the cancel. The close path uses
+        this before a market exit so the stop no longer reserves the base asset
+        (otherwise the close is rejected -2010 on margin, #710). A False result means
+        the order may still rest, or may have just filled, so the caller must NOT
+        submit a close (it would -2010, or over-sell an already-closed position).
+        """
+        if not (
+            self.enable_live_trading and self.exchange_interface and position.stop_loss_order_id
+        ):
+            return False
+        cancelled = False
+        try:
+            cancelled = bool(
+                self.exchange_interface.cancel_order(position.stop_loss_order_id, position.symbol)
+            )
+            if cancelled:
+                logger.info(
+                    "Cancelled stop-loss order %s for %s before close",
+                    position.stop_loss_order_id,
+                    position.symbol,
+                )
+        except Exception as e:
+            logger.warning(
+                "Error cancelling stop-loss order %s for %s: %s",
+                position.stop_loss_order_id,
+                position.symbol,
+                e,
+            )
+        # Only stop tracking when the cancel is confirmed; otherwise the order may
+        # still be live on the exchange and must remain watched.
+        if cancelled and self.order_tracker:
+            self.order_tracker.stop_tracking(position.stop_loss_order_id)
+        return cancelled
+
+    def _reprotect_position(self, position: Position) -> None:
+        """Re-place a stop-loss after a failed close left a position momentarily naked.
+
+        Reached only when a market close failed *after* its resting stop was
+        cancelled to free the base balance (#710). Re-establish protection at the
+        tracked stop price so the position is not left unprotected. The periodic
+        reconciler — which re-places a missing stop-loss or emergency-closes — is the
+        ultimate backstop if this inline attempt cannot run or also fails.
+        """
+        stop_price = getattr(position, "stop_loss", None)
+        quantity = getattr(position, "quantity", None)
+        if (
+            not self.enable_live_trading
+            or not self.exchange_interface
+            or not stop_price
+            or stop_price <= 0
+            or not quantity
+            or quantity <= 0
+        ):
+            logger.critical(
+                "CRITICAL: %s close failed after its stop-loss was cancelled and it "
+                "cannot be re-protected inline (stop_price=%s, quantity=%s) — position "
+                "is UNPROTECTED pending the reconciler. MANUAL REVIEW REQUIRED.",
+                position.symbol,
+                stop_price,
+                quantity,
+            )
+            self._send_alert(
+                f"🚨 {position.symbol} UNPROTECTED: close failed after stop-loss "
+                f"cancel and it could not be re-placed inline. Reconciler backstop "
+                f"engaged. MANUAL REVIEW REQUIRED."
+            )
+            return
+
+        sl_side = OrderSide.SELL if position.side == PositionSide.LONG else OrderSide.BUY
+        sl_order_id = None
+        try:
+            sl_order_id = self.exchange_interface.place_stop_loss_order(
+                symbol=position.symbol,
+                side=sl_side,
+                quantity=float(quantity),
+                stop_price=float(stop_price),
+                side_effect_type=SideEffectType.AUTO_REPAY,
+            )
+        except Exception as e:
+            logger.error(
+                "Re-protect: stop-loss placement raised for %s: %s",
+                position.symbol,
+                e,
+            )
+
+        if sl_order_id:
+            if position.order_id is not None:
+                self.live_position_tracker.set_stop_loss_order_id(position.order_id, sl_order_id)
+            if self.order_tracker:
+                self.order_tracker.track_order(sl_order_id, position.symbol)
+            logger.warning(
+                "Re-protected %s after a failed close: new stop-loss %s @ $%.2f",
+                position.symbol,
+                sl_order_id,
+                float(stop_price),
+            )
+        else:
+            logger.critical(
+                "CRITICAL: %s close failed AND re-placing its stop-loss failed — "
+                "position is UNPROTECTED pending the periodic reconciler. MANUAL "
+                "REVIEW REQUIRED.",
+                position.symbol,
+            )
+            self._send_alert(
+                f"🚨 {position.symbol} UNPROTECTED: close failed and stop-loss "
+                f"re-placement failed. Reconciler is the only backstop. REVIEW NOW."
+            )
 
     def _check_stop_loss_filled(self, position: Position) -> tuple[bool, float | None]:
         """Check if a stop-loss order already filled on the exchange."""

--- a/tests/unit/engines/live/test_close_cancel_stop_710.py
+++ b/tests/unit/engines/live/test_close_cancel_stop_710.py
@@ -1,16 +1,18 @@
-"""#710: cancel the resting stop-loss BEFORE a market close.
+"""#710: inventory-aware active close of a stop-protected margin position.
 
-On margin a resting stop-loss order reserves the position's base asset, so a
-market close submitted while it rests is rejected by the exchange with -2010
-("insufficient balance"). The close path must therefore:
+On margin a resting stop-loss order reserves the position's base asset, so a market
+close submitted while it rests is rejected -2010 ("insufficient balance"). The close
+path must:
 
-* cancel the resting stop FIRST (freeing the base balance), then close;
-* NOT submit the close if it cannot confirm the cancel (the order may have just
-  filled — closing would over-sell — or still rest — closing would -2010);
-* re-place the stop if the close then fails (never leave the position naked).
-
-These tests exercise ``LiveTradingEngine._execute_exit`` in live mode with mocked
-collaborators and assert the ordering / branching above.
+* re-query the stop's filled quantity BEFORE cancelling — if it has ANY fill (or its
+  state is unreadable), DEFER to the reconciler (held base != tracked size, so a
+  full-size close would over-sell a long / over-buy a short); leave it resting;
+* only cancel a provably clean (zero-fill) stop, then RE-CHECK the fill after the
+  (terminal) cancel and defer if it raced a fill;
+* close the full size only when the stop is confirmed clean both times;
+* if the close then fails, re-protect immediately — but only after verifying the
+  position is still actually held (avoid orphaning a stop on an ambiguous/already-
+  executed close), sizing for prior partial exits, with bounded retry.
 """
 
 from datetime import UTC, datetime
@@ -27,19 +29,35 @@ from tests.mocks import MockDatabaseManager
 
 
 @pytest.fixture(autouse=True)
-def _mock_db(monkeypatch):
-    """Use the in-memory MockDatabaseManager so construction needs no real DB."""
+def _fast_env(monkeypatch):
+    """In-memory DB + no real sleeps (re-protect retry uses time.sleep)."""
     monkeypatch.setattr("src.engines.live.trading_engine.DatabaseManager", MockDatabaseManager)
+    monkeypatch.setattr("src.engines.live.trading_engine.time.sleep", lambda *_a, **_k: None)
 
 
-def _make_live_engine(exit_result, *, cancel_returns=True):
-    """A LiveTradingEngine flipped to live mode with mocked exchange + exit handler.
+def _order(filled):
+    """A stop order mock with the given filled base quantity (None -> unreadable)."""
+    if filled is None:
+        return None
+    return Mock(filled_quantity=filled, status="NEW")
 
-    ``exit_result`` is the ``LiveExitResult`` the mocked market close returns.
-    Returns ``(engine, calls)`` where ``calls`` records the order of
-    cancel_order / execute_exit / place_stop_loss_order so tests can assert
-    cancel-before-close. The mocks live on ``engine.exchange_interface`` and
-    ``engine.live_exit_handler``.
+
+def _make_live_engine(
+    exit_result,
+    *,
+    cancel_returns=True,
+    cancel_raises=False,
+    sl_fills=(0.0, 0.0),
+    held=True,
+    borrowed=False,
+    place_returns="sl-new",
+):
+    """A LiveTradingEngine in live mode with mocked exchange + exit handler.
+
+    ``sl_fills`` is the sequence of filled quantities ``get_order`` reports across the
+    pre-/post-cancel checks (repeats the last). ``held`` controls the held-inventory
+    check; ``borrowed`` routes held via the short (borrowed) branch. Returns
+    ``(engine, calls)`` recording the cancel/close/reprotect order.
     """
     strategy = Mock()
     strategy.get_risk_overrides.return_value = None
@@ -56,50 +74,79 @@ def _make_live_engine(exit_result, *, cancel_returns=True):
         slippage_rate=0.0,
     )
 
-    # Flip to live mode with mocked collaborators.
     engine.enable_live_trading = True
     exchange = Mock()
     exchange.is_margin_mode = True
     engine.exchange_interface = exchange
     engine.order_tracker = Mock()
     engine.performance_tracker.record_trade = Mock()
-
-    # Force the market-close path (stop not already filled on the exchange).
     engine._check_stop_loss_filled = Mock(return_value=(False, None))
+
+    # get_order feeds _stop_loss_filled_quantity (pre/post cancel).
+    fills = list(sl_fills)
+
+    def _get_order(*_a, **_k):
+        f = fills.pop(0) if len(fills) > 1 else fills[0]
+        return _order(f)
+
+    exchange.get_order.side_effect = _get_order
+
+    # held-inventory check (_position_still_held).
+    if held and borrowed:
+        asset = {"free": "0", "locked": "0", "borrowed": "0.5", "netAsset": "-0.5"}
+    elif held:
+        asset = {"free": "1.0", "locked": "0", "borrowed": "0", "netAsset": "1.0"}
+    else:
+        asset = {"free": "0", "locked": "0", "borrowed": "0", "netAsset": "0"}
+    exchange.get_margin_account_asset.return_value = asset
 
     calls: list[str] = []
 
     def _cancel(*_a, **_k):
         calls.append("cancel")
+        if cancel_raises:
+            raise RuntimeError("boom")
         return cancel_returns
 
     def _close(*_a, **_k):
         calls.append("close")
         return exit_result
 
-    def _reprotect(*_a, **_k):
+    place_seq = list(place_returns) if isinstance(place_returns, list | tuple) else None
+
+    def _place(*_a, **_k):
         calls.append("reprotect")
-        return "sl-new"
+        if place_seq is not None:
+            return place_seq.pop(0) if len(place_seq) > 1 else place_seq[0]
+        return place_returns
 
     exchange.cancel_order.side_effect = _cancel
-    exchange.place_stop_loss_order.side_effect = _reprotect
+    exchange.place_stop_loss_order.side_effect = _place
     handler = Mock()
     handler.execute_exit.side_effect = _close
     engine.live_exit_handler = handler
-
     return engine, calls
 
 
-def _track_long(engine, *, stop_loss_order_id="sl-1", stop_loss=95.0, quantity=0.5):
+def _track(
+    engine,
+    *,
+    side=PositionSide.LONG,
+    stop_loss_order_id="sl-1",
+    stop_loss=95.0,
+    quantity=0.5,
+    current_size=0.25,
+    original_size=0.25,
+):
     position = Position(
         symbol="ETHUSDT",
-        side=PositionSide.LONG,
+        side=side,
         size=0.25,
         entry_price=100.0,
         entry_time=datetime(2025, 1, 1, tzinfo=UTC),
         order_id="order-1",
-        original_size=0.25,
-        current_size=0.25,
+        original_size=original_size,
+        current_size=current_size,
     )
     position.stop_loss_order_id = stop_loss_order_id
     position.stop_loss = stop_loss
@@ -121,75 +168,169 @@ def _exit(engine, position):
     )
 
 
-def test_market_close_cancels_resting_stop_before_submitting():
-    """The resting stop is cancelled BEFORE the market close is submitted."""
-    engine, calls = _make_live_engine(
-        LiveExitResult(success=True, realized_pnl=2.0, exit_price=110.0)
-    )
-    position = _track_long(engine, stop_loss_order_id="sl-1")
+def _ok(price=110.0):
+    return LiveExitResult(success=True, realized_pnl=2.0, exit_price=price)
+
+
+def _fail(err="-2010"):
+    return LiveExitResult(success=False, error=err)
+
+
+# --- clean stop -> cancel then close --------------------------------------------
+
+
+def test_clean_stop_cancelled_then_closed():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0, 0.0))
+    position = _track(engine)
 
     _exit(engine, position)
 
-    assert calls[:2] == ["cancel", "close"]
+    assert calls == ["cancel", "close"]
     engine.exchange_interface.cancel_order.assert_called_once_with("sl-1", "ETHUSDT")
     engine.live_exit_handler.execute_exit.assert_called_once()
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
 
 
-def test_market_close_aborts_when_cancel_unconfirmed():
-    """If the stop cancel cannot be confirmed, the close is NOT submitted."""
-    engine, calls = _make_live_engine(
-        LiveExitResult(success=True, realized_pnl=2.0, exit_price=110.0),
-        cancel_returns=False,
-    )
-    position = _track_long(engine, stop_loss_order_id="sl-1")
+# --- defer-on-fill (over-sell / over-buy prevention) ----------------------------
+
+
+def test_pre_cancel_fill_defers_without_cancel_or_close():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.3,))
+    position = _track(engine)
 
     _exit(engine, position)
 
-    # Close must not be attempted; the position stays tracked and protected.
+    # Partial fill before cancel -> defer: do not cancel or close.
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert calls == []
+
+
+def test_pre_cancel_unreadable_fill_defers():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(None,))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+
+
+def test_post_cancel_race_fill_defers_close():
+    # Clean before cancel, but a fill raced the cancel -> defer (no close).
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0, 0.4))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_called_once()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert calls == ["cancel"]
+
+
+def test_unconfirmed_cancel_aborts_close():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0,), cancel_returns=False)
+    position = _track(engine)
+
+    _exit(engine, position)
+
     engine.live_exit_handler.execute_exit.assert_not_called()
     assert "close" not in calls
     assert engine.live_position_tracker.has_position("order-1")
 
 
-def test_failed_close_after_cancel_reprotects():
-    """A close that fails after a confirmed cancel re-places the stop-loss."""
-    engine, calls = _make_live_engine(LiveExitResult(success=False, error="-2010"))
-    position = _track_long(engine, stop_loss_order_id="sl-1", stop_loss=95.0, quantity=0.5)
+def test_cancel_order_raises_aborts_close():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0,), cancel_raises=True)
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.live_exit_handler.execute_exit.assert_not_called()
+
+
+# --- re-protect after a failed close --------------------------------------------
+
+
+def test_failed_close_reprotects_when_still_held():
+    engine, calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=True)
+    position = _track(engine, quantity=0.5, current_size=0.5, original_size=0.5)
 
     _exit(engine, position)
 
     assert calls == ["cancel", "close", "reprotect"]
     engine.exchange_interface.place_stop_loss_order.assert_called_once()
-    kwargs = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
-    assert kwargs["symbol"] == "ETHUSDT"
-    assert kwargs["stop_price"] == 95.0
-    assert kwargs["quantity"] == 0.5
-    assert kwargs["side"] == OrderSide.SELL  # SELL stop protects a long
+    kw = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
+    assert kw["symbol"] == "ETHUSDT"
+    assert kw["stop_price"] == 95.0
+    assert kw["side"] == OrderSide.SELL
+    assert kw["quantity"] == pytest.approx(0.5)
 
 
-def test_market_close_without_resting_stop_does_not_cancel():
-    """No tracked stop → nothing to cancel; the close proceeds directly."""
-    engine, _calls = _make_live_engine(
-        LiveExitResult(success=True, realized_pnl=2.0, exit_price=110.0)
+def test_failed_close_skips_reprotect_when_not_held():
+    # Ambiguous close that actually executed -> no inventory -> do NOT orphan a stop.
+    engine, calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=False)
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
+    assert "reprotect" not in calls
+
+
+def test_reprotect_scales_quantity_for_partial_exit():
+    # current/original = 0.5 -> protect half the entry quantity.
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=True)
+    position = _track(engine, quantity=0.8, current_size=0.5, original_size=1.0)
+
+    _exit(engine, position)
+
+    kw = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
+    assert kw["quantity"] == pytest.approx(0.8 * 0.5 / 1.0)
+
+
+def test_short_reprotect_uses_buy_when_still_borrowed():
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=True, borrowed=True)
+    position = _track(
+        engine, side=PositionSide.SHORT, quantity=0.5, current_size=0.5, original_size=0.5
     )
-    position = _track_long(engine, stop_loss_order_id=None)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.place_stop_loss_order.assert_called_once()
+    kw = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
+    assert kw["side"] == OrderSide.BUY
+
+
+def test_reprotect_retries_then_succeeds():
+    engine, _calls = _make_live_engine(
+        _fail(), sl_fills=(0.0, 0.0), held=True, place_returns=[None, "sl-2"]
+    )
+    position = _track(engine, quantity=0.5, current_size=0.5, original_size=0.5)
+
+    _exit(engine, position)
+
+    assert engine.exchange_interface.place_stop_loss_order.call_count == 2
+
+
+# --- unchanged paths ------------------------------------------------------------
+
+
+def test_no_resting_stop_closes_directly():
+    engine, _calls = _make_live_engine(_ok())
+    position = _track(engine, stop_loss_order_id=None)
 
     _exit(engine, position)
 
     engine.exchange_interface.cancel_order.assert_not_called()
+    engine.exchange_interface.get_order.assert_not_called()
     engine.live_exit_handler.execute_exit.assert_called_once()
 
 
 def test_filled_stop_path_does_not_cancel_or_reprotect():
-    """When the stop already filled, no market close / cancel / re-protect occurs."""
-    engine, _calls = _make_live_engine(
-        LiveExitResult(success=True, realized_pnl=2.0, exit_price=95.0)
-    )
+    engine, _calls = _make_live_engine(_ok(price=95.0))
     engine._check_stop_loss_filled = Mock(return_value=(True, 95.0))
-    engine.live_exit_handler.execute_filled_exit = Mock(
-        return_value=LiveExitResult(success=True, realized_pnl=2.0, exit_price=95.0)
-    )
-    position = _track_long(engine, stop_loss_order_id="sl-1")
+    engine.live_exit_handler.execute_filled_exit = Mock(return_value=_ok(price=95.0))
+    position = _track(engine)
 
     _exit(engine, position)
 

--- a/tests/unit/engines/live/test_close_cancel_stop_710.py
+++ b/tests/unit/engines/live/test_close_cancel_stop_710.py
@@ -91,8 +91,10 @@ def _make_live_engine(
 
     exchange.get_order.side_effect = _get_order
 
-    # held-inventory check (_position_still_held).
-    if held and borrowed:
+    # held-inventory check (_position_still_held). held=None -> API failure (no asset).
+    if held is None:
+        asset = None
+    elif held and borrowed:
         asset = {"free": "0", "locked": "0", "borrowed": "0.5", "netAsset": "-0.5"}
     elif held:
         asset = {"free": "1.0", "locked": "0", "borrowed": "0", "netAsset": "1.0"}
@@ -336,4 +338,37 @@ def test_filled_stop_path_does_not_cancel_or_reprotect():
 
     engine.live_exit_handler.execute_filled_exit.assert_called_once()
     engine.exchange_interface.cancel_order.assert_not_called()
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
+
+
+def test_post_cancel_unreadable_state_defers_close():
+    # Clean before cancel; the post-cancel read is unreadable -> defer (no close).
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0, None))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_called_once()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert calls == ["cancel"]
+
+
+def test_reprotect_skips_when_held_check_api_fails():
+    # A failed close + an unreadable held-inventory check -> conservatively skip
+    # re-protect (do not orphan a stop); the reconciler reconciles.
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=None)
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
+
+
+def test_short_no_longer_borrowed_skips_reprotect():
+    # SHORT that is no longer borrowed (covered) -> not held -> no re-protect.
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=False)
+    position = _track(engine, side=PositionSide.SHORT)
+
+    _exit(engine, position)
+
     engine.exchange_interface.place_stop_loss_order.assert_not_called()

--- a/tests/unit/engines/live/test_close_cancel_stop_710.py
+++ b/tests/unit/engines/live/test_close_cancel_stop_710.py
@@ -1,0 +1,198 @@
+"""#710: cancel the resting stop-loss BEFORE a market close.
+
+On margin a resting stop-loss order reserves the position's base asset, so a
+market close submitted while it rests is rejected by the exchange with -2010
+("insufficient balance"). The close path must therefore:
+
+* cancel the resting stop FIRST (freeing the base balance), then close;
+* NOT submit the close if it cannot confirm the cancel (the order may have just
+  filled — closing would over-sell — or still rest — closing would -2010);
+* re-place the stop if the close then fails (never leave the position naked).
+
+These tests exercise ``LiveTradingEngine._execute_exit`` in live mode with mocked
+collaborators and assert the ordering / branching above.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pytest
+
+pytestmark = pytest.mark.fast
+
+from src.data_providers.exchange_interface import OrderSide
+from src.engines.live.execution.exit_handler import LiveExitResult
+from src.engines.live.trading_engine import LiveTradingEngine, Position, PositionSide
+from tests.mocks import MockDatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def _mock_db(monkeypatch):
+    """Use the in-memory MockDatabaseManager so construction needs no real DB."""
+    monkeypatch.setattr("src.engines.live.trading_engine.DatabaseManager", MockDatabaseManager)
+
+
+def _make_live_engine(exit_result, *, cancel_returns=True):
+    """A LiveTradingEngine flipped to live mode with mocked exchange + exit handler.
+
+    ``exit_result`` is the ``LiveExitResult`` the mocked market close returns.
+    Returns ``(engine, calls)`` where ``calls`` records the order of
+    cancel_order / execute_exit / place_stop_loss_order so tests can assert
+    cancel-before-close. The mocks live on ``engine.exchange_interface`` and
+    ``engine.live_exit_handler``.
+    """
+    strategy = Mock()
+    strategy.get_risk_overrides.return_value = None
+    data_provider = Mock()
+    data_provider.get_current_price.return_value = 100.0
+
+    engine = LiveTradingEngine(
+        strategy=strategy,
+        data_provider=data_provider,
+        initial_balance=1_000.0,
+        enable_live_trading=False,
+        log_trades=False,
+        fee_rate=0.0,
+        slippage_rate=0.0,
+    )
+
+    # Flip to live mode with mocked collaborators.
+    engine.enable_live_trading = True
+    exchange = Mock()
+    exchange.is_margin_mode = True
+    engine.exchange_interface = exchange
+    engine.order_tracker = Mock()
+    engine.performance_tracker.record_trade = Mock()
+
+    # Force the market-close path (stop not already filled on the exchange).
+    engine._check_stop_loss_filled = Mock(return_value=(False, None))
+
+    calls: list[str] = []
+
+    def _cancel(*_a, **_k):
+        calls.append("cancel")
+        return cancel_returns
+
+    def _close(*_a, **_k):
+        calls.append("close")
+        return exit_result
+
+    def _reprotect(*_a, **_k):
+        calls.append("reprotect")
+        return "sl-new"
+
+    exchange.cancel_order.side_effect = _cancel
+    exchange.place_stop_loss_order.side_effect = _reprotect
+    handler = Mock()
+    handler.execute_exit.side_effect = _close
+    engine.live_exit_handler = handler
+
+    return engine, calls
+
+
+def _track_long(engine, *, stop_loss_order_id="sl-1", stop_loss=95.0, quantity=0.5):
+    position = Position(
+        symbol="ETHUSDT",
+        side=PositionSide.LONG,
+        size=0.25,
+        entry_price=100.0,
+        entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        order_id="order-1",
+        original_size=0.25,
+        current_size=0.25,
+    )
+    position.stop_loss_order_id = stop_loss_order_id
+    position.stop_loss = stop_loss
+    position.quantity = quantity
+    engine.live_position_tracker.track_recovered_position(position, db_id=None)
+    return position
+
+
+def _exit(engine, position):
+    engine._execute_exit(
+        position=position,
+        reason="signal-exit",
+        limit_price=None,
+        current_price=110.0,
+        candle_high=None,
+        candle_low=None,
+        candle=None,
+        skip_live_close=False,
+    )
+
+
+def test_market_close_cancels_resting_stop_before_submitting():
+    """The resting stop is cancelled BEFORE the market close is submitted."""
+    engine, calls = _make_live_engine(
+        LiveExitResult(success=True, realized_pnl=2.0, exit_price=110.0)
+    )
+    position = _track_long(engine, stop_loss_order_id="sl-1")
+
+    _exit(engine, position)
+
+    assert calls[:2] == ["cancel", "close"]
+    engine.exchange_interface.cancel_order.assert_called_once_with("sl-1", "ETHUSDT")
+    engine.live_exit_handler.execute_exit.assert_called_once()
+
+
+def test_market_close_aborts_when_cancel_unconfirmed():
+    """If the stop cancel cannot be confirmed, the close is NOT submitted."""
+    engine, calls = _make_live_engine(
+        LiveExitResult(success=True, realized_pnl=2.0, exit_price=110.0),
+        cancel_returns=False,
+    )
+    position = _track_long(engine, stop_loss_order_id="sl-1")
+
+    _exit(engine, position)
+
+    # Close must not be attempted; the position stays tracked and protected.
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert "close" not in calls
+    assert engine.live_position_tracker.has_position("order-1")
+
+
+def test_failed_close_after_cancel_reprotects():
+    """A close that fails after a confirmed cancel re-places the stop-loss."""
+    engine, calls = _make_live_engine(LiveExitResult(success=False, error="-2010"))
+    position = _track_long(engine, stop_loss_order_id="sl-1", stop_loss=95.0, quantity=0.5)
+
+    _exit(engine, position)
+
+    assert calls == ["cancel", "close", "reprotect"]
+    engine.exchange_interface.place_stop_loss_order.assert_called_once()
+    kwargs = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
+    assert kwargs["symbol"] == "ETHUSDT"
+    assert kwargs["stop_price"] == 95.0
+    assert kwargs["quantity"] == 0.5
+    assert kwargs["side"] == OrderSide.SELL  # SELL stop protects a long
+
+
+def test_market_close_without_resting_stop_does_not_cancel():
+    """No tracked stop → nothing to cancel; the close proceeds directly."""
+    engine, _calls = _make_live_engine(
+        LiveExitResult(success=True, realized_pnl=2.0, exit_price=110.0)
+    )
+    position = _track_long(engine, stop_loss_order_id=None)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.live_exit_handler.execute_exit.assert_called_once()
+
+
+def test_filled_stop_path_does_not_cancel_or_reprotect():
+    """When the stop already filled, no market close / cancel / re-protect occurs."""
+    engine, _calls = _make_live_engine(
+        LiveExitResult(success=True, realized_pnl=2.0, exit_price=95.0)
+    )
+    engine._check_stop_loss_filled = Mock(return_value=(True, 95.0))
+    engine.live_exit_handler.execute_filled_exit = Mock(
+        return_value=LiveExitResult(success=True, realized_pnl=2.0, exit_price=95.0)
+    )
+    position = _track_long(engine, stop_loss_order_id="sl-1")
+
+    _exit(engine, position)
+
+    engine.live_exit_handler.execute_filled_exit.assert_called_once()
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()


### PR DESCRIPTION
Fixes #710.

## Problem
On Binance cross-margin, a resting stop-loss SELL order **reserves the position's base asset**. The close path submitted a MARKET SELL for the full size and only cancelled the stop **after** a successful close — so an active exit / take-profit on a stop-protected margin long was rejected by the exchange with **`-2010` ("insufficient balance")** because the stop still held the base.

Observed in production (2026-06-07): a profitable ETHUSDT long logged 4× `Failed to close position … code=-2010` over 08:56–08:59 UTC. It self-resolved and the position stayed protected (the close simply never executed), but the bot could not actively exit when its close path fired.

## Fix
In `LiveTradingEngine._execute_exit_locked`'s market-close branch:
1. **Cancel the resting stop FIRST** (`_cancel_stop_loss_order`) to free the base balance, then submit the close.
2. **If the cancel can't be confirmed, do NOT close** — the order may have just filled (closing would over-sell) or still rest (closing would `-2010`). The position stays protected and retries next cycle.
3. **If the close fails after a confirmed cancel, re-place the stop immediately** (`_reprotect_position`) so the position is never left naked. The periodic reconciler (which re-places missing stops / emergency-closes) is the ultimate backstop.
4. Remove the now-redundant post-close cancel block.

The whole exit already runs under a per-base-asset `RLock`, so the cancel→close→reprotect sequence is serialized against entry / the orphan-sweep.

## User-facing impact
- Stop-protected margin positions can now be **actively closed** (signal exit / take-profit), not only via the stop firing.
- No new naked-position risk: the close is skipped on unconfirmed cancel, and re-protected on post-cancel failure.
- **No deploy in this PR** — develop only.

## Testing
- New `tests/unit/engines/live/test_close_cancel_stop_710.py` (5 tests): cancel-before-close ordering; abort-on-unconfirmed-cancel (no close, position stays tracked); re-protect on failed close (re-places SELL stop @ tracked price); no-cancel-without-stop; filled-stop path untouched.
- Regression: existing exit/close-path suites green (`test_margin_interest_close_flow`, `test_margin_side_effect`, `test_exit_conditions`, `test_close_position_parity`, `test_order_execution`) — 82 passed.
- `black` / `ruff` clean; `mypy` adds no new errors in the changed range.
- In review: `/codex-code-review` (gpt-5.5) + `architecture-reviewer` + `code-reviewer` (running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)