### PR TITLE
promote(#710): inventory-aware close fix to production

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import DBAPIError, InterfaceError, OperationalError
 
 from src.config import get_config
 from src.config.constants import (
+    BORROW_DUST_EPSILON,
     DEFAULT_ACCOUNT_SNAPSHOT_INTERVAL,
     DEFAULT_CHECK_INTERVAL,
     DEFAULT_DATA_FRESHNESS_THRESHOLD,
@@ -4010,6 +4011,55 @@ class LiveTradingEngine:
                     current_balance=self.current_balance,
                 )
             else:
+                # #710: On margin a resting stop-loss order reserves the position's
+                # base asset, so a market close submitted while it rests is rejected
+                # with -2010 (insufficient balance). We must cancel the stop first to
+                # free the balance — but ONLY when it is safe to close the full size.
+                #
+                # Inventory-awareness: a stop that has ANY fill means held base !=
+                # tracked size, so a full-size close would over-sell (long) / over-buy
+                # (short). Re-query the stop's filled quantity BEFORE cancelling (no
+                # unprotected window — it stays resting) and AGAIN after the confirmed
+                # (terminal) cancel; on any fill, or any unconfirmable state, DEFER to
+                # the periodic reconciler instead of closing. Only a provably clean
+                # (zero-fill) stop is cancelled and the full size closed.
+                protective_order_cancelled = False
+                if (
+                    self.enable_live_trading
+                    and self.exchange_interface
+                    and position.stop_loss_order_id
+                ):
+                    pre_filled = self._stop_loss_filled_quantity(position)
+                    if pre_filled is None or pre_filled > BORROW_DUST_EPSILON:
+                        logger.warning(
+                            "Deferring market close of %s: resting stop %s is mid-fill or "
+                            "its state is unconfirmable (filled=%s) — reconciler will "
+                            "adjust. Not cancelling or closing.",
+                            position.symbol,
+                            position.stop_loss_order_id,
+                            pre_filled,
+                        )
+                        return
+                    if not self._cancel_stop_loss_order(position):
+                        logger.warning(
+                            "Skipping market close of %s: could not confirm cancel of "
+                            "resting stop-loss %s; position remains protected, will retry.",
+                            position.symbol,
+                            position.stop_loss_order_id,
+                        )
+                        return
+                    protective_order_cancelled = True
+                    post_filled = self._stop_loss_filled_quantity(position)
+                    if post_filled is None or post_filled > BORROW_DUST_EPSILON:
+                        logger.warning(
+                            "Deferring market close of %s: stop %s filled during cancel "
+                            "(filled=%s) — reconciler will adjust. Not closing.",
+                            position.symbol,
+                            position.stop_loss_order_id,
+                            post_filled,
+                        )
+                        return
+
                 exit_result = self.live_exit_handler.execute_exit(
                     position=position,
                     exit_reason=reason,
@@ -4020,6 +4070,13 @@ class LiveTradingEngine:
                     candle_low=candle_low,
                     data_provider=self.data_provider,
                 )
+                if not exit_result.success and protective_order_cancelled:
+                    # The close failed after we cancelled a clean (zero-fill) stop, so
+                    # the position is momentarily unprotected — re-protect immediately
+                    # (verifying it is still held, to avoid orphaning a stop on an
+                    # ambiguous / already-executed close). The periodic reconciler is
+                    # the ultimate backstop. (#710)
+                    self._reprotect_position(position)
             if not exit_result.success:
                 logger.error(
                     "Failed to close position %s: %s",
@@ -4191,28 +4248,11 @@ class LiveTradingEngine:
                     margin_interest_cost=interest_cost,
                 )
 
-            if (
-                self.enable_live_trading
-                and self.exchange_interface
-                and position.stop_loss_order_id
-                and not sl_already_filled
-            ):
-                try:
-                    cancelled = self.exchange_interface.cancel_order(
-                        position.stop_loss_order_id, position.symbol
-                    )
-                    if cancelled:
-                        logger.info(
-                            "Cancelled stop-loss order %s for %s",
-                            position.stop_loss_order_id,
-                            position.symbol,
-                        )
-                except Exception as e:
-                    logger.warning("Error cancelling stop-loss order: %s", e)
-
-                if self.order_tracker:
-                    self.order_tracker.stop_tracking(position.stop_loss_order_id)
-
+            # NOTE(#710): the resting stop-loss is now cancelled BEFORE the market
+            # close (see the close path above) so it cannot reserve the base asset
+            # and trigger -2010. No post-close cancel is needed here; on a successful
+            # close the position (and its already-cancelled stop) are removed by the
+            # exit handler.
             logger.info(
                 "📈 Closed %s position for %s: PnL=$%.2f, Reason=%s, Balance=$%.2f",
                 position.side.value,
@@ -4233,6 +4273,209 @@ class LiveTradingEngine:
             )
         except Exception as e:
             logger.error("Failed to close position %s: %s", position.order_id, e, exc_info=True)
+
+    def _cancel_stop_loss_order(self, position: Position) -> bool:
+        """Cancel a position's resting stop-loss order and stop tracking it.
+
+        Returns True only when the exchange confirms the cancel. The close path uses
+        this before a market exit so the stop no longer reserves the base asset
+        (otherwise the close is rejected -2010 on margin, #710). A False result means
+        the order may still rest, or may have just filled, so the caller must NOT
+        submit a close (it would -2010, or over-sell an already-closed position).
+        """
+        if not (
+            self.enable_live_trading and self.exchange_interface and position.stop_loss_order_id
+        ):
+            return False
+        cancelled = False
+        try:
+            cancelled = bool(
+                self.exchange_interface.cancel_order(position.stop_loss_order_id, position.symbol)
+            )
+            if cancelled:
+                logger.info(
+                    "Cancelled stop-loss order %s for %s before close",
+                    position.stop_loss_order_id,
+                    position.symbol,
+                )
+        except Exception as e:
+            logger.warning(
+                "Error cancelling stop-loss order %s for %s: %s",
+                position.stop_loss_order_id,
+                position.symbol,
+                e,
+            )
+        # Only stop tracking when the cancel is confirmed; otherwise the order may
+        # still be live on the exchange and must remain watched.
+        if cancelled and self.order_tracker:
+            self.order_tracker.stop_tracking(position.stop_loss_order_id)
+        return cancelled
+
+    def _stop_loss_filled_quantity(self, position: Position) -> float | None:
+        """Return the filled (executed) base quantity of a position's stop-loss order.
+
+        ``0.0`` for an unfilled stop, the filled base quantity for a partial/full fill,
+        or ``None`` if the order cannot be read (missing / API error). The close path
+        treats ``None`` and any non-zero fill as "unsafe to inline-close" and defers to
+        the reconciler — a partially-filled stop means held base != tracked size, so a
+        full-size close would over-sell (long) / over-buy (short). (#710)
+        """
+        if not (
+            self.enable_live_trading and self.exchange_interface and position.stop_loss_order_id
+        ):
+            return 0.0
+        try:
+            order = self.exchange_interface.get_order(position.stop_loss_order_id, position.symbol)
+        except Exception as e:
+            logger.warning(
+                "Could not read stop-loss order %s for %s: %s",
+                position.stop_loss_order_id,
+                position.symbol,
+                e,
+            )
+            return None
+        if order is None:
+            return None
+        return float(getattr(order, "filled_quantity", 0.0) or 0.0)
+
+    def _position_still_held(self, position: Position) -> bool:
+        """Whether the position's inventory is still actually held on the exchange.
+
+        Checked before an inline re-protect so a stop is not re-placed on a position an
+        ambiguous / already-executed close has actually closed (which would orphan a
+        stop). Conservative: any unreadable/uncertain state returns ``False`` (do not
+        re-place; the reconciler reconciles exchange truth). (#710)
+        """
+        if not (self.enable_live_trading and self.exchange_interface):
+            return False
+        from src.engines.live.reconciliation import PositionReconciler
+
+        base = PositionReconciler._extract_base_asset(position.symbol)
+        dust = float(BORROW_DUST_EPSILON)
+        try:
+            get_asset = getattr(self.exchange_interface, "get_margin_account_asset", None)
+            if getattr(self.exchange_interface, "is_margin_mode", False) and callable(get_asset):
+                asset = get_asset(base)
+                if not asset:
+                    return False
+                if position.side == PositionSide.SHORT:
+                    # A short is still held while base remains borrowed (owed).
+                    return float(asset.get("borrowed", 0.0) or 0.0) > dust
+                free = float(asset.get("free", 0.0) or 0.0)
+                locked = float(asset.get("locked", 0.0) or 0.0)
+                return (free + locked) > dust
+            # Spot / no margin-asset accessor: long inventory is the base balance.
+            bal = self.exchange_interface.get_balance(base)
+            if not bal:
+                return False
+            return (
+                float(getattr(bal, "free", 0.0) or 0.0) + float(getattr(bal, "locked", 0.0) or 0.0)
+            ) > dust
+        except Exception as e:
+            logger.warning("Could not confirm held inventory for %s: %s", position.symbol, e)
+            return False
+
+    def _held_protection_quantity(self, position: Position) -> float:
+        """Base quantity to protect, scaled for any prior partial exits.
+
+        Mirrors the reconciler's re-placement sizing ``quantity * current/original`` so
+        a re-protected stop covers the *remaining* held size, not the full entry size.
+        """
+        quantity = getattr(position, "quantity", None)
+        if not quantity or quantity <= 0:
+            return 0.0
+        current = getattr(position, "current_size", None)
+        original = getattr(position, "original_size", None)
+        if current is not None and original is not None and original > 0:
+            return float(quantity) * (float(current) / float(original))
+        return float(quantity)
+
+    def _reprotect_position(self, position: Position) -> None:
+        """Re-place a stop-loss after a failed close left a position momentarily naked.
+
+        Reached only when a market close failed *after* its clean (zero-fill) resting
+        stop was cancelled to free the base balance (#710). Re-establish protection
+        immediately rather than waiting for the ~120s reconciler — but first verify the
+        position is still actually held (the close may be ambiguous / already executed)
+        to avoid orphaning a stop, and size for any prior partial exits. The reconciler
+        is the ultimate backstop if this attempt cannot run or also fails.
+        """
+        if not (self.enable_live_trading and self.exchange_interface):
+            return
+        if not self._position_still_held(position):
+            logger.warning(
+                "%s appears no longer held after a failed close — not re-placing a "
+                "stop (the reconciler will reconcile exchange state).",
+                position.symbol,
+            )
+            return
+
+        stop_price = getattr(position, "stop_loss", None)
+        quantity = self._held_protection_quantity(position)
+        if not stop_price or stop_price <= 0 or quantity <= 0:
+            logger.critical(
+                "CRITICAL: %s close failed after its stop-loss was cancelled and it "
+                "cannot be re-protected inline (stop_price=%s, quantity=%s) — position "
+                "is UNPROTECTED pending the reconciler. MANUAL REVIEW REQUIRED.",
+                position.symbol,
+                stop_price,
+                quantity,
+            )
+            self._send_alert(
+                f"🚨 {position.symbol} UNPROTECTED: close failed after stop-loss "
+                f"cancel and it could not be re-placed inline. Reconciler backstop "
+                f"engaged. MANUAL REVIEW REQUIRED."
+            )
+            return
+
+        sl_side = OrderSide.SELL if position.side == PositionSide.LONG else OrderSide.BUY
+        sl_order_id = None
+        retry_delay = 1.0
+        for attempt in range(3):
+            try:
+                sl_order_id = self.exchange_interface.place_stop_loss_order(
+                    symbol=position.symbol,
+                    side=sl_side,
+                    quantity=float(quantity),
+                    stop_price=float(stop_price),
+                    side_effect_type=SideEffectType.AUTO_REPAY,
+                )
+                if sl_order_id:
+                    break
+            except Exception as e:
+                logger.warning(
+                    "Re-protect attempt %s/3 for %s failed: %s",
+                    attempt + 1,
+                    position.symbol,
+                    e,
+                )
+            if attempt < 2:
+                time.sleep(retry_delay)
+                retry_delay *= 2
+
+        if sl_order_id:
+            if position.order_id is not None:
+                self.live_position_tracker.set_stop_loss_order_id(position.order_id, sl_order_id)
+            if self.order_tracker:
+                self.order_tracker.track_order(sl_order_id, position.symbol)
+            logger.warning(
+                "Re-protected %s after a failed close: new stop-loss %s @ $%.2f (qty=%.8f)",
+                position.symbol,
+                sl_order_id,
+                float(stop_price),
+                float(quantity),
+            )
+        else:
+            logger.critical(
+                "CRITICAL: %s close failed AND re-placing its stop-loss failed after "
+                "retries — position is UNPROTECTED pending the periodic reconciler. "
+                "MANUAL REVIEW REQUIRED.",
+                position.symbol,
+            )
+            self._send_alert(
+                f"🚨 {position.symbol} UNPROTECTED: close failed and stop-loss "
+                f"re-placement failed. Reconciler is the only backstop. REVIEW NOW."
+            )
 
     def _check_stop_loss_filled(self, position: Position) -> tuple[bool, float | None]:
         """Check if a stop-loss order already filled on the exchange."""

--- a/tests/unit/engines/live/test_close_cancel_stop_710.py
+++ b/tests/unit/engines/live/test_close_cancel_stop_710.py
@@ -1,0 +1,374 @@
+"""#710: inventory-aware active close of a stop-protected margin position.
+
+On margin a resting stop-loss order reserves the position's base asset, so a market
+close submitted while it rests is rejected -2010 ("insufficient balance"). The close
+path must:
+
+* re-query the stop's filled quantity BEFORE cancelling — if it has ANY fill (or its
+  state is unreadable), DEFER to the reconciler (held base != tracked size, so a
+  full-size close would over-sell a long / over-buy a short); leave it resting;
+* only cancel a provably clean (zero-fill) stop, then RE-CHECK the fill after the
+  (terminal) cancel and defer if it raced a fill;
+* close the full size only when the stop is confirmed clean both times;
+* if the close then fails, re-protect immediately — but only after verifying the
+  position is still actually held (avoid orphaning a stop on an ambiguous/already-
+  executed close), sizing for prior partial exits, with bounded retry.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pytest
+
+pytestmark = pytest.mark.fast
+
+from src.data_providers.exchange_interface import OrderSide
+from src.engines.live.execution.exit_handler import LiveExitResult
+from src.engines.live.trading_engine import LiveTradingEngine, Position, PositionSide
+from tests.mocks import MockDatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def _fast_env(monkeypatch):
+    """In-memory DB + no real sleeps (re-protect retry uses time.sleep)."""
+    monkeypatch.setattr("src.engines.live.trading_engine.DatabaseManager", MockDatabaseManager)
+    monkeypatch.setattr("src.engines.live.trading_engine.time.sleep", lambda *_a, **_k: None)
+
+
+def _order(filled):
+    """A stop order mock with the given filled base quantity (None -> unreadable)."""
+    if filled is None:
+        return None
+    return Mock(filled_quantity=filled, status="NEW")
+
+
+def _make_live_engine(
+    exit_result,
+    *,
+    cancel_returns=True,
+    cancel_raises=False,
+    sl_fills=(0.0, 0.0),
+    held=True,
+    borrowed=False,
+    place_returns="sl-new",
+):
+    """A LiveTradingEngine in live mode with mocked exchange + exit handler.
+
+    ``sl_fills`` is the sequence of filled quantities ``get_order`` reports across the
+    pre-/post-cancel checks (repeats the last). ``held`` controls the held-inventory
+    check; ``borrowed`` routes held via the short (borrowed) branch. Returns
+    ``(engine, calls)`` recording the cancel/close/reprotect order.
+    """
+    strategy = Mock()
+    strategy.get_risk_overrides.return_value = None
+    data_provider = Mock()
+    data_provider.get_current_price.return_value = 100.0
+
+    engine = LiveTradingEngine(
+        strategy=strategy,
+        data_provider=data_provider,
+        initial_balance=1_000.0,
+        enable_live_trading=False,
+        log_trades=False,
+        fee_rate=0.0,
+        slippage_rate=0.0,
+    )
+
+    engine.enable_live_trading = True
+    exchange = Mock()
+    exchange.is_margin_mode = True
+    engine.exchange_interface = exchange
+    engine.order_tracker = Mock()
+    engine.performance_tracker.record_trade = Mock()
+    engine._check_stop_loss_filled = Mock(return_value=(False, None))
+
+    # get_order feeds _stop_loss_filled_quantity (pre/post cancel).
+    fills = list(sl_fills)
+
+    def _get_order(*_a, **_k):
+        f = fills.pop(0) if len(fills) > 1 else fills[0]
+        return _order(f)
+
+    exchange.get_order.side_effect = _get_order
+
+    # held-inventory check (_position_still_held). held=None -> API failure (no asset).
+    if held is None:
+        asset = None
+    elif held and borrowed:
+        asset = {"free": "0", "locked": "0", "borrowed": "0.5", "netAsset": "-0.5"}
+    elif held:
+        asset = {"free": "1.0", "locked": "0", "borrowed": "0", "netAsset": "1.0"}
+    else:
+        asset = {"free": "0", "locked": "0", "borrowed": "0", "netAsset": "0"}
+    exchange.get_margin_account_asset.return_value = asset
+
+    calls: list[str] = []
+
+    def _cancel(*_a, **_k):
+        calls.append("cancel")
+        if cancel_raises:
+            raise RuntimeError("boom")
+        return cancel_returns
+
+    def _close(*_a, **_k):
+        calls.append("close")
+        return exit_result
+
+    place_seq = list(place_returns) if isinstance(place_returns, list | tuple) else None
+
+    def _place(*_a, **_k):
+        calls.append("reprotect")
+        if place_seq is not None:
+            return place_seq.pop(0) if len(place_seq) > 1 else place_seq[0]
+        return place_returns
+
+    exchange.cancel_order.side_effect = _cancel
+    exchange.place_stop_loss_order.side_effect = _place
+    handler = Mock()
+    handler.execute_exit.side_effect = _close
+    engine.live_exit_handler = handler
+    return engine, calls
+
+
+def _track(
+    engine,
+    *,
+    side=PositionSide.LONG,
+    stop_loss_order_id="sl-1",
+    stop_loss=95.0,
+    quantity=0.5,
+    current_size=0.25,
+    original_size=0.25,
+):
+    position = Position(
+        symbol="ETHUSDT",
+        side=side,
+        size=0.25,
+        entry_price=100.0,
+        entry_time=datetime(2025, 1, 1, tzinfo=UTC),
+        order_id="order-1",
+        original_size=original_size,
+        current_size=current_size,
+    )
+    position.stop_loss_order_id = stop_loss_order_id
+    position.stop_loss = stop_loss
+    position.quantity = quantity
+    engine.live_position_tracker.track_recovered_position(position, db_id=None)
+    return position
+
+
+def _exit(engine, position):
+    engine._execute_exit(
+        position=position,
+        reason="signal-exit",
+        limit_price=None,
+        current_price=110.0,
+        candle_high=None,
+        candle_low=None,
+        candle=None,
+        skip_live_close=False,
+    )
+
+
+def _ok(price=110.0):
+    return LiveExitResult(success=True, realized_pnl=2.0, exit_price=price)
+
+
+def _fail(err="-2010"):
+    return LiveExitResult(success=False, error=err)
+
+
+# --- clean stop -> cancel then close --------------------------------------------
+
+
+def test_clean_stop_cancelled_then_closed():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0, 0.0))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    assert calls == ["cancel", "close"]
+    engine.exchange_interface.cancel_order.assert_called_once_with("sl-1", "ETHUSDT")
+    engine.live_exit_handler.execute_exit.assert_called_once()
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
+
+
+# --- defer-on-fill (over-sell / over-buy prevention) ----------------------------
+
+
+def test_pre_cancel_fill_defers_without_cancel_or_close():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.3,))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    # Partial fill before cancel -> defer: do not cancel or close.
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert calls == []
+
+
+def test_pre_cancel_unreadable_fill_defers():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(None,))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+
+
+def test_post_cancel_race_fill_defers_close():
+    # Clean before cancel, but a fill raced the cancel -> defer (no close).
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0, 0.4))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_called_once()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert calls == ["cancel"]
+
+
+def test_unconfirmed_cancel_aborts_close():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0,), cancel_returns=False)
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert "close" not in calls
+    assert engine.live_position_tracker.has_position("order-1")
+
+
+def test_cancel_order_raises_aborts_close():
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0,), cancel_raises=True)
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.live_exit_handler.execute_exit.assert_not_called()
+
+
+# --- re-protect after a failed close --------------------------------------------
+
+
+def test_failed_close_reprotects_when_still_held():
+    engine, calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=True)
+    position = _track(engine, quantity=0.5, current_size=0.5, original_size=0.5)
+
+    _exit(engine, position)
+
+    assert calls == ["cancel", "close", "reprotect"]
+    engine.exchange_interface.place_stop_loss_order.assert_called_once()
+    kw = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
+    assert kw["symbol"] == "ETHUSDT"
+    assert kw["stop_price"] == 95.0
+    assert kw["side"] == OrderSide.SELL
+    assert kw["quantity"] == pytest.approx(0.5)
+
+
+def test_failed_close_skips_reprotect_when_not_held():
+    # Ambiguous close that actually executed -> no inventory -> do NOT orphan a stop.
+    engine, calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=False)
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
+    assert "reprotect" not in calls
+
+
+def test_reprotect_scales_quantity_for_partial_exit():
+    # current/original = 0.5 -> protect half the entry quantity.
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=True)
+    position = _track(engine, quantity=0.8, current_size=0.5, original_size=1.0)
+
+    _exit(engine, position)
+
+    kw = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
+    assert kw["quantity"] == pytest.approx(0.8 * 0.5 / 1.0)
+
+
+def test_short_reprotect_uses_buy_when_still_borrowed():
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=True, borrowed=True)
+    position = _track(
+        engine, side=PositionSide.SHORT, quantity=0.5, current_size=0.5, original_size=0.5
+    )
+
+    _exit(engine, position)
+
+    engine.exchange_interface.place_stop_loss_order.assert_called_once()
+    kw = engine.exchange_interface.place_stop_loss_order.call_args.kwargs
+    assert kw["side"] == OrderSide.BUY
+
+
+def test_reprotect_retries_then_succeeds():
+    engine, _calls = _make_live_engine(
+        _fail(), sl_fills=(0.0, 0.0), held=True, place_returns=[None, "sl-2"]
+    )
+    position = _track(engine, quantity=0.5, current_size=0.5, original_size=0.5)
+
+    _exit(engine, position)
+
+    assert engine.exchange_interface.place_stop_loss_order.call_count == 2
+
+
+# --- unchanged paths ------------------------------------------------------------
+
+
+def test_no_resting_stop_closes_directly():
+    engine, _calls = _make_live_engine(_ok())
+    position = _track(engine, stop_loss_order_id=None)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.exchange_interface.get_order.assert_not_called()
+    engine.live_exit_handler.execute_exit.assert_called_once()
+
+
+def test_filled_stop_path_does_not_cancel_or_reprotect():
+    engine, _calls = _make_live_engine(_ok(price=95.0))
+    engine._check_stop_loss_filled = Mock(return_value=(True, 95.0))
+    engine.live_exit_handler.execute_filled_exit = Mock(return_value=_ok(price=95.0))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.live_exit_handler.execute_filled_exit.assert_called_once()
+    engine.exchange_interface.cancel_order.assert_not_called()
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
+
+
+def test_post_cancel_unreadable_state_defers_close():
+    # Clean before cancel; the post-cancel read is unreadable -> defer (no close).
+    engine, calls = _make_live_engine(_ok(), sl_fills=(0.0, None))
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.cancel_order.assert_called_once()
+    engine.live_exit_handler.execute_exit.assert_not_called()
+    assert calls == ["cancel"]
+
+
+def test_reprotect_skips_when_held_check_api_fails():
+    # A failed close + an unreadable held-inventory check -> conservatively skip
+    # re-protect (do not orphan a stop); the reconciler reconciles.
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=None)
+    position = _track(engine)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()
+
+
+def test_short_no_longer_borrowed_skips_reprotect():
+    # SHORT that is no longer borrowed (covered) -> not held -> no re-protect.
+    engine, _calls = _make_live_engine(_fail(), sl_fills=(0.0, 0.0), held=False)
+    position = _track(engine, side=PositionSide.SHORT)
+
+    _exit(engine, position)
+
+    engine.exchange_interface.place_stop_loss_order.assert_not_called()


### PR DESCRIPTION
Surgical production promote of the #710 close-path fix (PR #711, merged to `develop`).

## Why now
Live prod is actively hitting the bug: **34× `-2010` failed closes** of position `47320160965` over 3h (ongoing) — the bot cannot actively exit a profitable, SL-protected ETHUSDT long. No capital loss (position stays stop-protected), but it's stuck. This fix resolves it.

## What
Cherry-pick of develop squash `2c72fdaf` onto `origin/main`. **`git patch-id --stable` verified IDENTICAL** to the develop change (`4ade91bf…`) — no drift. Touches only `trading_engine.py` + a new test file; all dependencies (`BORROW_DUST_EPSILON`, `_execute_exit_locked`, `get_margin_account_asset`) already on `main`.

The fix: re-query the resting stop's `filled_quantity` before/after a terminal cancel; defer to the reconciler on any fill/unreadable state; close only a provably clean stop (no over-sell/over-buy); re-protect on a failed close only if still held, sized for partial exits, with retry.

## Review status
- codex-code-review: **APPROVE** (no blocking close-path findings) on #711.
- architecture-reviewer + code-reviewer: findings addressed.
- 16 targeted tests + 155-test exit/close regression green on develop.
- Pre-existing reconciler gaps scoped to #712 / #713 / #714.

**Merging this deploys to production.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)