### PR TITLE
docs(lessons): add §3 railway/log-level gotchas + §5.4 benign-noise signatures

### DIFF
--- a/.claude/LESSONS.md
+++ b/.claude/LESSONS.md
@@ -135,6 +135,13 @@ state (`get_open_orders`, account sync, the actual order id) before acting or al
   **Always close stdin** (`< /dev/null` or pipe to `tail`) or it hangs on
   "Reading additional input from stdin…". Run scoped from a neutral cwd with
   `--skip-git-repo-check --model gpt-5.5`.
+- **`railway` resolves the project link by cwd** — run `railway logs`/`status` from the linked repo
+  dir (worktree root), NOT `/tmp` (an unlinked dir errors `No linked project found`). Redirect
+  output to `/tmp`, but run the command from the repo.
+- **Prod logs use 4-char level tags** `[ERRO]`/`[WARN]`/`[INFO]` — NOT `[ERROR]`. Grep `\[ERRO\]`
+  or severity is undercounted.
+- **Target prod explicitly:** `railway logs -e production -s "Trading Bot" -n 400` (env is
+  `production`, the live bot service is `Trading Bot`).
 
 ---
 
@@ -215,6 +222,15 @@ keep the skill generic and let the specifics live here.
 - `51077` matching a **timestamp nanosecond suffix** (`…243651077Z`) — anchor the grep (`code=51077`,
   `(code=51077)`); don't match bare digits in UTC timestamps.
 - An expected deploy boot (one you / the operator just triggered).
+- `[WARN] New order found on exchange: <id> … / [INFO] Skipping creation of new order <id> from
+  sync` — `account_sync` re-detecting the resting stop-loss each cycle and (by design) not
+  duplicating it into the DB. Benign; that order IS the protective SL.
+- `[ERRO] Task exception was never retrieved → KeyError('margin_subscription:0')` (binance
+  `threaded_stream.py:74`) at user-stream circuit-open — benign teardown noise (fix tracked in #716;
+  disappears once it ships).
+- The kline self-heal sequence (`Kline WS error: Connection closed` → `RESYNCING` → `KlineBuffer
+  resynced … candles` → `Kline WebSocket recovered … WS primary again (#662)`) — the GOOD path,
+  ~30 s, no data gap. Do NOT alarm.
 
 ### 5.5 Verify before alarming (phantom premises)
 A recurring/cron prompt may assert e.g. "a real ETH LONG was ORPHANED at 19:12 → double-exposure!".


### PR DESCRIPTION
## Summary

Closes #718.

Adds 6 new entries to `.claude/LESSONS.md` drawn from hard-won operational experience:

**§3 — Operational / tooling gotchas (3 new bullets):**
- `railway` resolves the project link by **cwd** — must run `railway logs`/`status` from the repo dir, not `/tmp`
- Prod logs use 4-char level tags `[ERRO]`/`[WARN]`/`[INFO]` — grepping `[ERROR]` undercounts severity
- Canonical prod log command: `railway logs -e production -s "Trading Bot" -n 400`

**§5.4 — Known-benign — do NOT alarm (3 new bullets):**
- `[WARN] New order found on exchange … / [INFO] Skipping creation` — `account_sync` re-detecting the resting SL each cycle; by design, not a duplicate
- `[ERRO] Task exception … KeyError('margin_subscription:0')` at user-stream circuit-open — teardown noise; fix tracked in #716
- Kline self-heal sequence (`Connection closed` → `RESYNCING` → `resynced` → `recovered`) — the GOOD path (~30 s), no data gap

## Test plan

- [x] Codex review (`gpt-5.5 --full-auto`) — **APPROVE**, no issues found
- [x] Diff reviewed manually: 16 insertions, docs-only, no code changed
- [x] Formatting matches existing bullet style throughout

🤖 Generated with [Claude Code](https://claude.ai/claude-code)