### PR TITLE
fix(live): suppress benign python-binance socket-teardown KeyError on circuit-open (#716)

### DIFF
--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -2077,9 +2077,85 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             # loop has no run_until_complete nesting, so it does NOT reintroduce the
             # "cannot enter context" re-entrancy spam that #646 fixed.
             self._twm_loop = asyncio.new_event_loop()
+            # Intercept the benign teardown KeyError raised inside python-binance's
+            # start_listener task on socket stop (#716). The exception fires inside the
+            # library coroutine on THIS loop, so a try/except around stop_socket can't
+            # reach it — only the loop's own exception handler can.
+            self._twm_loop.set_exception_handler(self._twm_loop_exception_handler)
             twm_kwargs["loop"] = self._twm_loop
             self._twm = ThreadedWebsocketManager(**twm_kwargs)
             self._twm.start()
+
+    def _twm_loop_exception_handler(
+        self, loop: asyncio.AbstractEventLoop, context: dict[str, Any]
+    ) -> None:
+        """Suppress python-binance's benign socket-teardown ``KeyError`` (#716).
+
+        When a user/kline socket is stopped, ``stop_socket`` flips
+        ``self._socket_running[path]`` to ``False`` and the library's
+        ``start_listener`` coroutine then ``del``s that key on exit. A race in
+        the library re-evaluates ``while self._socket_running[path]`` after the
+        key is gone, raising ``KeyError(path)`` inside the listener task. The
+        socket is being torn down on purpose (e.g. the #616 circuit-open drop to
+        REST polling), so this is teardown noise — but it surfaces as
+        ``Task exception was never retrieved`` (3× per circuit-open) and trips
+        monitoring that greps ``Traceback``.
+
+        The exception is raised inside the library task on this loop, so it is
+        unreachable from a ``try/except`` around our ``stop_socket`` call; the
+        loop's exception handler is the only interception point. Only the
+        specific library teardown ``KeyError`` (one raised by the
+        ``while self._socket_running[path]`` subscript in python-binance's
+        ``threaded_stream.start_listener``) is downgraded to DEBUG — every other
+        loop exception, including a real ``KeyError`` raised by our user-data
+        callback that python-binance invokes *inside* ``start_listener``, is
+        delegated to asyncio's default handler so genuine errors keep their
+        normal ERROR visibility.
+        """
+        if self._is_socket_teardown_keyerror(context.get("exception")):
+            logger.debug(
+                "Suppressed python-binance socket-teardown KeyError(%s) on stop (#716)",
+                self._keyerror_path(context.get("exception")),
+            )
+            return
+        loop.default_exception_handler(context)
+
+    @staticmethod
+    def _is_socket_teardown_keyerror(exc: BaseException | None) -> bool:
+        """True iff ``exc`` is the library's ``start_listener`` teardown KeyError.
+
+        The teardown ``KeyError`` is raised directly by the
+        ``while self._socket_running[path]`` subscript, so its *deepest*
+        traceback frame is ``start_listener`` in python-binance's
+        ``binance/ws/threaded_stream.py``. A real ``KeyError`` raised by the
+        user-data callback (which the library invokes *inside* ``start_listener``
+        via ``callback(msg)``) has frames *below* ``start_listener`` and so is
+        NOT matched — checking only the deepest frame (plus the module path)
+        keeps a genuine live-trading failure from being silently swallowed.
+        """
+        if not isinstance(exc, KeyError):
+            return False
+        tb = exc.__traceback__
+        if tb is None:
+            return False
+        while tb.tb_next is not None:
+            tb = tb.tb_next  # Walk to the deepest (raise-site) frame.
+        code = tb.tb_frame.f_code
+        # Separator-agnostic path anchor (POSIX '/' and Windows '\\' both keep
+        # the 'binance' and 'threaded_stream.py' substrings intact).
+        filename = code.co_filename
+        return (
+            code.co_name == "start_listener"
+            and filename.endswith("threaded_stream.py")
+            and "binance" in filename
+        )
+
+    @staticmethod
+    def _keyerror_path(exc: BaseException | None) -> str:
+        """Best-effort socket path from a KeyError for diagnostic logging."""
+        if isinstance(exc, KeyError) and exc.args:
+            return str(exc.args[0])
+        return "unknown"
 
     def _socket_on_twm_loop(self, start_fn: Callable[[], Any]) -> Any:
         """Invoke a TWM ``start_*_socket`` call with the manager's own loop installed

--- a/tests/unit/test_binance_provider_websocket.py
+++ b/tests/unit/test_binance_provider_websocket.py
@@ -1,6 +1,8 @@
 """Tests for BinanceProvider WebSocket stream management."""
 
-import threading
+import asyncio
+import gc
+import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -447,3 +449,299 @@ class TestOnStreamDisconnect:
         provider._on_user_disconnect()
         assert provider._user_ws_state == WebSocketState.RESYNCING
         assert provider._kline_ws_state == WebSocketState.PRIMARY
+
+
+class _FakeSocket:
+    """Minimal async-context socket whose ``recv`` returns a configurable value.
+
+    A falsy return makes python-binance's ``start_listener`` hit ``continue``
+    and re-evaluate ``while self._socket_running[path]`` (the teardown raise
+    site); a truthy return makes it invoke ``callback(msg)``.
+    """
+
+    def __init__(self, recv_value=None):
+        self._recv_value = recv_value
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def recv(self):
+        return self._recv_value
+
+
+def _capture_real_teardown_keyerror() -> KeyError:
+    """Return the *genuine* python-binance teardown ``KeyError``.
+
+    Drives the real ``ThreadedApiManager.start_listener`` through the
+    ``stop_socket`` race so the captured exception has the true
+    ``threaded_stream.py`` ``start_listener`` raise-site frame — exercising the
+    provider's module-path anchor rather than a faked frame.
+    """
+    from binance.ws.threaded_stream import ThreadedApiManager
+
+    captured: dict[str, KeyError] = {}
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(lambda _loop, ctx: captured.__setitem__("exc", ctx["exception"]))
+        mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+        mgr._socket_running = {"margin_subscription:0": True}
+        mgr._log = logging.getLogger("test.binance")
+        task = asyncio.create_task(
+            mgr.start_listener(
+                _FakeSocket(recv_value=None), "margin_subscription:0", lambda m: None
+            )
+        )
+        await asyncio.sleep(0)
+        del mgr._socket_running["margin_subscription:0"]
+        await asyncio.sleep(0.05)
+        del task
+        gc.collect()
+        await asyncio.sleep(0.05)
+
+    asyncio.run(scenario())
+    exc = captured.get("exc")
+    assert isinstance(exc, KeyError), "expected a real teardown KeyError"
+    return exc
+
+
+def _capture_real_callback_keyerror() -> KeyError:
+    """Return a real ``KeyError`` raised by the user callback inside ``start_listener``.
+
+    python-binance invokes ``callback(msg)`` *inside* ``start_listener``, so a
+    callback failure's traceback passes *through* ``start_listener`` but its
+    deepest frame is the callback — the exact false-positive the discriminator
+    must NOT suppress.
+    """
+    from binance.ws.threaded_stream import ThreadedApiManager
+
+    captured: dict[str, KeyError] = {}
+
+    def bad_callback(_msg) -> None:
+        raise KeyError("orderId")  # a genuine downstream lookup failure
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(lambda _loop, ctx: captured.__setitem__("exc", ctx["exception"]))
+        mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+        mgr._socket_running = {"margin_subscription:0": True}
+        mgr._log = logging.getLogger("test.binance")
+        task = asyncio.create_task(
+            mgr.start_listener(
+                _FakeSocket(recv_value={"e": "executionReport"}),
+                "margin_subscription:0",
+                bad_callback,
+            )
+        )
+        await asyncio.sleep(0.05)
+        del task
+        gc.collect()
+        await asyncio.sleep(0.05)
+
+    asyncio.run(scenario())
+    exc = captured.get("exc")
+    assert isinstance(exc, KeyError), "expected a real callback KeyError"
+    return exc
+
+
+class TestTwmLoopExceptionHandler:
+    """Tests for the TWM loop exception handler that suppresses the benign
+    python-binance socket-teardown ``KeyError`` on circuit-open (#716)."""
+
+    @pytest.mark.fast
+    def test_detects_real_teardown_keyerror(self, provider):
+        """The genuine library teardown KeyError is classified as teardown noise."""
+        exc = _capture_real_teardown_keyerror()
+        assert provider._is_socket_teardown_keyerror(exc) is True
+
+    @pytest.mark.fast
+    def test_ignores_callback_keyerror_through_start_listener(self, provider):
+        """A callback KeyError (deepest frame is the callback) is NOT suppressed.
+
+        This is the live-trading safety case: python-binance runs our callback
+        inside ``start_listener``, so a real downstream KeyError's traceback
+        passes through ``start_listener`` — but it must still reach the default
+        handler (ERROR), not be hidden at DEBUG.
+        """
+        exc = _capture_real_callback_keyerror()
+        assert provider._is_socket_teardown_keyerror(exc) is False
+
+    @pytest.mark.fast
+    def test_ignores_non_keyerror(self, provider):
+        """A non-KeyError loop exception is never classified as teardown noise."""
+        assert provider._is_socket_teardown_keyerror(ValueError("x")) is False
+        assert provider._is_socket_teardown_keyerror(None) is False
+
+    @pytest.mark.fast
+    def test_ignores_keyerror_without_traceback(self, provider):
+        """A bare KeyError (no traceback) cannot be the teardown signature."""
+        assert provider._is_socket_teardown_keyerror(KeyError("margin_subscription:0")) is False
+
+    @pytest.mark.fast
+    def test_handler_suppresses_teardown_keyerror(self, provider, caplog):
+        """The teardown KeyError is logged at DEBUG and not delegated to default."""
+        mock_loop = MagicMock()
+        exc = _capture_real_teardown_keyerror()
+        context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        with caplog.at_level(logging.DEBUG, logger="src.data_providers.binance_provider"):
+            provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_not_called()
+        assert any(
+            "socket-teardown KeyError" in rec.message and rec.levelno == logging.DEBUG
+            for rec in caplog.records
+        )
+
+    @pytest.mark.fast
+    def test_handler_delegates_unrelated_exception(self, provider):
+        """A non-teardown loop exception is delegated to the default handler."""
+        mock_loop = MagicMock()
+        context = {"message": "boom", "exception": ValueError("unrelated")}
+
+        provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_called_once_with(context)
+
+    @pytest.mark.fast
+    def test_handler_delegates_callback_keyerror(self, provider):
+        """A callback KeyError still reaches the default handler (stays visible)."""
+        mock_loop = MagicMock()
+        exc = _capture_real_callback_keyerror()
+        context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_called_once_with(context)
+
+    @pytest.mark.fast
+    def test_ensure_twm_installs_handler_on_loop(self, provider):
+        """_ensure_twm wires the suppression handler onto the per-manager loop."""
+        with (
+            patch("src.data_providers.binance_provider.ThreadedWebsocketManager") as mock_twm_cls,
+            patch(
+                "src.data_providers.binance_provider.get_binance_api_endpoint", return_value="com"
+            ),
+        ):
+            mock_twm_cls.return_value = MagicMock()
+            provider._ensure_twm()
+
+        assert provider._twm_loop is not None
+        # Bound methods are recreated per access, so compare by underlying
+        # function + instance rather than identity.
+        installed = provider._twm_loop.get_exception_handler()
+        assert installed.__func__ is BinanceProvider._twm_loop_exception_handler
+        assert installed.__self__ is provider
+        provider._twm_loop.close()
+
+
+class TestCircuitOpenTeardownNoUncaughtKeyError:
+    """End-to-end reproduction of the #716 circuit-open teardown race against the
+    REAL python-binance ``start_listener`` coroutine — asserts the resulting
+    KeyError surfaces no uncaught exception once the provider handler is wired."""
+
+    @pytest.mark.fast
+    def test_real_library_teardown_keyerror_is_suppressed(self, provider):
+        """Drive python-binance start_listener through the stop_socket race.
+
+        Reproduces the exact prod signature: ``stop_user_stream`` flips
+        ``_socket_running[path]`` to False, the library deletes the key on exit,
+        and the listener loop re-reads it → ``KeyError('margin_subscription:0')``
+        on the TWM loop. With the provider's exception handler installed, the
+        error is intercepted (DEBUG) and nothing reaches the loop's default
+        handler, so no ``Task exception was never retrieved`` ERROR is emitted.
+
+        The default-handler spy is bound to the *concrete* running loop
+        instance (not the abstract base), since that is what asyncio actually
+        invokes — patching ``AbstractEventLoop`` would not observe the call.
+        """
+        pytest.importorskip("binance.ws.threaded_stream")
+        from binance.ws.threaded_stream import ThreadedApiManager
+
+        delegated: list[dict] = []
+
+        async def scenario() -> None:
+            loop = asyncio.get_running_loop()
+            loop.set_exception_handler(provider._twm_loop_exception_handler)
+            # Spy on the CONCRETE loop's default handler — this is the real call
+            # target when the provider handler delegates.
+            real_default = loop.default_exception_handler
+
+            def spy_default(context):
+                delegated.append(context)
+                return real_default(context)
+
+            with patch.object(loop, "default_exception_handler", spy_default):
+                mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+                mgr._socket_running = {"margin_subscription:0": True}
+                mgr._log = logging.getLogger("test.binance")
+
+                task = asyncio.create_task(
+                    mgr.start_listener(
+                        _FakeSocket(recv_value=None), "margin_subscription:0", lambda m: None
+                    )
+                )
+                await asyncio.sleep(0)  # enter the read loop once
+                # Simulate stop_socket(key) + the library's `del` on the racing exit.
+                del mgr._socket_running["margin_subscription:0"]
+                await asyncio.sleep(0.05)
+                del task  # drop ref → exception reported as "never retrieved"
+                gc.collect()
+                await asyncio.sleep(0.05)
+
+        asyncio.run(scenario())
+
+        # The benign teardown KeyError must NOT have reached the default handler
+        # (which is what logs the ERROR + Traceback that trips monitoring).
+        assert delegated == []
+
+    @pytest.mark.fast
+    def test_real_library_callback_keyerror_is_not_suppressed(self, provider):
+        """A real callback KeyError DOES reach the loop default handler.
+
+        Guards the live-trading safety property: if our user-data callback
+        raises a genuine ``KeyError`` while python-binance runs it inside
+        ``start_listener``, the provider handler must delegate it to the default
+        handler (ERROR + Traceback) instead of hiding it at DEBUG.
+        """
+        pytest.importorskip("binance.ws.threaded_stream")
+        from binance.ws.threaded_stream import ThreadedApiManager
+
+        delegated: list[dict] = []
+
+        def bad_callback(_msg) -> None:
+            raise KeyError("orderId")
+
+        async def scenario() -> None:
+            loop = asyncio.get_running_loop()
+            loop.set_exception_handler(provider._twm_loop_exception_handler)
+
+            def spy_default(context):
+                # Record the delegation and swallow so the genuine traceback
+                # doesn't spam test output; we only assert delegation happened.
+                delegated.append(context)
+
+            with patch.object(loop, "default_exception_handler", spy_default):
+                mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+                mgr._socket_running = {"margin_subscription:0": True}
+                mgr._log = logging.getLogger("test.binance")
+
+                task = asyncio.create_task(
+                    mgr.start_listener(
+                        _FakeSocket(recv_value={"e": "executionReport"}),
+                        "margin_subscription:0",
+                        bad_callback,
+                    )
+                )
+                await asyncio.sleep(0.05)
+                del task
+                gc.collect()
+                await asyncio.sleep(0.05)
+
+        asyncio.run(scenario())
+
+        assert len(delegated) == 1
+        assert isinstance(delegated[0].get("exception"), KeyError)


### PR DESCRIPTION
## Summary

Fixes #716. On margin user-data-stream circuit-open (the `REST_DEGRADED` fallback, #616), the margin WS listener task died with an uncaught `KeyError('margin_subscription:0')`, logged 3× as `[ERRO] Task exception was never retrieved`. It is benign teardown noise (the socket is intentionally being torn down; REST fallback keeps positions protected) but it spams ERROR/Traceback and trips monitoring that greps `Traceback` / `Task exception`.

## Root cause

`stop_user_stream()` calls python-binance `ThreadedWebsocketManager.stop_socket(key)`, which sets `self._socket_running[path] = False`. The library's `start_listener` coroutine (an asyncio task on the provider's private TWM event loop) loops on `while self._socket_running[path]:` and `del`s that key on exit. A teardown-ordering race re-evaluates the `while self._socket_running[path]` subscript **after** the key is deleted, raising an uncaught `KeyError(path)` inside the task. Because the exception fires inside the library task on the TWM loop, a `try/except` around our `stop_socket` call cannot reach it — asyncio's default loop exception handler logs it as `Task exception was never retrieved`.

## Fix

Install a per-loop exception handler on the provider's TWM event loop (in `_ensure_twm`) that:
- Downgrades to **DEBUG** *only* this specific library teardown `KeyError`, identified by its **deepest (raise-site) traceback frame** being `start_listener` in python-binance's `threaded_stream.py`.
- Delegates **every other** loop exception to asyncio's default handler — including a genuine `KeyError` raised by our user-data callback, which python-binance invokes *inside* `start_listener` (deepest frame = the callback, not `start_listener`) — so real live-trading failures keep their normal ERROR + Traceback visibility.

This is the only viable interception point (the exception is raised inside the library task on the loop), it is scoped to the provider's own loop, and it is not a broad `except`.

## User-facing impact

- No more `KeyError('margin_subscription:0')` / `Task exception was never retrieved` ERROR + Traceback on circuit-open — removes the false-positive that trips `Traceback`-grepping monitors (LESSONS §5.2).
- Circuit-breaker + REST-fallback behavior is otherwise unchanged; position protection (OrderTracker polling + periodic reconciler) is unaffected.

## Testing

- New tests drive the **real** python-binance `start_listener` through:
  - the teardown race → asserts the `KeyError` is suppressed and nothing reaches the concrete loop's default handler;
  - a callback `KeyError` → asserts it **is** delegated to the default handler (live-trading safety: real errors must not be hidden).
- Unit coverage for the discriminator (`_is_socket_teardown_keyerror`): genuine teardown KeyError, callback KeyError through `start_listener`, non-KeyError, and bare KeyError without traceback.
- `tests/unit/test_binance_provider_websocket.py`: **42 passed**.
- Related suite (engine WS health/websocket, ws-filter, provider): **173 passed**.
- Full fast unit suite: **1125 passed**.
- `black` + `ruff` clean on changed files. `mypy`: no new errors (40 pre-existing `union-attr` errors in this file are unrelated to this change).
- Reviewed via OpenAI Codex (gpt-5.5) — **APPROVE** after one iteration (tightened the discriminator to the deepest frame + module-path anchor, and fixed the test default-handler spy to target the concrete loop).

Refs #616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)