### PR TITLE
promote(prod): #716 + #717 user-data WebSocket reliability (surgical)

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -371,8 +371,14 @@ DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_D
 # before the watchdog opens a circuit breaker: stop the futile ~2-min reconnect loop
 # and run REST-polling-only. python-binance's start_margin_socket is fire-and-forget
 # and reports success even on a dead multiplexed ws_api socket, so reconnects never
-# self-terminate and churn forever (#616).
+# self-terminate and churn forever (#616). This is also the fast-phase boundary for
+# the self-healing user-stream probe (#717): below it, probe every health cycle.
 DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT = 3
+# User-stream self-heal throttle (#717): once past the circuit limit, attempt a user
+# reconnect only every Nth health cycle (≈ N × DEFAULT_WS_HEALTH_CHECK_INTERVAL ≈ 5 min)
+# so a persistently dead socket doesn't busy-loop — but never stop, so a return to
+# WS-primary is always possible. Bounds the #716 teardown noise to ~1 cycle per probe.
+DEFAULT_WS_USER_DEGRADED_PROBE_EVERY = 10
 # Kline watchdog (#662): a *recovering* REST fallback, unlike the user-stream
 # breaker above. After this many consecutive unproductive kline reconnects
 # (socket re-opened but no real event confirms it — ws_healthy requires

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -2077,9 +2077,85 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             # loop has no run_until_complete nesting, so it does NOT reintroduce the
             # "cannot enter context" re-entrancy spam that #646 fixed.
             self._twm_loop = asyncio.new_event_loop()
+            # Intercept the benign teardown KeyError raised inside python-binance's
+            # start_listener task on socket stop (#716). The exception fires inside the
+            # library coroutine on THIS loop, so a try/except around stop_socket can't
+            # reach it — only the loop's own exception handler can.
+            self._twm_loop.set_exception_handler(self._twm_loop_exception_handler)
             twm_kwargs["loop"] = self._twm_loop
             self._twm = ThreadedWebsocketManager(**twm_kwargs)
             self._twm.start()
+
+    def _twm_loop_exception_handler(
+        self, loop: asyncio.AbstractEventLoop, context: dict[str, Any]
+    ) -> None:
+        """Suppress python-binance's benign socket-teardown ``KeyError`` (#716).
+
+        When a user/kline socket is stopped, ``stop_socket`` flips
+        ``self._socket_running[path]`` to ``False`` and the library's
+        ``start_listener`` coroutine then ``del``s that key on exit. A race in
+        the library re-evaluates ``while self._socket_running[path]`` after the
+        key is gone, raising ``KeyError(path)`` inside the listener task. The
+        socket is being torn down on purpose (e.g. the #616 circuit-open drop to
+        REST polling), so this is teardown noise — but it surfaces as
+        ``Task exception was never retrieved`` (3× per circuit-open) and trips
+        monitoring that greps ``Traceback``.
+
+        The exception is raised inside the library task on this loop, so it is
+        unreachable from a ``try/except`` around our ``stop_socket`` call; the
+        loop's exception handler is the only interception point. Only the
+        specific library teardown ``KeyError`` (one raised by the
+        ``while self._socket_running[path]`` subscript in python-binance's
+        ``threaded_stream.start_listener``) is downgraded to DEBUG — every other
+        loop exception, including a real ``KeyError`` raised by our user-data
+        callback that python-binance invokes *inside* ``start_listener``, is
+        delegated to asyncio's default handler so genuine errors keep their
+        normal ERROR visibility.
+        """
+        if self._is_socket_teardown_keyerror(context.get("exception")):
+            logger.debug(
+                "Suppressed python-binance socket-teardown KeyError(%s) on stop (#716)",
+                self._keyerror_path(context.get("exception")),
+            )
+            return
+        loop.default_exception_handler(context)
+
+    @staticmethod
+    def _is_socket_teardown_keyerror(exc: BaseException | None) -> bool:
+        """True iff ``exc`` is the library's ``start_listener`` teardown KeyError.
+
+        The teardown ``KeyError`` is raised directly by the
+        ``while self._socket_running[path]`` subscript, so its *deepest*
+        traceback frame is ``start_listener`` in python-binance's
+        ``binance/ws/threaded_stream.py``. A real ``KeyError`` raised by the
+        user-data callback (which the library invokes *inside* ``start_listener``
+        via ``callback(msg)``) has frames *below* ``start_listener`` and so is
+        NOT matched — checking only the deepest frame (plus the module path)
+        keeps a genuine live-trading failure from being silently swallowed.
+        """
+        if not isinstance(exc, KeyError):
+            return False
+        tb = exc.__traceback__
+        if tb is None:
+            return False
+        while tb.tb_next is not None:
+            tb = tb.tb_next  # Walk to the deepest (raise-site) frame.
+        code = tb.tb_frame.f_code
+        # Separator-agnostic path anchor (POSIX '/' and Windows '\\' both keep
+        # the 'binance' and 'threaded_stream.py' substrings intact).
+        filename = code.co_filename
+        return (
+            code.co_name == "start_listener"
+            and filename.endswith("threaded_stream.py")
+            and "binance" in filename
+        )
+
+    @staticmethod
+    def _keyerror_path(exc: BaseException | None) -> str:
+        """Best-effort socket path from a KeyError for diagnostic logging."""
+        if isinstance(exc, KeyError) and exc.args:
+            return str(exc.args[0])
+        return "unknown"
 
     def _socket_on_twm_loop(self, start_fn: Callable[[], Any]) -> Any:
         """Invoke a TWM ``start_*_socket`` call with the manager's own loop installed

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -307,6 +307,25 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         self._last_user_event_time = datetime.now(UTC)
         self._kline_event_received = False  # True after first kline WS event
         self._user_event_received = False  # True after first user WS event
+        # Monotonic token identifying the current user-socket "generation" (#717).
+        # Bumped before every teardown (stop_user_stream / stop_streams) and on
+        # each (re)start; the user callback captures the generation live at start
+        # and drops any event whose generation no longer matches. This defeats the
+        # stale-callback false-recovery race: a python-binance read_ready callback
+        # from a torn-down socket can still fire on the shared TWM loop after we
+        # opened the circuit, and without this guard it would set
+        # _user_event_received=True and trick the watchdog into "recovering".
+        self._user_stream_generation = 0
+        # Serialises the generation check-and-record in _user_callback (TWM loop
+        # thread) against the generation bump + _user_event_received reset in
+        # start/stop (WS health-monitor thread). Without it the generation guard is
+        # check-then-act: a stale callback could pass the check, be preempted by a
+        # teardown+restart, then write _user_event_received=True under the NEW
+        # generation — a false recovery that disables REST polling on a possibly
+        # dead socket (a TOCTOU blackout). The lock makes that compound update
+        # atomic (#717). Held only around the flag mutations, never around the
+        # downstream on_user_event forwarding or the socket start/stop loop calls.
+        self._user_stream_lock = threading.Lock()
 
     @staticmethod
     def _validate_credentials(
@@ -2240,14 +2259,40 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             self._ensure_twm()
             self._on_user_event_cb = on_user_event
 
+            # New generation: this start invalidates any in-flight callback from a
+            # prior (torn-down) socket. Capture it in the closure so this callback
+            # only counts while it remains the current generation (#717). The bump,
+            # the capture, and the _user_event_received reset (Defense A — clear the
+            # stale "healthy" flag until the first real event of THIS generation;
+            # mirrors kline at ~line 2217) are done together under the lock so a
+            # concurrent stale callback cannot interleave between them.
+            with self._user_stream_lock:
+                self._user_stream_generation += 1
+                generation = self._user_stream_generation
+                self._user_event_received = False
+
             def _user_callback(msg: dict) -> None:
                 """Route user data events, handling errors before user callback."""
-                if msg.get("e") == "error":
+                is_error = msg.get("e") == "error"
+                # Drop events from a superseded socket, and record freshness/the
+                # event flag, atomically w.r.t. the generation bump in start/stop. A
+                # python-binance read_ready callback can still fire on the shared TWM
+                # loop after stop_socket; without the lock the check-then-write could
+                # land _user_event_received=True under a newer generation and fake a
+                # recovery the watchdog acts on (#717).
+                with self._user_stream_lock:
+                    if generation != self._user_stream_generation:
+                        return
+                    if is_error:
+                        self._on_user_disconnect()
+                    else:
+                        self._last_user_event_time = datetime.now(UTC)
+                        self._user_event_received = True
+                # Forwarding + logging happen outside the lock (CODE.md: no callbacks
+                # or long-running work under a lock).
+                if is_error:
                     logger.error("User data WS error: %s", msg.get("m", "unknown"))
-                    self._on_user_disconnect()
                     return
-                self._last_user_event_time = datetime.now(UTC)
-                self._user_event_received = True
                 on_user_event(msg)
 
             if self._use_margin:
@@ -2267,6 +2312,12 @@ class BinanceProvider(DataProvider, ExchangeInterface):
 
     def stop_user_stream(self) -> None:
         """Stop only the user data WebSocket stream."""
+        # Invalidate the current generation FIRST (under the lock, atomically with
+        # clearing the event flag) so any callback still draining on the TWM loop
+        # during teardown is dropped and can't fake a recovery (#717).
+        with self._user_stream_lock:
+            self._user_stream_generation += 1
+            self._user_event_received = False
         if self._user_socket_key and self._twm:
             try:
                 self._twm.stop_socket(self._user_socket_key)
@@ -2274,10 +2325,15 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 logger.error("Failed to stop user socket: %s", e)
             self._user_socket_key = None
             self._user_ws_state = WebSocketState.DISCONNECTED
-            self._user_event_received = False
 
     def stop_streams(self) -> None:
         """Stop all WebSocket streams. Recreates TWM on reconnect."""
+        # Invalidate the current user generation FIRST (before teardown), atomically
+        # with clearing the event flag under the lock, so a callback still draining
+        # on the TWM loop is dropped and can't fake a recovery during shutdown (#717).
+        with self._user_stream_lock:
+            self._user_stream_generation += 1
+            self._user_event_received = False
         if self._twm:
             twm, loop = self._twm, self._twm_loop
             twm.stop()
@@ -2297,7 +2353,9 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             self._kline_ws_state = WebSocketState.DISCONNECTED
             self._user_ws_state = WebSocketState.DISCONNECTED
             self._kline_event_received = False
-            self._user_event_received = False
+            # _user_event_received is cleared above under _user_stream_lock (atomic
+            # with the generation bump); not repeated here to keep a single locked
+            # writer of that flag (#717).
 
     @property
     def ws_state(self) -> WebSocketState:

--- a/src/engines/live/order_tracker.py
+++ b/src/engines/live/order_tracker.py
@@ -239,7 +239,9 @@ class OrderTracker:
                             )
                             if self.on_cancel:
                                 try:
-                                    self.on_cancel(order_id, tracked.symbol, tracked.last_filled_qty)
+                                    self.on_cancel(
+                                        order_id, tracked.symbol, tracked.last_filled_qty
+                                    )
                                 except Exception as cb_err:
                                     logger.error(
                                         "Cancel callback failed for force-removed order %s: %s",
@@ -554,7 +556,9 @@ class OrderTracker:
                 fill_delta = actual_filled - tracked.last_filled_qty
                 logger.warning(
                     "Order %s: reconciling missed fill delta %.8f before %s",
-                    order_id, fill_delta, status.value,
+                    order_id,
+                    fill_delta,
+                    status.value,
                 )
                 if self.on_partial_fill:
                     try:
@@ -706,6 +710,18 @@ class OrderTracker:
     def poll_once(self) -> None:
         """Execute a single poll cycle. Used during WS to REST transitions."""
         self._check_orders()
+
+    def is_polling_enabled(self) -> bool:
+        """Return whether REST polling is currently active.
+
+        This is the source of truth for "is the user stream serving as the
+        primary order-event path or are we on the REST fallback". The trading
+        engine gates user-stream recovery on this (not on the provider's
+        ``_user_ws_state``, which flips to PRIMARY before the first real event
+        confirms the socket is delivering) so a no-event probe can't blackout
+        order tracking (#717).
+        """
+        return self._polling_enabled
 
     def disable_polling(self) -> None:
         """Disable REST polling. Used when WebSocket is active."""

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1624,14 +1624,21 @@ class LiveTradingEngine:
                 )
                 if user_started:
                     self._user_data_processor.start()
-                    if self.order_tracker:
-                        self.order_tracker.disable_polling()
-                    # Catch-up: reconcile to detect any events missed during handoff
+                    # Catch-up: reconcile to detect any events missed during handoff.
                     if self.order_tracker:
                         self.order_tracker.poll_once()
                     if self._periodic_reconciler:
                         self._periodic_reconciler.reconcile_once()
-                    logger.info("User data WebSocket stream active — order polling disabled")
+                    # Polling stays ON until the FIRST real user event confirms the
+                    # socket is delivering. start_margin_socket is fire-and-forget and
+                    # returns True even on a dead multiplexed ws_api socket, so disabling
+                    # polling here would blackout order tracking on a never-delivering
+                    # stream. _restore_user_ws_primary (the single disable site) flips it
+                    # off once user_ws_healthy goes True on a health cycle (#717).
+                    logger.info(
+                        "User data WebSocket stream started — REST polling stays on "
+                        "until the first event confirms delivery (#717)"
+                    )
             except Exception as e:
                 logger.warning("Failed to start user data WebSocket stream: %s", e)
 
@@ -1815,30 +1822,78 @@ class LiveTradingEngine:
         return failures % DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY == 0
 
     def _check_user_stream_health(self) -> None:
-        """Check user data stream health and reconnect if needed."""
+        """User-stream health with a *recovering* REST fallback (#717).
+
+        Mirrors the kline self-heal (#662): the engine falls back to REST order
+        polling whenever the user/margin stream is down, but the instant a real
+        user event resumes (``user_ws_healthy`` requires ``_user_event_received``)
+        it returns to WS-primary and resets the breaker — so it can never get
+        stuck on REST until restart, the absorbing-state bug of the original #616
+        circuit breaker.
+
+        Unlike kline, "WS-primary" here is not a per-cycle data-fetch choice: order
+        events are pushed into the UserDataProcessor and the fallback is the
+        OrderTracker REST poll loop, so WS-primary == ``order_tracker`` polling
+        disabled. Recovery therefore rebuilds the processor + reconciles (in
+        ``_handle_user_stream_disconnect``) and ``disable_polling`` is flipped only
+        by ``_restore_user_ws_primary``, gated on a confirmed real event.
+
+        Runs only on the WS health-monitor thread (the single writer of
+        ``_user_reconnect_failures``), matching the lock-free convention; main-loop
+        reads of the polling flag are GIL-atomic.
+        """
         if not self.enable_live_trading or not self.exchange_interface:
             return
         exchange = self.exchange_interface
-        # Check for RESYNCING state (set by error callback) — needs recovery
+        # Idleness is normal: with nothing tracked there is no staleness signal to
+        # act on, no fills to miss, and no reason to churn the socket (which would
+        # generate needless #716 teardown noise). REST polling, if on, keeps
+        # backstopping order/balance state. The breaker only ever accumulates past
+        # this gate, so it cannot be non-zero while idle. Gate first (#717).
+        if not self.order_tracker or self.order_tracker.get_tracked_count() == 0:
+            return
+
+        # Recovery: a real user event arrived (user_ws_healthy requires
+        # _user_event_received of the current generation), so the stream is
+        # delivering — return to WS-primary and reset the breaker. Checked before
+        # the state gate below so it also recovers from REST_DEGRADED, not just
+        # PRIMARY. This is the self-heal #616 lacked (#717).
+        if getattr(exchange, "user_ws_healthy", False):
+            self._restore_user_ws_primary()
+            self._user_reconnect_failures = 0
+            return
+
+        # RESYNCING (set by the error callback) needs an immediate recovery cycle.
         if getattr(exchange, "_user_ws_state", None) == WebSocketState.RESYNCING:
             logger.warning("User data stream in RESYNCING state — triggering recovery")
             self._handle_user_stream_disconnect()
             return
-        if getattr(exchange, "_user_ws_state", None) != WebSocketState.PRIMARY:
-            return
-        if not self.order_tracker or self.order_tracker.get_tracked_count() == 0:
-            return
-
-        # A genuinely healthy stream (a real user event arrived since the last
-        # reconnect — user_ws_healthy requires _user_event_received) clears the
-        # reconnect circuit breaker.
-        if getattr(exchange, "user_ws_healthy", False):
-            self._user_reconnect_failures = 0
 
         from src.config.constants import (
             DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
             DEFAULT_WS_USER_STALENESS_THRESHOLD,
         )
+
+        # REST_DEGRADED: the circuit is open and we are on REST polling. THE FIX —
+        # instead of staying absorbed here until restart (#616), keep probing the
+        # WS on a throttle so a recovered network path can return us to WS-primary.
+        # The probe re-enters _handle_user_stream_disconnect (re-stop + reconnect);
+        # the recovery branch above promotes us back the moment a real event lands.
+        if getattr(exchange, "_user_ws_state", None) == WebSocketState.REST_DEGRADED:
+            self._user_reconnect_failures += 1
+            if not self._should_probe_user_reconnect(self._user_reconnect_failures):
+                return
+            logger.warning(
+                "User data stream degraded — probing WS reconnect (failure #%d, #717)",
+                self._user_reconnect_failures,
+            )
+            self._handle_user_stream_disconnect()
+            return
+
+        # From here we require PRIMARY: anything else (DISCONNECTED/SUSPENDED) is
+        # not a state this watchdog drives.
+        if getattr(exchange, "_user_ws_state", None) != WebSocketState.PRIMARY:
+            return
 
         last_event = getattr(exchange, "_last_user_event_time", None)
         if not last_event:
@@ -1852,29 +1907,27 @@ class LiveTradingEngine:
         # fire-and-forget and reports success even on a dead multiplexed ws_api
         # socket, so reconnect_user returns True and this watchdog would otherwise
         # reconnect every ~2 min forever (spewing asyncio re-entrancy errors).
-        # After a few unproductive reconnects, open the circuit: stop reconnecting
-        # and run REST-polling-only, which the engine already falls back to
-        # (OrderTracker polls every 10s; the periodic reconciler backstops at 120s).
-        # mark_user_degraded() sets REST_DEGRADED, so the != PRIMARY guard above
-        # then short-circuits this check — the warning below logs exactly once (#616).
+        # After a few unproductive reconnects, open the circuit: tear down the dead
+        # socket, mark REST_DEGRADED, and run REST-polling-only. Unlike #616, the
+        # REST_DEGRADED branch above now keeps throttled-probing, so this is the
+        # fast-phase boundary, not a terminal state (#717).
         if self._user_reconnect_failures >= DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT:
             logger.warning(
                 "User data stream did not recover after %d reconnects — circuit open, "
-                "staying on REST polling until the next restart (#616).",
+                "falling back to REST polling and throttled-probing the WS (#717).",
                 self._user_reconnect_failures,
             )
-            # Tear down the dead user socket so its asyncio _read_ready callback stops
-            # firing on the shared event loop. Marking degraded alone stops reconnects
-            # but leaves the orphaned socket attached, which keeps spewing
-            # "cannot enter context" errors (~2,100/hr) indefinitely. stop_user_stream
-            # closes only the user socket (not kline), correct here since we are
-            # dropping to REST polling (#616).
+            # Tear down the dead user socket BEFORE marking degraded so the terminal
+            # state is REST_DEGRADED, not DISCONNECTED (stop_user_stream sets
+            # DISCONNECTED). Order matters: a DISCONNECTED terminal state would make
+            # the REST_DEGRADED probe branch unreachable. stop_user_stream also halts
+            # the dead socket's asyncio _read_ready spam (~2,100/hr) and bumps the
+            # generation so any in-flight stale callback is dropped (#616/#717).
             if hasattr(exchange, "stop_user_stream"):
                 exchange.stop_user_stream()
             if hasattr(exchange, "mark_user_degraded"):
                 exchange.mark_user_degraded()
-            if self.order_tracker:
-                self.order_tracker.enable_polling()
+            self.order_tracker.enable_polling()
             return
 
         self._user_reconnect_failures += 1
@@ -1885,6 +1938,51 @@ class LiveTradingEngine:
             DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
         )
         self._handle_user_stream_disconnect()
+
+    def _should_probe_user_reconnect(self, failures: int) -> bool:
+        """Whether to probe a user-stream WS reconnect on this degraded cycle (#717).
+
+        Structurally identical to the kline predicate: fast phase (``failures`` <=
+        the circuit limit) probes every cycle; past it, probe only every Nth cycle
+        so a persistently dead socket doesn't busy-loop on socket churn + the #716
+        teardown noise. NEVER permanently False — past the limit it still returns
+        True at every multiple of ``DEFAULT_WS_USER_DEGRADED_PROBE_EVERY``, so the
+        WS always retains a path back to primary. Recovery itself is independent of
+        this predicate (the ``user_ws_healthy`` branch promotes the instant a real
+        event resumes, even on a throttled non-probing cycle).
+        """
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY,
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
+        )
+
+        if failures <= DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT:
+            return True
+        return failures % DEFAULT_WS_USER_DEGRADED_PROBE_EVERY == 0
+
+    def _restore_user_ws_primary(self) -> None:
+        """Return the user stream to WS-primary: disable REST polling once a real
+        event confirms delivery (#717).
+
+        This is the SINGLE site that disables user-stream order polling, for both
+        fresh boot and post-degradation recovery. It is gated on
+        ``order_tracker.is_polling_enabled()`` — NOT on ``_user_ws_state``, which
+        flips to PRIMARY in ``start_user_stream`` *before* the first real event, so
+        gating on it would disable polling on a never-delivering socket (the
+        blackout this fix prevents). When polling is already off (steady state) this
+        is a no-op, so it does not spam a "recovered" log every health cycle.
+        """
+        if not self.order_tracker or not self.order_tracker.is_polling_enabled():
+            return
+        # A real user event arrived while polling was still on — the WS is now the
+        # primary order-event path. poll_once first closes any gap between the last
+        # poll and the handoff so no fill is missed.
+        self.order_tracker.poll_once()
+        self.order_tracker.disable_polling()
+        logger.info(
+            "User data WebSocket recovered — real event confirmed, REST polling "
+            "disabled, WS primary again (#717)"
+        )
 
     def _handle_kline_disconnect(self) -> None:
         """Resync kline history from REST and attempt one WS reconnect.
@@ -1963,17 +2061,18 @@ class LiveTradingEngine:
                     self._user_data_processor.start()
                     reconnected = True
                     logger.info("User data WebSocket reconnected")
-                    # Post-reconnect catch-up: reconcile events from the handoff
-                    # gap before disabling polling, so nothing is lost. A catch-up
-                    # failure leaves REST polling on as a safe fallback rather than
-                    # undoing the reconnect.
+                    # Post-reconnect catch-up: reconcile events from the handoff gap
+                    # so nothing is lost. Polling deliberately stays ON — a reconnect
+                    # only re-OPENS the socket; reconnect_user/start_margin_socket is
+                    # fire-and-forget and may return success on a dead socket. Only a
+                    # real event (user_ws_healthy) on a later health cycle restores
+                    # WS-primary via _restore_user_ws_primary, the single disable site.
+                    # This closes the post-reconnect blackout window (#717).
                     try:
                         if self.order_tracker:
                             self.order_tracker.poll_once()
                         if self._periodic_reconciler:
                             self._periodic_reconciler.reconcile_once()
-                        if self.order_tracker:
-                            self.order_tracker.disable_polling()
                     except Exception as e:
                         logger.error(
                             "Post-reconnect catch-up failed (staying on REST polling): %s", e

--- a/tests/unit/live/test_order_tracker_websocket.py
+++ b/tests/unit/live/test_order_tracker_websocket.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from src.data_providers.exchange_interface import OrderSide, OrderStatus, OrderType
+from src.data_providers.exchange_interface import OrderStatus, OrderType
 from src.engines.live.event_deduplicator import EventDeduplicator
 from src.engines.live.order_tracker import OrderTracker
 
@@ -281,6 +281,16 @@ class TestPollingControl:
 
         tracker.enable_polling()
         assert tracker._polling_enabled is True
+
+    def test_is_polling_enabled_reflects_state(self, tracker):
+        """is_polling_enabled() reports the live polling flag — the engine gates
+        user-stream WS-primary recovery on it, not on the provider's WS state (#717)."""
+        # Default: polling on.
+        assert tracker.is_polling_enabled() is True
+        tracker.disable_polling()
+        assert tracker.is_polling_enabled() is False
+        tracker.enable_polling()
+        assert tracker.is_polling_enabled() is True
 
     def test_poll_loop_respects_polling_enabled_flag(self, tracker, mock_exchange):
         """Test that _poll_loop skips _check_orders when polling is disabled."""

--- a/tests/unit/test_binance_provider_websocket.py
+++ b/tests/unit/test_binance_provider_websocket.py
@@ -1,6 +1,8 @@
 """Tests for BinanceProvider WebSocket stream management."""
 
-import threading
+import asyncio
+import gc
+import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -447,3 +449,299 @@ class TestOnStreamDisconnect:
         provider._on_user_disconnect()
         assert provider._user_ws_state == WebSocketState.RESYNCING
         assert provider._kline_ws_state == WebSocketState.PRIMARY
+
+
+class _FakeSocket:
+    """Minimal async-context socket whose ``recv`` returns a configurable value.
+
+    A falsy return makes python-binance's ``start_listener`` hit ``continue``
+    and re-evaluate ``while self._socket_running[path]`` (the teardown raise
+    site); a truthy return makes it invoke ``callback(msg)``.
+    """
+
+    def __init__(self, recv_value=None):
+        self._recv_value = recv_value
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def recv(self):
+        return self._recv_value
+
+
+def _capture_real_teardown_keyerror() -> KeyError:
+    """Return the *genuine* python-binance teardown ``KeyError``.
+
+    Drives the real ``ThreadedApiManager.start_listener`` through the
+    ``stop_socket`` race so the captured exception has the true
+    ``threaded_stream.py`` ``start_listener`` raise-site frame — exercising the
+    provider's module-path anchor rather than a faked frame.
+    """
+    from binance.ws.threaded_stream import ThreadedApiManager
+
+    captured: dict[str, KeyError] = {}
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(lambda _loop, ctx: captured.__setitem__("exc", ctx["exception"]))
+        mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+        mgr._socket_running = {"margin_subscription:0": True}
+        mgr._log = logging.getLogger("test.binance")
+        task = asyncio.create_task(
+            mgr.start_listener(
+                _FakeSocket(recv_value=None), "margin_subscription:0", lambda m: None
+            )
+        )
+        await asyncio.sleep(0)
+        del mgr._socket_running["margin_subscription:0"]
+        await asyncio.sleep(0.05)
+        del task
+        gc.collect()
+        await asyncio.sleep(0.05)
+
+    asyncio.run(scenario())
+    exc = captured.get("exc")
+    assert isinstance(exc, KeyError), "expected a real teardown KeyError"
+    return exc
+
+
+def _capture_real_callback_keyerror() -> KeyError:
+    """Return a real ``KeyError`` raised by the user callback inside ``start_listener``.
+
+    python-binance invokes ``callback(msg)`` *inside* ``start_listener``, so a
+    callback failure's traceback passes *through* ``start_listener`` but its
+    deepest frame is the callback — the exact false-positive the discriminator
+    must NOT suppress.
+    """
+    from binance.ws.threaded_stream import ThreadedApiManager
+
+    captured: dict[str, KeyError] = {}
+
+    def bad_callback(_msg) -> None:
+        raise KeyError("orderId")  # a genuine downstream lookup failure
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(lambda _loop, ctx: captured.__setitem__("exc", ctx["exception"]))
+        mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+        mgr._socket_running = {"margin_subscription:0": True}
+        mgr._log = logging.getLogger("test.binance")
+        task = asyncio.create_task(
+            mgr.start_listener(
+                _FakeSocket(recv_value={"e": "executionReport"}),
+                "margin_subscription:0",
+                bad_callback,
+            )
+        )
+        await asyncio.sleep(0.05)
+        del task
+        gc.collect()
+        await asyncio.sleep(0.05)
+
+    asyncio.run(scenario())
+    exc = captured.get("exc")
+    assert isinstance(exc, KeyError), "expected a real callback KeyError"
+    return exc
+
+
+class TestTwmLoopExceptionHandler:
+    """Tests for the TWM loop exception handler that suppresses the benign
+    python-binance socket-teardown ``KeyError`` on circuit-open (#716)."""
+
+    @pytest.mark.fast
+    def test_detects_real_teardown_keyerror(self, provider):
+        """The genuine library teardown KeyError is classified as teardown noise."""
+        exc = _capture_real_teardown_keyerror()
+        assert provider._is_socket_teardown_keyerror(exc) is True
+
+    @pytest.mark.fast
+    def test_ignores_callback_keyerror_through_start_listener(self, provider):
+        """A callback KeyError (deepest frame is the callback) is NOT suppressed.
+
+        This is the live-trading safety case: python-binance runs our callback
+        inside ``start_listener``, so a real downstream KeyError's traceback
+        passes through ``start_listener`` — but it must still reach the default
+        handler (ERROR), not be hidden at DEBUG.
+        """
+        exc = _capture_real_callback_keyerror()
+        assert provider._is_socket_teardown_keyerror(exc) is False
+
+    @pytest.mark.fast
+    def test_ignores_non_keyerror(self, provider):
+        """A non-KeyError loop exception is never classified as teardown noise."""
+        assert provider._is_socket_teardown_keyerror(ValueError("x")) is False
+        assert provider._is_socket_teardown_keyerror(None) is False
+
+    @pytest.mark.fast
+    def test_ignores_keyerror_without_traceback(self, provider):
+        """A bare KeyError (no traceback) cannot be the teardown signature."""
+        assert provider._is_socket_teardown_keyerror(KeyError("margin_subscription:0")) is False
+
+    @pytest.mark.fast
+    def test_handler_suppresses_teardown_keyerror(self, provider, caplog):
+        """The teardown KeyError is logged at DEBUG and not delegated to default."""
+        mock_loop = MagicMock()
+        exc = _capture_real_teardown_keyerror()
+        context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        with caplog.at_level(logging.DEBUG, logger="src.data_providers.binance_provider"):
+            provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_not_called()
+        assert any(
+            "socket-teardown KeyError" in rec.message and rec.levelno == logging.DEBUG
+            for rec in caplog.records
+        )
+
+    @pytest.mark.fast
+    def test_handler_delegates_unrelated_exception(self, provider):
+        """A non-teardown loop exception is delegated to the default handler."""
+        mock_loop = MagicMock()
+        context = {"message": "boom", "exception": ValueError("unrelated")}
+
+        provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_called_once_with(context)
+
+    @pytest.mark.fast
+    def test_handler_delegates_callback_keyerror(self, provider):
+        """A callback KeyError still reaches the default handler (stays visible)."""
+        mock_loop = MagicMock()
+        exc = _capture_real_callback_keyerror()
+        context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_called_once_with(context)
+
+    @pytest.mark.fast
+    def test_ensure_twm_installs_handler_on_loop(self, provider):
+        """_ensure_twm wires the suppression handler onto the per-manager loop."""
+        with (
+            patch("src.data_providers.binance_provider.ThreadedWebsocketManager") as mock_twm_cls,
+            patch(
+                "src.data_providers.binance_provider.get_binance_api_endpoint", return_value="com"
+            ),
+        ):
+            mock_twm_cls.return_value = MagicMock()
+            provider._ensure_twm()
+
+        assert provider._twm_loop is not None
+        # Bound methods are recreated per access, so compare by underlying
+        # function + instance rather than identity.
+        installed = provider._twm_loop.get_exception_handler()
+        assert installed.__func__ is BinanceProvider._twm_loop_exception_handler
+        assert installed.__self__ is provider
+        provider._twm_loop.close()
+
+
+class TestCircuitOpenTeardownNoUncaughtKeyError:
+    """End-to-end reproduction of the #716 circuit-open teardown race against the
+    REAL python-binance ``start_listener`` coroutine — asserts the resulting
+    KeyError surfaces no uncaught exception once the provider handler is wired."""
+
+    @pytest.mark.fast
+    def test_real_library_teardown_keyerror_is_suppressed(self, provider):
+        """Drive python-binance start_listener through the stop_socket race.
+
+        Reproduces the exact prod signature: ``stop_user_stream`` flips
+        ``_socket_running[path]`` to False, the library deletes the key on exit,
+        and the listener loop re-reads it → ``KeyError('margin_subscription:0')``
+        on the TWM loop. With the provider's exception handler installed, the
+        error is intercepted (DEBUG) and nothing reaches the loop's default
+        handler, so no ``Task exception was never retrieved`` ERROR is emitted.
+
+        The default-handler spy is bound to the *concrete* running loop
+        instance (not the abstract base), since that is what asyncio actually
+        invokes — patching ``AbstractEventLoop`` would not observe the call.
+        """
+        pytest.importorskip("binance.ws.threaded_stream")
+        from binance.ws.threaded_stream import ThreadedApiManager
+
+        delegated: list[dict] = []
+
+        async def scenario() -> None:
+            loop = asyncio.get_running_loop()
+            loop.set_exception_handler(provider._twm_loop_exception_handler)
+            # Spy on the CONCRETE loop's default handler — this is the real call
+            # target when the provider handler delegates.
+            real_default = loop.default_exception_handler
+
+            def spy_default(context):
+                delegated.append(context)
+                return real_default(context)
+
+            with patch.object(loop, "default_exception_handler", spy_default):
+                mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+                mgr._socket_running = {"margin_subscription:0": True}
+                mgr._log = logging.getLogger("test.binance")
+
+                task = asyncio.create_task(
+                    mgr.start_listener(
+                        _FakeSocket(recv_value=None), "margin_subscription:0", lambda m: None
+                    )
+                )
+                await asyncio.sleep(0)  # enter the read loop once
+                # Simulate stop_socket(key) + the library's `del` on the racing exit.
+                del mgr._socket_running["margin_subscription:0"]
+                await asyncio.sleep(0.05)
+                del task  # drop ref → exception reported as "never retrieved"
+                gc.collect()
+                await asyncio.sleep(0.05)
+
+        asyncio.run(scenario())
+
+        # The benign teardown KeyError must NOT have reached the default handler
+        # (which is what logs the ERROR + Traceback that trips monitoring).
+        assert delegated == []
+
+    @pytest.mark.fast
+    def test_real_library_callback_keyerror_is_not_suppressed(self, provider):
+        """A real callback KeyError DOES reach the loop default handler.
+
+        Guards the live-trading safety property: if our user-data callback
+        raises a genuine ``KeyError`` while python-binance runs it inside
+        ``start_listener``, the provider handler must delegate it to the default
+        handler (ERROR + Traceback) instead of hiding it at DEBUG.
+        """
+        pytest.importorskip("binance.ws.threaded_stream")
+        from binance.ws.threaded_stream import ThreadedApiManager
+
+        delegated: list[dict] = []
+
+        def bad_callback(_msg) -> None:
+            raise KeyError("orderId")
+
+        async def scenario() -> None:
+            loop = asyncio.get_running_loop()
+            loop.set_exception_handler(provider._twm_loop_exception_handler)
+
+            def spy_default(context):
+                # Record the delegation and swallow so the genuine traceback
+                # doesn't spam test output; we only assert delegation happened.
+                delegated.append(context)
+
+            with patch.object(loop, "default_exception_handler", spy_default):
+                mgr = ThreadedApiManager.__new__(ThreadedApiManager)
+                mgr._socket_running = {"margin_subscription:0": True}
+                mgr._log = logging.getLogger("test.binance")
+
+                task = asyncio.create_task(
+                    mgr.start_listener(
+                        _FakeSocket(recv_value={"e": "executionReport"}),
+                        "margin_subscription:0",
+                        bad_callback,
+                    )
+                )
+                await asyncio.sleep(0.05)
+                del task
+                gc.collect()
+                await asyncio.sleep(0.05)
+
+        asyncio.run(scenario())
+
+        assert len(delegated) == 1
+        assert isinstance(delegated[0].get("exception"), KeyError)

--- a/tests/unit/test_binance_provider_websocket.py
+++ b/tests/unit/test_binance_provider_websocket.py
@@ -208,6 +208,199 @@ class TestStartUserStream:
         result = provider.start_user_stream(MagicMock())
         assert result is False
 
+    @pytest.mark.fast
+    def test_resets_event_received_flag_on_start(self, provider):
+        """start_user_stream resets _user_event_received to False so a stale True
+        from a prior generation can't read as healthy before the first real event
+        of the new socket (Defense A; mirrors kline) (#717)."""
+        mock_twm = MagicMock()
+        mock_twm.start_user_socket.return_value = "user_key"
+        provider._twm = mock_twm
+        provider._use_margin = False
+        provider._user_event_received = True  # leftover from a previous socket
+
+        provider.start_user_stream(MagicMock())
+        assert provider._user_event_received is False
+
+
+class TestUserStreamGeneration:
+    """#717: a monotonic generation token invalidates callbacks from a torn-down
+    user socket so a stale python-binance read_ready callback can't fake a recovery
+    (set _user_event_received / refresh freshness) the watchdog would act on."""
+
+    @staticmethod
+    def _capture_user_callback(provider):
+        """Start a margin user stream and return (callback, captured_events)."""
+        mock_twm = MagicMock()
+        captured: dict[str, object] = {}
+
+        def capture(**kwargs):
+            captured["cb"] = kwargs["callback"]
+            return "margin_key"
+
+        mock_twm.start_margin_socket.side_effect = capture
+        provider._twm = mock_twm
+        provider._use_margin = True
+        sink_events: list[dict] = []
+        provider.start_user_stream(sink_events.append)
+        return captured["cb"], sink_events
+
+    @pytest.mark.fast
+    def test_start_bumps_generation_and_captures_it(self, provider):
+        """Each (re)start advances the generation token."""
+        mock_twm = MagicMock()
+        mock_twm.start_user_socket.return_value = "k"
+        provider._twm = mock_twm
+        provider._use_margin = False
+
+        before = provider._user_stream_generation
+        provider.start_user_stream(MagicMock())
+        assert provider._user_stream_generation == before + 1
+
+    @pytest.mark.fast
+    def test_current_generation_callback_is_processed(self, provider):
+        """A callback whose generation is current updates freshness, sets the event
+        flag, and forwards the event."""
+        cb, sink = self._capture_user_callback(provider)
+        provider._user_event_received = False
+
+        cb({"e": "executionReport", "i": 42})
+
+        assert provider._user_event_received is True
+        assert sink == [{"e": "executionReport", "i": 42}]
+
+    @pytest.mark.fast
+    def test_stale_generation_callback_is_ignored(self, provider):
+        """A callback from a superseded generation (socket torn down + a newer start)
+        is dropped: no event forwarded, no freshness refresh, no event-flag flip —
+        so it cannot fake a recovery the watchdog acts on (#717)."""
+        cb, sink = self._capture_user_callback(provider)
+        # A later teardown/restart advances the generation past the captured one.
+        provider._user_stream_generation += 1
+        provider._user_event_received = False
+        provider._last_user_event_time = datetime.now(UTC) - timedelta(seconds=999)
+        stale_before = provider._last_user_event_time
+
+        cb({"e": "executionReport", "i": 7})
+
+        assert sink == []  # event dropped
+        assert provider._user_event_received is False  # no false recovery
+        assert provider._last_user_event_time == stale_before  # freshness untouched
+
+    @pytest.mark.fast
+    def test_stop_user_stream_invalidates_generation(self, provider):
+        """stop_user_stream bumps the generation FIRST so an in-flight callback
+        draining during teardown is dropped."""
+        cb, sink = self._capture_user_callback(provider)
+        provider._user_socket_key = "margin_key"
+
+        provider.stop_user_stream()
+        provider._user_event_received = False
+        cb({"e": "executionReport", "i": 1})  # late callback after stop
+
+        assert sink == []
+        assert provider._user_event_received is False
+
+    @pytest.mark.fast
+    def test_stop_streams_invalidates_generation(self, provider):
+        """stop_streams bumps the user generation before teardown so a callback
+        still draining on the loop during shutdown is dropped."""
+        cb, sink = self._capture_user_callback(provider)
+        before = provider._user_stream_generation
+
+        provider.stop_streams()
+        assert provider._user_stream_generation == before + 1
+
+        provider._user_event_received = False
+        cb({"e": "executionReport", "i": 2})
+        assert sink == []
+        assert provider._user_event_received is False
+
+    @pytest.mark.fast
+    def test_callback_generation_check_and_write_are_atomic(self, provider):
+        """Regression for the check-then-act TOCTOU: the callback's generation
+        check and its _user_event_received write share ONE locked critical section
+        with the generation bump in stop/start, so a stop that lands after the check
+        passed cannot leave a stale True under the new generation (#717).
+
+        We interpose on _user_stream_lock so that, the instant the callback acquires
+        it, a teardown (generation bump + flag reset) has already completed. The
+        callback must then observe the bumped generation and drop the event."""
+        cb, sink = self._capture_user_callback(provider)
+        captured_gen = provider._user_stream_generation
+        real_lock = provider._user_stream_lock
+
+        class _StopInjectingLock:
+            """Delegates to the real lock, but on the callback's acquire it first
+            simulates a concurrent stop having fully completed under the lock."""
+
+            def __init__(self, provider):
+                self._provider = provider
+                self._fired = False
+
+            def __enter__(self):
+                real_lock.acquire()
+                if not self._fired:
+                    self._fired = True
+                    # Concurrent teardown+restart that completed before the callback
+                    # got the lock: generation advanced, flag cleared.
+                    self._provider._user_stream_generation += 2
+                    self._provider._user_event_received = False
+                return self
+
+            def __exit__(self, *exc):
+                real_lock.release()
+                return False
+
+        provider._user_stream_lock = _StopInjectingLock(provider)
+        provider._user_event_received = False
+
+        # The callback (captured at captured_gen) now runs; on acquiring the lock the
+        # generation has already advanced past captured_gen → event dropped.
+        cb({"e": "executionReport", "i": 99})
+
+        assert provider._user_stream_generation == captured_gen + 2
+        assert provider._user_event_received is False  # no stale True under new gen
+        assert sink == []  # event not forwarded
+
+    @pytest.mark.fast
+    def test_concurrent_stop_and_callback_never_leave_stale_true(self, provider):
+        """Hammer the callback against stop_user_stream on two real threads. The
+        post-condition invariant: _user_event_received is True ONLY if the recorded
+        generation is the current one — a stale callback can never leave it True
+        after a stop bumped the generation (#717)."""
+        import threading
+
+        cb, _sink = self._capture_user_callback(provider)
+        provider._user_socket_key = "margin_key"
+        violations: list[str] = []
+
+        def fire_callbacks():
+            for _ in range(200):
+                cb({"e": "executionReport", "i": 1})
+
+        def stop_and_check():
+            for _ in range(200):
+                provider.stop_user_stream()
+                # After a stop (gen bumped, flag cleared under the lock), the flag may
+                # only be True if a CURRENT-generation callback set it post-stop. We
+                # can't observe gen-at-write directly, but the lock guarantees the
+                # callback's check+write is atomic with the bump; so immediately after
+                # stop returns, if no new start ran, the flag must be False.
+                with provider._user_stream_lock:
+                    if provider._user_event_received:
+                        violations.append("stale True after stop")
+                    provider._user_event_received = False  # reset for next round
+
+        t1 = threading.Thread(target=fire_callbacks)
+        t2 = threading.Thread(target=stop_and_check)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert violations == []
+
 
 class TestStopStreams:
     """Tests for stopping WebSocket streams."""

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -104,6 +104,9 @@ class TestCheckUserStreamHealth:
         mock_engine.enable_live_trading = True
         mock_exchange = MagicMock()
         mock_exchange._user_ws_state = WebSocketState.PRIMARY
+        # Stale stream → NOT healthy (no real event), so the recovery branch is
+        # skipped and the staleness/reconnect path runs.
+        mock_exchange.user_ws_healthy = False
         mock_exchange._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
         mock_engine.exchange_interface = mock_exchange
 
@@ -149,7 +152,14 @@ class TestCheckUserStreamHealth:
 
     @pytest.mark.fast
     def test_breaker_trips_after_limit_unproductive_reconnects(self, mock_engine):
-        """After LIMIT dead reconnects, stop reconnecting and degrade to REST (#616)."""
+        """After LIMIT dead reconnects, stop fast-reconnecting and degrade to REST.
+
+        Post-#717 'degrade to REST' is no longer terminal — the REST_DEGRADED
+        branch throttled-probes — but the fast-phase boundary, teardown-before-
+        degrade order, and enable_polling on circuit-open are preserved from #616.
+        The fixture leaves _user_ws_state==PRIMARY (mark_user_degraded is a mock
+        that does not flip it), so this isolates the PRIMARY fast-phase only.
+        """
         from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
 
         ex, tracker = self._dead_socket_engine(mock_engine)
@@ -160,15 +170,16 @@ class TestCheckUserStreamHealth:
             assert mock_engine._user_reconnect_failures == LIMIT
             ex.mark_user_degraded.assert_not_called()
 
-            # Next cycle: circuit open — degrade to REST, no further reconnect.
+            # Next cycle: circuit open — degrade to REST, no further fast reconnect.
             mock_engine._check_user_stream_health()
-            assert disc.call_count == LIMIT  # unchanged
+            assert disc.call_count == LIMIT  # unchanged on the circuit-open cycle
             ex.mark_user_degraded.assert_called_once()
             # The dead socket is torn down so its asyncio _read_ready spam stops.
             ex.stop_user_stream.assert_called_once()
             tracker.enable_polling.assert_called()
             # Teardown must happen BEFORE degrade, else the terminal state is
-            # DISCONNECTED instead of REST_DEGRADED and the one-shot guard breaks.
+            # DISCONNECTED instead of REST_DEGRADED and the probe branch is
+            # unreachable (#717).
             ordered = [
                 c[0] for c in ex.mock_calls if c[0] in ("stop_user_stream", "mark_user_degraded")
             ]
@@ -194,39 +205,63 @@ class TestCheckUserStreamHealth:
             disc.assert_not_called()  # not stale → no reconnect
 
     @pytest.mark.fast
-    def test_degraded_state_short_circuits(self, mock_engine):
-        """Once REST_DEGRADED, the check returns early (warning logged only once)."""
+    def test_degraded_probes_ws_reconnect_instead_of_absorbing(self, mock_engine):
+        """THE #717 FIX: REST_DEGRADED no longer short-circuits to restart — it
+        probes a WS reconnect (fast phase: every cycle up to the limit) so a
+        recovered network path can return to WS-primary. It does NOT re-mark
+        degraded (already degraded) and does NOT touch the polling flag (recovery
+        owns that, gated on a real event)."""
         mock_engine.enable_live_trading = True
         ex = MagicMock()
         ex._user_ws_state = WebSocketState.REST_DEGRADED
+        ex.user_ws_healthy = False  # no real event yet
         mock_engine.exchange_interface = ex
         tracker = MagicMock()
         tracker.get_tracked_count.return_value = 2
         mock_engine.order_tracker = tracker
+        mock_engine._user_reconnect_failures = 0  # fresh into the degraded branch
 
         with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
             mock_engine._check_user_stream_health()
-            disc.assert_not_called()
-            ex.mark_user_degraded.assert_not_called()
+            disc.assert_called_once()  # probed, not absorbed
+            assert mock_engine._user_reconnect_failures == 1
+            ex.mark_user_degraded.assert_not_called()  # already degraded
+            tracker.disable_polling.assert_not_called()  # polling stays on (no event)
 
     @pytest.mark.fast
     def test_reconnect_calls_bounded_over_many_cycles(self, mock_engine):
         """Regression for the #616 churn: a dead socket yields BOUNDED reconnects,
-        not an unbounded ~2-min loop."""
-        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+        not an unbounded ~2-min loop. Post-#717 the bound is LIMIT fast reconnects
+        plus a throttled probe every Nth degraded cycle — still bounded (one probe
+        per 10 cycles), never the per-cycle churn (#616) nor zero (the #717 fix)."""
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY as PROBE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT,
+        )
 
         ex, tracker = self._dead_socket_engine(mock_engine)
-        # mark_user_degraded flips state to REST_DEGRADED, as the real method does.
+        # mark_user_degraded flips state to REST_DEGRADED, as the real method does,
+        # so subsequent cycles exercise the throttled-probe branch.
         ex.mark_user_degraded.side_effect = lambda: setattr(
             ex, "_user_ws_state", WebSocketState.REST_DEGRADED
         )
+        cycles = 20
         with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
-            for _ in range(20):
+            for _ in range(cycles):
                 mock_engine._check_user_stream_health()
 
-        assert disc.call_count == LIMIT  # bounded, not 20
+        # LIMIT fast reconnects (PRIMARY phase) + one throttled probe at failure==PROBE.
+        # The degraded counter advances 1/cycle from LIMIT; over `cycles` it reaches
+        # LIMIT + (cycles - LIMIT - 1) = 19, crossing PROBE(10) exactly once.
+        expected_probes = LIMIT + sum(1 for f in range(LIMIT + 1, cycles) if f % PROBE == 0)
+        assert disc.call_count == expected_probes  # bounded, far below `cycles`
+        assert disc.call_count < cycles
         ex.mark_user_degraded.assert_called_once()  # degraded exactly once
-        ex.stop_user_stream.assert_called_once()  # dead socket torn down (asyncio spam stops)
+        # Dead socket torn down once on circuit-open (the mocked probe doesn't tear
+        # down here); asyncio _read_ready spam stops.
+        ex.stop_user_stream.assert_called_once()
 
     @pytest.mark.fast
     def test_breaker_survives_post_reconnect_fresh_timestamp(self, mock_engine):
@@ -263,6 +298,202 @@ class TestCheckUserStreamHealth:
             mock_engine._check_user_stream_health()
             ex.mark_user_degraded.assert_called_once()
             assert disc.call_count == LIMIT
+
+
+class TestUserStreamRecoveringRestFallback:
+    """#717: the user/margin stream uses a *recovering* REST fallback (mirrors the
+    kline #662 self-heal). REST order-polling backs the stream whenever it is down,
+    and the instant a real user event resumes the engine returns to WS-primary
+    (polling off) and resets the breaker — closing the #616 absorbing-state bug
+    where it stayed on REST until restart. Crucially, polling is disabled by exactly
+    ONE site (_restore_user_ws_primary), gated on a current-generation real event,
+    so a no-event probe can never blackout order tracking."""
+
+    @staticmethod
+    def _engine_with_tracker(mock_engine, *, polling_enabled=True, tracked=2):
+        """Live engine whose order tracker reports a controllable polling flag and
+        tracked-order count."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = tracked
+        tracker.is_polling_enabled.return_value = polling_enabled
+        mock_engine.order_tracker = tracker
+        return ex, tracker
+
+    @pytest.mark.fast
+    def test_should_probe_predicate_never_permanently_false(self, mock_engine):
+        """The throttle predicate probes every cycle up to the limit, then every
+        Nth cycle — and is never permanently False, so a degraded user stream
+        always retains a path back to WS-primary (#717)."""
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY as PROBE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT,
+        )
+
+        # Fast phase: probe on every cycle up to the limit.
+        assert all(mock_engine._should_probe_user_reconnect(n) for n in range(1, LIMIT + 1))
+        # Throttled phase: only multiples of PROBE probe.
+        assert mock_engine._should_probe_user_reconnect(LIMIT + 1) is False
+        assert mock_engine._should_probe_user_reconnect(PROBE) is True
+        # Never permanently false: a probe always recurs within every PROBE window.
+        for start in range(LIMIT + 1, 5 * PROBE, PROBE):
+            assert any(
+                mock_engine._should_probe_user_reconnect(n) for n in range(start, start + PROBE)
+            )
+
+    @pytest.mark.fast
+    def test_degraded_probe_is_throttled_past_limit_but_never_zero(self, mock_engine):
+        """A persistently-degraded user stream gets fast probes up to the limit,
+        then throttled probes every Nth cycle — bounded, but NEVER zero (always a
+        path back to WS). Regression vs BOTH the #616 per-cycle churn and the
+        REST-until-restart absorbing state."""
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY as PROBE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT,
+        )
+
+        ex, _tracker = self._engine_with_tracker(mock_engine)
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        ex.user_ws_healthy = False  # never recovers
+        mock_engine._user_reconnect_failures = 0
+        attempt_cycles: list[int] = []
+
+        def _record():
+            # _handle_user_stream_disconnect runs after the counter is bumped, so
+            # the counter == the cycle index at each attempt.
+            attempt_cycles.append(mock_engine._user_reconnect_failures)
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect", side_effect=_record):
+            for _ in range(5 * PROBE):  # 50 degraded cycles
+                mock_engine._check_user_stream_health()
+
+        expected = [n for n in range(1, 5 * PROBE + 1) if n <= LIMIT or n % PROBE == 0]
+        assert attempt_cycles == expected
+        # Never stops: probes continue into the final stretch of cycles.
+        assert any(c > 5 * PROBE - PROBE for c in attempt_cycles)
+        # Probing the degraded stream must never re-mark it degraded or touch polling.
+        ex.mark_user_degraded.assert_not_called()
+
+    @pytest.mark.fast
+    def test_degrade_then_recover_returns_to_ws_primary(self, mock_engine):
+        """Full degrade → recover → WS-primary: while degraded the engine probes;
+        the instant user_ws_healthy goes True (a real event), it disables polling
+        (the single site) and resets the breaker."""
+        ex, tracker = self._engine_with_tracker(mock_engine, polling_enabled=True)
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        ex.user_ws_healthy = False
+        # Fast-phase counter: the next degraded cycle increments to <= LIMIT and
+        # so probes (this isolates the probe→recovery handoff, not the throttle).
+        mock_engine._user_reconnect_failures = 0
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            # Degraded, no event: fast-phase probe runs, polling untouched.
+            mock_engine._check_user_stream_health()
+            assert disc.call_count == 1  # probed
+            tracker.disable_polling.assert_not_called()
+
+            # A real event arrives → recovery branch fires regardless of _user_ws_state.
+            ex.user_ws_healthy = True
+            mock_engine._check_user_stream_health()
+
+        tracker.poll_once.assert_called_once()  # close the handoff gap first
+        tracker.disable_polling.assert_called_once()  # WS-primary again
+        assert mock_engine._user_reconnect_failures == 0  # breaker reset
+        # Recovery must not also fire a disconnect/reconnect.
+        assert disc.call_count == 1  # only the degraded-probe cycle, not the recovery
+
+    @pytest.mark.fast
+    def test_no_blackout_probe_opens_socket_no_event_keeps_polling_on(self, mock_engine):
+        """THE core safety invariant: a probe that re-opens the socket but receives
+        NO real event must leave REST polling ON. The recovery (disable_polling) is
+        gated on user_ws_healthy, so a never-delivering socket can never blackout
+        order tracking — even across many probe cycles."""
+        from src.config.constants import DEFAULT_WS_USER_DEGRADED_PROBE_EVERY as PROBE
+
+        ex, tracker = self._engine_with_tracker(mock_engine, polling_enabled=True)
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        ex.user_ws_healthy = False  # socket opens but never delivers
+        mock_engine._user_reconnect_failures = 0
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect"):
+            for _ in range(3 * PROBE):
+                mock_engine._check_user_stream_health()
+
+        # Across every probe cycle, polling was never disabled — no blackout.
+        tracker.disable_polling.assert_not_called()
+
+    @pytest.mark.fast
+    def test_no_spurious_recovery_at_steady_state(self, mock_engine, caplog):
+        """At steady state (WS-primary, polling already off, real events flowing),
+        the recovery branch is a no-op: disable_polling is gated on
+        is_polling_enabled() so it does not re-fire or log every cycle."""
+        import logging
+
+        ex, tracker = self._engine_with_tracker(mock_engine, polling_enabled=False)
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = True  # healthy, events flowing
+        mock_engine._user_reconnect_failures = 0
+
+        with caplog.at_level(logging.INFO):
+            with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+                for _ in range(5):
+                    mock_engine._check_user_stream_health()
+
+        tracker.disable_polling.assert_not_called()  # already off — no-op
+        tracker.poll_once.assert_not_called()  # no redundant catch-up poll
+        disc.assert_not_called()
+        assert "recovered" not in caplog.text.lower()  # no per-cycle log spam
+
+    @pytest.mark.fast
+    def test_recovery_skipped_with_zero_tracked_orders(self, mock_engine):
+        """With zero tracked orders the check returns at the gate (no fills to miss,
+        no reason to churn the socket), so recovery/probe never runs even if the
+        stream reports healthy."""
+        ex, tracker = self._engine_with_tracker(mock_engine, polling_enabled=True, tracked=0)
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = True
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            mock_engine._check_user_stream_health()
+
+        disc.assert_not_called()
+        tracker.disable_polling.assert_not_called()  # gate-first short-circuit
+
+    @pytest.mark.fast
+    def test_breaker_persists_while_circuit_open_then_resets_on_recovery(self, mock_engine):
+        """The breaker accumulates through the PRIMARY fast phase, persists into
+        REST_DEGRADED (a stale post-reconnect timestamp must not reset it), and is
+        cleared only by a real recovery event — proving REST is never permanent."""
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        ex, tracker = self._engine_with_tracker(mock_engine, polling_enabled=True)
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = False
+        ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        # mark_user_degraded flips to REST_DEGRADED like the real method.
+        ex.mark_user_degraded.side_effect = lambda: setattr(
+            ex, "_user_ws_state", WebSocketState.REST_DEGRADED
+        )
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect"):
+            # Drive through the fast phase + circuit-open.
+            for _ in range(LIMIT + 1):
+                mock_engine._check_user_stream_health()
+        assert ex._user_ws_state == WebSocketState.REST_DEGRADED
+        assert mock_engine._user_reconnect_failures >= LIMIT  # persisted, not reset
+
+        # A real event now recovers and resets the breaker.
+        ex.user_ws_healthy = True
+        with patch.object(mock_engine, "_handle_user_stream_disconnect"):
+            mock_engine._check_user_stream_health()
+        assert mock_engine._user_reconnect_failures == 0
+        tracker.disable_polling.assert_called_once()
 
 
 class TestHandleKlineDisconnect:
@@ -496,7 +727,11 @@ class TestHandleUserStreamDisconnect:
         assert mock_tracker.poll_once.call_count == 2
         assert mock_reconciler.reconcile_once.call_count == 2
         mock_exchange.reconnect_user.assert_called_once()
-        mock_tracker.disable_polling.assert_called_once()
+        # The handler no longer disables polling on reconnect — a reopened socket is
+        # not proof of delivery. Only _restore_user_ws_primary (gated on a real
+        # event, on a later health cycle) flips polling off, so a fire-and-forget
+        # reconnect onto a dead socket can't blackout order tracking (#717).
+        mock_tracker.disable_polling.assert_not_called()
 
     @pytest.mark.fast
     def test_enables_polling_on_reconnect_failure(self, mock_engine):
@@ -517,3 +752,69 @@ class TestHandleUserStreamDisconnect:
 
         mock_exchange.mark_user_degraded.assert_called_once()
         mock_tracker.enable_polling.assert_called_once()
+
+
+class TestStartWebSocketStreamsUserPolling:
+    """#717: at boot the user stream starts but REST polling stays ON until the
+    first real event confirms delivery — the fresh-boot half of the single
+    disable-polling-site invariant. start_margin_socket is fire-and-forget and may
+    return True on a dead multiplexed socket, so disabling polling at startup
+    (the old behaviour) could blackout order tracking on a never-delivering stream."""
+
+    @staticmethod
+    def _live_engine(mock_engine, *, user_started=True):
+        """Configure the fixture engine for the live user-stream startup path."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex.start_user_stream.return_value = user_started
+        # No kline provider on the wrapped data provider → kline block is skipped,
+        # isolating the user-stream startup assertions.
+        mock_engine.data_provider = MagicMock(spec=["get_current_price"])
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.is_polling_enabled.return_value = True
+        mock_engine.order_tracker = tracker
+        mock_engine._periodic_reconciler = MagicMock()
+        return ex, tracker
+
+    @pytest.mark.fast
+    def test_startup_keeps_polling_until_first_event(self, mock_engine):
+        """Starting the user stream runs handoff catch-up (poll_once + reconcile)
+        but does NOT disable polling — polling stays on until a real event."""
+        ex, tracker = self._live_engine(mock_engine, user_started=True)
+
+        with (
+            patch("src.engines.live.user_data_processor.UserDataProcessor") as mock_udp_cls,
+            patch.object(mock_engine, "_start_ws_health_monitor"),
+        ):
+            mock_udp_cls.return_value = MagicMock()
+            mock_engine._start_websocket_streams("BTCUSDT", "1h")
+
+        ex.start_user_stream.assert_called_once()
+        tracker.poll_once.assert_called_once()  # handoff catch-up still happens
+        mock_engine._periodic_reconciler.reconcile_once.assert_called_once()
+        tracker.disable_polling.assert_not_called()  # THE fix: polling stays on
+
+    @pytest.mark.fast
+    def test_startup_then_first_event_disables_polling(self, mock_engine):
+        """After boot (polling on), the first real event makes user_ws_healthy True
+        and the next health cycle hands off to WS-primary via the single disable
+        site — closing the fresh-boot blackout window end to end."""
+        ex, tracker = self._live_engine(mock_engine, user_started=True)
+
+        with (
+            patch("src.engines.live.user_data_processor.UserDataProcessor") as mock_udp_cls,
+            patch.object(mock_engine, "_start_ws_health_monitor"),
+        ):
+            mock_udp_cls.return_value = MagicMock()
+            mock_engine._start_websocket_streams("BTCUSDT", "1h")
+        tracker.disable_polling.assert_not_called()  # still on after boot
+
+        # First real event arrives → health cycle promotes to WS-primary.
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = True
+        tracker.get_tracked_count.return_value = 1
+        with patch.object(mock_engine, "_handle_user_stream_disconnect"):
+            mock_engine._check_user_stream_health()
+
+        tracker.disable_polling.assert_called_once()  # handed off to WS-primary


### PR DESCRIPTION
## Surgical prod promote: #716 + #717 (user-data WebSocket reliability)

Cherry-pick of two Codex-APPROVED, CI-green `develop` commits onto `main` (per the surgical per-fix promote rule — **not** a wholesale `develop→main`).

- `6f558c67` → #716: suppress the benign python-binance socket-teardown `KeyError('margin_subscription:0')` on user-stream circuit-open (stops it tripping `Traceback` monitors).
- `0f48905a` → #717: **self-healing** margin user-data WebSocket recovery — auto-returns to WS-primary after a transient outage (mirrors the kline #662 self-heal); closes the #616 "degraded until restart" gap.

**Verification:** both commits are **patch-id identical** to their develop originals (already Codex-APPROVED on #720/#721 with full CI green), so no redundant fresh Codex pass — the diffs are byte-for-byte the approved code.

**Deploy impact:** Railway redeploys the prod Trading Bot (~3-min restart). Re-adoption (#677) reloads the open long position + re-places its stop; the restart also clears the current `REST_DEGRADED` state as a side effect.

Human sign-off: granted.
