### PR TITLE
chore(deps): bump python-binance to 1.0.37 across all requirements files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ description = "AI Trading Bot CLI and tools"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "python-binance>=1.0.36",
+    "python-binance>=1.0.37",
     "pandas>=2.1.4",
     "python-dotenv>=1.0.0",
     "numpy>=1.26.2",

--- a/requirements-github.txt
+++ b/requirements-github.txt
@@ -5,7 +5,7 @@
 # Note: onnxruntime is stubbed automatically by tests/conftest.py
 
 # Core runtime
-python-binance==1.0.19
+python-binance==1.0.37
 pandas==2.2.0
 python-dotenv==1.0.0
 numpy==1.26.4

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -1,6 +1,6 @@
 # Server requirements - lighter build without heavy libraries for training models
 # Production dependencies with pinned versions for stability
-python-binance==1.0.36
+python-binance==1.0.37
 pandas==2.1.4
 python-dotenv==1.0.0
 numpy==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Use locally - includes heavy libraries for training models
-python-binance==1.0.36
+python-binance==1.0.37
 pandas==2.2.0
 python-dotenv==1.0.0
 numpy==1.26.4

--- a/src/ml/cloud/requirements-cloud.txt
+++ b/src/ml/cloud/requirements-cloud.txt
@@ -15,7 +15,7 @@ tf2onnx>=1.16.0
 protobuf<5.0.0,>=3.20.3
 
 # Data providers (for downloading training data)
-python-binance>=1.0.19
+python-binance>=1.0.37
 requests>=2.31.0
 python-dotenv>=1.0.0
 ccxt>=4.4.85


### PR DESCRIPTION
## What
Bump `python-binance` to **1.0.37** (current, 2026-06-08) across **all five** pins so every environment — including GitHub/CI — is consistent:

| File | Was | Now |
|---|---|---|
| `requirements.txt` | `==1.0.36` | `==1.0.37` |
| `requirements-server.txt` | `==1.0.36` | `==1.0.37` |
| `requirements-github.txt` | **`==1.0.19`** (stale) | `==1.0.37` |
| `src/ml/cloud/requirements-cloud.txt` | **`>=1.0.19`** (stale) | `>=1.0.37` |
| `pyproject.toml` | `>=1.0.36` | `>=1.0.37` |

## Why
Currency + consistency hygiene — the GitHub and cloud pins were years stale (1.0.19). **1.0.37 is a trivial "minor ids adjustments" release** (verified against the changelog); it does **NOT** fix the #616/#723 margin-WS issue — that fix is tracked separately. CI on this PR is the meaningful gate (it runs the full suite against 1.0.37). Prod arrival of the runtime bump (requirements.txt/server) will ride the next sign-off-gated prod promote.

Refs #723, #724
