### PR TITLE
fix(live): exponential-backoff user WS probe + flag-gated hard reconnect (#723)

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -374,11 +374,35 @@ DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_D
 # self-terminate and churn forever (#616). This is also the fast-phase boundary for
 # the self-healing user-stream probe (#717): below it, probe every health cycle.
 DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT = 3
-# User-stream self-heal throttle (#717): once past the circuit limit, attempt a user
-# reconnect only every Nth health cycle (≈ N × DEFAULT_WS_HEALTH_CHECK_INTERVAL ≈ 5 min)
-# so a persistently dead socket doesn't busy-loop — but never stop, so a return to
-# WS-primary is always possible. Bounds the #716 teardown noise to ~1 cycle per probe.
+# User-stream self-heal throttle (#717): the FIRST throttled-probe boundary, in
+# absolute failure-count. Past the circuit limit the watchdog probes on an
+# *exponential-backoff* schedule (not a fixed cadence) so a persistently dead socket
+# stops busy-looping yet never stops entirely — a return to WS-primary is always
+# possible. This is the initial boundary (10 ≈ 5 min at the 30 s health interval, so
+# the first degraded probe's latency is unchanged from the old fixed every-10 cadence);
+# subsequent boundaries grow geometrically (see the backoff knobs below). #723 widened
+# this from a fixed every-10 cadence to bound the unrecoverable-stream churn (#616):
+# python-binance 1.0.36 multiplexes the margin user stream over a shared ws_api socket
+# that an in-place re-subscribe can't restore, so the probe is effectively REST-primary
+# upkeep — backing it off cuts churn ~200/day → ~50-80/day. Reused as the schedule's
+# FIRST boundary so the first-probe latency stays coherent with the historical value.
 DEFAULT_WS_USER_DEGRADED_PROBE_EVERY = 10
+# Exponential-backoff knobs for the user degraded-probe schedule (#723). The gap
+# between consecutive probe boundaries starts at FIRST and is multiplied by BACKOFF_BASE
+# each step until it would exceed CEILING, after which it is fixed at CEILING forever —
+# giving the boundary sequence 10, 20, 40, 80, 160, 280, 400, 520, … (gaps 10, 20, 40,
+# 80, then 120-capped). Because the post-ramp gap is the constant CEILING, every window
+# of CEILING consecutive failures still contains a probe → the #717 never-permanently-
+# False invariant holds (a recovered network always returns to WS-primary). The schedule
+# is generated ITERATIVELY from these three constants (FIRST/BASE/CEILING), never
+# hardcoded, so retuning is a one-line constant change.
+DEFAULT_WS_USER_DEGRADED_PROBE_BACKOFF_BASE = 2  # Geometric growth factor for the gap.
+DEFAULT_WS_USER_DEGRADED_PROBE_FIRST_BOUNDARY = (
+    DEFAULT_WS_USER_DEGRADED_PROBE_EVERY  # First throttled-probe at absolute failure 10.
+)
+# Max spacing between probes once the geometric ramp saturates (120 cycles × 30 s health
+# interval ≈ 60 min ceiling). Drop to 60 for a ~30 min ceiling if churn is still too high.
+DEFAULT_WS_USER_DEGRADED_PROBE_CEILING = 120
 # Kline watchdog (#662): a *recovering* REST fallback, unlike the user-stream
 # breaker above. After this many consecutive unproductive kline reconnects
 # (socket re-opened but no real event confirms it — ws_healthy requires

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -2503,6 +2503,63 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 time.sleep(backoff)
         return False
 
+    def hard_reconnect_user(self, on_user_event: Callable[[dict], None] | None = None) -> bool:
+        """Fully rebuild the user stream on a fresh AsyncClient/ws_api socket (#723).
+
+        Unlike ``reconnect_user`` (which only ``stop_socket`` + re-subscribes over the
+        SAME shared ``client.ws_api`` object), this tears the whole TWM down via
+        ``stop_streams`` — which calls ``AsyncClient.close_connection`` and drops
+        ``ws_api`` — then ``_ensure_twm`` builds a NEW ``ThreadedWebsocketManager`` →
+        new ``AsyncClient`` → brand-new ``WebsocketAPI`` (empty subscription/route map,
+        fresh read loop, fresh TCP socket), and ``start_user_stream`` subscribes over
+        it. This is the margin analogue of what makes the kline stream recover (a
+        genuinely fresh socket), and the only supported-library way to escape an
+        object-level-degraded ws_api the in-place re-subscribe can't restore (#616 M1).
+
+        Gated OFF by default behind ``FEATURE_WS_USER_HARD_RECONNECT`` at the call site
+        (the engine), so this method only runs when deliberately enabled. It does NOT
+        touch the kline stream (kline lives on a separate provider/TWM) and CANNOT
+        sever order placement or stop-loss submission (those use the separate
+        synchronous ``self._client``, never the TWM's ``AsyncClient``).
+
+        The generation token is bumped under ``_user_stream_lock`` inside both
+        ``stop_streams`` and ``start_user_stream`` (reused as-is), so a stale callback
+        from the torn-down AsyncClient is dropped and cannot fake recovery. Like
+        ``reconnect_user``, returning True means only that a socket was *opened* — real
+        WS-primary recovery is still gated on a confirmed event via the engine's single
+        ``_restore_user_ws_primary`` disable site, so a fire-and-forget start on a still-
+        broken (M2 server-side) socket cannot blackout order tracking.
+
+        Args:
+            on_user_event: Fresh callback for the rebuilt stream. If None, reuses the
+                previously stored callback.
+
+        Returns:
+            True if the stream was restarted, False otherwise.
+        """
+        callback = on_user_event or self._on_user_event_cb
+        if not callback:
+            return False
+        try:
+            # Full teardown: closes the AsyncClient (ws_api=None) and the TWM loop. The
+            # user generation is bumped under the lock here, invalidating any in-flight
+            # callback from the old socket before the new one is built.
+            self.stop_streams()
+        except Exception as e:
+            # A failed teardown must not be reported as a recovered stream. Leave the
+            # caller to keep REST polling on / re-mark degraded (no false PRIMARY).
+            logger.error("Hard user-stream reconnect: teardown (stop_streams) failed: %s", e)
+            return False
+        try:
+            # Rebuild the TWM → new AsyncClient → fresh ws_api, then subscribe over it.
+            # start_user_stream calls _ensure_twm internally, but call it explicitly so a
+            # rebuild failure surfaces here distinctly from a subscribe failure.
+            self._ensure_twm()
+            return self.start_user_stream(callback)
+        except Exception as e:
+            logger.error("Hard user-stream reconnect: rebuild/start failed: %s", e)
+            return False
+
 
 # Aliases for backward compatibility
 BinanceDataProvider = BinanceProvider

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1883,11 +1883,21 @@ class LiveTradingEngine:
             self._user_reconnect_failures += 1
             if not self._should_probe_user_reconnect(self._user_reconnect_failures):
                 return
+            # Decide the reconnect MODE here, BEFORE _handle_user_stream_disconnect's
+            # stop_user_stream flips state to DISCONNECTED (the handler can no longer
+            # read REST_DEGRADED). hard=True (full teardown + fresh AsyncClient/ws_api,
+            # #723) only when the flag is on AND the kline/user coupling guard passes;
+            # otherwise the cheap in-place re-subscribe. This is the ONLY caller that
+            # may set hard=True.
+            hard = self._should_hard_reconnect_user()
             logger.warning(
-                "User data stream degraded — probing WS reconnect (failure #%d, #717)",
+                "User data stream degraded — probing WS %s (failure #%d, "
+                "next probe in ~%.0fm, #717/#723)",
+                "HARD-reconnect" if hard else "reconnect",
                 self._user_reconnect_failures,
+                self._user_next_probe_eta_minutes(self._user_reconnect_failures),
             )
-            self._handle_user_stream_disconnect()
+            self._handle_user_stream_disconnect(hard=hard)
             return
 
         # From here we require PRIMARY: anything else (DISCONNECTED/SUSPENDED) is
@@ -1940,25 +1950,140 @@ class LiveTradingEngine:
         self._handle_user_stream_disconnect()
 
     def _should_probe_user_reconnect(self, failures: int) -> bool:
-        """Whether to probe a user-stream WS reconnect on this degraded cycle (#717).
+        """Whether to probe a user-stream WS reconnect on this degraded cycle (#717/#723).
 
-        Structurally identical to the kline predicate: fast phase (``failures`` <=
-        the circuit limit) probes every cycle; past it, probe only every Nth cycle
-        so a persistently dead socket doesn't busy-loop on socket churn + the #716
-        teardown noise. NEVER permanently False — past the limit it still returns
-        True at every multiple of ``DEFAULT_WS_USER_DEGRADED_PROBE_EVERY``, so the
-        WS always retains a path back to primary. Recovery itself is independent of
-        this predicate (the ``user_ws_healthy`` branch promotes the instant a real
-        event resumes, even on a throttled non-probing cycle).
+        Fast phase (``failures`` <= the circuit limit) probes every cycle for quick
+        recovery. Throttled phase: probe on an *exponential-backoff* schedule of
+        absolute failure-count boundaries (10, 20, 40, 80, 160, 280, 400, 520, …),
+        not the old fixed every-Nth cadence, so an unrecoverable margin stream (the
+        #616 dead multiplexed ws_api socket an in-place re-subscribe can't restore)
+        stops churning ~200×/day while still being probed indefinitely.
+
+        NEVER permanently False — past the geometric ramp the gap is fixed at the
+        CEILING, so every CEILING-wide window of ``failures`` still contains a probe
+        boundary; the WS therefore always retains a path back to primary (#717's
+        guarantee). Recovery itself is independent of this predicate (the
+        ``user_ws_healthy`` branch in ``_check_user_stream_health`` promotes the
+        instant a real event resumes, even on a throttled non-probing cycle).
+
+        Pure function of ``failures`` (no mutable backoff state), preserving the
+        lock-free single-writer model: the boundary set is derived analytically from
+        the three backoff constants on every call (see ``_user_probe_boundary_reached``).
         """
-        from src.config.constants import (
-            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY,
-            DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
-        )
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT
 
         if failures <= DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT:
             return True
-        return failures % DEFAULT_WS_USER_DEGRADED_PROBE_EVERY == 0
+        return self._user_probe_boundary_reached(failures)
+
+    @staticmethod
+    def _user_probe_boundary_reached(failures: int) -> bool:
+        """True iff ``failures`` is an exponential-backoff probe boundary (#723).
+
+        Boundaries start at ``FIRST`` and grow by gaps that double each step
+        (``gap *= BASE``) until a gap would exceed ``CEILING``, after which the gap
+        is fixed at ``CEILING`` forever — yielding the sequence
+        ``FIRST, FIRST+FIRST, …`` = ``10, 20, 40, 80, 160, 280, 400, 520, 640, …``
+        (gaps ``10, 20, 40, 80, 120, 120, …``) for the default constants. The set is
+        generated ITERATIVELY from the constants (no hardcoded list, no closed form —
+        a cumulative-sum closed form would give the wrong ``10, 30, 70, 150, …``): we
+        walk boundaries up to ``failures`` and test exact equality. Membership is the
+        whole predicate, so the walk is O(log(failures/FIRST)) up to the ramp then
+        O((failures-ramp)/CEILING) — cheap at the once-per-30-s health-check cadence.
+
+        The post-ramp gap equals the constant ``CEILING``, so every window of
+        ``CEILING`` consecutive failure counts contains exactly one boundary — the
+        never-permanently-False invariant the user stream relies on (#717).
+        """
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_BACKOFF_BASE as BASE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_CEILING as CEILING,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_FIRST_BOUNDARY as FIRST,
+        )
+
+        if failures < FIRST:
+            return False
+        boundary = FIRST
+        gap = FIRST
+        # Advance to the first boundary >= failures, growing the gap geometrically
+        # (capped at CEILING). The order — add the gap, THEN grow it — makes the first
+        # increment FIRST (10→20), matching the pinned 10,20,40,80,160,280,… schedule.
+        while boundary < failures:
+            boundary += gap
+            gap = min(gap * BASE, CEILING)
+        return boundary == failures
+
+    @staticmethod
+    def _user_next_probe_eta_minutes(failures: int) -> float:
+        """Approx minutes until the next user degraded-probe after ``failures`` (#723).
+
+        Diagnostic only: the gap (in health cycles) from the current failure count to
+        the next exponential-backoff boundary, scaled by the health-check interval, so
+        the degraded-probe log shows the backoff widening (e.g. "next probe in ~5m" →
+        "~10m" → "~60m") for prod monitoring. Derived from the same constants as the
+        boundary set, so it can never drift from the actual probe cadence.
+        """
+        from src.config.constants import (
+            DEFAULT_WS_HEALTH_CHECK_INTERVAL as INTERVAL,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_BACKOFF_BASE as BASE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_CEILING as CEILING,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_FIRST_BOUNDARY as FIRST,
+        )
+
+        # Walk to the first boundary strictly past `failures`; the cycle gap to it,
+        # times the seconds-per-cycle, is the ETA. (At a boundary, this returns the
+        # gap to the NEXT one — the spacing that will apply after this probe fires.)
+        boundary = FIRST
+        gap = FIRST
+        while boundary <= failures:
+            boundary += gap
+            gap = min(gap * BASE, CEILING)
+        return (boundary - failures) * INTERVAL / 60.0
+
+    def _should_hard_reconnect_user(self) -> bool:
+        """Whether the degraded probe should use a HARD reconnect this cycle (#723).
+
+        True only when ALL hold:
+        1. ``FEATURE_WS_USER_HARD_RECONNECT`` is enabled (default OFF — money/stability-
+           adjacent, ships inert per LESSONS §3/§4). A missing env var resolves False.
+        2. The kline and user streams are on SEPARATE providers (B-VERIFY-1). The hard
+           path does a full ``exchange_interface.stop_streams()``; if a future refactor
+           ever co-located kline on the same provider (``_ws_kline_provider is
+           exchange_interface``), that teardown would also kill kline. We REFUSE the
+           hard path in that case — log CRITICAL and fall back to the cheap in-place
+           reconnect — rather than a bare ``assert`` that would crash the WS health
+           thread (the codex guard, #723).
+        3. The provider actually exposes ``hard_reconnect_user`` (defensive).
+
+        Pure read; safe on the WS health thread (no state mutation, never raises).
+        """
+        from src.config.feature_flags import is_enabled
+
+        if not is_enabled("ws_user_hard_reconnect", False):
+            return False
+        if not hasattr(self.exchange_interface, "hard_reconnect_user"):
+            return False
+        # Coupling guard: a shared provider would let the user teardown kill kline.
+        if (
+            self._ws_kline_provider is not None
+            and self._ws_kline_provider is self.exchange_interface
+        ):
+            logger.critical(
+                "Kline and user streams share a provider — refusing hard reconnect, "
+                "using in-place reconnect (#723)"
+            )
+            return False
+        return True
 
     def _restore_user_ws_primary(self) -> None:
         """Return the user stream to WS-primary: disable REST polling once a real
@@ -2014,13 +2139,28 @@ class LiveTradingEngine:
         except Exception as e:
             logger.error("Kline reconnect attempt failed: %s", e)
 
-    def _handle_user_stream_disconnect(self) -> None:
-        """Handle user data stream failure. Resync orders and attempt reconnect."""
+    def _handle_user_stream_disconnect(self, *, hard: bool = False) -> None:
+        """Handle user data stream failure. Resync orders and attempt reconnect.
+
+        ``hard`` selects the reconnect strategy and MUST be decided by the caller:
+        this handler's first action (``stop_user_stream``) flips ``_user_ws_state`` to
+        DISCONNECTED, so the handler can no longer read "were we REST_DEGRADED?" itself
+        (the codex ordering fix, #723). When ``hard`` is True it does a full
+        teardown + fresh-AsyncClient rebuild (``hard_reconnect_user``); otherwise the
+        cheap in-place re-subscribe (``reconnect_user``). Only the REST_DEGRADED
+        throttled-probe branch passes ``hard=True`` (and only when
+        ``FEATURE_WS_USER_HARD_RECONNECT`` is on AND the kline/user coupling guard
+        passes); the fast-phase, RESYNCING, and PRIMARY-stale callers pass ``hard=False``
+        so a flag-on PRIMARY/RESYNCING cycle still uses the cheap path.
+        """
         from src.engines.live.user_data_processor import UserDataProcessor
 
         if not self.enable_live_trading or not self.exchange_interface:
             return
-        # 1. Stop the old user socket FIRST to prevent new events arriving
+        # 1. Stop the old user socket FIRST to prevent new events arriving. (When
+        #    hard=True the subsequent hard_reconnect_user does a full stop_streams
+        #    teardown anyway; this early stop_user_stream keeps the state machine /
+        #    generation bump identical across both paths and is harmless/idempotent.)
         if hasattr(self.exchange_interface, "stop_user_stream"):
             self.exchange_interface.stop_user_stream()
         # 2. Now drain the UserDataProcessor (no new events can arrive)
@@ -2047,20 +2187,32 @@ class LiveTradingEngine:
             self.exchange_interface.mark_user_degraded()
             logger.critical("UserDataProcessor did not stop cleanly — staying in REST_DEGRADED")
             return
-        # 6. Attempt user stream reconnect with fresh callback
+        # 6. Attempt user stream reconnect with fresh callback. `hard` (decided by the
+        #    caller, see docstring) picks a full teardown + fresh-AsyncClient rebuild
+        #    (#723) over the cheap in-place re-subscribe. Both are fire-and-forget: a
+        #    True return means a socket opened, NOT that it delivers — recovery stays
+        #    gated on a real event via _restore_user_ws_primary (the single disable
+        #    site), so neither path can blackout order tracking on a dead socket (#717).
+        reconnect_method = "hard_reconnect_user" if hard else "reconnect_user"
         reconnected = False
-        if hasattr(self.exchange_interface, "reconnect_user"):
+        if hasattr(self.exchange_interface, reconnect_method):
             try:
                 new_processor = UserDataProcessor(
                     order_tracker=self.order_tracker,
                 )
-                if self.exchange_interface.reconnect_user(
-                    on_user_event=new_processor.enqueue,
-                ):
+                reconnect_fn = getattr(self.exchange_interface, reconnect_method)
+                if reconnect_fn(on_user_event=new_processor.enqueue):
                     self._user_data_processor = new_processor
                     self._user_data_processor.start()
                     reconnected = True
-                    logger.info("User data WebSocket reconnected")
+                    logger.info(
+                        "User data WebSocket %s",
+                        (
+                            "hard-reconnected (fresh AsyncClient/ws_api, #723)"
+                            if hard
+                            else "reconnected"
+                        ),
+                    )
                     # Post-reconnect catch-up: reconcile events from the handoff gap
                     # so nothing is lost. Polling deliberately stays ON — a reconnect
                     # only re-OPENS the socket; reconnect_user/start_margin_socket is

--- a/tests/unit/test_binance_provider_websocket.py
+++ b/tests/unit/test_binance_provider_websocket.py
@@ -622,6 +622,126 @@ class TestReconnect:
         assert result is False
 
 
+class TestHardReconnectUser:
+    """#723 Phase 2: hard_reconnect_user fully rebuilds the user stream on a FRESH
+    AsyncClient/ws_api (stop_streams → _ensure_twm → start_user_stream), the margin
+    analogue of kline recovery. Returning True means a socket *opened*, not that it
+    delivers — recovery stays gated on a real event at the engine."""
+
+    @pytest.mark.fast
+    def test_calls_stop_streams_then_ensure_twm_then_start_in_order(self, provider):
+        """The teardown → rebuild → start sequence runs in that exact order (E.8)."""
+        provider._on_user_event_cb = MagicMock()
+        order: list[str] = []
+
+        with (
+            patch.object(provider, "stop_streams", side_effect=lambda: order.append("stop")),
+            patch.object(provider, "_ensure_twm", side_effect=lambda: order.append("ensure")),
+            patch.object(
+                provider,
+                "start_user_stream",
+                side_effect=lambda cb: (order.append("start"), True)[1],
+            ) as mock_start,
+        ):
+            result = provider.hard_reconnect_user()
+
+        assert result is True
+        assert order == ["stop", "ensure", "start"]
+        mock_start.assert_called_once_with(provider._on_user_event_cb)
+
+    @pytest.mark.fast
+    def test_uses_fresh_callback_when_provided(self, provider):
+        """A fresh callback is forwarded to start_user_stream (stale callbacks must
+        not reference a stopped consumer, CODE.md §238)."""
+        provider._on_user_event_cb = MagicMock()
+        fresh_cb = MagicMock()
+
+        with (
+            patch.object(provider, "stop_streams"),
+            patch.object(provider, "_ensure_twm"),
+            patch.object(provider, "start_user_stream", return_value=True) as mock_start,
+        ):
+            provider.hard_reconnect_user(on_user_event=fresh_cb)
+
+        mock_start.assert_called_once_with(fresh_cb)
+
+    @pytest.mark.fast
+    def test_returns_false_without_callback(self, provider):
+        """No callback stored and none provided → returns False, no teardown."""
+        provider._on_user_event_cb = None
+        with patch.object(provider, "stop_streams") as mock_stop:
+            result = provider.hard_reconnect_user()
+        assert result is False
+        mock_stop.assert_not_called()
+
+    @pytest.mark.fast
+    def test_bumps_generation_via_stop_and_start(self, provider):
+        """The generation is advanced by the real stop_streams + start_user_stream
+        locked bumps, so a stale callback from the torn-down AsyncClient is dropped
+        (E.8/E.12). Uses the real stop_streams/start path with a mocked TWM."""
+        mock_twm = MagicMock()
+        mock_twm.start_user_socket.return_value = "user_key"
+        provider._twm = mock_twm
+        provider._twm_loop = None  # _socket_on_twm_loop falls through to direct call
+        provider._use_margin = False
+        provider._on_user_event_cb = MagicMock()
+        before = provider._user_stream_generation
+
+        # Real stop_streams nulls self._twm; the rebuild (mocked here) restores a fresh
+        # TWM so the subsequent real start_user_stream can subscribe over it.
+        def _rebuild_twm():
+            provider._twm = mock_twm
+
+        with patch.object(provider, "_ensure_twm", side_effect=_rebuild_twm):
+            result = provider.hard_reconnect_user()
+
+        assert result is True
+        # stop_streams bumps once, start_user_stream bumps once → +2.
+        assert provider._user_stream_generation == before + 2
+
+    @pytest.mark.fast
+    def test_teardown_failure_returns_false_no_rebuild(self, provider):
+        """If stop_streams raises, hard_reconnect_user returns False and does NOT
+        attempt a rebuild/start — no false PRIMARY on a failed teardown (E.13)."""
+        provider._on_user_event_cb = MagicMock()
+        with (
+            patch.object(provider, "stop_streams", side_effect=RuntimeError("twm stuck")),
+            patch.object(provider, "_ensure_twm") as mock_ensure,
+            patch.object(provider, "start_user_stream") as mock_start,
+        ):
+            result = provider.hard_reconnect_user()
+        assert result is False
+        mock_ensure.assert_not_called()
+        mock_start.assert_not_called()
+
+    @pytest.mark.fast
+    def test_rebuild_failure_returns_false(self, provider):
+        """If _ensure_twm raises after teardown, returns False (degraded, no false
+        PRIMARY) and does not call start (E.13)."""
+        provider._on_user_event_cb = MagicMock()
+        with (
+            patch.object(provider, "stop_streams"),
+            patch.object(provider, "_ensure_twm", side_effect=RuntimeError("loop create failed")),
+            patch.object(provider, "start_user_stream") as mock_start,
+        ):
+            result = provider.hard_reconnect_user()
+        assert result is False
+        mock_start.assert_not_called()
+
+    @pytest.mark.fast
+    def test_start_returns_false_propagates_false(self, provider):
+        """If start_user_stream returns False on the fresh socket, hard_reconnect_user
+        returns False → caller marks degraded; no false PRIMARY recovery (E.13)."""
+        provider._on_user_event_cb = MagicMock()
+        with (
+            patch.object(provider, "stop_streams"),
+            patch.object(provider, "_ensure_twm"),
+            patch.object(provider, "start_user_stream", return_value=False),
+        ):
+            result = provider.hard_reconnect_user()
+        assert result is False
+
+
 class TestOnStreamDisconnect:
     """Tests for per-stream disconnect handlers."""
 

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -231,12 +231,10 @@ class TestCheckUserStreamHealth:
     @pytest.mark.fast
     def test_reconnect_calls_bounded_over_many_cycles(self, mock_engine):
         """Regression for the #616 churn: a dead socket yields BOUNDED reconnects,
-        not an unbounded ~2-min loop. Post-#717 the bound is LIMIT fast reconnects
-        plus a throttled probe every Nth degraded cycle — still bounded (one probe
-        per 10 cycles), never the per-cycle churn (#616) nor zero (the #717 fix)."""
-        from src.config.constants import (
-            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY as PROBE,
-        )
+        not an unbounded ~2-min loop. Post-#717/#723 the bound is LIMIT fast
+        reconnects plus a probe on the exponential-backoff boundary schedule — still
+        bounded (and rarer than the old every-10), never the per-cycle churn (#616)
+        nor zero (the #717 fix)."""
         from src.config.constants import (
             DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT,
         )
@@ -247,15 +245,16 @@ class TestCheckUserStreamHealth:
         ex.mark_user_degraded.side_effect = lambda: setattr(
             ex, "_user_ws_state", WebSocketState.REST_DEGRADED
         )
-        cycles = 20
+        cycles = 25  # past the first backoff boundary (10) and the second (20)
         with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
             for _ in range(cycles):
                 mock_engine._check_user_stream_health()
 
-        # LIMIT fast reconnects (PRIMARY phase) + one throttled probe at failure==PROBE.
-        # The degraded counter advances 1/cycle from LIMIT; over `cycles` it reaches
-        # LIMIT + (cycles - LIMIT - 1) = 19, crossing PROBE(10) exactly once.
-        expected_probes = LIMIT + sum(1 for f in range(LIMIT + 1, cycles) if f % PROBE == 0)
+        # LIMIT fast reconnects (PRIMARY phase) + backoff-boundary probes at the
+        # absolute failure counts 10 and 20 (the degraded counter advances 1/cycle
+        # from LIMIT, reaching cycles-1=24, crossing boundaries 10 and 20).
+        boundaries_hit = [b for b in (10, 20) if b < cycles]
+        expected_probes = LIMIT + len(boundaries_hit)
         assert disc.call_count == expected_probes  # bounded, far below `cycles`
         assert disc.call_count < cycles
         ex.mark_user_degraded.assert_called_once()  # degraded exactly once
@@ -324,11 +323,12 @@ class TestUserStreamRecoveringRestFallback:
 
     @pytest.mark.fast
     def test_should_probe_predicate_never_permanently_false(self, mock_engine):
-        """The throttle predicate probes every cycle up to the limit, then every
-        Nth cycle — and is never permanently False, so a degraded user stream
-        always retains a path back to WS-primary (#717)."""
+        """The throttle predicate probes every cycle up to the limit, then on the
+        #723 exponential-backoff boundary schedule — and is never permanently False
+        past the ramp (the gap is fixed at CEILING), so a degraded user stream always
+        retains a path back to WS-primary (#717)."""
         from src.config.constants import (
-            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY as PROBE,
+            DEFAULT_WS_USER_DEGRADED_PROBE_CEILING as CEILING,
         )
         from src.config.constants import (
             DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT,
@@ -336,24 +336,23 @@ class TestUserStreamRecoveringRestFallback:
 
         # Fast phase: probe on every cycle up to the limit.
         assert all(mock_engine._should_probe_user_reconnect(n) for n in range(1, LIMIT + 1))
-        # Throttled phase: only multiples of PROBE probe.
+        # Throttled phase: the first boundary probes; a value just past it does not.
         assert mock_engine._should_probe_user_reconnect(LIMIT + 1) is False
-        assert mock_engine._should_probe_user_reconnect(PROBE) is True
-        # Never permanently false: a probe always recurs within every PROBE window.
-        for start in range(LIMIT + 1, 5 * PROBE, PROBE):
+        assert mock_engine._should_probe_user_reconnect(10) is True  # first boundary
+        # Never permanently false: past the geometric ramp the gap is the constant
+        # CEILING, so every window of CEILING consecutive failures contains a probe.
+        ramp_end = 520  # past the ramp, boundaries are CEILING-spaced (… 400, 520, 640)
+        for start in range(ramp_end, ramp_end + 4 * CEILING, CEILING):
             assert any(
-                mock_engine._should_probe_user_reconnect(n) for n in range(start, start + PROBE)
+                mock_engine._should_probe_user_reconnect(n) for n in range(start, start + CEILING)
             )
 
     @pytest.mark.fast
     def test_degraded_probe_is_throttled_past_limit_but_never_zero(self, mock_engine):
-        """A persistently-degraded user stream gets fast probes up to the limit,
-        then throttled probes every Nth cycle — bounded, but NEVER zero (always a
-        path back to WS). Regression vs BOTH the #616 per-cycle churn and the
-        REST-until-restart absorbing state."""
-        from src.config.constants import (
-            DEFAULT_WS_USER_DEGRADED_PROBE_EVERY as PROBE,
-        )
+        """A persistently-degraded user stream gets fast probes up to the limit, then
+        probes on the #723 exponential-backoff boundary schedule — bounded, but NEVER
+        zero (always a path back to WS). Regression vs BOTH the #616 per-cycle churn
+        and the REST-until-restart absorbing state."""
         from src.config.constants import (
             DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT,
         )
@@ -364,19 +363,25 @@ class TestUserStreamRecoveringRestFallback:
         mock_engine._user_reconnect_failures = 0
         attempt_cycles: list[int] = []
 
-        def _record():
+        def _record(**_kwargs):
             # _handle_user_stream_disconnect runs after the counter is bumped, so
             # the counter == the cycle index at each attempt.
             attempt_cycles.append(mock_engine._user_reconnect_failures)
 
+        horizon = 640  # spans the geometric ramp into the CEILING-spaced tail
         with patch.object(mock_engine, "_handle_user_stream_disconnect", side_effect=_record):
-            for _ in range(5 * PROBE):  # 50 degraded cycles
+            for _ in range(horizon):
                 mock_engine._check_user_stream_health()
 
-        expected = [n for n in range(1, 5 * PROBE + 1) if n <= LIMIT or n % PROBE == 0]
+        # Fast phase 1..LIMIT, then the exact backoff boundaries 10,20,40,80,160,…,640.
+        boundaries = {10, 20, 40, 80, 160, 280, 400, 520, 640}
+        expected = [n for n in range(1, horizon + 1) if n <= LIMIT or n in boundaries]
         assert attempt_cycles == expected
-        # Never stops: probes continue into the final stretch of cycles.
-        assert any(c > 5 * PROBE - PROBE for c in attempt_cycles)
+        # Never stops: a probe fires at the very end of the horizon (640).
+        assert attempt_cycles[-1] == 640
+        # Far fewer than the old fixed every-10 cadence (which would be ~64 probes).
+        old_cadence_count = LIMIT + sum(1 for n in range(LIMIT + 1, horizon + 1) if n % 10 == 0)
+        assert len(attempt_cycles) < old_cadence_count
         # Probing the degraded stream must never re-mark it degraded or touch polling.
         ex.mark_user_degraded.assert_not_called()
 
@@ -753,6 +758,58 @@ class TestHandleUserStreamDisconnect:
         mock_exchange.mark_user_degraded.assert_called_once()
         mock_tracker.enable_polling.assert_called_once()
 
+    @pytest.mark.fast
+    def test_hard_true_routes_to_hard_reconnect_user(self, mock_engine):
+        """#723: hard=True dispatches the full-teardown rebuild (hard_reconnect_user),
+        NOT the in-place reconnect_user."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex.hard_reconnect_user.return_value = True
+        mock_engine.exchange_interface = ex
+        mock_engine.order_tracker = MagicMock()
+        mock_engine._periodic_reconciler = MagicMock()
+
+        with patch("src.engines.live.user_data_processor.UserDataProcessor"):
+            mock_engine._handle_user_stream_disconnect(hard=True)
+
+        ex.hard_reconnect_user.assert_called_once()
+        ex.reconnect_user.assert_not_called()
+
+    @pytest.mark.fast
+    def test_hard_false_routes_to_in_place_reconnect_user(self, mock_engine):
+        """#723: hard=False (the default) keeps the cheap in-place reconnect_user."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex.reconnect_user.return_value = True
+        mock_engine.exchange_interface = ex
+        mock_engine.order_tracker = MagicMock()
+        mock_engine._periodic_reconciler = MagicMock()
+
+        with patch("src.engines.live.user_data_processor.UserDataProcessor"):
+            mock_engine._handle_user_stream_disconnect(hard=False)
+
+        ex.reconnect_user.assert_called_once()
+        ex.hard_reconnect_user.assert_not_called()
+
+    @pytest.mark.fast
+    def test_hard_reconnect_returns_false_marks_degraded_no_false_primary(self, mock_engine):
+        """#723: a hard reconnect that returns False (e.g. teardown/rebuild failed)
+        leaves the stream degraded with polling on — no false PRIMARY (E.13)."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex.hard_reconnect_user.return_value = False
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        mock_engine.order_tracker = tracker
+        mock_engine._periodic_reconciler = MagicMock()
+
+        with patch("src.engines.live.user_data_processor.UserDataProcessor"):
+            mock_engine._handle_user_stream_disconnect(hard=True)
+
+        ex.mark_user_degraded.assert_called_once()
+        tracker.enable_polling.assert_called_once()  # polling stays ON
+        tracker.disable_polling.assert_not_called()  # recovery only ever via a real event
+
 
 class TestStartWebSocketStreamsUserPolling:
     """#717: at boot the user stream starts but REST polling stays ON until the
@@ -818,3 +875,316 @@ class TestStartWebSocketStreamsUserPolling:
             mock_engine._check_user_stream_health()
 
         tracker.disable_polling.assert_called_once()  # handed off to WS-primary
+
+
+class TestUserDegradedProbeBackoffSchedule:
+    """#723 Phase 1: the user degraded-probe uses an EXPONENTIAL-BACKOFF schedule of
+    absolute failure-count boundaries (10, 20, 40, 80, 160, 280, 400, 520, 640, …),
+    generated iteratively from the three backoff constants — NOT a fixed every-Nth
+    cadence and NOT a hardcoded list. Bounds the unrecoverable-margin-stream churn
+    (#616) while preserving #717's never-permanently-False path back to WS-primary."""
+
+    # The pinned boundary sequence the plan flags as the arithmetic most likely to
+    # drift. Generated below from the constants and asserted equal to this.
+    PINNED_BOUNDARIES = [10, 20, 40, 80, 160, 280, 400, 520, 640]
+
+    @staticmethod
+    def _generate_boundaries(max_failure):
+        """Reference generator: walk boundaries from the constants up to max_failure."""
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_BACKOFF_BASE as BASE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_CEILING as CEILING,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_USER_DEGRADED_PROBE_FIRST_BOUNDARY as FIRST,
+        )
+
+        out = []
+        boundary = FIRST
+        gap = FIRST
+        while boundary <= max_failure:
+            out.append(boundary)
+            boundary += gap
+            gap = min(gap * BASE, CEILING)
+        return out
+
+    @pytest.mark.fast
+    def test_generated_boundary_list_matches_pinned_sequence(self, mock_engine):
+        """The boundary set generated from FIRST/BASE/CEILING equals the pinned
+        10,20,40,80,160,280,400,520,640 — a constant-drift regression guard (E.1)."""
+        assert self._generate_boundaries(640) == self.PINNED_BOUNDARIES
+
+    @pytest.mark.fast
+    def test_post_ramp_gaps_all_equal_ceiling(self, mock_engine):
+        """Once the geometric ramp saturates, every gap equals CEILING (E.1) — the
+        property that makes the schedule never-permanently-False."""
+        from src.config.constants import DEFAULT_WS_USER_DEGRADED_PROBE_CEILING as CEILING
+
+        boundaries = self._generate_boundaries(5 * CEILING)
+        gaps = [boundaries[i + 1] - boundaries[i] for i in range(len(boundaries) - 1)]
+        # Gaps ramp 10,20,40,80 then are pinned at CEILING (120) thereafter.
+        assert gaps[:4] == [10, 20, 40, 80]
+        assert all(g == CEILING for g in gaps[4:])
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize("failures", [1, 2, 3, 10, 20, 40, 80, 160, 280, 400, 520])
+    def test_probe_true_at_fast_phase_and_every_boundary(self, mock_engine, failures):
+        """True at the fast phase (1..LIMIT) and at every backoff boundary (E.1)."""
+        assert mock_engine._should_probe_user_reconnect(failures) is True
+
+    @pytest.mark.fast
+    @pytest.mark.parametrize("failures", [4, 9, 11, 21, 39, 81, 159, 161, 279, 281, 399, 401])
+    def test_probe_false_at_non_boundaries(self, mock_engine, failures):
+        """False at non-boundary failure counts straddling the boundaries (E.1)."""
+        assert mock_engine._should_probe_user_reconnect(failures) is False
+
+    @pytest.mark.fast
+    def test_never_permanently_false_past_ramp(self, mock_engine):
+        """For ANY window of CEILING consecutive failures past the geometric ramp, at
+        least one returns True — forever (the #717 path-back guarantee) (E.2)."""
+        from src.config.constants import DEFAULT_WS_USER_DEGRADED_PROBE_CEILING as CEILING
+
+        ramp_end = 520
+        for start in range(ramp_end, ramp_end + 8 * CEILING):
+            window = range(start, start + CEILING)
+            assert any(mock_engine._should_probe_user_reconnect(n) for n in window), start
+
+    @pytest.mark.fast
+    def test_fast_phase_unchanged(self, mock_engine):
+        """Fast phase still probes every cycle up to the limit (regression guard for
+        #717's quick recovery) (E.3)."""
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        assert all(mock_engine._should_probe_user_reconnect(n) for n in range(1, LIMIT + 1))
+
+    @pytest.mark.fast
+    def test_churn_strictly_below_old_cadence_and_monotonically_rarer(self, mock_engine):
+        """Over a long horizon the backoff fires strictly fewer probes than the old
+        fixed every-10, and the spacing is monotonically non-decreasing until the
+        CEILING — the intended churn reduction (E.4)."""
+        horizon = 1000
+        probes = [n for n in range(1, horizon + 1) if mock_engine._should_probe_user_reconnect(n)]
+        old_every_10 = [n for n in range(1, horizon + 1) if n <= 3 or n % 10 == 0]
+        assert len(probes) < len(old_every_10)  # strictly fewer
+        # ~12 probes over 1000 cycles vs ~100 for the old cadence (plan's target).
+        assert len(probes) < 20
+
+        # Spacing between consecutive throttled boundaries is monotonically
+        # non-decreasing (it doubles, then plateaus at CEILING) — never gets denser.
+        from src.config.constants import DEFAULT_WS_USER_DEGRADED_PROBE_CEILING as CEILING
+
+        throttled = [p for p in probes if p >= 10]
+        gaps = [throttled[i + 1] - throttled[i] for i in range(len(throttled) - 1)]
+        assert gaps == sorted(gaps)  # non-decreasing
+        assert max(gaps) == CEILING
+
+    @pytest.mark.fast
+    def test_recovery_under_backoff_returns_to_primary(self, mock_engine):
+        """Mid-backoff (a non-probing throttled cycle), a real event still recovers
+        immediately: recovery is independent of the probe predicate (E.5)."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        ex.user_ws_healthy = False
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        tracker.is_polling_enabled.return_value = True
+        mock_engine.order_tracker = tracker
+        # Sit at a NON-boundary failure count (no probe this cycle).
+        mock_engine._user_reconnect_failures = 158  # 159 next cycle, not a boundary
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as disc:
+            mock_engine._check_user_stream_health()  # 159 → no probe
+            disc.assert_not_called()
+            assert mock_engine._user_reconnect_failures == 159
+
+            # A real event arrives mid-backoff → recover regardless of the predicate.
+            ex.user_ws_healthy = True
+            mock_engine._check_user_stream_health()
+
+        tracker.disable_polling.assert_called_once()
+        assert mock_engine._user_reconnect_failures == 0  # breaker reset
+
+    @pytest.mark.fast
+    def test_next_probe_eta_widens_with_backoff(self, mock_engine):
+        """The diagnostic ETA helper reports a widening gap (≈5m → 10m → 60m) as the
+        backoff ramps, derived from the same constants so it can't drift (D.3)."""
+        # At failure 3 (just before the first boundary 10): 7 cycles × 30s = 3.5m.
+        assert mock_engine._user_next_probe_eta_minutes(3) == pytest.approx(3.5)
+        # At boundary 10: gap to the NEXT boundary (20) = 10 cycles × 30s = 5m.
+        assert mock_engine._user_next_probe_eta_minutes(10) == pytest.approx(5.0)
+        # At boundary 80: gap to 160 = 80 cycles × 30s = 40m.
+        assert mock_engine._user_next_probe_eta_minutes(80) == pytest.approx(40.0)
+        # Past the ramp (e.g. 520): gap is CEILING (120) × 30s = 60m.
+        assert mock_engine._user_next_probe_eta_minutes(520) == pytest.approx(60.0)
+
+    @pytest.mark.fast
+    def test_kline_predicate_and_constant_untouched(self, mock_engine):
+        """Phase 1 must NOT touch kline: its predicate is still the fixed every-Nth
+        cadence and its constant is unchanged (E.7)."""
+        from src.config.constants import (
+            DEFAULT_WS_KLINE_DEGRADED_PROBE_EVERY as KLINE_PROBE,
+        )
+        from src.config.constants import (
+            DEFAULT_WS_KLINE_RECONNECT_CIRCUIT_LIMIT as KLINE_LIMIT,
+        )
+
+        assert KLINE_PROBE == 10  # unchanged
+        # Kline still uses the simple modulo cadence (NOT the user backoff schedule):
+        # multiples of KLINE_PROBE past the limit probe; non-multiples do not.
+        assert mock_engine._should_probe_kline_reconnect(KLINE_LIMIT + 1) is False
+        assert mock_engine._should_probe_kline_reconnect(2 * KLINE_PROBE) is True
+        assert mock_engine._should_probe_kline_reconnect(2 * KLINE_PROBE + 1) is False
+        # The user backoff boundary 20 would also be a kline probe (both multiples of
+        # 10), but the user-specific boundary 40-vs-30 distinction proves they differ:
+        assert mock_engine._should_probe_kline_reconnect(30) is True  # kline: 30%10==0
+        assert mock_engine._should_probe_user_reconnect(30) is False  # user: 30 not a boundary
+
+
+class TestUserHardReconnectMode:
+    """#723 Phase 2: a flag-gated full teardown + fresh-AsyncClient rebuild
+    (hard_reconnect_user). Ships INERT (FEATURE_WS_USER_HARD_RECONNECT default OFF).
+    The mode is decided by the CALLER before stop_user_stream flips state, and a
+    kline/user coupling falls back to in-place reconnect (never crashes the thread)."""
+
+    @staticmethod
+    def _degraded_engine(mock_engine, *, kline_provider=None):
+        """Live engine sitting in REST_DEGRADED at the first backoff boundary so the
+        next health cycle probes."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        ex.user_ws_healthy = False
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        tracker.is_polling_enabled.return_value = True
+        mock_engine.order_tracker = tracker
+        # Separate kline provider by default (the real topology): not the exchange.
+        mock_engine._ws_kline_provider = (
+            kline_provider if kline_provider is not None else MagicMock()
+        )
+        # Land exactly on boundary 10 next cycle so _should_probe_user_reconnect True.
+        mock_engine._user_reconnect_failures = 9
+        return ex, tracker
+
+    @pytest.mark.fast
+    def test_flag_off_uses_in_place_reconnect(self, mock_engine):
+        """Flag OFF (default): the degraded probe passes hard=False → in-place
+        reconnect path (E.10)."""
+        ex, _tracker = self._degraded_engine(mock_engine)
+        with (
+            patch("src.config.feature_flags.is_enabled", return_value=False) as flag,
+            patch.object(mock_engine, "_handle_user_stream_disconnect") as disc,
+        ):
+            mock_engine._check_user_stream_health()
+        disc.assert_called_once_with(hard=False)
+        # Even if never queried due to short-circuit, assert the flag key if used.
+        if flag.called:
+            assert flag.call_args[0][0] == "ws_user_hard_reconnect"
+
+    @pytest.mark.fast
+    def test_flag_on_degraded_uses_hard_reconnect(self, mock_engine):
+        """Flag ON + REST_DEGRADED + failures>LIMIT: the probe passes hard=True (E.10)."""
+        ex, _tracker = self._degraded_engine(mock_engine)
+        with (
+            patch("src.config.feature_flags.is_enabled", return_value=True),
+            patch.object(mock_engine, "_handle_user_stream_disconnect") as disc,
+        ):
+            mock_engine._check_user_stream_health()
+        disc.assert_called_once_with(hard=True)
+
+    @pytest.mark.fast
+    def test_flag_on_primary_stale_still_uses_in_place(self, mock_engine):
+        """Flag ON but PRIMARY-stale path → hard=False (mode decided by caller, not
+        read inside the handler post-teardown) (E.10)."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = False
+        ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        mock_engine._ws_kline_provider = MagicMock()
+        mock_engine._user_reconnect_failures = 0  # fast phase
+
+        with (
+            patch("src.config.feature_flags.is_enabled", return_value=True),
+            patch.object(mock_engine, "_handle_user_stream_disconnect") as disc,
+        ):
+            mock_engine._check_user_stream_health()
+        # PRIMARY-stale caller never passes hard → default False.
+        disc.assert_called_once_with()
+
+    @pytest.mark.fast
+    def test_flag_on_resyncing_still_uses_in_place(self, mock_engine):
+        """Flag ON but RESYNCING path → in-place (hard=False default) (E.10)."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.RESYNCING
+        ex.user_ws_healthy = False
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        mock_engine._ws_kline_provider = MagicMock()
+
+        with (
+            patch("src.config.feature_flags.is_enabled", return_value=True),
+            patch.object(mock_engine, "_handle_user_stream_disconnect") as disc,
+        ):
+            mock_engine._check_user_stream_health()
+        disc.assert_called_once_with()  # RESYNCING caller: no hard kwarg
+
+    @pytest.mark.fast
+    def test_coupling_guard_falls_back_to_in_place_and_does_not_raise(self, mock_engine, caplog):
+        """B-VERIFY-1 guard: if kline and user share a provider, flag ON + degraded
+        logs CRITICAL and uses in-place reconnect (hard=False) — and does NOT raise
+        (the WS health thread must not crash) (E.11)."""
+        import logging
+
+        ex, _tracker = self._degraded_engine(mock_engine)
+        # Co-locate: kline provider IS the exchange interface (the dangerous topology).
+        mock_engine._ws_kline_provider = ex
+
+        with (
+            patch("src.config.feature_flags.is_enabled", return_value=True),
+            patch.object(mock_engine, "_handle_user_stream_disconnect") as disc,
+            caplog.at_level(logging.CRITICAL),
+        ):
+            mock_engine._check_user_stream_health()  # must not raise
+
+        disc.assert_called_once_with(hard=False)  # fell back to cheap path
+        assert any(
+            "share a provider" in r.message and r.levelno == logging.CRITICAL
+            for r in caplog.records
+        )
+
+    @pytest.mark.fast
+    def test_should_hard_reconnect_helper_default_off(self, mock_engine):
+        """_should_hard_reconnect_user is False when the flag is unset (default OFF),
+        so a missing env var can never silently enable the teardown path (E.13)."""
+        ex = MagicMock()
+        mock_engine.exchange_interface = ex
+        mock_engine._ws_kline_provider = MagicMock()
+        # No FEATURE_WS_USER_HARD_RECONNECT in env, no overrides → resolves OFF.
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("FEATURE_WS_USER_HARD_RECONNECT", None)
+            assert mock_engine._should_hard_reconnect_user() is False
+
+    @pytest.mark.fast
+    def test_should_hard_reconnect_helper_false_when_method_missing(self, mock_engine):
+        """Defensive: even flag ON, if the provider lacks hard_reconnect_user the
+        helper returns False (no AttributeError at probe time)."""
+        ex = MagicMock(spec=["reconnect_user", "stop_user_stream", "mark_user_degraded"])
+        mock_engine.exchange_interface = ex
+        mock_engine._ws_kline_provider = MagicMock()
+        with patch("src.config.feature_flags.is_enabled", return_value=True):
+            assert mock_engine._should_hard_reconnect_user() is False


### PR DESCRIPTION
## Summary

Closes the #723 gap: after #717 shipped, prod observation showed the **margin user-data WebSocket perpetually throttled-probes without ever recovering**. #717's REST fallback is safe (order/balance stay correct via polling), but the stream never restores event delivery because **#616's root cause is unfixed** — python-binance 1.0.x multiplexes the margin subscription over a shared `ws_api` socket, and an in-place re-subscribe (`reconnect_user`) reuses that already-degraded object. The margin user stream is, in practice, a REST-primary stream.

This PR is the two-phase plan from the Codex-approved investigation (`/tmp/issue-723-plan.md`):

### Phase 1 — ships **ACTIVE** (lowest risk; pure predicate change, no live-WS surface touched)
Exponential-backoff the degraded probe. `_should_probe_user_reconnect` now probes on an **absolute failure-count boundary schedule** `10, 20, 40, 80, 160, 280, 400, 520, …` (gaps double, then plateau at the `CEILING`), generated **iteratively** from three new constants (`FIRST=10`, `BACKOFF_BASE=2`, `CEILING=120`) — not the old fixed every-10 cadence. Over 1000 degraded cycles the probe count drops from ~100 → ~12, cutting churn **~200/day → ~50–80/day** and the #716 teardown noise.

- Preserves #717's **never-permanently-False** invariant: the post-ramp gap equals `CEILING`, so every `CEILING`-wide window of failures still contains a probe → a recovered network always returns to WS-primary.
- Fast phase (`failures <= LIMIT`, every cycle) unchanged.
- **Kline is untouched** (separate predicate, separate constant).
- The degraded-probe log now reports the widening `next probe in ~Nm` for prod monitoring.

### Phase 2 — ships **INERT** behind `FEATURE_WS_USER_HARD_RECONNECT` (default **OFF**)
`hard_reconnect_user()` does a full `stop_streams` (closes the `AsyncClient` + `ws_api`) → `_ensure_twm` rebuild (fresh `AsyncClient` → brand-new `WebsocketAPI`) → `start_user_stream` — the margin analogue of what makes kline recover, and the only **supported-library** way to escape an object-level-degraded `ws_api`.

- **Mode decided by the caller** before `_handle_user_stream_disconnect`'s `stop_user_stream` flips state to `DISCONNECTED` (the handler takes a `hard` kwarg; it can no longer re-read `REST_DEGRADED`). Only the `REST_DEGRADED` throttled-probe branch sets `hard=True`, and only when the flag is ON **and** the coupling guard passes. Fast-phase / `RESYNCING` / `PRIMARY`-stale callers always use the cheap in-place path.
- **Coupling guard, not a bare assert:** if a future refactor ever co-located kline on the user provider (`_ws_kline_provider is exchange_interface`), `_should_hard_reconnect_user` logs **CRITICAL** and falls back to in-place reconnect — it never raises, so the WS health thread can't crash.
- **B-VERIFY-1/2 hold** (re-asserted as regression guards): kline runs on a separate provider/TWM, and order placement uses the separate **synchronous** `Client` — a user-stream teardown can touch **neither kline nor order/stop-loss submission**.
- **Generation/TOCTOU:** reuses the existing locked generation bumps in `stop_streams` + `start_user_stream`, so a stale callback from the torn-down `AsyncClient` can't fake recovery.
- Recovery stays gated on a **real event** via the single `_restore_user_ws_primary` disable site, so a fire-and-forget start on a still-broken (M2 server-side) socket cannot blackout order tracking.

## Safety / #717 invariants preserved
- **Single `disable_polling` site** (`_restore_user_ws_primary`) — neither phase adds another.
- **Never-permanently-False probe** — explicitly preserved and tested in the backoff.
- **Generation-token race protection** — untouched in Phase 1; Phase 2 reuses it.
- **No money-moving logic touched** — SL is exchange-side; REST polling backstops order/balance throughout. Both phases only change *how often / how* we probe a WS that REST already covers.

## Testing
- New + updated unit tests (all green locally on the `1.0.x`-with-`binance.ws` venv):
  - **Phase 1:** exact backoff schedule (True at `1,2,3,10,20,40,80,160,280,400,520`; False at the straddling non-boundaries `4,9,11,21,39,81,159,161,279,281,399,401`); generated list == pinned sequence; post-ramp gaps all == `CEILING`; never-permanently-False windows; fast-phase unchanged; churn strictly < old cadence + monotonically rarer; recovery-under-backoff; ETA-widens; **kline predicate/constant untouched**.
  - **Phase 2:** mode-decided-by-caller (flag OFF → `hard=False`; flag ON + degraded → `hard=True`; flag ON + PRIMARY-stale/RESYNCING → still in-place; fast-phase → in-place); coupling-guard CRITICAL + fallback + no-raise; `hard_reconnect_user` order (stop→ensure→start) + generation bump (+2); failure paths (`stop_streams` raises → polling stays ON / no false PRIMARY; `_ensure_twm` raises → no start; `start_user_stream` False → returns False → caller marks degraded); flag default-OFF.
  - **`pytest tests/unit/test_trading_engine_ws_health.py tests/unit/test_binance_provider_websocket.py` → 129 passed.** Broader `pytest -m fast` → **1191 passed, 0 failures**.
- `black --check`, `ruff check` clean on changed files. `mypy`: changed lines introduce zero new errors (repo has pre-existing type debt elsewhere, unchanged). `bandit`: no new Medium/High.
- **Codex review (gpt-5.5): `VERDICT: APPROVE`** — zero findings at any severity; independently verified all 8 focus points (iterative backoff, never-permanently-False, flag default-OFF, mode-by-caller-before-teardown, coupling-guard-not-assert, generation/TOCTOU, kline/order-client untouched, failure paths) and ran the suite (129 passed).

## Deviations from the plan (with rationale)
1. **Backoff generator ordering corrected.** The plan's Part-D *pseudocode* doubled the gap **before** adding it, which yields the wrong `10, 30, 70, 150, …` (the very closed-form the plan warns against). I followed the plan's **pinned prose target** `10, 20, 40, 80, 160, 280, 400, 520` and implemented the generator that produces it (add gap → **then** double, capped at `CEILING`). The pinned test asserts the exact sequence.
2. **`requirements-github.txt` pin — superseded by #725.** The task's STEP 3 asked to fix the stale `1.0.19` → `1.0.36`. While this was in progress, **#725 (`87cfbceb`) merged to `develop` and bumped python-binance to `1.0.37` across all three requirements files.** This branch is rebased onto that commit, so the stale-pin problem is **already resolved uniformly at `1.0.37`** — I deliberately did **not** regress it back to `1.0.36`. Net: no requirements change in this PR; STEP 3's goal (aligned, non-stale pin) is satisfied by #725.
3. **Feature-flag accessor.** Used `is_enabled("ws_user_hard_reconnect", False)` (the repo's binary flag convention; default-OFF, parses `off`/`on`/`true`/`false`) rather than the 3-mode `get_flag(..., "off")` string pattern the orphaned-borrow sweep uses — this flag is a simple on/off, so the binary getter is the idiomatic fit.

## Prod gating (per #723 + repo daemon rules)
⚠️ HIGH-RISK WS/event-loop subsystem. **Prod promote gates on explicit human sign-off** (surgical per-fix cherry-pick onto `main` with patch-id verification, not a wholesale `develop→main` merge). Phase 1 ships active but is unit-tested arithmetic with no live-WS surface. **Phase 2 ships inert; its activation is a deliberate `FEATURE_WS_USER_HARD_RECONNECT` flip (a Railway restart) + live observation**, and is declared "effective" only on a **confirmed real user-stream event after a hard reconnect** (not a `start==True` or subscribe-200) — optionally via a human-approved tiny non-marketable test order to distinguish M1 (now fixed) from M2 (server-side, still broken). If M2 dominates, leave the flag OFF and keep Phase-1 bounded churn as the durable state.

Refs #616, #717. Supersedes the stale-pin part of STEP 3 via #725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)