### PR TITLE
fix(live): audit + alert margin-equity sync corrections

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Margin-equity balance corrections are now audited and alertable.
+  `margin_equity_sync_correction` book-downs (written by
+  `AccountSynchronizer._sync_margin_equity`) previously updated the balance ledger
+  without recording a `reconciliation_audit_events` row or a warning-level
+  `system_events` row, so the single largest capital event a margin session can
+  produce was invisible to monitoring/auditing — a −$15.75 (−15.8%) production
+  book-down on 2026-06-03 (and a second −$1.37 on 2026-06-05) left zero audit
+  trail. The path now emits both records via a new best-effort
+  `_record_equity_correction_audit` helper: an immutable audit row
+  (`entity_type='balance'`, `field='total_balance'`, before/after values, severity
+  `HIGH`, escalating to `CRITICAL` when divergence ≥ 5%) and a `BALANCE_ADJUSTMENT`
+  system event at `warning` severity (`critical` when ≥ 5%) so alerting can see large
+  book-downs. Both writes are independently guarded so a logging failure can neither
+  raise into the sync loop nor unwind the already-persisted correction; emission is
+  skipped entirely if `update_balance` itself reports failure (no audit for a
+  correction that never persisted). The audit binds to the same session the balance
+  write used — resolved via `update_balance`'s own `_current_session_id` fallback — so
+  the first post-restart correction (when `AccountSynchronizer.session_id` has not yet
+  been assigned) is captured too, not just steady-state periodic syncs.
 - Live position/trade recovery no longer crashes on `Decimal`-vs-`float`
   arithmetic. `DatabaseManager.get_active_positions` and `get_recent_trades`
   now coerce SQLAlchemy `Numeric(18,8)` columns (which read back from

--- a/src/engines/live/account_sync.py
+++ b/src/engines/live/account_sync.py
@@ -15,6 +15,7 @@ from src.config.constants import (
     DEFAULT_ACCOUNT_SYNC_MIN_INTERVAL_MINUTES,
     DEFAULT_BALANCE_DISCREPANCY_THRESHOLD_PCT,
     DEFAULT_POSITION_SIZE_COMPARISON_TOLERANCE,
+    DEFAULT_RECONCILIATION_BALANCE_THRESHOLD_PCT,
 )
 from src.data_providers.exchange_interface import (
     AccountBalance,
@@ -24,7 +25,8 @@ from src.data_providers.exchange_interface import (
 )
 from src.data_providers.exchange_interface import OrderStatus as ExchangeOrderStatus
 from src.database.manager import DatabaseManager
-from src.database.models import PositionSide, TradeSource
+from src.database.models import EventType, PositionSide, TradeSource
+from src.engines.live.reconciliation import Severity
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +71,7 @@ class AccountSynchronizer:
         self._use_margin = use_margin
         self.last_sync_time: datetime | None = None
 
-    def sync_account_data(
-        self, force: bool = False, symbol: str | None = None
-    ) -> SyncResult:
+    def sync_account_data(self, force: bool = False, symbol: str | None = None) -> SyncResult:
         """
         Synchronize all account data from the exchange.
 
@@ -125,12 +125,8 @@ class AccountSynchronizer:
             # Balance/position sync remains skipped in margin mode because USDT
             # netAsset doesn't reflect true equity when shorts are open.
             if not self._use_margin:
-                balance_sync_result = self._sync_balances(
-                    exchange_data.get("balances", [])
-                )
-                position_sync_result = self._sync_positions(
-                    exchange_data.get("positions", [])
-                )
+                balance_sync_result = self._sync_balances(exchange_data.get("balances", []))
+                position_sync_result = self._sync_positions(exchange_data.get("positions", []))
             else:
                 # Margin: reconcile the tracked balance against true net equity
                 # (assets minus liabilities), not USDT alone. Position sync stays
@@ -196,7 +192,20 @@ class AccountSynchronizer:
         if equity is None or equity <= 0:
             return {"synced": False, "reason": "equity unavailable"}
 
-        current_db_balance = self.db_manager.get_current_balance(self.session_id)
+        # Resolve the session id exactly as update_balance does (it falls back to the
+        # DB manager's _current_session_id). During the INITIAL startup sync this
+        # synchronizer's own session_id is still None — trading_engine assigns it only
+        # AFTER sync_account_data() returns — yet the session already exists on the DB
+        # manager. Without this fallback a real startup correction would persist (via
+        # update_balance's own fallback) while the audit/event were silently skipped,
+        # re-opening the exact gap this path exists to close.
+        effective_session_id = (
+            self.session_id
+            if self.session_id is not None
+            else getattr(self.db_manager, "_current_session_id", None)
+        )
+
+        current_db_balance = self.db_manager.get_current_balance(effective_session_id)
         diff_pct = (
             abs(equity - current_db_balance) / current_db_balance * 100
             if current_db_balance > 0
@@ -206,9 +215,7 @@ class AccountSynchronizer:
         # Flat iff net equity matches USDT cash (no position value or liability).
         usdt_bal = self.exchange.get_balance("USDT")
         usdt_total = (
-            float(usdt_bal.total)
-            if usdt_bal is not None and usdt_bal.total is not None
-            else None
+            float(usdt_bal.total) if usdt_bal is not None and usdt_bal.total is not None else None
         )
         flat_tolerance = max(1.0, equity * 0.01)
         if usdt_total is None or abs(equity - usdt_total) > flat_tolerance:
@@ -237,15 +244,138 @@ class AccountSynchronizer:
             equity,
             diff_pct,
         )
-        self.db_manager.update_balance(
-            equity, "margin_equity_sync_correction", "system", self.session_id
+        balance_updated = self.db_manager.update_balance(
+            equity, "margin_equity_sync_correction", "system", effective_session_id
         )
+        if not balance_updated:
+            # update_balance swallows its own errors and returns False; don't emit
+            # an audit trail or alert claiming a correction that never persisted.
+            logger.error(
+                "Margin equity correction did NOT persist (update_balance returned "
+                "False): tracked $%.2f vs true equity $%.2f — skipping audit/event",
+                current_db_balance,
+                equity,
+            )
+            return {
+                "synced": False,
+                "corrected": False,
+                "reason": "balance update failed",
+                "old_balance": current_db_balance,
+                "new_balance": equity,
+            }
+
+        # This book-down is the largest capital event a margin session can produce
+        # and was historically invisible to auditing/alerting (the prod gap behind
+        # this fix). Record the immutable audit trail + an operator alert; the 1%
+        # correction gate above guarantees the move is already material. Pass the
+        # resolved session id so the audit binds to the same session the balance
+        # write used (critical for the startup sync where self.session_id is None).
+        self._record_equity_correction_audit(
+            current_db_balance, equity, diff_pct, effective_session_id
+        )
+
         return {
             "synced": True,
             "corrected": True,
             "old_balance": current_db_balance,
             "new_balance": equity,
         }
+
+    def _record_equity_correction_audit(
+        self,
+        old_balance: float,
+        new_equity: float,
+        diff_pct: float,
+        session_id: int | None,
+    ) -> None:
+        """Persist the audit trail and operator alert for a margin-equity book-down.
+
+        A ``margin_equity_sync_correction`` can be the single largest capital event
+        of a session, so every correction MUST leave a ``reconciliation_audit_events``
+        row (before/after values) and — because the 1% correction gate guarantees the
+        move is already material — a warning+ ``system_events`` row so monitoring and
+        alerting can see large book-downs.
+
+        Both writes are best-effort and independently guarded: per CODE.md ("wrap
+        callback invocations in try/except so failures don't block state updates"),
+        an observability failure must neither raise into the sync loop nor unwind the
+        already-persisted balance correction.
+
+        Args:
+            old_balance: Tracked balance before the correction.
+            new_equity: True cross-margin equity the balance was corrected to.
+            diff_pct: Absolute divergence as a percentage of the old balance.
+            session_id: The session the balance write was bound to (the caller's
+                resolved effective id, which falls back to the DB manager's current
+                session). Must be the same id update_balance used.
+        """
+        if session_id is None:
+            # Defensive only: the caller resolves session_id the same way
+            # update_balance does, so a persisted correction always has a non-None
+            # id here. Kept so a degenerate call logs rather than crashes.
+            logger.error(
+                "Cannot audit margin-equity correction (tracked $%.2f -> $%.2f): "
+                "no active session_id",
+                old_balance,
+                new_equity,
+            )
+            return
+
+        delta = new_equity - old_balance
+        # ``diff_pct`` is a percentage (0-100); the shared CRITICAL threshold
+        # constant is a fraction (0.05 == 5%), so scale it to percent to compare.
+        is_critical = diff_pct >= DEFAULT_RECONCILIATION_BALANCE_THRESHOLD_PCT * 100
+        # Reuse the reconciler's severity vocabulary so this audit row matches every
+        # other log_audit_event call site. SystemEvent uses its own lowercase scale.
+        audit_severity = (Severity.CRITICAL if is_critical else Severity.HIGH).value
+        event_severity = "critical" if is_critical else "warning"
+        reason = (
+            f"Margin equity sync correction: tracked balance ${old_balance:.2f} vs "
+            f"true cross-margin equity ${new_equity:.2f} "
+            f"(Δ ${delta:+.2f}, {diff_pct:.2f}%) while flat"
+        )
+
+        try:
+            self.db_manager.log_audit_event(
+                session_id=session_id,
+                entity_type="balance",
+                entity_id=None,
+                field="total_balance",
+                old_value=f"{old_balance:.8f}",
+                new_value=f"{new_equity:.8f}",
+                reason=reason,
+                severity=audit_severity,
+            )
+        except Exception as e:
+            # Best-effort: degraded observability must not break the sync loop.
+            logger.error(
+                "Failed to record margin-equity reconciliation audit event: %s",
+                e,
+                exc_info=True,
+            )
+
+        try:
+            self.db_manager.log_event(
+                event_type=EventType.BALANCE_ADJUSTMENT,
+                message=reason,
+                severity=event_severity,
+                component="account_sync.margin_equity",
+                details={
+                    "old_balance": old_balance,
+                    "new_balance": new_equity,
+                    "delta": delta,
+                    "diff_pct": diff_pct,
+                    "update_reason": "margin_equity_sync_correction",
+                },
+                session_id=session_id,
+            )
+        except Exception as e:
+            # Best-effort: degraded observability must not break the sync loop.
+            logger.error(
+                "Failed to record margin-equity reconciliation system event: %s",
+                e,
+                exc_info=True,
+            )
 
     def _sync_balances(self, exchange_balances: list[AccountBalance]) -> dict[str, Any]:
         """Synchronize account balances"""

--- a/tests/unit/engines/live/test_account_sync_margin.py
+++ b/tests/unit/engines/live/test_account_sync_margin.py
@@ -223,3 +223,36 @@ def test_margin_equity_correction_audited_during_startup_session_handoff():
     assert db.log_audit_event.call_args.kwargs["session_id"] == 7
     db.log_event.assert_called_once()
     assert db.log_event.call_args.kwargs["session_id"] == 7
+
+
+def test_margin_equity_system_event_failure_does_not_break_correction():
+    """The system-event (log_event) write is best-effort and guarded independently of
+    the audit write: a log_event failure must neither raise into the sync loop nor flip
+    the already-persisted correction. Companion to the log_audit_event-failure test —
+    pins the SECOND of the two independently wrapped observability writes so a future
+    refactor of that try/except can't let a system_events fault escape into
+    sync_account_data() and report success=False after a real book-down.
+    """
+    sync, db = _make_sync(equity=84.14, db_balance=99.89, usdt_total=84.14)
+    db.log_event.side_effect = RuntimeError("system_events table unavailable")
+
+    res = sync._sync_margin_equity()  # must not raise
+
+    assert res["corrected"] is True
+    db.update_balance.assert_called_once()
+    db.log_audit_event.assert_called_once()  # audit still written despite the event failure
+
+
+def test_margin_equity_exactly_five_percent_divergence_is_critical():
+    """The CRITICAL boundary is inclusive (>=): an exactly-5.0% book-down is
+    CRITICAL/critical, not HIGH/warning. 100.00 -> 95.00 makes diff_pct land exactly on
+    DEFAULT_RECONCILIATION_BALANCE_THRESHOLD_PCT * 100 (verified float-exact), so a
+    >= -> > regression would silently demote boundary book-downs and this test catches it.
+    """
+    sync, db = _make_sync(equity=95.0, db_balance=100.0, usdt_total=95.0)
+
+    res = sync._sync_margin_equity()
+
+    assert res["corrected"] is True
+    assert db.log_audit_event.call_args.kwargs["severity"] == "CRITICAL"
+    assert db.log_event.call_args.kwargs["severity"] == "critical"

--- a/tests/unit/engines/live/test_account_sync_margin.py
+++ b/tests/unit/engines/live/test_account_sync_margin.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from src.database.models import EventType
 from src.engines.live.account_sync import AccountSynchronizer
 
 pytestmark = pytest.mark.unit
@@ -52,14 +53,10 @@ def test_get_account_equity_spot_uses_usdt_total(mock_config, mock_client_class)
 def _make_sync(equity, db_balance, usdt_total):
     exchange = Mock()
     exchange.get_account_equity.return_value = equity
-    exchange.get_balance.return_value = (
-        Mock(total=usdt_total) if usdt_total is not None else None
-    )
+    exchange.get_balance.return_value = Mock(total=usdt_total) if usdt_total is not None else None
     db = Mock()
     db.get_current_balance.return_value = db_balance
-    sync = AccountSynchronizer(
-        exchange=exchange, db_manager=db, session_id=1, use_margin=True
-    )
+    sync = AccountSynchronizer(exchange=exchange, db_manager=db, session_id=1, use_margin=True)
     return sync, db
 
 
@@ -117,3 +114,112 @@ def test_margin_equity_no_correct_when_equity_zero_or_negative():
 
     assert res["synced"] is False
     db.update_balance.assert_not_called()
+
+
+def test_margin_equity_correction_records_audit_and_system_event():
+    """A book-down MUST leave both an audit row and a warning+ system event.
+
+    Regression guard: in prod on 2026-06-03 a margin_equity_sync_correction booked
+    the tracked balance from $99.89 down to true equity $84.14 (-15.8%, the single
+    largest capital event of the fortnight) yet wrote ZERO reconciliation_audit_events
+    and ZERO warning+ system_events rows, so monitoring never saw it.
+    """
+    sync, db = _make_sync(equity=84.14, db_balance=99.89, usdt_total=84.14)
+
+    res = sync._sync_margin_equity()
+
+    assert res["corrected"] is True
+    db.update_balance.assert_called_once()
+
+    # (a) immutable reconciliation audit row with before/after values
+    db.log_audit_event.assert_called_once()
+    audit = db.log_audit_event.call_args.kwargs
+    assert audit["session_id"] == 1
+    assert audit["entity_type"] == "balance"
+    assert audit["field"] == "total_balance"
+    assert audit["severity"] == "CRITICAL"  # >=5% book-down is material
+    assert float(audit["old_value"]) == pytest.approx(99.89)
+    assert float(audit["new_value"]) == pytest.approx(84.14)
+    assert audit["reason"]  # non-empty human-readable explanation
+
+    # (b) operator-facing system event at warning+ severity for alerting
+    db.log_event.assert_called_once()
+    event = db.log_event.call_args.kwargs
+    assert event["event_type"] == EventType.BALANCE_ADJUSTMENT
+    assert event["severity"] == "critical"  # warning+ (critical for >=5%)
+    assert event["session_id"] == 1
+
+
+def test_margin_equity_small_correction_is_high_warning():
+    """A >1% but <5% book-down -> HIGH audit + 'warning' system event (not critical).
+
+    Mirrors the second unaudited prod event (2026-06-05, ~ -1.6%).
+    """
+    # 84.14 -> 82.77 is -1.63%: above the 1% correction gate, below the 5% CRITICAL line.
+    sync, db = _make_sync(equity=82.77, db_balance=84.14, usdt_total=82.77)
+
+    res = sync._sync_margin_equity()
+
+    assert res["corrected"] is True
+    assert db.log_audit_event.call_args.kwargs["severity"] == "HIGH"
+    assert db.log_event.call_args.kwargs["severity"] == "warning"
+
+
+def test_margin_equity_no_audit_or_event_when_within_threshold():
+    """No correction -> no audit row and no system event are emitted."""
+    sync, db = _make_sync(equity=99.50, db_balance=99.89, usdt_total=99.50)
+
+    sync._sync_margin_equity()
+
+    db.update_balance.assert_not_called()
+    db.log_audit_event.assert_not_called()
+    db.log_event.assert_not_called()
+
+
+def test_margin_equity_audit_logging_failure_does_not_break_correction():
+    """Observability writes are best-effort: a failure must neither raise nor
+    unwind the already-persisted balance correction, and the two writes are
+    independently guarded (an audit failure still attempts the system event)."""
+    sync, db = _make_sync(equity=84.14, db_balance=99.89, usdt_total=84.14)
+    db.log_audit_event.side_effect = RuntimeError("audit table unavailable")
+
+    res = sync._sync_margin_equity()  # must not raise
+
+    assert res["corrected"] is True
+    db.update_balance.assert_called_once()
+    db.log_event.assert_called_once()  # attempted despite the audit failure
+
+
+def test_margin_equity_no_audit_when_balance_update_fails():
+    """If the balance write itself fails (update_balance -> False), do NOT emit an
+    audit/alert claiming a correction that never persisted."""
+    sync, db = _make_sync(equity=84.14, db_balance=99.89, usdt_total=84.14)
+    db.update_balance.return_value = False
+
+    res = sync._sync_margin_equity()
+
+    assert res["synced"] is False
+    assert res["corrected"] is False
+    db.log_audit_event.assert_not_called()
+    db.log_event.assert_not_called()
+
+
+def test_margin_equity_correction_audited_during_startup_session_handoff():
+    """Startup edge (found in Codex review): the synchronizer's own session_id is
+    still None during the INITIAL sync — trading_engine assigns it only AFTER
+    sync_account_data() returns — but the DB manager already has a current session, so
+    update_balance persists via its _current_session_id fallback. The audit + system
+    event MUST still fire, bound to that resolved session, not be silently skipped.
+    """
+    sync, db = _make_sync(equity=84.14, db_balance=99.89, usdt_total=84.14)
+    sync.session_id = None  # not yet assigned during the initial sync
+    db._current_session_id = 7  # update_balance / get_current_balance fall back to this
+    db.update_balance.return_value = True
+
+    res = sync._sync_margin_equity()
+
+    assert res["corrected"] is True
+    db.log_audit_event.assert_called_once()
+    assert db.log_audit_event.call_args.kwargs["session_id"] == 7
+    db.log_event.assert_called_once()
+    assert db.log_event.call_args.kwargs["session_id"] == 7


### PR DESCRIPTION
## Summary

Margin-equity balance corrections (`update_reason='margin_equity_sync_correction'`, written by `AccountSynchronizer._sync_margin_equity`) updated the balance ledger but recorded **no** `reconciliation_audit_events` row and **no** warning-level `system_events` row. The single largest capital event a margin session can produce was invisible to monitoring and post-incident auditing — a **−$15.75 (−15.8%)** production book-down on 2026-06-03 07:01 UTC, and a second −$1.37 on 2026-06-05, both left zero audit trail.

Contributes to #36 (Add Audit Trail And Observability) — closes one of its catalogued "events that never emit an audit/system event" gaps.

## What changed

`_sync_margin_equity` now, after a correction persists, calls a new best-effort helper `_record_equity_correction_audit` that writes:

- a **`reconciliation_audit_events`** row — `entity_type='balance'`, `field='total_balance'`, before/after values, severity `HIGH` (escalating to `CRITICAL` when divergence ≥ 5%, using the reconciler's `Severity` enum);
- a **`system_events`** row — `EventType.BALANCE_ADJUSTMENT` at `warning` severity (`critical` at ≥ 5%), so alerting can see large book-downs.

Additional robustness:

- **Honors `update_balance`'s return value** — if the balance write fails, emission is skipped and the result reports `corrected: False` (no audit for a correction that never persisted). This also closes a latent DB/in-memory balance divergence: both engine consumers gate the in-memory balance overwrite on `corrected`.
- **Binds the audit to the same session the balance write used** — resolved via `update_balance`'s own `_current_session_id` fallback — so the **first post-restart correction** (when `AccountSynchronizer.session_id` has not yet been assigned during the initial sync) is captured, not just steady-state periodic syncs. _(Found in Codex review.)_
- Both observability writes are independently wrapped in `try/except` (log at ERROR with `exc_info`), so a logging failure can neither raise into the sync loop nor unwind the already-persisted correction (per CODE.md Error Handling / State Management).

## Testing

- **6 new unit tests** in `tests/unit/engines/live/test_account_sync_margin.py` (13 in file, all green): both records written (CRITICAL/critical — the prod case), HIGH/warning small correction, no-emit within threshold, best-effort audit-failure path, no-emit when the balance write itself fails, and the startup session-handoff regression (verified RED without the fix, GREEN with it).
- **Full unit suite green** (`atb test unit`, ~54s).
- `black --check` clean; the added code is ruff- and mypy-clean.
- Reviewed by `architecture-reviewer`, `code-reviewer`, and **Codex (gpt-5.5)** — all APPROVE.

## Notes for reviewers

- This file carries **pre-existing** mypy (10) and ruff (3× UP038) findings in untouched methods (`_sync_positions` / `_sync_orders` / `recover_missing_trades`) — confirmed byte-identical on `develop`; CI's merge gate (`tests.yml`) runs pytest only.
- Review surfaced a real **pre-existing runtime bug**: `recover_missing_trades` calls `log_trade(order_id=...)`, a kwarg that does not exist (it's `exit_order_id`) and has no `**kwargs`, so it would `TypeError` whenever it recovers a trade. Left out of this PR to keep scope focused; flagged for a separate fix.
- The 3 incidental formatting hunks in `account_sync.py` (a signature, two call sites, a ternary) are `black` normalizing the file to the project's `line-length = 100` (the file was already non-compliant on `develop`).

Related: #659 (Layer-2 margin balance correction at cold boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
