### PR TITLE
fix(live): correct log_trade kwarg in trade recovery + clear static-analysis debt

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Live trade recovery on the `emergency_sync` path no longer silently fails.
+  `AccountSynchronizer.recover_missing_trades` called
+  `DatabaseManager.log_trade(order_id=...)`, but `log_trade` has no `order_id`
+  parameter (the field is `exit_order_id`) and no `**kwargs`, so every recovered
+  trade raised `TypeError` — swallowed by the per-trade `except` — and was never
+  persisted to the ledger. Maps `trade.order_id` onto `exit_order_id` (which feeds
+  the `Trade.order_id` column). Adds a regression test that drives
+  `recover_missing_trades` with an autospec'd `DatabaseManager`, so the real
+  `log_trade` signature is enforced. Also clears pre-existing mypy loop-variable
+  and ruff `UP038` debt on `account_sync.py` (behaviour-neutral).
 - Live position/trade recovery no longer crashes on `Decimal`-vs-`float`
   arithmetic. `DatabaseManager.get_active_positions` and `get_recent_trades`
   now coerce SQLAlchemy `Numeric(18,8)` columns (which read back from

--- a/src/engines/live/account_sync.py
+++ b/src/engines/live/account_sync.py
@@ -271,7 +271,7 @@ class AccountSynchronizer:
 
             if usdt_balance:
                 # Validate total is numeric
-                if usdt_balance.total is None or not isinstance(usdt_balance.total, (int, float)):
+                if usdt_balance.total is None or not isinstance(usdt_balance.total, int | float):
                     logger.error(
                         "Invalid USDT balance total: %s (type=%s) - skipping sync",
                         usdt_balance.total,
@@ -336,9 +336,12 @@ class AccountSynchronizer:
             for exchange_pos in exchange_positions:
                 # Find matching position in database
                 db_pos = None
-                for pos in db_positions:
-                    if pos["symbol"] == exchange_pos.symbol and pos["side"] == exchange_pos.side:
-                        db_pos = pos
+                for position_row in db_positions:
+                    if (
+                        position_row["symbol"] == exchange_pos.symbol
+                        and position_row["side"] == exchange_pos.side
+                    ):
+                        db_pos = position_row
                         break
 
                 if db_pos:
@@ -347,8 +350,8 @@ class AccountSynchronizer:
                     exchange_size = exchange_pos.size
                     db_size = db_pos["size"]
 
-                    if not isinstance(exchange_size, (int, float)) or not isinstance(
-                        db_size, (int, float)
+                    if not isinstance(exchange_size, int | float) or not isinstance(
+                        db_size, int | float
                     ):
                         logger.warning(
                             "Skipping position sync with non-numeric size: "
@@ -408,13 +411,13 @@ class AccountSynchronizer:
 
             # Check for positions that exist in database but not in exchange
             for db_pos in db_positions:
-                exchange_pos = None
+                matching_exchange_pos = None
                 for pos in exchange_positions:
                     if pos.symbol == db_pos["symbol"] and pos.side == db_pos["side"]:
-                        exchange_pos = pos
+                        matching_exchange_pos = pos
                         break
 
-                if not exchange_pos:
+                if not matching_exchange_pos:
                     # Position exists in database but not on exchange
                     logger.warning(
                         f"Position closed on exchange: {db_pos['symbol']} {db_pos['side']}"
@@ -461,10 +464,10 @@ class AccountSynchronizer:
             for exchange_order in exchange_orders:
                 # Find matching order in database
                 db_order = None
-                for order in db_orders:
-                    order_id = order["exchange_order_id"] or order["internal_order_id"]
+                for order_row in db_orders:
+                    order_id = order_row["exchange_order_id"] or order_row["internal_order_id"]
                     if order_id == exchange_order.order_id:
-                        db_order = order
+                        db_order = order_row
                         break
 
                 if db_order:
@@ -524,14 +527,14 @@ class AccountSynchronizer:
 
             # Check for orders that exist in database but not in exchange
             for db_order in db_orders:
-                exchange_order = None
+                matching_exchange_order = None
                 order_id = db_order["exchange_order_id"] or db_order["internal_order_id"]
                 for order in exchange_orders:
                     if order.order_id == order_id:
-                        exchange_order = order
+                        matching_exchange_order = order
                         break
 
-                if not exchange_order:
+                if not matching_exchange_order:
                     # Order exists in database but not on exchange
                     logger.warning("Order cancelled on exchange: %s", order_id)
 
@@ -619,7 +622,7 @@ class AccountSynchronizer:
                             exit_reason="recovered_from_exchange",
                             strategy_name="exchange_recovery",
                             source=TradeSource.LIVE,
-                            order_id=trade.order_id,
+                            exit_order_id=trade.order_id,
                             session_id=self.session_id,
                         )
 

--- a/tests/unit/engines/live/test_account_sync_recovery.py
+++ b/tests/unit/engines/live/test_account_sync_recovery.py
@@ -22,7 +22,7 @@ import pytest
 from src.database.manager import DatabaseManager
 from src.engines.live.account_sync import AccountSynchronizer
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.fast
 
 
 def _make_exchange_trade():

--- a/tests/unit/engines/live/test_account_sync_recovery.py
+++ b/tests/unit/engines/live/test_account_sync_recovery.py
@@ -1,0 +1,65 @@
+"""Unit tests for AccountSynchronizer.recover_missing_trades.
+
+Regression guard for a signature-mismatch bug: recover_missing_trades called
+``DatabaseManager.log_trade`` with ``order_id=...``, but log_trade's parameter
+is ``exit_order_id`` (it has no ``order_id`` kwarg and no ``**kwargs``). Against
+the real signature this raised ``TypeError`` at runtime whenever a missing trade
+was actually recovered (the ``emergency_sync`` path), and the error was silently
+swallowed by the per-trade try/except -- so trades failed to recover with no
+crash.
+
+The DatabaseManager is ``create_autospec``'d so the mock enforces the real
+log_trade signature: the old ``order_id=...`` call raises ``TypeError`` here
+exactly as it did in production, and a successful recovery proves the fixed
+call is signature-compatible.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import Mock, create_autospec
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.engines.live.account_sync import AccountSynchronizer
+
+pytestmark = pytest.mark.unit
+
+
+def _make_exchange_trade():
+    """A single exchange trade with an order id, not present in the DB."""
+    trade = Mock()
+    trade.trade_id = "T-123"
+    trade.order_id = "O-456"
+    trade.symbol = "BTCUSDT"
+    trade.side = Mock(value="BUY")
+    trade.price = 50_000.0
+    trade.quantity = 0.01
+    trade.time = datetime.now(UTC)
+    return trade
+
+
+def test_recover_missing_trades_logs_with_exit_order_id():
+    """A missing exchange trade is recovered via ``log_trade(exit_order_id=...)``.
+
+    With an autospec'd DatabaseManager, calling log_trade with the old wrong
+    kwarg (``order_id=...``) raises TypeError exactly as in production, so
+    ``recovered_trades == 1`` proves the call is signature-compatible and does
+    not raise.
+    """
+    exchange = Mock()
+    exchange.get_recent_trades.return_value = [_make_exchange_trade()]
+
+    db = create_autospec(DatabaseManager, instance=True)
+    db.get_trades_by_symbol_and_date.return_value = []  # nothing logged yet
+
+    sync = AccountSynchronizer(exchange=exchange, db_manager=db, session_id=1)
+
+    result = sync.recover_missing_trades("BTCUSDT")
+
+    # 0 if log_trade raised TypeError and was swallowed by the per-trade except.
+    assert result["recovered_trades"] == 1
+
+    db.log_trade.assert_called_once()
+    call_kwargs = db.log_trade.call_args.kwargs
+    assert call_kwargs["exit_order_id"] == "O-456"
+    assert "order_id" not in call_kwargs


### PR DESCRIPTION
## What

Fixes a latent crash in live trade recovery, plus clears pre-existing static-analysis debt on `src/engines/live/account_sync.py`.

**The bug.** `AccountSynchronizer.recover_missing_trades()` called `DatabaseManager.log_trade(order_id=...)`, but `log_trade` has no `order_id` parameter and no `**kwargs` — the matching parameter is `exit_order_id`. Against the real signature this raised `TypeError` on **every** actually-recovered trade (the `emergency_sync` path). The per-trade `except Exception` swallowed it, so missing trades silently failed to recover with no crash. Fix: map `trade.order_id` onto `exit_order_id`, which feeds the `Trade.order_id` column (`manager.py:812`).

## Why it matters

`emergency_sync` is the crash-recovery path that re-syncs trades the bot missed while down. With the wrong kwarg it could never persist a single recovered trade — the trade ledger stayed permanently incomplete with no error signal. This is exactly the phantom/missing-state class of bug this codebase has been firefighting.

## Also in this PR (pre-existing debt on the same file, surfaced by `atb dev quality`)

- **mypy** (loop-variable type confusion → 0 errors): renamed the dict-typed inner loop vars (`pos`→`position_row`, `order`→`order_row`) and the second-loop `None` accumulators (`exchange_pos`→`matching_exchange_pos`, `exchange_order`→`matching_exchange_order`) so each name has a single type. Behavior-neutral.
- **ruff UP038** (×3): `isinstance(x, (int, float))` → `isinstance(x, int | float)`.

## Testing

- New regression test `tests/unit/engines/live/test_account_sync_recovery.py` drives `recover_missing_trades` with an **autospec'd `DatabaseManager`** (enforces the real `log_trade` signature), asserting it's called with `exit_order_id=...` and that recovery doesn't raise. Verified RED on the old kwarg (`assert 0 == 1`) → GREEN after the fix.
- `atb test unit` — full suite passes, no regressions.
- mypy: 0 errors on the file (was 10). ruff: clean.
- Existing sync tests (`test_sync_positions_comprehensive`, `test_sync_orders_comprehensive`, …) still pass — the loop renames change nothing observable.

## Reviewer notes

- The `exit_order_id` → `Trade.order_id` mapping is type- and semantics-correct; recovery skips already-present trades, so the `(order_id, session_id)` unique constraint is unaffected.
- **The margin-equity audit code in `_sync_margin_equity` was intentionally not touched.**
- Pre-existing **black** formatting debt on this file is left as-is: black-check fails on hunks that all sit in untouched code (including inside `_sync_margin_equity`), so it can't pass without reformatting that protected method. CI enforces pytest, not black. Best cleaned up as a standalone pass once this lands.

## Out-of-scope follow-ups (flagged by review, not addressed here)

- `recover_missing_trades` returns `recovered: True` even on partial/total per-trade failure, and no caller reads the counts — silent masking (pre-existing).
- `tests/integration/test_account_sync.py` uses a plain `Mock()` (not autospec), so it can't catch this signature class of bug; the new unit test closes that gap.
- `docs/changelog.md` has no entry for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)