### PR TITLE
fix(reconciliation): fail-closed stop-loss lookup — never re-place a stop on an unconfirmed lookup (#713)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Reconciler no longer places a DUPLICATE stop-loss when an order lookup
+  fails transiently (#713). `BinanceProvider.get_order` swallows every
+  exception into `None`, and both stop-loss verifiers (startup
+  `PositionReconciler._verify_stop_loss` and the periodic reconciler's
+  stop-verification loop) treated `None` as "stop missing" — clearing the
+  tracked `stop_loss_order_id` and re-placing a new stop while the original
+  could still be resting on the exchange (reserving base/margin, able to
+  cause -2010 on a later close, and able to flip the position if both
+  stops fill). Added a fail-closed `ExchangeInterface.get_order_checked`
+  (Binance override returns `None` only on a confirmed -2013
+  "order does not exist" and raises `OrderLookupError` on any unconfirmed
+  lookup), and both verifiers now skip the cycle on an unconfirmed lookup
+  instead of re-placing. Confirmed-missing stops are still re-placed.
 - Live trade recovery on the `emergency_sync` path no longer silently fails.
   `AccountSynchronizer.recover_missing_trades` called
   `DatabaseManager.log_trade(order_id=...)`, but `log_trade` has no `order_id`

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -44,6 +44,7 @@ from .exchange_interface import (
     AccountBalance,
     ExchangeInterface,
     Order,
+    OrderLookupError,
     OrderSide,
     OrderStatus,
     OrderType,
@@ -1464,6 +1465,47 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         except Exception as e:
             logger.error("Failed to get order %s: %s", order_id, e)
             return None
+
+    def get_order_checked(self, order_id: str, symbol: str) -> Order | None:
+        """Fail-closed order lookup (see ExchangeInterface.get_order_checked).
+
+        Unlike :meth:`get_order` (which swallows every error into ``None``),
+        this returns ``None`` only when Binance confirms the order does not
+        exist (error code -2013) and raises :class:`OrderLookupError` on any
+        unconfirmed lookup, so safety logic (e.g. the reconciler's stop-loss
+        re-placement) never mistakes a transient API failure for a missing
+        order and places a duplicate.
+        """
+        if not BINANCE_AVAILABLE or not self._client:
+            raise OrderLookupError(
+                f"Binance client unavailable — cannot confirm order {order_id} for {symbol}"
+            )
+
+        # Binance's orderId parameter only accepts numeric strings; route
+        # alphanumeric IDs (our atb_... idempotency keys) via origClientOrderId.
+        params: dict[str, Any] = {"symbol": symbol}
+        if order_id.isdigit():
+            params["orderId"] = order_id
+        else:
+            params["origClientOrderId"] = order_id
+
+        try:
+            order_data = self._call_get_order(**params)
+        except (BinanceAPIException, BinanceOrderException) as e:
+            if getattr(e, "code", None) == -2013 or "-2013" in str(e):
+                return None  # confirmed: order does not exist on the exchange
+            raise OrderLookupError(f"Order {order_id} lookup failed for {symbol}: {e}") from e
+        except Exception as e:
+            raise OrderLookupError(f"Order {order_id} lookup failed for {symbol}: {e}") from e
+
+        parsed = self._parse_order_data(order_data)
+        if parsed is None:
+            # Got a response but could not parse it — the order may well exist,
+            # so this is "unknown", not "confirmed absent".
+            raise OrderLookupError(
+                f"Order {order_id} response for {symbol} could not be parsed: {order_data!r}"
+            )
+        return parsed
 
     def get_recent_trades(self, symbol: str, limit: int = 100) -> list[Trade]:
         """Get recent trades for a symbol"""

--- a/src/data_providers/coinbase_provider.py
+++ b/src/data_providers/coinbase_provider.py
@@ -21,6 +21,7 @@ from .exchange_interface import (
     AccountBalance,
     ExchangeInterface,
     Order,
+    OrderLookupError,
     OrderSide,
     OrderStatus,
     OrderType,
@@ -381,6 +382,31 @@ class CoinbaseProvider(DataProvider, ExchangeInterface):
         except Exception as e:
             logger.error(f"Failed to get order {order_id}: {e}")
             return None
+
+    def get_order_checked(self, order_id: str, symbol: str) -> Order | None:
+        """Fail-closed order lookup (see ExchangeInterface.get_order_checked).
+
+        Returns ``None`` only when Coinbase confirms the order does not exist
+        (HTTP 404); any other failure — network error, rate limit, 5xx,
+        unparseable response — raises :class:`OrderLookupError` so safety
+        logic never mistakes a transient failure for a missing order (#713).
+        """
+        try:
+            od = self._request("GET", f"/orders/{order_id}", auth=True)
+            parsed = self._parse_order_data(od)
+        except requests.exceptions.HTTPError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status == 404:
+                return None  # confirmed: order does not exist on the exchange
+            raise OrderLookupError(f"Order {order_id} lookup failed for {symbol}: {e}") from e
+        except Exception as e:
+            raise OrderLookupError(f"Order {order_id} lookup failed for {symbol}: {e}") from e
+
+        if parsed is None:
+            raise OrderLookupError(
+                f"Order {order_id} response for {symbol} could not be parsed: {od!r}"
+            )
+        return parsed
 
     def get_recent_trades(self, symbol: str, limit: int = 100) -> list[Trade]:
         try:

--- a/src/data_providers/exchange_interface.py
+++ b/src/data_providers/exchange_interface.py
@@ -44,6 +44,16 @@ class SideEffectType:
     AUTO_REPAY = "AUTO_REPAY"  # Auto-repay on close (exits, stop-losses)
 
 
+class OrderLookupError(Exception):
+    """An order lookup could not be confirmed (transient API/network failure).
+
+    Raised by :meth:`ExchangeInterface.get_order_checked` so callers making
+    safety decisions can distinguish "order confirmed absent on the exchange"
+    (``None``) from "lookup failed — the order may still exist". Treating the
+    two the same is how a transient timeout turns into a duplicate stop-loss.
+    """
+
+
 @dataclass
 class AccountBalance:
     """Represents account balance information"""
@@ -188,6 +198,22 @@ class ExchangeInterface(ABC):
     def get_order(self, order_id: str, symbol: str) -> Order | None:
         """Get specific order by ID"""
         pass
+
+    def get_order_checked(self, order_id: str, symbol: str) -> Order | None:
+        """Fail-closed order lookup for safety decisions.
+
+        Returns the ``Order`` if found, ``None`` only when the exchange
+        *confirmed* the order does not exist, and raises
+        :class:`OrderLookupError` when the lookup could not be confirmed
+        (network error, rate limit, API failure).
+
+        The default delegates to :meth:`get_order`, which for most providers
+        swallows errors into ``None`` — i.e. the default CANNOT distinguish
+        "confirmed absent" from "unknown". Providers used for live trading
+        MUST override this with an implementation that raises
+        ``OrderLookupError`` on unconfirmed lookups (see ``BinanceProvider``).
+        """
+        return self.get_order(order_id, symbol)
 
     @abstractmethod
     def get_recent_trades(self, symbol: str, limit: int = 100) -> list[Trade]:

--- a/src/data_providers/exchange_interface.py
+++ b/src/data_providers/exchange_interface.py
@@ -207,13 +207,20 @@ class ExchangeInterface(ABC):
         :class:`OrderLookupError` when the lookup could not be confirmed
         (network error, rate limit, API failure).
 
-        The default delegates to :meth:`get_order`, which for most providers
-        swallows errors into ``None`` — i.e. the default CANNOT distinguish
-        "confirmed absent" from "unknown". Providers used for live trading
-        MUST override this with an implementation that raises
-        ``OrderLookupError`` on unconfirmed lookups (see ``BinanceProvider``).
+        The default fails CLOSED by raising: most ``get_order``
+        implementations swallow errors into ``None``, so delegating to them
+        would silently report "confirmed absent" on a transient failure —
+        exactly the bug this accessor exists to prevent (#713). Every
+        provider used for live trading must override this with an
+        implementation that distinguishes the exchange's "order does not
+        exist" response from other failures (see ``BinanceProvider`` /
+        ``CoinbaseProvider``).
         """
-        return self.get_order(order_id, symbol)
+        raise OrderLookupError(
+            f"get_order_checked is not implemented for {type(self).__name__} — "
+            f"cannot confirm absence of order {order_id} on {symbol}; treating "
+            "the lookup as unconfirmed. Override this method for live trading."
+        )
 
     @abstractmethod
     def get_recent_trades(self, symbol: str, limit: int = 100) -> list[Trade]:

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -39,14 +39,28 @@ from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.shared.models import PositionSide
 
 if TYPE_CHECKING:
-    from src.data_providers.exchange_interface import ExchangeInterface
+    from src.data_providers.exchange_interface import ExchangeInterface, Order
     from src.database.manager import DatabaseManager
     from src.engines.live.execution.position_tracker import LivePositionTracker
 
 logger = logging.getLogger(__name__)
 
 
-def lookup_order_fail_closed(exchange: Any, order_id: str, symbol: str) -> tuple[Any, bool]:
+@runtime_checkable
+class _OrderLookup(Protocol):
+    """Structural type for exchanges that can look up an order by id.
+
+    ``get_order_checked`` (the fail-closed variant) is optional and probed via
+    ``getattr`` in :func:`lookup_order_fail_closed`, so it is not part of the
+    protocol.
+    """
+
+    def get_order(self, order_id: str, symbol: str) -> Order | None: ...
+
+
+def lookup_order_fail_closed(
+    exchange: _OrderLookup, order_id: str, symbol: str
+) -> tuple[Order | None, bool]:
     """Look up an order distinguishing "confirmed absent" from "lookup failed".
 
     Returns ``(order, confirmed)``. ``confirmed=False`` means the lookup could

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@runtime_checkable
 class _OrderLookup(Protocol):
     """Structural type for exchanges that can look up an order by id.
 

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -34,7 +34,7 @@ from src.config.constants import (
     ORPHANED_BORROW_SWEEP_COOLDOWN_SECONDS,
 )
 from src.config.feature_flags import get_flag
-from src.data_providers.exchange_interface import SideEffectType
+from src.data_providers.exchange_interface import OrderLookupError, SideEffectType
 from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.shared.models import PositionSide
 
@@ -44,6 +44,36 @@ if TYPE_CHECKING:
     from src.engines.live.execution.position_tracker import LivePositionTracker
 
 logger = logging.getLogger(__name__)
+
+
+def lookup_order_fail_closed(exchange: Any, order_id: str, symbol: str) -> tuple[Any, bool]:
+    """Look up an order distinguishing "confirmed absent" from "lookup failed".
+
+    Returns ``(order, confirmed)``. ``confirmed=False`` means the lookup could
+    not be confirmed (transient API failure) — the caller must NOT treat the
+    order as missing. In particular it must not re-place a stop-loss: the
+    original may still rest on the exchange, and a duplicate stop reserves
+    balance (later -2010 rejections) and can flip the position if both fill
+    (#713).
+
+    Uses the provider's fail-closed ``get_order_checked`` when available;
+    falls back to legacy ``get_order`` (whose ``None`` is ambiguous but kept
+    as "confirmed" to preserve behavior for providers without the accessor).
+    """
+    checked = getattr(exchange, "get_order_checked", None)
+    if callable(checked):
+        try:
+            return checked(order_id, symbol), True
+        except OrderLookupError as e:
+            logger.warning(
+                "Order %s lookup for %s could not be confirmed — treating as "
+                "unknown (fail-closed): %s",
+                order_id,
+                symbol,
+                e,
+            )
+            return None, False
+    return exchange.get_order(order_id, symbol), True
 
 
 @runtime_checkable
@@ -1408,7 +1438,21 @@ class PositionReconciler:
         from src.data_providers.exchange_interface import OrderStatus as ExOrderStatus
 
         try:
-            sl_order = self.exchange.get_order(sl_order_id, position.symbol)
+            sl_order, confirmed = lookup_order_fail_closed(
+                self.exchange, sl_order_id, position.symbol
+            )
+            if not confirmed:
+                # Transient lookup failure — the stop may still be resting on
+                # the exchange. Do NOT clear the tracked ID or re-place (a
+                # duplicate stop reserves balance and can flip the position if
+                # both fill). The periodic reconciler re-checks shortly (#713).
+                logger.warning(
+                    "Skipping stop-loss verification for %s (order %s) — lookup "
+                    "unconfirmed this cycle; will re-check on the next pass.",
+                    position.symbol,
+                    sl_order_id,
+                )
+                return
             if not sl_order:
                 # SL order not found — may need re-placement
                 audit = AuditEvent(
@@ -2723,7 +2767,21 @@ class PeriodicReconciler:
                     OrderStatus as ExOrderStatus,
                 )
 
-                sl_order = self.exchange.get_order(sl_order_id, position.symbol)
+                sl_order, confirmed = lookup_order_fail_closed(
+                    self.exchange, sl_order_id, position.symbol
+                )
+                if not confirmed:
+                    # Transient lookup failure — the stop may still be resting
+                    # on the exchange. Treating it as "missing" would clear the
+                    # tracked ID and place a DUPLICATE stop (#713). Skip this
+                    # cycle; the next run (~2 min) re-checks.
+                    logger.warning(
+                        "Stop-loss %s for %s could not be verified this cycle "
+                        "(lookup failed) — skipping fail-closed, no re-placement.",
+                        sl_order_id,
+                        position.symbol,
+                    )
+                    continue
 
                 if sl_order and sl_order.status == ExOrderStatus.FILLED:
                     # SL triggered — remove position from tracker + close in DB

--- a/tests/integration/live/test_reconciliation_integration.py
+++ b/tests/integration/live/test_reconciliation_integration.py
@@ -81,6 +81,9 @@ class TestReconciliationIntegration:
         """MagicMock exchange with sensible defaults."""
         exchange = MagicMock()
         exchange.get_order.return_value = None
+        # Fail-closed lookup (#713) delegates to get_order so tests keep
+        # driving order responses through get_order for both accessors.
+        exchange.get_order_checked.side_effect = lambda oid, sym: exchange.get_order(oid, sym)
         exchange.get_order_by_client_id.return_value = None
         exchange.get_all_orders.return_value = []
         exchange.get_open_orders.return_value = []

--- a/tests/unit/data_providers/test_binance_provider.py
+++ b/tests/unit/data_providers/test_binance_provider.py
@@ -13,7 +13,7 @@ try:
         BinanceProvider,
         with_rate_limit_retry,
     )
-    from src.data_providers.exchange_interface import OrderSide
+    from src.data_providers.exchange_interface import OrderLookupError, OrderSide
 
     BINANCE_AVAILABLE = True
 except ImportError:
@@ -22,6 +22,7 @@ except ImportError:
     with_rate_limit_retry = None
     STOP_LOSS_LIMIT_SLIPPAGE_FACTOR = 0.005
     OrderSide = Mock
+    OrderLookupError = Exception
 
 
 @pytest.mark.unit
@@ -1382,6 +1383,108 @@ class TestGetOrderIdRouting:
 
         # Assert
         assert result is None
+
+
+@pytest.mark.skipif(not BINANCE_AVAILABLE, reason="Binance provider not available")
+@patch("src.data_providers.binance_provider.BINANCE_AVAILABLE", True)
+class TestGetOrderChecked:
+    """Fail-closed order lookup (#713).
+
+    get_order_checked must return None ONLY when Binance confirms the order
+    does not exist (-2013); any unconfirmed lookup raises OrderLookupError so
+    safety logic (reconciler stop-loss re-placement) never mistakes a transient
+    API failure for a missing order.
+    """
+
+    ORDER_PAYLOAD = {
+        "orderId": 12345,
+        "symbol": "BTCUSDT",
+        "status": "NEW",
+        "side": "SELL",
+        "type": "STOP_LOSS_LIMIT",
+        "origQty": "1.0",
+        "executedQty": "0.0",
+        "price": "50000.0",
+        "time": 1640995200000,
+        "updateTime": 1640995200000,
+    }
+
+    @staticmethod
+    def _make_provider(mock_config, mock_client_class):
+        mock_config_obj = Mock()
+        mock_config_obj.get_required.return_value = "fake_key"
+        mock_config.return_value = mock_config_obj
+        mock_client = Mock()
+        mock_client_class.return_value = mock_client
+        return BinanceProvider(), mock_client
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_returns_order_when_found(self, mock_config, mock_client_class):
+        provider, mock_client = self._make_provider(mock_config, mock_client_class)
+        mock_client.get_order.return_value = dict(self.ORDER_PAYLOAD)
+
+        order = provider.get_order_checked("12345", "BTCUSDT")
+
+        assert order is not None
+        assert order.order_id == "12345"
+        mock_client.get_order.assert_called_once_with(symbol="BTCUSDT", orderId="12345")
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_returns_none_only_on_confirmed_not_found(self, mock_config, mock_client_class):
+        from binance.exceptions import BinanceAPIException
+
+        provider, mock_client = self._make_provider(mock_config, mock_client_class)
+        mock_client.get_order.side_effect = BinanceAPIException(
+            Mock(), 400, '{"code": -2013, "msg": "Order does not exist."}'
+        )
+
+        assert provider.get_order_checked("12345", "BTCUSDT") is None
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_raises_on_api_error(self, mock_config, mock_client_class):
+        from binance.exceptions import BinanceAPIException
+
+        provider, mock_client = self._make_provider(mock_config, mock_client_class)
+        mock_client.get_order.side_effect = BinanceAPIException(
+            Mock(), 429, '{"code": -1003, "msg": "Too many requests."}'
+        )
+
+        with pytest.raises(OrderLookupError):
+            provider.get_order_checked("12345", "BTCUSDT")
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_raises_on_network_error(self, mock_config, mock_client_class):
+        provider, mock_client = self._make_provider(mock_config, mock_client_class)
+        mock_client.get_order.side_effect = ConnectionError("connection reset")
+
+        with pytest.raises(OrderLookupError):
+            provider.get_order_checked("12345", "BTCUSDT")
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_raises_when_client_unavailable(self, mock_config, mock_client_class):
+        provider, _ = self._make_provider(mock_config, mock_client_class)
+        provider._client = None
+
+        with pytest.raises(OrderLookupError):
+            provider.get_order_checked("12345", "BTCUSDT")
+
+    @patch("src.data_providers.binance_provider.Client")
+    @patch("src.data_providers.binance_provider.get_config")
+    def test_alphanumeric_id_routes_to_client_order_id(self, mock_config, mock_client_class):
+        provider, mock_client = self._make_provider(mock_config, mock_client_class)
+        mock_client.get_order.return_value = dict(self.ORDER_PAYLOAD)
+
+        order = provider.get_order_checked("atb_19d360981ab_3a4b0d5a", "BTCUSDT")
+
+        assert order is not None
+        mock_client.get_order.assert_called_once_with(
+            symbol="BTCUSDT", origClientOrderId="atb_19d360981ab_3a4b0d5a"
+        )
 
 
 # ========================================

--- a/tests/unit/data_providers/test_coinbase_provider.py
+++ b/tests/unit/data_providers/test_coinbase_provider.py
@@ -63,3 +63,117 @@ class TestCoinbaseProvider:
             provider = CoinbaseProvider()
             price = provider.get_current_price("BTC-USD")
             assert price == 12345.67
+
+
+class TestCoinbaseGetOrderChecked:
+    """Fail-closed order lookup (#713): None only on a confirmed 404."""
+
+    @staticmethod
+    def _provider() -> CoinbaseProvider:
+        with patch.dict(os.environ, {"ENV": "test"}, clear=False):
+            for key in ["COINBASE_API_KEY", "COINBASE_API_SECRET", "COINBASE_API_PASSPHRASE"]:
+                os.environ.pop(key, None)
+            return CoinbaseProvider()
+
+    @staticmethod
+    def _http_error(status_code: int):
+        import requests
+
+        response = Mock()
+        response.status_code = status_code
+        return requests.exceptions.HTTPError(response=response)
+
+    def test_returns_none_on_confirmed_404(self):
+        provider = self._provider()
+        with patch.object(provider, "_request", side_effect=self._http_error(404)):
+            assert provider.get_order_checked("abc-123", "BTC-USD") is None
+
+    def test_raises_on_server_error(self):
+        from src.data_providers.exchange_interface import OrderLookupError
+
+        provider = self._provider()
+        with patch.object(provider, "_request", side_effect=self._http_error(503)):
+            with pytest.raises(OrderLookupError):
+                provider.get_order_checked("abc-123", "BTC-USD")
+
+    def test_raises_on_network_error(self):
+        from src.data_providers.exchange_interface import OrderLookupError
+
+        provider = self._provider()
+        with patch.object(provider, "_request", side_effect=ConnectionError("reset")):
+            with pytest.raises(OrderLookupError):
+                provider.get_order_checked("abc-123", "BTC-USD")
+
+    def test_returns_order_when_found(self):
+        provider = self._provider()
+        payload = {
+            "id": "abc-123",
+            "product_id": "BTC-USD",
+            "side": "sell",
+            "type": "limit",
+            "size": "0.5",
+            "filled_size": "0.0",
+            "price": "50000.0",
+            "status": "open",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        with patch.object(provider, "_request", return_value=payload):
+            order = provider.get_order_checked("abc-123", "BTC-USD")
+        assert order is not None
+        assert order.order_id == "abc-123"
+
+
+def test_exchange_interface_default_get_order_checked_fails_closed():
+    """The ABC default must raise (unconfirmed), never silently delegate to a
+    get_order that swallows errors into None (#713)."""
+    from src.data_providers.exchange_interface import (
+        ExchangeInterface,
+        OrderLookupError,
+    )
+
+    class _MinimalExchange(ExchangeInterface):
+        def _initialize_client(self):
+            pass
+
+        def test_connection(self):
+            return True
+
+        def get_account_info(self):
+            return {}
+
+        def get_balances(self):
+            return []
+
+        def get_balance(self, asset):
+            return None
+
+        def get_positions(self, symbol=None):
+            return []
+
+        def get_open_orders(self, symbol=None):
+            return []
+
+        def get_order(self, order_id, symbol):
+            return None  # swallows errors — exactly why the default must raise
+
+        def get_recent_trades(self, symbol, limit=100):
+            return []
+
+        def place_order(self, *a, **k):
+            return None
+
+        def cancel_order(self, order_id, symbol):
+            return True
+
+        def cancel_all_orders(self, symbol=None):
+            return True
+
+        def get_symbol_info(self, symbol):
+            return None
+
+        def place_stop_loss_order(self, *a, **k):
+            return None
+
+    exchange = _MinimalExchange("key", "secret")
+    with pytest.raises(OrderLookupError):
+        exchange.get_order_checked("123", "BTCUSDT")

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from src.data_providers.exchange_interface import OrderLookupError
 from src.engines.live.reconciliation import (
     AuditEvent,
     PeriodicReconciler,
@@ -79,6 +80,11 @@ class MockBalance:
 def mock_exchange():
     exchange = MagicMock()
     exchange.get_order.return_value = None
+    # Fail-closed lookup (#713) delegates to get_order by default so tests can
+    # keep driving order responses through get_order (.return_value or
+    # .side_effect) for both accessors; fail-closed tests override this with
+    # side_effect = OrderLookupError(...).
+    exchange.get_order_checked.side_effect = lambda oid, sym: exchange.get_order(oid, sym)
     exchange.get_order_by_client_id.return_value = None
     exchange.get_all_orders.return_value = []
     exchange.get_my_trades.return_value = []
@@ -3014,3 +3020,95 @@ class TestReconciliationFeeAccounting:
         mock_pnl.assert_called_once()
         call_kwargs = mock_pnl.call_args
         assert call_kwargs[1]["exit_fee"] == pytest.approx(0.35)
+
+
+class TestFailClosedSLLookup:
+    """#713: a transient order-lookup failure must NOT be treated as a missing stop.
+
+    Treating an unconfirmed lookup as "missing" clears the tracked stop-loss
+    order id and places a DUPLICATE stop while the original may still rest on
+    the exchange — reserving balance (later -2010) and able to flip the
+    position if both fill.
+    """
+
+    def test_periodic_cycle_skips_sl_replace_on_unconfirmed_lookup(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Periodic cycle: OrderLookupError -> no re-placement, SL id retained."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            stop_loss_order_id="sl_transient_1",
+            exchange_order_id="entry_t1",
+            db_position_id=60,
+            quantity=0.5,
+        )
+        pos.stop_loss = 46000.0
+        mock_position_tracker.positions = {"entry_t1": pos}
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+        mock_exchange.get_order.return_value = entry_order
+        # SL lookup cannot be confirmed (transient API failure)
+        mock_exchange.get_order_checked.side_effect = OrderLookupError("timeout")
+        mock_exchange.get_open_orders.return_value = []
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+        )
+        reconciler._reconcile_cycle()
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        assert pos.stop_loss_order_id == "sl_transient_1"
+        mock_position_tracker.remove_position.assert_not_called()
+        mock_db.close_position.assert_not_called()
+
+    def test_startup_verify_stop_loss_skips_on_unconfirmed_lookup(
+        self, reconciler, mock_exchange, mock_db
+    ):
+        """Startup _verify_stop_loss: OrderLookupError -> no audit, no re-place."""
+        position = MockPosition(
+            stop_loss=49000.0,
+            stop_loss_order_id="sl_transient_2",
+            db_position_id=61,
+        )
+        mock_exchange.get_order_checked.side_effect = OrderLookupError("rate limited")
+
+        result = ReconciliationResult(
+            entity_type="position",
+            entity_id=61,
+            status="verified",
+            severity=Severity.LOW,
+        )
+        reconciler._verify_stop_loss(position, "sl_transient_2", result)
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        assert position.stop_loss_order_id == "sl_transient_2"
+        # No MISSING audit event persisted for an unconfirmed lookup
+        mock_db.log_audit_event.assert_not_called()
+        assert result.severity == Severity.LOW
+
+    def test_startup_verify_stop_loss_replaces_on_confirmed_missing(
+        self, reconciler, mock_exchange, mock_db
+    ):
+        """Regression guard: a CONFIRMED-absent stop is still re-placed."""
+        position = MockPosition(
+            stop_loss=49000.0,
+            stop_loss_order_id="sl_gone_1",
+            db_position_id=62,
+        )
+        mock_exchange.get_order.return_value = None  # delegation -> confirmed absent
+        mock_exchange.place_stop_loss_order.return_value = "new_sl_replaced"
+
+        result = ReconciliationResult(
+            entity_type="position",
+            entity_id=62,
+            status="verified",
+            severity=Severity.LOW,
+        )
+        reconciler._verify_stop_loss(position, "sl_gone_1", result)
+
+        mock_exchange.place_stop_loss_order.assert_called_once()
+        assert position.stop_loss_order_id == "new_sl_replaced"


### PR DESCRIPTION
## Summary

Fixes #713: the reconciler treated `get_order() → None` as "stop-loss missing" and re-placed a stop — but `BinanceProvider.get_order` returns `None` on **every** exception, so a transient API failure (timeout, rate limit, connectivity blip) could create a **duplicate** protective stop while the original still rests on the exchange. A duplicate stop reserves base/margin (→ later `-2010` rejections on the close path, cf. #710) and can flip the position if both stops fill.

Both decision sites had the bug (same class, LESSONS §1.8 / §2.1):
- `PositionReconciler._verify_stop_loss` (startup recovery)
- `PeriodicReconciler` stop-verification loop (every ~120 s)

## Changes

- **`ExchangeInterface.get_order_checked` + `OrderLookupError`** — fail-closed lookup contract: returns the `Order`; returns `None` **only** when the exchange confirmed the order does not exist; raises `OrderLookupError` when the lookup cannot be confirmed.
- **`BinanceProvider.get_order_checked`** — `None` only on Binance `-2013` ("Order does not exist"); any other API error, network error, unavailable client, or unparseable response raises `OrderLookupError`. Numeric IDs route via `orderId`, alphanumeric client IDs via `origClientOrderId`.
- **Reconciler** — new `lookup_order_fail_closed()` helper used by both verifiers: on an unconfirmed lookup it logs a warning and **skips the position for this cycle** (tracked `stop_loss_order_id` retained, no MISSING audit, no re-placement). Confirmed-missing stops are still re-placed exactly as before. Falls back to legacy `get_order` for providers without the accessor (unchanged behavior).

Audited the other four `get_order` call sites (`reconciliation.py` entry verify ×2, `trading_engine._stop_loss_filled_quantity`, `_check_stop_loss_filled`, legacy SL reconcile): all already fail-safe on `None` (no state mutation / conservative default) — left unchanged.

## Testing

- New: `TestGetOrderChecked` (6 provider tests: found / `-2013`→`None` / API error→raise / network→raise / client-unavailable→raise / client-id routing) and `TestFailClosedSLLookup` (periodic skip-on-unconfirmed, startup skip-on-unconfirmed, regression guard: confirmed-missing still re-places).
- Existing reconciliation suites pass unchanged in semantics via a fixture delegation (`get_order_checked` → `get_order`), so all prior order-driving patterns keep working.
- Full unit suite: **3869 passed, 103 skipped** locally.

## Risk

No behavior change when lookups succeed. The only new behavior: a failed lookup defers action to the next reconcile cycle (~2 min) instead of immediately re-placing — strictly safer for a protective-order decision.

https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN)_