### PR TITLE
fix(live): order-tracker polling give-up is not a cancel — keep the position, alert, defer to the reconciler

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- OrderTracker no longer converts an API outage into a position deletion.
+  After `MAX_API_ERROR_RETRIES` (10) consecutive failed/`None` polls
+  (~50 s at the live 5 s interval) the tracker fired `on_cancel`, and
+  `_handle_order_cancel` popped the (possibly live) position from the
+  tracker and refunded its entry fee — manufacturing untracked exchange
+  exposure, a corrupted balance, and room for a double entry on the next
+  signal, exactly during exchange API degradations (LESSONS §1.8 fail-open
+  class). Polling give-up now routes to a new `on_tracking_lost` callback;
+  the engine's `_handle_order_tracking_lost` keeps the position tracked,
+  leaves the balance untouched, and escalates with a critical
+  `system_events` row (`ORDER_TRACKING_LOST`) + webhook alert so the
+  periodic reconciler resolves the order's true state from the exchange.
+  `on_cancel` now fires only for exchange-confirmed terminal states.
 - Closed live `trades` rows now persist `commission` and `quantity` (previously
   always `0` / `NULL`). The live close path (`LiveTradingEngine._close_position`
   and the offline stop-loss reconciliation path) now passes `commission` and

--- a/src/engines/live/order_tracker.py
+++ b/src/engines/live/order_tracker.py
@@ -82,6 +82,7 @@ class OrderTracker:
         on_fill: Callable[[str, str, float, float], None] | None = None,
         on_partial_fill: Callable[[str, str, float, float], None] | None = None,
         on_cancel: Callable[[str, str, float], None] | None = None,
+        on_tracking_lost: Callable[[str, str, int], None] | None = None,
         event_deduplicator: EventDeduplicator | None = None,
     ):
         """
@@ -94,6 +95,14 @@ class OrderTracker:
             on_partial_fill: Callback(order_id, symbol, new_filled_qty, avg_price) for partial fills
             on_cancel: Callback(order_id, symbol, filled_qty) for cancelled/rejected orders.
                 filled_qty is the cumulative quantity filled before cancellation (0.0 if unfilled).
+                Invoked ONLY when the exchange confirmed the terminal state — never
+                for a lookup that merely failed.
+            on_tracking_lost: Callback(order_id, symbol, consecutive_failures) when the
+                tracker gives up polling an order whose state could NOT be confirmed
+                (persistent API errors/None lookups). The order may still be live on
+                the exchange, so the handler must NOT treat this as a cancellation
+                (no position removal, no fee refund) — escalate/alert and let the
+                reconciler resolve from exchange truth.
             event_deduplicator: Optional deduplicator for WebSocket events. A default
                 instance is created if not provided.
         """
@@ -102,6 +111,7 @@ class OrderTracker:
         self.on_fill = on_fill
         self.on_partial_fill = on_partial_fill
         self.on_cancel = on_cancel
+        self.on_tracking_lost = on_tracking_lost
         self._dedup = event_deduplicator or EventDeduplicator()
         self._polling_enabled = True  # Controls whether _poll_loop runs checks
 
@@ -231,24 +241,16 @@ class OrderTracker:
                         if tracked.api_error_count >= MAX_API_ERROR_RETRIES:
                             logger.critical(
                                 "CRITICAL: Order %s on %s returned None for %d consecutive "
-                                "polls. Force-removing to prevent infinite polling. "
-                                "MANUAL RECONCILIATION REQUIRED.",
+                                "polls. Abandoning tracking to prevent infinite polling. "
+                                "Order state is UNKNOWN (NOT a confirmed cancel) — the "
+                                "reconciler must resolve it from exchange truth.",
                                 order_id,
                                 tracked.symbol,
                                 tracked.api_error_count,
                             )
-                            if self.on_cancel:
-                                try:
-                                    self.on_cancel(
-                                        order_id, tracked.symbol, tracked.last_filled_qty
-                                    )
-                                except Exception as cb_err:
-                                    logger.error(
-                                        "Cancel callback failed for force-removed order %s: %s",
-                                        order_id,
-                                        cb_err,
-                                        exc_info=True,
-                                    )
+                            self._notify_tracking_lost(
+                                order_id, tracked.symbol, tracked.api_error_count
+                            )
                             self.stop_tracking(order_id)
                         elif tracked.callback_failure_count > 0:
                             logger.critical(
@@ -278,26 +280,20 @@ class OrderTracker:
                     if tracked.api_error_count >= MAX_API_ERROR_RETRIES:
                         logger.critical(
                             "CRITICAL: Order %s on %s failed %d consecutive API calls: %s. "
-                            "Force-removing to prevent infinite error loop. "
-                            "MANUAL RECONCILIATION REQUIRED.",
+                            "Abandoning tracking to prevent infinite error loop. "
+                            "Order state is UNKNOWN (NOT a confirmed cancel) — the "
+                            "reconciler must resolve it from exchange truth.",
                             order_id,
                             tracked.symbol,
                             tracked.api_error_count,
                             e,
                             exc_info=True,
                         )
-                        # Call cancel callback BEFORE stop_tracking so the callback
-                        # can still access order metadata if needed
-                        if self.on_cancel:
-                            try:
-                                self.on_cancel(order_id, tracked.symbol, tracked.last_filled_qty)
-                            except Exception as cb_err:
-                                logger.error(
-                                    "Cancel callback failed for force-removed order %s: %s",
-                                    order_id,
-                                    cb_err,
-                                    exc_info=True,
-                                )
+                        # Notify BEFORE stop_tracking so the callback can still
+                        # access order metadata if needed
+                        self._notify_tracking_lost(
+                            order_id, tracked.symbol, tracked.api_error_count
+                        )
                         self.stop_tracking(order_id)
                     else:
                         logger.warning(
@@ -307,6 +303,27 @@ class OrderTracker:
                             MAX_API_ERROR_RETRIES,
                             e,
                         )
+
+    def _notify_tracking_lost(self, order_id: str, symbol: str, failures: int) -> None:
+        """Invoke ``on_tracking_lost`` for an order whose state could not be confirmed.
+
+        Deliberately distinct from ``on_cancel`` (LESSONS §1.8 fail-open class): a
+        polling give-up is a fail-open lookup, not an exchange-confirmed cancel.
+        Routing it to the cancel handler used to delete a possibly-live position
+        and refund its entry fee — manufacturing untracked exposure and a
+        corrupted balance during any ~50s API degradation.
+        """
+        if not self.on_tracking_lost:
+            return
+        try:
+            self.on_tracking_lost(order_id, symbol, failures)
+        except Exception as cb_err:
+            logger.error(
+                "Tracking-lost callback failed for abandoned order %s: %s",
+                order_id,
+                cb_err,
+                exc_info=True,
+            )
 
     def _process_order_status(self, order_id: str, tracked: TrackedOrder, order: Order) -> None:
         """

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -580,6 +580,7 @@ class LiveTradingEngine:
                         on_fill=self._handle_order_fill,
                         on_partial_fill=self._handle_partial_fill,
                         on_cancel=self._handle_order_cancel,
+                        on_tracking_lost=self._handle_order_tracking_lost,
                     )
                     logger.info(
                         f"{provider_name} exchange interface and account synchronizer initialized"
@@ -4322,6 +4323,40 @@ class LiveTradingEngine:
                             )
                     else:
                         self.current_balance += refund_amount
+
+    def _handle_order_tracking_lost(self, order_id: str, symbol: str, failures: int) -> None:
+        """Handle the OrderTracker giving up on an order whose state is UNKNOWN.
+
+        Fail-closed counterpart to :meth:`_handle_order_cancel`: after
+        ``failures`` consecutive failed/None polls the order's exchange state
+        could not be confirmed, so the position (if any) is deliberately KEPT
+        tracked — removing it and refunding its entry fee here would vaporize a
+        possibly-live position from the books (untracked exposure, corrupted
+        balance, double-entry on the next signal). The periodic reconciler
+        resolves the true state from the exchange: it removes ghosts whose
+        entry order is confirmed cancelled and books offline stop-loss fills.
+        """
+        position = self.live_position_tracker.get_position(order_id)
+        message = (
+            f"Order {order_id} on {symbol} state UNKNOWN after {failures} consecutive "
+            f"failed polls — tracking abandoned (NOT treated as cancelled). "
+            f"{'Position kept tracked' if position is not None else 'No tracked position'}; "
+            f"reconciler will resolve from exchange truth."
+        )
+        logger.critical("CRITICAL: %s", message)
+        log_order_event(
+            "order_tracking_lost",
+            order_id=order_id,
+            symbol=symbol,
+        )
+        self._record_event(
+            EventType.ERROR,
+            message,
+            severity="critical",
+            component="order_tracker",
+            error_code="ORDER_TRACKING_LOST",
+            alert=True,
+        )
 
     def _execute_exit(
         self,

--- a/tests/unit/engines/live/test_order_tracking_lost.py
+++ b/tests/unit/engines/live/test_order_tracking_lost.py
@@ -1,0 +1,113 @@
+"""OrderTracker polling give-up must NOT be treated as an order cancellation.
+
+Previously the tracker fired ``on_cancel`` after MAX_API_ERROR_RETRIES
+consecutive failed/None polls, and ``_handle_order_cancel`` then popped the
+(possibly live) position from the tracker and refunded its entry fee — i.e. a
+~50 s exchange API degradation vaporized a real position from the books:
+untracked exposure, corrupted balance, and room for a double entry on the
+next signal (LESSONS §1.8 fail-open class).
+
+The give-up now routes to ``on_tracking_lost`` → ``_handle_order_tracking_lost``,
+which keeps the position, leaves the balance untouched, and escalates via a
+critical system event + alert so the reconciler resolves exchange truth.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.database.models import EventType
+from src.engines.live.trading_engine import LiveTradingEngine
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = pytest.mark.fast
+
+
+def make_engine() -> LiveTradingEngine:
+    with patch("src.engines.live.trading_engine.DatabaseManager"):
+        engine = LiveTradingEngine(
+            strategy=create_ml_basic_strategy(),
+            data_provider=MagicMock(),
+            initial_balance=1000.0,
+        )
+    engine.db_manager = MagicMock()
+    return engine
+
+
+def _track_fake_position(engine: LiveTradingEngine, order_id: str = "entry_1") -> MagicMock:
+    position = MagicMock()
+    position.symbol = "BTCUSDT"
+    position.order_id = order_id
+    engine.live_position_tracker.get_position = MagicMock(return_value=position)
+    engine.live_position_tracker.pop_position = MagicMock(return_value=position)
+    return position
+
+
+class TestHandleOrderTrackingLost:
+    def test_keeps_position_and_balance(self):
+        engine = make_engine()
+        _track_fake_position(engine)
+        balance_before = engine.current_balance
+
+        engine._handle_order_tracking_lost("entry_1", "BTCUSDT", 10)
+
+        engine.live_position_tracker.pop_position.assert_not_called()
+        assert engine.current_balance == balance_before
+        engine.db_manager.atomic_balance_update.assert_not_called()
+
+    def test_records_critical_event_with_alert(self):
+        engine = make_engine()
+        _track_fake_position(engine)
+
+        with patch.object(engine, "_record_event") as record:
+            engine._handle_order_tracking_lost("entry_1", "BTCUSDT", 10)
+
+        record.assert_called_once()
+        args, kwargs = record.call_args
+        assert args[0] == EventType.ERROR
+        assert "UNKNOWN" in args[1]
+        assert kwargs["severity"] == "critical"
+        assert kwargs["error_code"] == "ORDER_TRACKING_LOST"
+        assert kwargs["alert"] is True
+
+    def test_no_position_still_escalates_without_error(self):
+        engine = make_engine()
+        engine.live_position_tracker.get_position = MagicMock(return_value=None)
+
+        with patch.object(engine, "_record_event") as record:
+            engine._handle_order_tracking_lost("orphan_1", "ETHUSDT", 10)
+
+        record.assert_called_once()
+
+    def test_order_tracker_wiring_routes_give_up_to_tracking_lost(self):
+        """End-to-end: a tracker constructed like the engine's must call the
+        fail-closed handler, never _handle_order_cancel, on polling give-up."""
+        from src.engines.live.order_tracker import MAX_API_ERROR_RETRIES, OrderTracker
+
+        engine = make_engine()
+        exchange = MagicMock()
+        exchange.get_order.return_value = None
+        tracker = OrderTracker(
+            exchange=exchange,
+            poll_interval=0.01,
+            on_fill=engine._handle_order_fill,
+            on_partial_fill=engine._handle_partial_fill,
+            on_cancel=engine._handle_order_cancel,
+            on_tracking_lost=engine._handle_order_tracking_lost,
+        )
+        tracker.track_order("entry_42", "BTCUSDT")
+        _track_fake_position(engine, "entry_42")
+
+        with (
+            patch.object(engine, "_handle_order_cancel") as cancel,
+            patch.object(engine, "_record_event") as record,
+        ):
+            tracker.on_cancel = engine._handle_order_cancel
+            for _ in range(MAX_API_ERROR_RETRIES):
+                tracker._check_orders()
+
+        cancel.assert_not_called()
+        record.assert_called_once()
+        assert tracker.get_tracked_count() == 0

--- a/tests/unit/engines/live/test_order_tracking_lost.py
+++ b/tests/unit/engines/live/test_order_tracking_lost.py
@@ -14,11 +14,13 @@ critical system event + alert so the reconciler resolves exchange truth.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+from src.database.manager import DatabaseManager
 from src.database.models import EventType
+from src.engines.live.execution.position_tracker import LivePositionTracker
 from src.engines.live.trading_engine import LiveTradingEngine
 from src.strategies.ml_basic import create_ml_basic_strategy
 
@@ -32,7 +34,8 @@ def make_engine() -> LiveTradingEngine:
             data_provider=MagicMock(),
             initial_balance=1000.0,
         )
-    engine.db_manager = MagicMock()
+    # autospec catches signature mismatches on every db_manager call
+    engine.db_manager = create_autospec(DatabaseManager, instance=True)
     return engine
 
 
@@ -40,8 +43,11 @@ def _track_fake_position(engine: LiveTradingEngine, order_id: str = "entry_1") -
     position = MagicMock()
     position.symbol = "BTCUSDT"
     position.order_id = order_id
-    engine.live_position_tracker.get_position = MagicMock(return_value=position)
-    engine.live_position_tracker.pop_position = MagicMock(return_value=position)
+    # autospec'd tracker: get_position/pop_position calls are signature-checked
+    tracker = create_autospec(LivePositionTracker, instance=True)
+    tracker.get_position.return_value = position
+    tracker.pop_position.return_value = position
+    engine.live_position_tracker = tracker
     return position
 
 
@@ -74,7 +80,9 @@ class TestHandleOrderTrackingLost:
 
     def test_no_position_still_escalates_without_error(self):
         engine = make_engine()
-        engine.live_position_tracker.get_position = MagicMock(return_value=None)
+        tracker = create_autospec(LivePositionTracker, instance=True)
+        tracker.get_position.return_value = None
+        engine.live_position_tracker = tracker
 
         with patch.object(engine, "_record_event") as record:
             engine._handle_order_tracking_lost("orphan_1", "ETHUSDT", 10)

--- a/tests/unit/live/test_order_tracker.py
+++ b/tests/unit/live/test_order_tracker.py
@@ -23,6 +23,7 @@ def order_tracker(mock_exchange):
     on_fill = Mock()
     on_partial_fill = Mock()
     on_cancel = Mock()
+    on_tracking_lost = Mock()
 
     tracker = OrderTracker(
         exchange=mock_exchange,
@@ -30,6 +31,7 @@ def order_tracker(mock_exchange):
         on_fill=on_fill,
         on_partial_fill=on_partial_fill,
         on_cancel=on_cancel,
+        on_tracking_lost=on_tracking_lost,
     )
     return tracker
 
@@ -422,8 +424,12 @@ class TestApiErrorHandling:
         # Assert - order force-removed after max retries
         assert order_tracker.get_tracked_count() == 0
 
-    def test_persistent_api_errors_trigger_cancel_callback(self, order_tracker, mock_exchange):
-        """Test that force-removal after API errors calls the cancel callback."""
+    def test_persistent_api_errors_trigger_tracking_lost_not_cancel(
+        self, order_tracker, mock_exchange
+    ):
+        """A polling give-up is NOT a confirmed cancel: it must fire
+        on_tracking_lost (fail-closed escalation) and never on_cancel, which
+        would delete a possibly-live position and refund its entry fee."""
         # Arrange
         mock_exchange.get_order.side_effect = Exception("Binance -1100: Illegal characters")
         order_tracker.track_order("atb_bad_id", "BTCUSDT")
@@ -432,13 +438,16 @@ class TestApiErrorHandling:
         for _ in range(MAX_API_ERROR_RETRIES):
             order_tracker._check_orders()
 
-        # Assert - cancel callback invoked with last_filled_qty=0.0
-        order_tracker.on_cancel.assert_called_once_with("atb_bad_id", "BTCUSDT", 0.0)
+        # Assert - tracking-lost fired; cancel callback NOT invoked
+        order_tracker.on_tracking_lost.assert_called_once_with(
+            "atb_bad_id", "BTCUSDT", MAX_API_ERROR_RETRIES
+        )
+        order_tracker.on_cancel.assert_not_called()
 
-    def test_persistent_api_errors_with_partial_fill_passes_filled_qty(
+    def test_persistent_api_errors_with_partial_fill_fires_tracking_lost(
         self, order_tracker, mock_exchange
     ):
-        """Test that force-removal passes cumulative filled_qty from prior partial fills."""
+        """A partial fill before the API outage doesn't make the give-up a cancel."""
         # Arrange - first poll: partial fill, then persistent errors
         partial_order = MagicMock()
         partial_order.status = OrderStatus.PARTIALLY_FILLED
@@ -459,8 +468,31 @@ class TestApiErrorHandling:
         for _ in range(MAX_API_ERROR_RETRIES):
             order_tracker._check_orders()
 
-        # Assert - cancel callback receives the partial fill qty
-        order_tracker.on_cancel.assert_called_once_with("order456", "BTCUSDT", 0.3)
+        # Assert - abandoned as state-unknown (NOT a confirmed cancel, even
+        # with a prior partial fill); on_cancel must not fire
+        order_tracker.on_tracking_lost.assert_called_once_with(
+            "order456", "BTCUSDT", MAX_API_ERROR_RETRIES
+        )
+        order_tracker.on_cancel.assert_not_called()
+        assert order_tracker.get_tracked_count() == 0
+
+    def test_persistent_none_lookups_trigger_tracking_lost_not_cancel(
+        self, order_tracker, mock_exchange
+    ):
+        """get_order returning None (swallowed errors) is also state-unknown."""
+        # Arrange
+        mock_exchange.get_order.return_value = None
+        order_tracker.track_order("order_none", "BTCUSDT")
+
+        # Act
+        for _ in range(MAX_API_ERROR_RETRIES):
+            order_tracker._check_orders()
+
+        # Assert
+        order_tracker.on_tracking_lost.assert_called_once_with(
+            "order_none", "BTCUSDT", MAX_API_ERROR_RETRIES
+        )
+        order_tracker.on_cancel.assert_not_called()
         assert order_tracker.get_tracked_count() == 0
 
     def test_api_errors_below_threshold_keep_tracking(self, order_tracker, mock_exchange):
@@ -476,14 +508,15 @@ class TestApiErrorHandling:
         # Assert - order still tracked
         assert order_tracker.get_tracked_count() == 1
         order_tracker.on_cancel.assert_not_called()
+        order_tracker.on_tracking_lost.assert_not_called()
 
-    def test_cancel_callback_failure_during_force_remove_does_not_crash(
+    def test_tracking_lost_callback_failure_during_abandon_does_not_crash(
         self, order_tracker, mock_exchange
     ):
-        """Test that a failing cancel callback during force-removal is handled gracefully."""
+        """A failing tracking-lost callback during abandonment is handled gracefully."""
         # Arrange
         mock_exchange.get_order.side_effect = Exception("API error")
-        order_tracker.on_cancel.side_effect = RuntimeError("Callback bug")
+        order_tracker.on_tracking_lost.side_effect = RuntimeError("Callback bug")
         order_tracker.track_order("order_cb_fail", "BTCUSDT")
 
         # Act - exhaust retries (should not raise)

--- a/tests/unit/live/test_order_tracker_websocket.py
+++ b/tests/unit/live/test_order_tracker_websocket.py
@@ -73,12 +73,14 @@ def tracker(mock_exchange, dedup):
     on_fill = Mock()
     on_partial_fill = Mock()
     on_cancel = Mock()
+    on_tracking_lost = Mock()
     t = OrderTracker(
         exchange=mock_exchange,
         poll_interval=0.1,
         on_fill=on_fill,
         on_partial_fill=on_partial_fill,
         on_cancel=on_cancel,
+        on_tracking_lost=on_tracking_lost,
         event_deduplicator=dedup,
     )
     return t


### PR DESCRIPTION
## Summary

After `MAX_API_ERROR_RETRIES` (10) consecutive failed/`None` `get_order` polls (~50 s at the live 5 s interval), `OrderTracker` force-removed the order and fired **`on_cancel`** — and `_handle_order_cancel` then **popped the position from the tracker and refunded its entry fee**. But a polling give-up means the order state is *UNKNOWN*, not cancelled: `BinanceProvider.get_order` returns `None` on every exception, so any ~50 s exchange API degradation could vaporize a REAL live position from the books:

- the position + its stop-loss stay live on the exchange, **untracked** (the periodic reconciler early-returns when the tracker is empty),
- the bogus entry-fee refund corrupts the balance,
- `has_position_for_symbol` now passes → the next signal opens a **second** position (double exposure),
- the orphaned SL's eventual fill finds no position to book its loss against.

This is the LESSONS §1.8 fail-open class (a `None`-on-error accessor wired to a destructive action), found independently by two audit passes (see #735–#750 audit batch).

## Changes

- **`OrderTracker`**: new `on_tracking_lost(order_id, symbol, consecutive_failures)` callback. Both force-removal sites (the `None` path and the exception path) now invoke it instead of `on_cancel`, with the CRITICAL log rewritten to say the state is UNKNOWN. **`on_cancel` now fires only for exchange-confirmed CANCELED/REJECTED/EXPIRED statuses.**
- **`LiveTradingEngine._handle_order_tracking_lost`**: fail-closed handler — keeps the position tracked, touches no balance, logs CRITICAL, and emits a `system_events` row (`component=order_tracker`, `error_code=ORDER_TRACKING_LOST`, `severity=critical`) with webhook alert. The periodic reconciler remains the authority: it removes ghosts whose entry order is *confirmed* cancelled (with DB close) and books offline SL fills.

## Testing

- Tracker: give-up fires `on_tracking_lost` and never `on_cancel` on both paths, including after a prior partial fill; below-threshold errors keep tracking and fire nothing; a failing tracking-lost callback doesn't crash the poll loop.
- Engine: handler keeps position + balance untouched (`pop_position`/`atomic_balance_update` not called), emits the critical event with alert; works with no tracked position; end-to-end wiring test (tracker constructed exactly like the engine's).
- Full unit suite green locally on this branch rebased onto current `develop`.

## Risk

Strictly safer: the only behavior change is on the give-up path, which previously did the destructive thing. Confirmed cancels behave exactly as before.

https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN)_