### PR TITLE
fix(reconciliation): book realized PnL for stop-loss fills detected by the periodic reconciler

### DIFF
--- a/.claude/LESSONS.md
+++ b/.claude/LESSONS.md
@@ -104,6 +104,13 @@ was a **phantom**: no such SL order existed, account sync showed `0 open orders`
 sub-threshold dust. **Rule:** treat automated/stale context as a hypothesis; confirm against live
 state (`get_open_orders`, account sync, the actual order id) before acting or alarming.
 
+### 2.6 Conflicted PRs run NO CI — and that looks like "CI is stuck"
+A push to a PR branch whose merge with the base is conflicted (`mergeable_state: dirty`)
+produces **zero** check runs: `pull_request`-triggered workflows run on the merge ref, which
+GitHub cannot create. Nothing fails — checks simply never appear. **Rule:** when a PR push
+shows no checks after a few minutes, check `mergeable_state` first (the base may have moved),
+rebase onto the fresh base, and force-push; don't wait on or re-trigger phantom CI.
+
 ---
 
 ## 3. Operational / tooling gotchas

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,10 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the stop-verification branch closed the DB row with NO balance update
   (and no trade record), and the margin holdings check misclassified a
   just-filled short stop-loss (AUTO_REPAY zeroes the borrow) as
-  "externally closed", closing the row with no exit price at all. Every
+  "externally closed" (the spot holdings check had the identical flaw:
+  a filled stop also empties the held balance), closing the row with no
+  exit price at all. Every
   SL loss the reconciler processed before the engine's deferred-exit
   drain (~equal ~2-minute cadences, so a large fraction) silently never
   hit the balance → overstated capital → oversized subsequent positions.
+  Both the margin and spot holdings checks now consult the tracked stop
+  order before classifying an external close.
   Both paths now delegate to the startup reconciler's filled-SL handler
   (#731): DB close first (a failed close leaves the position tracked for
   retry), P&L with USD-normalized commission and margin interest, plus a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Periodic reconciler now books realized P&L when it detects a filled
+  stop-loss. Both detection paths previously corrupted tracked capital:
+  the stop-verification branch closed the DB row with NO balance update
+  (and no trade record), and the margin holdings check misclassified a
+  just-filled short stop-loss (AUTO_REPAY zeroes the borrow) as
+  "externally closed", closing the row with no exit price at all. Every
+  SL loss the reconciler processed before the engine's deferred-exit
+  drain (~equal ~2-minute cadences, so a large fraction) silently never
+  hit the balance → overstated capital → oversized subsequent positions.
+  Both paths now delegate to the startup reconciler's filled-SL handler
+  (#731): DB close first (a failed close leaves the position tracked for
+  retry), P&L with USD-normalized commission and margin interest, plus a
+  deduplicated `trades` row. The periodic wrapper skips when the engine's
+  deferred-exit drain already processed the fill (no double-booking) and
+  defers classification (fail-closed) when the stop's state cannot be
+  confirmed.
 - OrderTracker no longer converts an API outage into a position deletion.
   After `MAX_API_ERROR_RETRIES` (10) consecutive failed/`None` polls
   (~50 s at the live 5 s interval) the tracker fired `on_cancel`, and

--- a/docs/project_status.md
+++ b/docs/project_status.md
@@ -1,11 +1,22 @@
 # Project Status
 
-> **Last Updated**: 2026-04-27
+> **Last Updated**: 2026-06-10
 > **Maintainer Note**: This is a living document. Update at the start and end of each development session. Use the `/update-docs` command to keep this in sync.
 
 ---
 
 ## In Flight
+
+- **Live-capital bug-audit remediation (2026-06-10)** — a multi-agent code
+  audit produced 17 tracked findings (#734–#750) across order execution,
+  reconciliation, balance integrity, risk enforcement, and sync. Fix PRs in
+  flight: fail-closed stop-loss lookup (#733 → fixes #713), partial-ops
+  hard-disable (#734 interim), order-tracker tracking-lost handling, and
+  periodic-reconciler SL-fill PnL booking. Highest open items after the
+  PR train: close-quantity derivation (#737), balance-ledger serialization
+  (#735/#736), dead rate-limit retries (#738), stale-snapshot stop re-arm
+  (#739), live max-drawdown enforcement (#749), backtest partial-PnL
+  inflation (#748).
 
 - **Monitoring dashboard V2 redesign** — chart-led layout (left rail + KPI
   strip + hero equity chart + position inspector) replacing the legacy

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -3052,6 +3052,36 @@ class PeriodicReconciler:
                     held_qty = balance.total
 
                     if held_qty < position_qty * 0.5:
+                        # A just-filled stop-loss also empties the held balance
+                        # (the SL sold the inventory) — indistinguishable from an
+                        # external close by holdings alone. Check the tracked stop
+                        # order first so an SL fill books its real P&L instead of
+                        # the row being closed with no exit price and no balance
+                        # update (mirrors the margin branch above).
+                        sl_id = getattr(position, "stop_loss_order_id", None)
+                        if sl_id:
+                            from src.data_providers.exchange_interface import (
+                                OrderStatus as ExOrderStatus,
+                            )
+
+                            sl_order, confirmed = lookup_order_fail_closed(
+                                self.exchange, sl_id, position.symbol
+                            )
+                            if not confirmed:
+                                logger.warning(
+                                    "Position %s looks closed but its stop-loss %s "
+                                    "could not be verified — deferring classification.",
+                                    position.symbol,
+                                    sl_id,
+                                )
+                                continue
+                            if sl_order is not None and sl_order.status == ExOrderStatus.FILLED:
+                                if self._close_position_from_filled_sl(
+                                    order_key, position, sl_order
+                                ):
+                                    if Severity.HIGH > max_severity:
+                                        max_severity = Severity.HIGH
+                                continue
                         severity = Severity.HIGH
                         self.db_manager.log_audit_event(
                             session_id=self.session_id,

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2648,6 +2648,16 @@ class PeriodicReconciler:
         )
         # Shared per-base-asset exchange-mutation lock (serialises sweep vs entry/exit).
         self._lock_registry = lock_registry
+        # Reuses the startup reconciler's P&L realization (balance + audit) so a
+        # stop-loss fill detected by the periodic cycle books money identically
+        # to one detected at startup. Construction is side-effect-free.
+        self._position_reconciler = PositionReconciler(
+            exchange_interface=exchange_interface,
+            position_tracker=position_tracker,
+            db_manager=db_manager,
+            session_id=session_id,
+            use_margin=use_margin,
+        )
 
     def start(self) -> None:
         """Start the periodic reconciliation daemon thread."""
@@ -2702,6 +2712,59 @@ class PeriodicReconciler:
                 if not self._running:
                     break
                 time.sleep(1)
+
+    def _close_position_from_filled_sl(self, order_key: str, position: Any, sl_order: Any) -> bool:
+        """Book and close a position whose stop-loss filled on the exchange.
+
+        Delegates to the startup reconciler's filled-SL handler so the
+        periodic path books money identically: DB close FIRST (a failed close
+        leaves the position tracked for re-reconciliation), then realized P&L
+        into the session balance with the commission normalized to USD, plus
+        a deduplicated ``trades`` row. The periodic path previously closed
+        the DB row with NO balance update and no trade record, so every SL
+        loss the reconciler detected before the engine's deferred-exit drain
+        silently never hit tracked capital → overstated balance → oversized
+        subsequent positions.
+
+        Skips when the position is no longer tracked — the engine's
+        deferred SL-exit drain already processed this fill — so the P&L is
+        not double-booked. A residual race with an engine exit already in
+        flight remains until the reconciler is base-lock-aware (#714).
+
+        Returns True when this call closed the position.
+        """
+        if self.position_tracker.get_position(order_key) is None:
+            logger.info(
+                "Stop-loss fill for %s already processed elsewhere — skipping (periodic)",
+                order_key,
+            )
+            return False
+
+        self._position_reconciler._close_position_from_filled_sl(position, sl_order)
+
+        if self.position_tracker.get_position(order_key) is not None:
+            # DB close failed inside the handler — position intentionally left
+            # tracked (and the DB row OPEN) for the next cycle to retry.
+            return False
+
+        exit_price = float(sl_order.average_price) if sl_order.average_price else None
+        self.db_manager.log_audit_event(
+            session_id=self.session_id,
+            entity_type="position",
+            entity_id=getattr(position, "db_position_id", None),
+            field="status",
+            old_value="OPEN",
+            new_value="CLOSED_BY_SL",
+            reason=f"Stop-loss filled @ {exit_price} (periodic check)",
+            severity=Severity.HIGH.value,
+        )
+        logger.warning(
+            "Stop-loss filled for %s @ %s (periodic check) — removed position %s",
+            position.symbol,
+            exit_price,
+            order_key,
+        )
+        return True
 
     def _reconcile_cycle(self) -> None:
         """Execute one reconciliation cycle."""
@@ -2838,13 +2901,44 @@ class PeriodicReconciler:
                             position_gone = True
 
                     if position_gone:
+                        # A just-filled stop-loss also zeroes borrowed/held
+                        # (AUTO_REPAY repays the borrow on fill), which this
+                        # balance heuristic cannot tell apart from an external
+                        # close. Check the tracked stop order first so an SL
+                        # fill books its real P&L instead of the row being
+                        # closed with no exit price and no balance update.
+                        sl_id = getattr(position, "stop_loss_order_id", None)
+                        if sl_id:
+                            from src.data_providers.exchange_interface import (
+                                OrderStatus as ExOrderStatus,
+                            )
+
+                            sl_order, confirmed = lookup_order_fail_closed(
+                                self.exchange, sl_id, symbol
+                            )
+                            if not confirmed:
+                                # Unknown SL state — do not classify the close
+                                # this cycle (fail-closed); re-check next run.
+                                logger.warning(
+                                    "Margin position %s looks closed but its stop-loss "
+                                    "%s could not be verified — deferring classification.",
+                                    symbol,
+                                    sl_id,
+                                )
+                                continue
+                            if sl_order is not None and sl_order.status == ExOrderStatus.FILLED:
+                                if self._close_position_from_filled_sl(
+                                    order_key, position, sl_order
+                                ):
+                                    if Severity.HIGH > max_severity:
+                                        max_severity = Severity.HIGH
+                                continue
                         logger.warning(
                             "Margin position %s appears externally closed — "
                             "cancelling SL and removing from tracker",
                             symbol,
                         )
                         # Cancel exchange SL to prevent orphaned order
-                        sl_id = getattr(position, "stop_loss_order_id", None)
                         if sl_id:
                             try:
                                 self.exchange.cancel_order(sl_id, symbol)
@@ -3027,30 +3121,11 @@ class PeriodicReconciler:
                     continue
 
                 if sl_order and sl_order.status == ExOrderStatus.FILLED:
-                    # SL triggered — remove position from tracker + close in DB
-                    exit_price = float(sl_order.average_price) if sl_order.average_price else None
-                    self.db_manager.log_audit_event(
-                        session_id=self.session_id,
-                        entity_type="position",
-                        entity_id=getattr(position, "db_position_id", None),
-                        field="status",
-                        old_value="OPEN",
-                        new_value="CLOSED_BY_SL",
-                        reason=f"Stop-loss filled @ {exit_price} (periodic check)",
-                        severity=Severity.HIGH.value,
-                    )
-                    self.position_tracker.remove_position(order_key)
-                    db_pos_id = getattr(position, "db_position_id", None)
-                    if db_pos_id is not None:
-                        self.db_manager.close_position(db_pos_id, exit_price=exit_price)
-                    logger.warning(
-                        "Stop-loss filled for %s @ %s (periodic check) — " "removed position %s",
-                        position.symbol,
-                        exit_price,
-                        order_key,
-                    )
-                    if Severity.HIGH > max_severity:
-                        max_severity = Severity.HIGH
+                    # SL triggered — book realized P&L, remove from tracker,
+                    # close in DB (all in the shared handler).
+                    if self._close_position_from_filled_sl(order_key, position, sl_order):
+                        if Severity.HIGH > max_severity:
+                            max_severity = Severity.HIGH
 
                 elif (
                     sl_order and sl_order.status in (ExOrderStatus.CANCELLED, ExOrderStatus.EXPIRED)

--- a/tests/integration/live/test_reconciliation_integration.py
+++ b/tests/integration/live/test_reconciliation_integration.py
@@ -652,9 +652,18 @@ class TestReconciliationIntegration:
             position_tracker,
             stop_loss_order_id="sl_active_001",
         )
-        # Entry order is FILLED (valid)
+        # Entry order is FILLED (valid); the stop-loss was CANCELLED by the
+        # external actor before they market-sold the inventory. (A FILLED
+        # stop here would — correctly — classify as a stop-loss close and
+        # book P&L instead of an external close.)
         mock_exchange.get_order.side_effect = lambda oid, sym: (
             MockExchangeOrder(
+                order_id=oid,
+                status=ExOrderStatus.CANCELLED,
+                filled_quantity=0.0,
+            )
+            if oid == "sl_active_001"
+            else MockExchangeOrder(
                 order_id=oid,
                 status=ExOrderStatus.FILLED,
                 average_price=50000.0,

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3268,3 +3268,105 @@ class TestPeriodicSLFillBooksPnl:
 
         mock_position_tracker.remove_position.assert_not_called()
         mock_db.close_position.assert_not_called()
+
+
+class TestSpotSLFillNotExternalClose:
+    """Spot variant of the step-1b misclassification: a filled stop-loss also
+    empties the held balance, which the holdings heuristic alone cannot tell
+    apart from an external close."""
+
+    def test_spot_long_sl_fill_books_pnl_not_external_close(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            order_id="entry_spot",
+            stop_loss_order_id="sl_spot",
+            exchange_order_id="entry_spot",
+            db_position_id=90,
+        )
+        mock_position_tracker.positions = {"entry_spot": pos}
+        mock_position_tracker.get_position.side_effect = [pos, None, None]
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+        sl_order = MockExchangeOrder(
+            order_id="sl_spot", status=ExOS.FILLED, average_price=48000.0, commission=0.05
+        )
+        mock_exchange.get_order.side_effect = lambda oid, sym: (
+            sl_order if oid == "sl_spot" else entry_order
+        )
+        # Held base emptied by the SL sale
+        mock_exchange.get_balance.side_effect = lambda asset: (
+            MockBalance(asset="USDT", total=1000.0)
+            if asset == "USDT"
+            else MockBalance(asset=asset, total=0.0, free=0.0, locked=0.0)
+        )
+        mock_exchange.get_open_orders.return_value = []
+        mock_db.get_current_balance.return_value = 1000.0
+        mock_db.close_position.return_value = True
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+        )
+        reconciler._reconcile_cycle()
+
+        # Closed as an SL fill with the real price, P&L booked...
+        mock_db.close_position.assert_called_once_with(90, exit_price=48000.0)
+        pnl_calls = [
+            c
+            for c in mock_db.update_balance.call_args_list
+            if str(c.args[1]).startswith("reconciliation_close")
+        ]
+        assert len(pnl_calls) == 1
+        # ...and NOT misclassified as an external close (no-PnL row)
+        external = [
+            c
+            for c in mock_db.log_audit_event.call_args_list
+            if "CLOSED_EXTERNALLY" in str(c)
+        ]
+        assert external == []
+
+    def test_spot_unconfirmed_sl_defers_classification(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            order_id="entry_spot2",
+            stop_loss_order_id="sl_spot2",
+            exchange_order_id="entry_spot2",
+            db_position_id=91,
+        )
+        mock_position_tracker.positions = {"entry_spot2": pos}
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+
+        def checked(oid, sym):
+            if oid == "sl_spot2":
+                raise OrderLookupError("timeout")
+            return entry_order
+
+        mock_exchange.get_order.return_value = entry_order
+        mock_exchange.get_order_checked.side_effect = checked
+        mock_exchange.get_balance.side_effect = lambda asset: (
+            MockBalance(asset="USDT", total=1000.0)
+            if asset == "USDT"
+            else MockBalance(asset=asset, total=0.0, free=0.0, locked=0.0)
+        )
+        mock_exchange.get_open_orders.return_value = []
+        mock_db.get_current_balance.return_value = 1000.0
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+        )
+        reconciler._reconcile_cycle()
+
+        mock_position_tracker.remove_position.assert_not_called()
+        mock_db.close_position.assert_not_called()

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -2134,6 +2134,7 @@ class TestPeriodicReconcilerSLVerification:
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
         pos = MockPosition(
+            order_id="entry_1",
             stop_loss_order_id="sl_periodic_1",
             exchange_order_id="entry_1",
             db_position_id=50,
@@ -2147,6 +2148,11 @@ class TestPeriodicReconcilerSLVerification:
         )
         mock_exchange.get_order.side_effect = [entry_order, sl_order]
         mock_exchange.get_open_orders.return_value = []
+        # Wrapper pre-check sees the position; after the delegated close the
+        # tracker no longer has it (the handler removed it on success).
+        mock_position_tracker.get_position.side_effect = [pos, None]
+        mock_db.get_current_balance.return_value = 1000.0
+        mock_db.close_position.return_value = True
 
         reconciler = PeriodicReconciler(
             exchange_interface=mock_exchange,
@@ -2156,9 +2162,9 @@ class TestPeriodicReconcilerSLVerification:
         )
         reconciler._reconcile_cycle()
 
-        # Position removed from tracker and closed in DB
-        mock_position_tracker.remove_position.assert_called_once_with("entry_1")
+        # DB closed first, then removed from the tracker (delegated handler)
         mock_db.close_position.assert_called_once_with(50, exit_price=48000.0)
+        mock_position_tracker.remove_position.assert_called_once_with("entry_1")
         mock_db.log_audit_event.assert_any_call(
             session_id=1,
             entity_type="position",
@@ -2169,6 +2175,18 @@ class TestPeriodicReconcilerSLVerification:
             reason="Stop-loss filled @ 48000.0 (periodic check)",
             severity="HIGH",
         )
+        # Realized P&L booked to the session balance (parity with the startup
+        # path): long 0.1 qty, entry 50000 -> SL fill 48000 = -200 gross,
+        # minus the SL order's 0.05 commission. (Scoped to the reconciliation
+        # P&L write; the cycle's later balance-verification step may also call
+        # update_balance.)
+        pnl_calls = [
+            c
+            for c in mock_db.update_balance.call_args_list
+            if str(c.args[1]).startswith("reconciliation_close")
+        ]
+        assert len(pnl_calls) == 1
+        assert pnl_calls[0].args[0] == pytest.approx(1000.0 - 200.0 - 0.05)
 
     def test_cycle_replaces_cancelled_sl(self, mock_exchange, mock_position_tracker, mock_db):
         """Periodic cycle re-places a cancelled SL order."""
@@ -3115,3 +3133,138 @@ class TestFailClosedSLLookup:
 
         mock_exchange.place_stop_loss_order.assert_called_once()
         assert position.stop_loss_order_id == "new_sl_replaced"
+
+
+class TestPeriodicSLFillBooksPnl:
+    """The periodic reconciler must book a detected SL fill's P&L (it
+    previously closed the DB row with NO balance update, silently
+    overstating capital by every SL loss it detected before the engine's
+    deferred-exit drain)."""
+
+    def _make_filled_sl_cycle(self, mock_exchange, mock_position_tracker, mock_db, pos):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+        sl_order = MockExchangeOrder(
+            order_id=pos.stop_loss_order_id,
+            status=ExOS.FILLED,
+            average_price=48000.0,
+            commission=0.05,
+        )
+        mock_exchange.get_order.side_effect = lambda oid, sym: (
+            sl_order if oid == pos.stop_loss_order_id else entry_order
+        )
+        mock_exchange.get_open_orders.return_value = []
+        mock_db.get_current_balance.return_value = 1000.0
+        return PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+        )
+
+    def test_skips_booking_when_already_processed(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """pop_position=None means the engine drain already booked this fill —
+        the reconciler must not double-book."""
+        pos = MockPosition(
+            order_id="entry_done",
+            stop_loss_order_id="sl_done",
+            exchange_order_id="entry_done",
+            db_position_id=70,
+        )
+        mock_position_tracker.positions = {"entry_done": pos}
+        mock_position_tracker.get_position.return_value = None
+        reconciler = self._make_filled_sl_cycle(mock_exchange, mock_position_tracker, mock_db, pos)
+
+        reconciler._reconcile_cycle()
+
+        pnl_calls = [
+            c
+            for c in mock_db.update_balance.call_args_list
+            if str(c.args[1]).startswith("reconciliation_close")
+        ]
+        assert pnl_calls == []
+        mock_db.close_position.assert_not_called()
+
+    def test_margin_short_sl_fill_books_pnl_not_external_close(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """A short whose SL filled (AUTO_REPAY zeroes the borrow) must be
+        booked as an SL close with its fill price — not closed as 'externally
+        closed' with no exit price and no P&L."""
+        pos = MockPosition(
+            order_id="entry_short",
+            side="short",
+            stop_loss_order_id="sl_short",
+            exchange_order_id="entry_short",
+            db_position_id=71,
+        )
+        mock_position_tracker.positions = {"entry_short": pos}
+        # Realistic tracker semantics: step 1b's handler sees the position and
+        # removes it on success; step 2 (iterating the same cycle's stale
+        # snapshot) then finds it gone and skips.
+        mock_position_tracker.get_position.side_effect = [pos, None, None]
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)
+        reconciler = self._make_filled_sl_cycle(mock_exchange, mock_position_tracker, mock_db, pos)
+        reconciler._use_margin = True
+        reconciler._position_reconciler._use_margin = False  # skip interest lookup
+        mock_db.close_position.return_value = True
+
+        reconciler._reconcile_cycle()
+
+        # Booked as SL close with the fill price...
+        mock_db.close_position.assert_called_once_with(71, exit_price=48000.0)
+        # ...with realized P&L: short entry 50000 -> cover 48000 on 0.1 qty
+        # = +200 gross, minus 0.05 SL commission. Booked exactly once even
+        # though step 2 re-sees the position in its stale snapshot (the
+        # pop-claim makes the second attempt a no-op).
+        pnl_calls = [
+            c
+            for c in mock_db.update_balance.call_args_list
+            if str(c.args[1]).startswith("reconciliation_close")
+        ]
+        assert len(pnl_calls) == 1
+        assert pnl_calls[0].args[0] == pytest.approx(1000.0 + 200.0 - 0.05)
+
+    def test_margin_short_unconfirmed_sl_defers_classification(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """If the SL lookup fails while the position looks externally closed,
+        the reconciler must retain the position this cycle (fail-closed)."""
+        pos = MockPosition(
+            side="short",
+            stop_loss_order_id="sl_unknown",
+            exchange_order_id="entry_unknown",
+            db_position_id=72,
+        )
+        mock_position_tracker.positions = {"entry_unknown": pos}
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)
+
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+
+        def checked(oid, sym):
+            if oid == "sl_unknown":
+                raise OrderLookupError("timeout")
+            return entry_order
+
+        mock_exchange.get_order.return_value = entry_order
+        mock_exchange.get_order_checked.side_effect = checked
+        mock_exchange.get_open_orders.return_value = []
+        mock_db.get_current_balance.return_value = 1000.0
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+        )
+        reconciler._use_margin = True
+
+        reconciler._reconcile_cycle()
+
+        mock_position_tracker.remove_position.assert_not_called()
+        mock_db.close_position.assert_not_called()

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3324,9 +3324,7 @@ class TestSpotSLFillNotExternalClose:
         assert len(pnl_calls) == 1
         # ...and NOT misclassified as an external close (no-PnL row)
         external = [
-            c
-            for c in mock_db.log_audit_event.call_args_list
-            if "CLOSED_EXTERNALLY" in str(c)
+            c for c in mock_db.log_audit_event.call_args_list if "CLOSED_EXTERNALLY" in str(c)
         ]
         assert external == []
 


### PR DESCRIPTION
## Summary

The periodic reconciler's two stop-loss-fill detection paths both corrupted tracked capital:

1. **Stop-verification branch**: on a FILLED stop it logged an audit row, removed the position, and closed the DB row — with **no balance update and no trade record**. The startup reconciler books PnL for the identical situation (since #731 it also writes a deduplicated `trades` row); the periodic path booked **nothing**. The periodic cycle races the engine's deferred SL-exit drain at a ~equal ~2-minute cadence, so it plausibly wins a large fraction of SL fills — each one a silent balance overstatement → oversized subsequent positions, with the loss never recorded as a trade.
2. **Margin holdings check (step 1b)**: a just-filled short stop-loss zeroes the borrow via `AUTO_REPAY`, which the `borrowed<=0` heuristic cannot distinguish from an external close — so the row was closed with **no exit price and no PnL at all**.

## Changes

Both periodic paths now delegate to the startup reconciler's `PositionReconciler._close_position_from_filled_sl` (introduced by #731), inheriting its full contract: **DB close first** (a failed close leaves the position tracked and the row OPEN for the next cycle to retry), realized PnL with USD-normalized SL commission and margin interest, and a **deduplicated `trades` row**.

The periodic wrapper adds:
- a tracker-membership pre/post check: skips when the engine's deferred SL-exit drain already processed the fill (no double-booking; the residual race with an in-flight engine exit remains until the reconciler is base-lock-aware, #714),
- step 1b consults the tracked stop order *before* classifying an external close: FILLED → SL close with the real fill price; lookup unconfirmed → defer classification this cycle (fail-closed, #713 semantics); confirmed not-filled → legacy external-close path,
- the `CLOSED_BY_SL` position audit row on success.

Also rides: a LESSONS.md entry (conflicted PRs run no CI — check `mergeable_state` first) and the project-status note for the 2026-06-10 audit.

## Testing

- Updated `test_cycle_detects_sl_filled`: asserts DB-close-first + tracker removal + the realized-PnL balance write (gross −200 − 0.05 USDT commission on the reconciliation reason code).
- New: skip-when-already-processed (no booking, no close), margin-short SL fill books PnL with the fill price instead of external-close-without-price (booked exactly once across step 1b + the stale step-2 snapshot), unconfirmed SL lookup defers classification (position retained).
- Full unit suite: **3929 passed, 103 skipped** on this branch rebased onto current `develop` (incl. #731/#752).

Refs #714, #739 (stale-snapshot re-arm — distinct remaining issue), #735/#736 (balance-ledger atomicity epic).

https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN)_