### PR TITLE
fix(live): re-place REJECTED stop-losses and escalate unexpected stop-loss termination (#741)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- A REJECTED stop-loss is now re-placed and an unexpected stop-loss
+  termination escalates (#741). The reconciler's re-placement branches
+  (periodic loop and startup `_verify_stop_loss`) matched only
+  CANCELLED/EXPIRED/missing, so a triggered STOP_LOSS_LIMIT whose limit
+  leg was rejected by margin checks (-2010 class) fell through every
+  cycle — position permanently unprotected, no escalation. Both branches
+  now treat REJECTED as terminal. The engine's `_handle_order_cancel`
+  also no longer ignores stop-loss order ids: when a tracked position's
+  stop terminates unexpectedly it clears the stale id (so the
+  reconciler's missing-stop path re-protects next cycle), logs CRITICAL,
+  and emits a `system_events` row (`STOP_LOSS_CANCELLED`) with webhook
+  alert. Deliberate close-path cancels are unaffected (they stop
+  tracking the order before the callback can fire).
 - Repo-wide static-analysis debt cleared — `atb dev quality` (black, ruff,
   mypy, bandit) now passes from a red baseline of 26 unformatted files, 171
   ruff errors, ~700 mypy errors across ~90 files, and 25 bandit findings.

--- a/src/engines/live/execution/position_tracker.py
+++ b/src/engines/live/execution/position_tracker.py
@@ -272,8 +272,15 @@ class LivePositionTracker:
             self._positions[order_id] = position
             self._position_db_ids[order_id] = db_id
 
-    def set_stop_loss_order_id(self, order_id: str, stop_loss_order_id: str) -> None:
-        """Update the stop-loss order ID for a tracked position."""
+    def set_stop_loss_order_id(self, order_id: str, stop_loss_order_id: str | None) -> None:
+        """Update the stop-loss order ID for a tracked position.
+
+        ``None`` clears the in-memory reference (e.g. after the exchange
+        reports the stop terminally cancelled/rejected, #741) so the
+        reconciler's missing-stop path re-protects; the DB write is skipped
+        for ``None`` (``update_position`` ignores ``None`` kwargs) and the
+        stale persisted id is overwritten when the replacement stop is placed.
+        """
         with self._positions_lock:
             position = self._positions.get(order_id)
             if position is None:

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1567,8 +1567,15 @@ class PositionReconciler:
 
                 return
 
-            if sl_order.status in (ExOrderStatus.CANCELLED, ExOrderStatus.EXPIRED):
-                # SL was cancelled or expired — position is unprotected
+            if sl_order.status in (
+                ExOrderStatus.CANCELLED,
+                ExOrderStatus.EXPIRED,
+                ExOrderStatus.REJECTED,
+            ):
+                # SL was cancelled/expired/rejected — position is unprotected.
+                # REJECTED matters: a triggered STOP_LOSS_LIMIT whose limit leg
+                # is rejected by margin checks (-2010 class) is terminal too —
+                # without it here the stop is never re-placed (#741).
                 filled_qty = getattr(sl_order, "filled_quantity", None) or 0.0
 
                 # If the SL partially executed before cancellation/expiry,
@@ -3173,9 +3180,19 @@ class PeriodicReconciler:
                             max_severity = Severity.HIGH
 
                 elif (
-                    sl_order and sl_order.status in (ExOrderStatus.CANCELLED, ExOrderStatus.EXPIRED)
+                    sl_order
+                    and sl_order.status
+                    in (
+                        ExOrderStatus.CANCELLED,
+                        ExOrderStatus.EXPIRED,
+                        # A triggered stop whose limit leg was rejected by margin
+                        # checks (-2010 class) is terminal: without REJECTED here
+                        # it fell through every cycle and the position stayed
+                        # unprotected with no escalation (#741).
+                        ExOrderStatus.REJECTED,
+                    )
                 ) or sl_order is None:
-                    # SL cancelled/expired/missing — attempt re-placement
+                    # SL cancelled/expired/rejected/missing — attempt re-placement
                     status_desc = sl_order.status.value if sl_order else "MISSING"
                     logger.warning(
                         "Stop-loss %s for %s is %s — attempting re-placement",

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4293,11 +4293,6 @@ class LiveTradingEngine:
     def _handle_stop_loss_cancelled(self, order_id: str, symbol: str) -> bool:
         """Escalate when a tracked position's stop-loss order terminates unexpectedly.
 
-        Previously this case was a silent no-op: ``_handle_order_cancel`` only
-        popped positions by ENTRY order id, so a stop-loss whose terminal state
-        (CANCELED/REJECTED/EXPIRED) arrived via the OrderTracker left the
-        position believed-protected with no re-protection and no alert (#741).
-
         Clears the stale in-memory ``stop_loss_order_id`` so the periodic
         reconciler's missing-stop path re-places protection on its next cycle
         (which also persists the NEW id over the stale DB value), and emits a

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -4290,6 +4290,48 @@ class LiveTradingEngine:
                 )
                 return
 
+    def _handle_stop_loss_cancelled(self, order_id: str, symbol: str) -> bool:
+        """Escalate when a tracked position's stop-loss order terminates unexpectedly.
+
+        Previously this case was a silent no-op: ``_handle_order_cancel`` only
+        popped positions by ENTRY order id, so a stop-loss whose terminal state
+        (CANCELED/REJECTED/EXPIRED) arrived via the OrderTracker left the
+        position believed-protected with no re-protection and no alert (#741).
+
+        Clears the stale in-memory ``stop_loss_order_id`` so the periodic
+        reconciler's missing-stop path re-places protection on its next cycle
+        (which also persists the NEW id over the stale DB value), and emits a
+        critical ``system_events`` row + webhook alert. Deliberate cancels from
+        the close path don't reach here — that path stops tracking the SL order
+        before the callback can fire.
+
+        Returns True when ``order_id`` matched a tracked position's stop-loss.
+        """
+        matched_key: str | None = None
+        for pos_key, position in self.live_position_tracker.positions.items():
+            if getattr(position, "stop_loss_order_id", None) == order_id:
+                matched_key = pos_key
+                break
+        if matched_key is None:
+            return False
+
+        self.live_position_tracker.set_stop_loss_order_id(matched_key, None)
+        message = (
+            f"Stop-loss order {order_id} for OPEN {symbol} position {matched_key} was "
+            f"cancelled/rejected/expired on the exchange — position is UNPROTECTED until "
+            f"the reconciler re-places it (next cycle)."
+        )
+        logger.critical("CRITICAL: %s", message)
+        self._record_event(
+            EventType.ERROR,
+            message,
+            severity="critical",
+            component="order_tracker",
+            error_code="STOP_LOSS_CANCELLED",
+            alert=True,
+        )
+        return True
+
     def _handle_order_cancel(self, order_id: str, symbol: str, filled_qty: float = 0.0) -> None:
         """Handle an order cancellation/rejection notification from OrderTracker.
 
@@ -4309,6 +4351,14 @@ class LiveTradingEngine:
             order_id=order_id,
             symbol=symbol,
         )
+        # Not an entry order? Check whether a tracked position's STOP-LOSS was
+        # cancelled/rejected/expired out from under it (#741). Must run before
+        # pop_position: popping by an SL order id can never match (positions
+        # are keyed by entry order id), but the position it protects must not
+        # be left silently unprotected.
+        if self._handle_stop_loss_cancelled(order_id, symbol):
+            return
+
         # Check if this was an entry order for a position we thought we had.
         # Use atomic pop_position() for thread safety - combines get + remove
         # in a single lock acquisition (called from OrderTracker background thread).

--- a/tests/unit/engines/live/test_stop_loss_cancel_escalation_741.py
+++ b/tests/unit/engines/live/test_stop_loss_cancel_escalation_741.py
@@ -1,0 +1,91 @@
+"""#741: a tracked position's stop-loss terminating unexpectedly must escalate.
+
+Previously _handle_order_cancel only popped positions by ENTRY order id, so a
+stop-loss order's terminal CANCELED/REJECTED/EXPIRED notification was a silent
+no-op — the position stayed believed-protected with no re-protection and no
+alert. Now the engine clears the stale stop_loss_order_id (so the periodic
+reconciler's missing-stop path re-places protection) and emits a critical
+system event + alert.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.database.models import EventType
+from src.engines.live.trading_engine import LiveTradingEngine
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = pytest.mark.fast
+
+
+def make_engine() -> LiveTradingEngine:
+    with patch("src.engines.live.trading_engine.DatabaseManager"):
+        engine = LiveTradingEngine(
+            strategy=create_ml_basic_strategy(),
+            data_provider=MagicMock(),
+            initial_balance=1000.0,
+        )
+    engine.db_manager = MagicMock()
+    return engine
+
+
+def _with_tracked_position(engine: LiveTradingEngine, sl_id: str = "sl_42") -> MagicMock:
+    position = MagicMock()
+    position.symbol = "BTCUSDT"
+    position.order_id = "entry_42"
+    position.stop_loss_order_id = sl_id
+    engine.live_position_tracker = MagicMock()
+    engine.live_position_tracker.positions = {"entry_42": position}
+    return position
+
+
+class TestStopLossCancelEscalation:
+    def test_sl_cancel_clears_id_and_escalates(self):
+        engine = make_engine()
+        _with_tracked_position(engine, "sl_42")
+
+        with patch.object(engine, "_record_event") as record:
+            engine._handle_order_cancel("sl_42", "BTCUSDT")
+
+        engine.live_position_tracker.set_stop_loss_order_id.assert_called_once_with(
+            "entry_42", None
+        )
+        record.assert_called_once()
+        args, kwargs = record.call_args
+        assert args[0] == EventType.ERROR
+        assert "UNPROTECTED" in args[1]
+        assert kwargs["severity"] == "critical"
+        assert kwargs["error_code"] == "STOP_LOSS_CANCELLED"
+        assert kwargs["alert"] is True
+        # The entry-cancel branch must not run for an SL order id
+        engine.live_position_tracker.pop_position.assert_not_called()
+
+    def test_unrelated_order_id_is_not_escalated(self):
+        engine = make_engine()
+        _with_tracked_position(engine, "sl_42")
+        engine.live_position_tracker.pop_position.return_value = None
+
+        with patch.object(engine, "_record_event") as record:
+            engine._handle_order_cancel("some_other_order", "BTCUSDT")
+
+        record.assert_not_called()
+        engine.live_position_tracker.set_stop_loss_order_id.assert_not_called()
+        # falls through to the normal entry-cancel handling
+        engine.live_position_tracker.pop_position.assert_called_once_with("some_other_order")
+
+    def test_entry_cancel_path_unchanged(self):
+        engine = make_engine()
+        position = MagicMock()
+        position.symbol = "BTCUSDT"
+        position.metadata = {}
+        position.stop_loss_order_id = None
+        engine.live_position_tracker = MagicMock()
+        engine.live_position_tracker.positions = {"entry_9": position}
+        engine.live_position_tracker.pop_position.return_value = position
+
+        engine._handle_order_cancel("entry_9", "BTCUSDT")
+
+        engine.live_position_tracker.pop_position.assert_called_once_with("entry_9")

--- a/tests/unit/engines/live/test_stop_loss_cancel_escalation_741.py
+++ b/tests/unit/engines/live/test_stop_loss_cancel_escalation_741.py
@@ -10,11 +10,14 @@ system event + alert.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
+from src.database.manager import DatabaseManager
 from src.database.models import EventType
+from src.engines.live.execution.position_tracker import LivePosition, LivePositionTracker
 from src.engines.live.trading_engine import LiveTradingEngine
 from src.strategies.ml_basic import create_ml_basic_strategy
 
@@ -28,17 +31,33 @@ def make_engine() -> LiveTradingEngine:
             data_provider=MagicMock(),
             initial_balance=1000.0,
         )
-    engine.db_manager = MagicMock()
+    # autospec catches signature mismatches on every db_manager call
+    engine.db_manager = create_autospec(DatabaseManager, instance=True)
     return engine
 
 
-def _with_tracked_position(engine: LiveTradingEngine, sl_id: str = "sl_42") -> MagicMock:
-    position = MagicMock()
-    position.symbol = "BTCUSDT"
-    position.order_id = "entry_42"
-    position.stop_loss_order_id = sl_id
-    engine.live_position_tracker = MagicMock()
-    engine.live_position_tracker.positions = {"entry_42": position}
+def _make_position(sl_id: str | None, order_id: str = "entry_42") -> LivePosition:
+    """A real LivePosition (no mock) so attribute access is the real contract."""
+    return LivePosition(
+        symbol="BTCUSDT",
+        side="long",
+        entry_price=50000.0,
+        entry_time=datetime.now(UTC),
+        size=0.05,
+        quantity=0.001,
+        order_id=order_id,
+        stop_loss=48000.0,
+        stop_loss_order_id=sl_id,
+    )
+
+
+def _with_tracked_position(engine: LiveTradingEngine, sl_id: str = "sl_42") -> LivePosition:
+    position = _make_position(sl_id)
+    # autospec'd tracker: positions/set_stop_loss_order_id/pop_position calls
+    # are signature-checked
+    tracker = create_autospec(LivePositionTracker, instance=True)
+    tracker.positions = {"entry_42": position}
+    engine.live_position_tracker = tracker
     return position
 
 
@@ -78,14 +97,12 @@ class TestStopLossCancelEscalation:
 
     def test_entry_cancel_path_unchanged(self):
         engine = make_engine()
-        position = MagicMock()
-        position.symbol = "BTCUSDT"
-        position.metadata = {}
-        position.stop_loss_order_id = None
-        engine.live_position_tracker = MagicMock()
-        engine.live_position_tracker.positions = {"entry_9": position}
-        engine.live_position_tracker.pop_position.return_value = position
+        position = _make_position(sl_id=None, order_id="entry_9")
+        tracker = create_autospec(LivePositionTracker, instance=True)
+        tracker.positions = {"entry_9": position}
+        tracker.pop_position.return_value = position
+        engine.live_position_tracker = tracker
 
         engine._handle_order_cancel("entry_9", "BTCUSDT")
 
-        engine.live_position_tracker.pop_position.assert_called_once_with("entry_9")
+        tracker.pop_position.assert_called_once_with("entry_9")

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3366,3 +3366,69 @@ class TestSpotSLFillNotExternalClose:
 
         mock_position_tracker.remove_position.assert_not_called()
         mock_db.close_position.assert_not_called()
+
+
+class TestRejectedStopLossReplaced:
+    """#741: a REJECTED stop-loss is terminal (e.g. triggered limit leg hit a
+    -2010 margin reject) and must be re-placed like CANCELLED/EXPIRED — it
+    previously fell through every cycle, leaving the position unprotected."""
+
+    def test_periodic_cycle_replaces_rejected_sl(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            stop_loss_order_id="sl_rejected",
+            exchange_order_id="entry_rej",
+            db_position_id=80,
+            quantity=0.5,
+        )
+        pos.stop_loss = 46000.0
+        mock_position_tracker.positions = {"entry_rej": pos}
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+        sl_order = MockExchangeOrder(
+            order_id="sl_rejected", status=ExOS.REJECTED, filled_quantity=0.0
+        )
+        mock_exchange.get_order.side_effect = lambda oid, sym: (
+            sl_order if oid == "sl_rejected" else entry_order
+        )
+        mock_exchange.get_open_orders.return_value = []
+        mock_exchange.place_stop_loss_order.return_value = "new_sl_after_reject"
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+        )
+        reconciler._reconcile_cycle()
+
+        mock_exchange.place_stop_loss_order.assert_called_once()
+        assert pos.stop_loss_order_id == "new_sl_after_reject"
+
+    def test_startup_verify_replaces_rejected_sl(self, reconciler, mock_exchange, mock_db):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        position = MockPosition(
+            stop_loss=49000.0,
+            stop_loss_order_id="sl_rej_startup",
+            db_position_id=81,
+        )
+        sl_order = MockExchangeOrder(
+            order_id="sl_rej_startup", status=ExOS.REJECTED, filled_quantity=0.0
+        )
+        mock_exchange.get_order.return_value = sl_order
+        mock_exchange.place_stop_loss_order.return_value = "new_sl_startup"
+
+        result = ReconciliationResult(
+            entity_type="position",
+            entity_id=81,
+            status="verified",
+            severity=Severity.LOW,
+        )
+        reconciler._verify_stop_loss(position, "sl_rej_startup", result)
+
+        mock_exchange.place_stop_loss_order.assert_called_once()
+        assert position.stop_loss_order_id == "new_sl_startup"


### PR DESCRIPTION
## Summary

Fixes #741 — two halves that together left a live position **permanently unprotected with zero escalation**:

1. **Reconciler**: the stop re-placement branches (periodic stop-verification loop and startup `_verify_stop_loss`) matched only CANCELLED/EXPIRED or missing. A triggered `STOP_LOSS_LIMIT` whose limit leg is rejected by margin checks (the `-2010` class, LESSONS §5.2) reports **REJECTED** — terminal, but it fell through every cycle: never re-placed, never severity-escalated.
2. **Engine**: `_handle_order_cancel` only popped positions by ENTRY order id, so OrderTracker's terminal notification for a **stop-loss** order id was a silent no-op (the docstring even promised handling that didn't exist).

## Changes

- Both reconciler branches now treat `REJECTED` as terminal (re-place path), with partial-fill accounting unchanged.
- New `LiveTradingEngine._handle_stop_loss_cancelled`, called first from `_handle_order_cancel`: matches the order id against tracked positions' `stop_loss_order_id`; on match it clears the stale in-memory id (the reconciler's missing-stop path then re-protects on its next ~2-min cycle and overwrites the stale persisted id with the replacement's), logs CRITICAL, and emits a `system_events` row (`component=order_tracker`, `error_code=STOP_LOSS_CANCELLED`, `severity=critical`) with webhook alert. Deliberate close-path cancels never reach the callback — the close path stops tracking the SL order immediately after cancelling (#710 sequence).
- `LivePositionTracker.set_stop_loss_order_id` now accepts `None` (clears memory; the DB write is skipped by `update_position`'s `None`-filter — documented; the replacement stop's id overwrites the stale row value, and restart recovery now handles a REJECTED stop anyway).

## Testing

- Periodic cycle re-places a REJECTED stop (mirrors the CANCELLED test); startup `_verify_stop_loss` re-places a REJECTED stop.
- Engine escalation: clears the id + emits the critical event with alert and skips the entry-cancel logic; unrelated order ids fall through to normal handling unchanged; entry-cancel path regression-guarded.
- Full unit suite: **3936 passed, 103 skipped** on this branch rebased onto current `develop`.

## Risk

Strictly additive protection: REJECTED was previously a dead branch, and the new escalation only fires for an order id that matches a tracked position's stop-loss — a case that was previously a silent no-op.

https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Atv7dvZtsdpkPJhZdi6QMN)_