### PR TITLE
fix(cli): populate-dummy passes exit_order_id to log_trade

### DIFF
--- a/cli/commands/data.py
+++ b/cli/commands/data.py
@@ -614,11 +614,7 @@ def _populate_dummy(ns: argparse.Namespace) -> int:
                 if side == PositionSide.LONG
                 else (entry_price - exit_price) * quantity
             )
-            # NOTE: suspected bug — log_trade() has no `order_id` parameter (only
-            # `exit_order_id`), so this call raises TypeError at runtime and the
-            # except below reports a failed population. Left unchanged (type-level
-            # cleanup only); tracked for a separate behavioral fix.
-            db.log_trade(  # type: ignore[call-arg]
+            db.log_trade(
                 session_id=sid,
                 symbol=sym,
                 side=side,
@@ -634,7 +630,7 @@ def _populate_dummy(ns: argparse.Namespace) -> int:
                 ),
                 strategy_name=random.choice(strategies),
                 confidence_score=random.uniform(0.3, 0.95),
-                order_id=f"order_{i}_{random.randint(1000, 9999)}",
+                exit_order_id=f"order_{i}_{random.randint(1000, 9999)}",
                 stop_loss=entry_price * 0.95,
                 take_profit=entry_price * 1.05,
                 strategy_config={},

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `atb data populate-dummy` works again (#763): `log_trade` was called with the
+  nonexistent `order_id` kwarg (the parameter is `exit_order_id`), so the first
+  generated trade raised `TypeError` and the command always failed. Same bug
+  class as #732; an autospec'd regression test now enforces the real signature.
 - A REJECTED stop-loss is now re-placed and an unexpected stop-loss
   termination escalates (#741). The reconciler's re-placement branches
   (periodic loop and startup `_verify_stop_loss`) matched only

--- a/tests/unit/cli/test_data.py
+++ b/tests/unit/cli/test_data.py
@@ -363,3 +363,34 @@ class TestSafePickleLoad:
 
         with pytest.raises(pickle.UnpicklingError):
             _safe_pickle_load(io.BytesIO(pickle.dumps(_Evil())))
+
+
+class TestDataPopulateDummy:
+    """Tests for the populate-dummy command (regression for #763)."""
+
+    @pytest.mark.fast
+    def test_log_trade_called_with_exit_order_id(self):
+        """``log_trade`` must be invoked with ``exit_order_id`` — the autospec
+        enforces the real ``DatabaseManager.log_trade`` signature, so a
+        regression to the nonexistent ``order_id`` kwarg raises ``TypeError``
+        and the command exits 1."""
+        from unittest.mock import create_autospec
+
+        from cli.commands.data import _populate_dummy
+        from src.database.manager import DatabaseManager
+
+        ns = argparse.Namespace(database_url=None, trades=3, confirm=True)
+
+        mock_db = create_autospec(DatabaseManager, instance=True)
+        mock_db.create_trading_session.return_value = 1
+        mock_db.log_trade.return_value = 1
+
+        with patch("src.database.manager.DatabaseManager", return_value=mock_db):
+            result = _populate_dummy(ns)
+
+        assert result == 0
+        assert mock_db.log_trade.call_count == 3
+        for call in mock_db.log_trade.call_args_list:
+            assert "exit_order_id" in call.kwargs
+            assert call.kwargs["exit_order_id"].startswith("order_")
+            assert "order_id" not in call.kwargs


### PR DESCRIPTION
## Summary

Fixes #763 — `atb data populate-dummy` could never succeed: `_populate_dummy` called `DatabaseManager.log_trade(order_id=...)`, but `log_trade` has no `order_id` parameter (the matching parameter is `exit_order_id`) and no `**kwargs`. The first generated trade raised `TypeError`, the broad `except` reported a generic "Failed to populate database", and the command exited 1.

Same bug class as the #732 production defect in `recover_missing_trades`.

## Changes

- `cli/commands/data.py`: `order_id=` → `exit_order_id=` (feeds the `Trade.order_id` column); removed the now-obsolete `# type: ignore[call-arg]` and NOTE comment.
- `tests/unit/cli/test_data.py`: new `TestDataPopulateDummy` regression test using `create_autospec(DatabaseManager, instance=True)` so the **real** `log_trade` signature is enforced — with the old code this test fails (TypeError → exit 1).
- `docs/changelog.md`: entry.

## Testing

- `pytest tests/unit/cli/test_data.py` — 12 passed (incl. new regression test).
- black / ruff / mypy clean on touched files.

Closes #763

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_