### PR TITLE
fix(live): descriptive error when update_model has no current strategy

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `StrategyManager.update_model` with no strategy loaded now fails with the
+  intended descriptive `ValueError` (#765) instead of an `AttributeError`
+  raised while formatting the error message itself (`self.current_strategy.name`
+  on `None`), which surfaced as a misleading generic failed update.
 - A REJECTED stop-loss is now re-placed and an unexpected stop-loss
   termination escalates (#741). The reconciler's re-placement branches
   (periodic loop and startup `_verify_stop_loss`) matched only

--- a/src/engines/live/strategy_manager.py
+++ b/src/engines/live/strategy_manager.py
@@ -271,12 +271,9 @@ class StrategyManager:
                     not self.current_strategy
                     or self.current_strategy.name.lower() != strategy_name.lower()
                 ):
-                    # Latent bug kept as-is for behavior parity: when
-                    # current_strategy is None this f-string raises
-                    # AttributeError instead of ValueError; both are caught by
-                    # the outer except and surface as a failed update.
+                    current_name = self.current_strategy.name if self.current_strategy else "<none>"
                     raise ValueError(
-                        f"Current strategy {self.current_strategy.name} doesn't match {strategy_name}"  # type: ignore[union-attr]
+                        f"Current strategy {current_name} doesn't match {strategy_name}"
                     )
 
                 # Validate model if requested

--- a/tests/unit/live/test_strategy_manager_unit.py
+++ b/tests/unit/live/test_strategy_manager_unit.py
@@ -155,3 +155,44 @@ class TestStrategyVersioning:
         manager.load_strategy("ml_basic", version="v1.1")
         comparison = manager.get_performance_comparison()
         assert isinstance(comparison, dict)
+
+    def test_update_model_without_current_strategy_reports_descriptive_error(
+        self, temp_directory, caplog
+    ):
+        """Regression for #765: with no strategy loaded, update_model must fail
+        with the descriptive mismatch ValueError, not an AttributeError from
+        dereferencing ``self.current_strategy.name`` inside the f-string."""
+        import logging
+
+        manager = StrategyManager(staging_dir=str(temp_directory))
+        assert manager.current_strategy is None
+
+        model_path = temp_directory / "model.onnx"
+        model_path.write_bytes(b"dummy")
+
+        with caplog.at_level(logging.ERROR):
+            result = manager.update_model("ml_basic", str(model_path), validate_model=False)
+
+        assert result is False
+        assert "doesn't match" in caplog.text
+        assert "<none>" in caplog.text
+        assert "AttributeError" not in caplog.text
+        assert "NoneType" not in caplog.text
+
+    def test_update_model_mismatched_strategy_name_reports_current_name(
+        self, temp_directory, caplog
+    ):
+        """The mismatch error still names the loaded strategy when one exists."""
+        import logging
+
+        manager = StrategyManager(staging_dir=str(temp_directory))
+        manager.load_strategy("ml_basic")
+
+        model_path = temp_directory / "model.onnx"
+        model_path.write_bytes(b"dummy")
+
+        with caplog.at_level(logging.ERROR):
+            result = manager.update_model("other_strategy", str(model_path), validate_model=False)
+
+        assert result is False
+        assert "doesn't match other_strategy" in caplog.text


### PR DESCRIPTION
## Summary

Fixes #765 — `StrategyManager.update_model`'s strategy-mismatch guard raised `AttributeError` instead of the intended descriptive `ValueError` whenever `current_strategy` was `None`: the error message's own f-string dereferenced `self.current_strategy.name`. The outer `except Exception` then logged a misleading `'NoneType' object has no attribute 'name'` as a generic failed update.

## Changes

- `src/engines/live/strategy_manager.py`: bind `current_name` (`"<none>"` when no strategy is loaded) before raising; removed the stale `# type: ignore[union-attr]` and latent-bug comment.
- `tests/unit/live/test_strategy_manager_unit.py`: two regression tests — no-strategy-loaded case asserts the log contains the descriptive mismatch message (and **not** `AttributeError`/`NoneType`); mismatched-name case asserts the loaded strategy's name still appears.

## Testing

- `pytest tests/unit/live/test_strategy_manager_unit.py` — 14 passed (2 new).
- black / ruff / mypy clean on touched files.

Closes #765

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_