### PR TITLE
fix(risk): build_time_exit_policy maps real TimeExitPolicy parameters

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `build_time_exit_policy` (engines/shared) can now actually build a policy
+  (#760): it passed `exit_time`/`exit_days` kwargs that `TimeExitPolicy` does
+  not accept, so it always raised `TypeError` internally and returned `None`.
+  It now maps the same `time_exits` config shape as both engines' builders
+  (max holding, end-of-day/weekend flat, timezone, restrictions) and honors
+  both `params.time_exits` and the legacy `params.max_holding_hours` fallback.
 - A REJECTED stop-loss is now re-placed and an unexpected stop-loss
   termination escalates (#741). The reconciler's re-placement branches
   (periodic loop and startup `_verify_stop_loss`) matched only

--- a/src/engines/shared/risk_configuration.py
+++ b/src/engines/shared/risk_configuration.py
@@ -9,7 +9,15 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from src.config.constants import DEFAULT_BREAKEVEN_BUFFER, DEFAULT_BREAKEVEN_THRESHOLD
+from src.config.constants import (
+    DEFAULT_BREAKEVEN_BUFFER,
+    DEFAULT_BREAKEVEN_THRESHOLD,
+    DEFAULT_END_OF_DAY_FLAT,
+    DEFAULT_MARKET_TIMEZONE,
+    DEFAULT_MAX_HOLDING_HOURS,
+    DEFAULT_TIME_RESTRICTIONS,
+    DEFAULT_WEEKEND_FLAT,
+)
 
 if TYPE_CHECKING:
     from src.position_management.dynamic_risk import DynamicRiskConfig
@@ -182,14 +190,21 @@ def build_time_exit_policy(
 ) -> TimeExitPolicy | None:
     """Build time exit policy from strategy/risk overrides.
 
+    Maps the same ``time_exits`` config shape as both engines' builders
+    (``Backtester._build_time_exit_policy`` and the live engine's inline
+    construction): ``max_holding_hours``, ``end_of_day_flat``, ``weekend_flat``,
+    ``market_timezone``, ``time_restrictions``.
+
     Args:
         strategy: Strategy with optional get_risk_overrides() method.
-        risk_manager: Risk manager with optional params attribute.
+        risk_manager: Risk manager with optional params attribute. Both the
+            engines' ``params.time_exits`` dict and the legacy
+            ``params.max_holding_hours`` attribute are honored as fallbacks.
 
     Returns:
         TimeExitPolicy if configuration exists, None otherwise.
     """
-    from src.position_management.time_exits import TimeExitPolicy
+    from src.position_management.time_exits import TimeExitPolicy, TimeRestrictions
 
     # Get overrides from strategy
     try:
@@ -207,34 +222,39 @@ def build_time_exit_policy(
     if not time_cfg and risk_manager:
         params = getattr(risk_manager, "params", None)
         if params:
-            # Check if params has time exit settings
-            max_holding = getattr(params, "max_holding_hours", None)
-            if max_holding is not None:
-                time_cfg = {"max_holding_hours": max_holding}
+            time_cfg = getattr(params, "time_exits", None)
+            if not time_cfg:
+                # Legacy single-setting fallback
+                max_holding = getattr(params, "max_holding_hours", None)
+                if max_holding is not None:
+                    time_cfg = {"max_holding_hours": max_holding}
 
-    if time_cfg:
-        max_holding = time_cfg.get("max_holding_hours")
-        exit_time_str = time_cfg.get("exit_time")
-        exit_days = time_cfg.get("exit_days")
+    if not time_cfg:
+        return None
+    if not isinstance(time_cfg, dict):
+        logger.warning("Ignoring non-dict time_exits config: %r", time_cfg)
+        return None
 
-        if max_holding is not None:
-            try:
-                # KNOWN BUG (typing surfaced, behavior preserved): TimeExitPolicy has no
-                # exit_time/exit_days parameters, so this call always raises TypeError,
-                # is caught below, and the function returns None. Removing the kwargs
-                # would change runtime behavior; tracked for a separate behavioral fix.
-                return TimeExitPolicy(  # type: ignore[call-arg]
-                    max_holding_hours=int(max_holding),
-                    exit_time=exit_time_str,
-                    exit_days=exit_days,
-                )
-            except (TypeError, ValueError) as e:
-                logger.warning(
-                    "Failed to build TimeExitPolicy due to invalid max_holding_hours: %s", e
-                )
-                return None
+    try:
+        restrictions_cfg = time_cfg.get("time_restrictions")
+        if restrictions_cfg is None:
+            restrictions_cfg = DEFAULT_TIME_RESTRICTIONS
+        restrictions = TimeRestrictions(
+            no_overnight=bool(restrictions_cfg.get("no_overnight", False)),
+            no_weekend=bool(restrictions_cfg.get("no_weekend", False)),
+            trading_hours_only=bool(restrictions_cfg.get("trading_hours_only", False)),
+        )
 
-    return None
+        return TimeExitPolicy(
+            max_holding_hours=time_cfg.get("max_holding_hours", DEFAULT_MAX_HOLDING_HOURS),
+            end_of_day_flat=time_cfg.get("end_of_day_flat", DEFAULT_END_OF_DAY_FLAT),
+            weekend_flat=time_cfg.get("weekend_flat", DEFAULT_WEEKEND_FLAT),
+            market_timezone=time_cfg.get("market_timezone", DEFAULT_MARKET_TIMEZONE),
+            time_restrictions=restrictions,
+        )
+    except (TypeError, ValueError, AttributeError) as e:
+        logger.warning("Failed to build TimeExitPolicy from config %r: %s", time_cfg, e)
+        return None
 
 
 def extract_risk_overrides(strategy: Any) -> dict[str, Any]:

--- a/tests/unit/engines/shared/test_risk_configuration.py
+++ b/tests/unit/engines/shared/test_risk_configuration.py
@@ -73,6 +73,7 @@ class TestBuildTimeExitPolicy:
 
     @pytest.mark.fast
     def test_defaults_applied_for_missing_keys(self):
+        """Keys omitted from the config fall back to their DEFAULT_* constants."""
         strategy = _StrategyWithOverrides({"time_exits": {"weekend_flat": True}})
 
         policy = build_time_exit_policy(strategy)
@@ -105,6 +106,7 @@ class TestBuildTimeExitPolicy:
 
     @pytest.mark.fast
     def test_returns_none_without_config(self):
+        """No time_exits config (None override or missing attribute) returns None."""
         strategy = _StrategyWithOverrides(None)
 
         assert build_time_exit_policy(strategy) is None
@@ -112,6 +114,14 @@ class TestBuildTimeExitPolicy:
 
     @pytest.mark.fast
     def test_non_dict_config_returns_none(self):
+        """A non-dict time_exits value emits a warning and returns None."""
         strategy = _StrategyWithOverrides({"time_exits": "24h"})
+
+        assert build_time_exit_policy(strategy) is None
+
+    @pytest.mark.fast
+    def test_invalid_time_restrictions_type_returns_none(self):
+        """A non-dict time_restrictions value triggers the except handler and returns None."""
+        strategy = _StrategyWithOverrides({"time_exits": {"time_restrictions": "invalid"}})
 
         assert build_time_exit_policy(strategy) is None

--- a/tests/unit/engines/shared/test_risk_configuration.py
+++ b/tests/unit/engines/shared/test_risk_configuration.py
@@ -1,0 +1,117 @@
+"""Tests for shared risk configuration builders (regression for #760)."""
+
+import pytest
+
+from src.config.constants import DEFAULT_MAX_HOLDING_HOURS
+from src.engines.shared.risk_configuration import build_time_exit_policy
+from src.position_management.time_exits import TimeExitPolicy
+
+pytestmark = pytest.mark.unit
+
+
+class _StrategyWithOverrides:
+    def __init__(self, overrides):
+        self._overrides = overrides
+
+    def get_risk_overrides(self):
+        return self._overrides
+
+
+class _Params:
+    def __init__(self, **attrs):
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+class _RiskManager:
+    def __init__(self, params):
+        self.params = params
+
+
+class TestBuildTimeExitPolicy:
+    @pytest.mark.fast
+    def test_builds_policy_from_strategy_overrides(self):
+        """Regression for #760: a max_holding_hours config must produce a
+        policy (the old code passed nonexistent kwargs and always returned
+        None)."""
+        strategy = _StrategyWithOverrides({"time_exits": {"max_holding_hours": 24}})
+
+        policy = build_time_exit_policy(strategy)
+
+        assert isinstance(policy, TimeExitPolicy)
+        assert policy.max_holding_hours == 24
+
+    @pytest.mark.fast
+    def test_maps_full_config_shape(self):
+        """The helper maps the same config keys as both engines' builders."""
+        strategy = _StrategyWithOverrides(
+            {
+                "time_exits": {
+                    "max_holding_hours": 48,
+                    "end_of_day_flat": True,
+                    "weekend_flat": True,
+                    "market_timezone": "America/New_York",
+                    "time_restrictions": {
+                        "no_overnight": True,
+                        "no_weekend": False,
+                        "trading_hours_only": True,
+                    },
+                }
+            }
+        )
+
+        policy = build_time_exit_policy(strategy)
+
+        assert isinstance(policy, TimeExitPolicy)
+        assert policy.max_holding_hours == 48
+        assert policy.end_of_day_flat is True
+        assert policy.weekend_flat is True
+        assert policy.market_timezone == "America/New_York"
+        assert policy.time_restrictions.no_overnight is True
+        assert policy.time_restrictions.no_weekend is False
+        assert policy.time_restrictions.trading_hours_only is True
+
+    @pytest.mark.fast
+    def test_defaults_applied_for_missing_keys(self):
+        strategy = _StrategyWithOverrides({"time_exits": {"weekend_flat": True}})
+
+        policy = build_time_exit_policy(strategy)
+
+        assert isinstance(policy, TimeExitPolicy)
+        assert policy.max_holding_hours == DEFAULT_MAX_HOLDING_HOURS
+        assert policy.weekend_flat is True
+
+    @pytest.mark.fast
+    def test_falls_back_to_risk_manager_time_exits_params(self):
+        """Engines read params.time_exits — the shared helper must too."""
+        strategy = _StrategyWithOverrides(None)
+        risk_manager = _RiskManager(_Params(time_exits={"max_holding_hours": 12}))
+
+        policy = build_time_exit_policy(strategy, risk_manager)
+
+        assert isinstance(policy, TimeExitPolicy)
+        assert policy.max_holding_hours == 12
+
+    @pytest.mark.fast
+    def test_falls_back_to_legacy_max_holding_hours_param(self):
+        """The helper's original params.max_holding_hours fallback still works."""
+        strategy = _StrategyWithOverrides(None)
+        risk_manager = _RiskManager(_Params(max_holding_hours=6))
+
+        policy = build_time_exit_policy(strategy, risk_manager)
+
+        assert isinstance(policy, TimeExitPolicy)
+        assert policy.max_holding_hours == 6
+
+    @pytest.mark.fast
+    def test_returns_none_without_config(self):
+        strategy = _StrategyWithOverrides(None)
+
+        assert build_time_exit_policy(strategy) is None
+        assert build_time_exit_policy(object()) is None
+
+    @pytest.mark.fast
+    def test_non_dict_config_returns_none(self):
+        strategy = _StrategyWithOverrides({"time_exits": "24h"})
+
+        assert build_time_exit_policy(strategy) is None


### PR DESCRIPTION
## Summary

Fixes #760 — `build_time_exit_policy` in `engines/shared/risk_configuration.py` could never return a policy: it passed `exit_time=`/`exit_days=` kwargs that `TimeExitPolicy` does not define, so construction always raised `TypeError`, was caught, and the function returned `None` with a misleading "invalid max_holding_hours" warning. (No production caller today — both engines carry their own working builders — but it is exported shared API.)

## Changes

- `src/engines/shared/risk_configuration.py`: the helper now mirrors the two engines' working builders exactly — maps the real `time_exits` config shape (`max_holding_hours`, `end_of_day_flat`, `weekend_flat`, `market_timezone`, `time_restrictions`) with the same `src/config/constants` defaults. Fallback order: strategy overrides → `risk_manager.params.time_exits` (engines' convention) → legacy `params.max_holding_hours`. Non-dict configs are rejected with a warning instead of an `AttributeError`. Removed the stale `# type: ignore[call-arg]` and `KNOWN BUG` comment.
- `tests/unit/engines/shared/test_risk_configuration.py` (new): 7 tests covering the regression case, full config mapping, defaults, both fallbacks, no-config, and non-dict config.

This makes the shared helper a faithful drop-in for the engines' duplicated logic, so a future consolidation PR can delete the two copies.

## Testing

- `pytest tests/unit/engines/shared/test_risk_configuration.py` — 7 passed.
- black / ruff / mypy clean on touched files.

Closes #760

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_