### PR TITLE
fix(types): TradeProtocol uses read-only properties — drop call-site casts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `TradeProtocol` members are now read-only properties (#767), so concrete
+  trade classes with narrower types (non-Optional datetimes, `PositionSide`
+  enum side) conform structurally — the three `cast("TradeProtocol", ...)`
+  workarounds at the engines' `record_trade` call sites are gone. The `side`
+  member is honestly typed `str | Enum | None` (record_trade stringifies it).
 - A REJECTED stop-loss is now re-placed and an unexpected stop-loss
   termination escalates (#741). The reconciler's re-placement branches
   (periodic loop and startup `_verify_stop_loss`) matched only

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -77,7 +77,6 @@ if TYPE_CHECKING:
     from src.data_providers.data_provider import DataProvider
     from src.data_providers.sentiment_provider import SentimentDataProvider
     from src.database.manager import DatabaseManager
-    from src.performance.tracker import TradeProtocol
     from src.strategies.components.runtime import SupportsRuntimeHooks
 
 logger = logging.getLogger(__name__)
@@ -1328,11 +1327,8 @@ class Backtester:
             total_fee = entry_fee_logged + float(exit_fee)
             total_slippage = entry_slippage_logged + float(slippage)
             # Update performance tracking.
-            # cast: BaseTrade satisfies TradeProtocol at runtime (record_trade reads
-            # via getattr); the static mismatch is mutable-attribute invariance only
-            # (protocol declares e.g. datetime | None, BaseTrade narrows to datetime).
             self.performance_tracker.record_trade(
-                trade=cast("TradeProtocol", completed_trade), fee=total_fee, slippage=total_slippage
+                trade=completed_trade, fee=total_fee, slippage=total_slippage
             )
             self.performance_tracker.update_balance(self.balance, timestamp=current_time)
 

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -110,7 +110,6 @@ if TYPE_CHECKING:
     from src.engines.live.kline_buffer import KlineBuffer
     from src.engines.live.reconciliation import PeriodicReconciler
     from src.engines.live.user_data_processor import UserDataProcessor
-    from src.performance.tracker import TradeProtocol
 
 logger = logging.getLogger(__name__)
 
@@ -4718,10 +4717,8 @@ class LiveTradingEngine:
 
             # Include margin interest in performance tracker fees so
             # reported PnL, win rate, and net metrics account for financing.
-            # BaseTrade satisfies TradeProtocol at runtime; mutable-attribute
-            # invariance rejects its narrower non-Optional datetime fields.
             self.performance_tracker.record_trade(
-                trade=cast("TradeProtocol", trade),
+                trade=trade,
                 fee=total_fee + interest_cost,
                 slippage=total_slippage,
             )
@@ -6112,10 +6109,8 @@ class LiveTradingEngine:
                         pnl_percent=pnl_pct_sized,
                         exit_reason="stop_loss_offline",
                     )
-                    # BaseTrade satisfies TradeProtocol at runtime; mutable-attribute
-                    # invariance rejects its narrower non-Optional datetime fields.
                     self.performance_tracker.record_trade(
-                        trade=cast("TradeProtocol", trade),
+                        trade=trade,
                         fee=exit_fee + offline_interest_cost,
                         slippage=exit_slippage_cost,
                     )

--- a/src/performance/tracker.py
+++ b/src/performance/tracker.py
@@ -11,6 +11,7 @@ import math
 import threading
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
+from enum import Enum
 from typing import Any, Protocol, runtime_checkable
 
 import pandas as pd
@@ -23,13 +24,26 @@ class TradeProtocol(Protocol):
     """Protocol for trade objects that can be recorded.
 
     This protocol defines the minimum interface required for trade tracking.
+    Members are read-only properties, so conformance is covariant: a concrete
+    trade class may expose narrower types (e.g. a non-Optional ``datetime``
+    entry_time, or a ``PositionSide`` enum side) and still structurally
+    conform. ``record_trade`` only reads these values.
     """
 
-    pnl: float | None
-    entry_time: datetime | None
-    exit_time: datetime | None
-    symbol: str | None
-    side: str | None
+    @property
+    def pnl(self) -> float | None: ...
+
+    @property
+    def entry_time(self) -> datetime | None: ...
+
+    @property
+    def exit_time(self) -> datetime | None: ...
+
+    @property
+    def symbol(self) -> str | None: ...
+
+    @property
+    def side(self) -> str | Enum | None: ...
 
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/performance/test_tracker.py
+++ b/tests/unit/performance/test_tracker.py
@@ -885,6 +885,6 @@ class TestTradeProtocolConformance:
         metrics = tracker.get_metrics()
         assert metrics.total_trades == 1
         assert metrics.winning_trades == 1
-        recorded = tracker.get_trades()[0] if hasattr(tracker, "get_trades") else None
-        if recorded is not None:
-            assert "long" in str(recorded["side"]).lower()
+        trades = tracker.get_trade_history()
+        assert trades, "Expected at least one recorded trade"
+        assert "long" in str(trades[0]["side"]).lower()

--- a/tests/unit/performance/test_tracker.py
+++ b/tests/unit/performance/test_tracker.py
@@ -852,3 +852,39 @@ class TestPerformanceTrackerMetricsCache:
         final = tracker.get_metrics()
         assert final.total_trades == 100
         assert final.winning_trades == 100
+
+
+class TestTradeProtocolConformance:
+    """Regression for #767: TradeProtocol members are read-only properties so
+    concrete trade classes with narrower types conform without casts."""
+
+    @pytest.mark.fast
+    def test_base_trade_records_without_cast(self):
+        """A real BaseTrade (enum side, non-Optional datetimes) is accepted
+        directly and its side is stringified into the trade record."""
+        from src.engines.shared.models import BaseTrade, PositionSide
+        from src.performance.tracker import TradeProtocol
+
+        trade = BaseTrade(
+            symbol="BTCUSDT",
+            side=PositionSide.LONG,
+            entry_price=100.0,
+            exit_price=110.0,
+            entry_time=datetime(2024, 1, 1, 10, tzinfo=UTC),
+            exit_time=datetime(2024, 1, 1, 12, tzinfo=UTC),
+            size=0.1,
+            pnl=10.0,
+        )
+
+        # Runtime structural check still holds with property members
+        assert isinstance(trade, TradeProtocol)
+
+        tracker = PerformanceTracker(initial_balance=1000.0)
+        tracker.record_trade(trade, fee=1.0, slippage=0.5)
+
+        metrics = tracker.get_metrics()
+        assert metrics.total_trades == 1
+        assert metrics.winning_trades == 1
+        recorded = tracker.get_trades()[0] if hasattr(tracker, "get_trades") else None
+        if recorded is not None:
+            assert "long" in str(recorded["side"]).lower()


### PR DESCRIPTION
## Summary

Fixes #767 — `TradeProtocol` declared its members as plain mutable attributes, which are **invariant** under PEP 544: concrete trade classes with narrower types (`BaseTrade`'s non-Optional `entry_time`/`exit_time`, `PositionSide` enum `side`) failed structural conformance, forcing `cast("TradeProtocol", ...)` at every `record_trade` call site.

## Changes

- `src/performance/tracker.py`: protocol members converted to read-only `@property` declarations (conformance becomes covariant; `record_trade` only ever reads these values). `side` honestly widened to `str | Enum | None` — its sole consumer is `str(getattr(trade, "side", None))`.
- Removed all three call-site casts and the now-unused `TYPE_CHECKING` imports: backtest engine (`record_trade` in `_finalize_trade` path) and both live-engine paths (close-position and offline stop-loss).
- `tests/unit/performance/test_tracker.py`: conformance regression test recording a real `BaseTrade` (enum side, tz-aware datetimes) — also asserts `isinstance(trade, TradeProtocol)` still works under `@runtime_checkable` with property members.

Pure typing change — zero runtime delta.

## Testing

- `pytest tests/unit/performance tests/unit/backtesting tests/unit/engines/backtest` — 258 passed.
- mypy clean on all three touched modules **with the casts removed** (that is the regression check).
- black / ruff clean.

Closes #767

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_