### PR TITLE
fix(quality): silence pandas SettingWithCopy + nanosecond truncation warnings (supersedes #667)

### DIFF
--- a/docs/research/ops-snapshots/2026-06-04_1200.md
+++ b/docs/research/ops-snapshots/2026-06-04_1200.md
@@ -1,0 +1,146 @@
+# Ops Snapshot — 2026-06-04 12:00 UTC
+
+**Overall**: yellow
+**Environment**: charter incomplete — operating mode unknown (TODOs unfilled)
+
+---
+
+## Process
+
+- `atb live-health` without a strategy argument exits with error 2 (strategy positional arg required). No running process detected in this environment.
+- No `atb live` process observed running. Health endpoint at PORT=8000 is not reachable (no process to serve it).
+- Railway CLI (`railway`) is not installed in this environment; deployment status on Railway cannot be verified directly.
+- Git remote: `http://local_proxy@127.0.0.1:33631/git/bumpy-croc/ai-trading-bot` (local proxy, not GitHub). `gh` CLI cannot reach GitHub — repo is air-gapped from GitHub here.
+- Current HEAD branch: `claude/dazzling-mccarthy-75E3W` (not `main`). HEAD commit: `28a93a2 fix(ws): recovering REST fallback for kline stream (#662) (#664)`.
+
+## Charter Status
+
+**CRITICAL CONFIG GAP**: `charter.md` contains only TODO placeholders. The following fields are all unfilled:
+- Operating mode (paper vs. live) — unknown
+- Capital under management — unknown
+- Environments in use — unknown
+- Active symbols — unknown
+- Risk tolerance thresholds — all TODO
+- Escalation method and SLA — unknown
+- Autonomy spend limit — unknown
+
+Per CLAUDE.md: "If the charter is missing or invalid, refuse to make material decisions." This system is not in a state where the daemon can safely operate autonomously.
+
+## Database
+
+- `atb db verify` fails: `DATABASE_URL is required but not set.`
+- No PostgreSQL connection available in this environment.
+- Cannot verify migration state, open positions table, or trades table via DB.
+
+## Recent Trade Log
+
+**File**: `logs/trades/trades_202606.json` (6 records)
+
+All 6 trades share identical characteristics — this is anomalous:
+- Symbol: BTCUSDT, side: long, size: 0.1, entry: $50,000, exit: $48,000, PnL: -$40 (-0.4%) each
+- exit_reason: `stop_loss_offline` on every trade
+- duration_minutes: ~0.000015 (sub-millisecond — effectively zero duration)
+- Trades come in pairs with identical timestamps (milliseconds apart): two pairs at 11:55:31, two at 11:57:21, two at 11:57:37
+
+**Assessment**: These look like test/fixture-generated records from running the test suite, not real trading activity. The `stop_loss_offline` exit reason and sub-millisecond durations confirm this. The duplicate pairs are consistent with parallel test workers writing the same scenario twice.
+
+No evidence of real trading activity in this log.
+
+## Open Positions
+
+- Cannot verify via DB (no DATABASE_URL).
+- Health endpoint not available (no running process).
+- No open positions detectable from available data.
+
+## Incidents
+
+- `.claude/state/incidents/` contains only `README.md` — no open incidents on file.
+- GitHub cannot be queried (`gh` not authenticated to remote).
+
+## Proposals
+
+- `.claude/state/proposals/` contains only `README.md` — no active proposals on file.
+
+## Log History
+
+- `log.md` contains only the initialization entry (1970-01-01 00:00). No prior anomaly calls to calibrate against. No baseline exists.
+
+## Unit Tests
+
+**Result: PASS — 3648 passed, 103 skipped, 333 deselected, 55 warnings** (136.79s)
+
+Warnings — all non-fatal but worth noting:
+
+1. **`SettingWithCopyWarning`** (pandas) — 4 occurrences in `src/ml/training_pipeline/features.py` at lines 312, 317, 346, 349. DataFrame slice assignment without `.loc`. This is a correctness risk if the warning graduates to an error in a future pandas version; data may be silently dropped.
+2. **`UserWarning: Discarding nonzero nanoseconds in conversion`** — `src/performance/tracker.py:169`. Nanosecond timestamp precision loss on conversion to Python datetime. Low risk but indicates sub-second precision may be silently dropped.
+3. Slowest test: `test_one_minute_timeframe` — 40.78s. Acceptable for `--slow` exclusion candidates.
+
+## Code Quality
+
+### Black (formatting)
+
+11 files would be reformatted — **black check FAILS**:
+- `src/engines/live/account_sync.py`
+- `src/engines/live/execution/execution_engine.py`
+- `src/engines/live/kline_buffer.py`
+- `src/engines/live/margin_interest_tracker.py`
+- `src/engines/live/execution/position_tracker.py`
+- `src/engines/live/order_tracker.py`
+- `src/engines/live/user_data_processor.py`
+- `src/infrastructure/logging/binance_ws_filter.py`
+- `src/data_providers/binance_provider.py`
+- `src/database/manager.py`
+- `src/engines/live/reconciliation.py`
+
+Note: all 7 of the live-engine files that fail black are in `src/engines/live/` — the same subsystem that received recent fixes (#660, #655, #653, #650). This suggests the recent PR burst was merged without running `black`.
+
+### Ruff (linting)
+
+**47 errors total, 19 auto-fixable.** Breakdown by category:
+- `UP038` (28 occurrences): `isinstance((X, Y))` instead of `isinstance(X | Y)`. Spread across `src/engines/live/`, `src/engines/shared/`, `src/data_providers/`, `src/database/`, `src/tech/indicators/`.
+- `F401` (5 occurrences): Unused imports.
+  - `src/data_providers/binance_provider.py:49` — `SideEffectType` unused
+  - `src/engines/live/reconciliation.py:17` — `datetime.datetime` unused (shadowed by re-import at line 451)
+  - `src/engines/live/reconciliation.py:26` — `DEFAULT_RECONCILIATION_DUST_THRESHOLD` unused
+  - `src/engines/live/reconciliation.py:423` — `LivePosition` unused
+- `I001` (3 occurrences): Unsorted import blocks.
+- `UP007` / `UP035` / `UP037`: Type annotation modernization (low severity).
+- `B007` (1): `src/engines/live/reconciliation.py:159` — loop variable `order_id` assigned but never used in loop body.
+- `F811` (1): `src/engines/live/reconciliation.py:451` — `datetime` re-imported, shadowing line 17.
+
+**Most concerning ruff finding**: `reconciliation.py` has an F811 (shadowed import) and an F401 (unused `datetime` import at line 17) that could indicate a copy-paste error introduced in recent refactoring. This module is responsible for crash recovery and position reconciliation — worth a careful read.
+
+## Railway / CI
+
+- Railway CLI not available. Cannot check deployment status, restart count, or resource usage.
+- GitHub Actions not accessible (`gh` unauthenticated). CI status for `main` branch unknown.
+- Remote is a local proxy; cannot determine if production deploy is current.
+
+---
+
+## Anomalies Summary
+
+| # | Severity | Description |
+|---|---|---|
+| 1 | P2 | Charter entirely unfilled — operating mode, capital, escalation all unknown. Daemon cannot make material decisions safely. |
+| 2 | P2 | DATABASE_URL not set — DB health, open positions, migration state unverifiable. |
+| 3 | P2 | 11 live-engine source files fail `black --check` — all recently modified files in `src/engines/live/`. |
+| 4 | P2 | 47 ruff lint errors including unused imports and a shadowed import in `reconciliation.py`. |
+| 5 | P3 | 4x `SettingWithCopyWarning` in `src/ml/training_pipeline/features.py` (lines 312, 317, 346, 349). |
+| 6 | P3 | Nanosecond precision loss in `src/performance/tracker.py:169`. |
+| 7 | P3 | Trade log contains only test-generated records (6 stop_loss_offline, sub-ms duration). No real trading activity confirmed. |
+| 8 | P3 | `reconciliation.py:159` — loop variable `order_id` unused (B007). Potential logic gap in reconciliation loop. |
+
+## Actions Taken
+
+- Read charter, log, incidents, proposals: no open incidents, no proposals.
+- Ran `atb db verify`: failed (no DATABASE_URL).
+- Ran unit test suite: 3648 passed.
+- Ran `black --check`: 11 files would reformat.
+- Ran `ruff check`: 47 errors.
+- Reviewed `logs/trades/trades_202606.json`: test fixtures only.
+- Created `docs/research/ops-snapshots/` directory (was missing).
+
+## Escalations
+
+None automatically triggered. P2 findings documented above. Charter gaps prevent knowing whether human escalation is warranted for any of these — the escalation method itself is a TODO.

--- a/src/ml/training_pipeline/features.py
+++ b/src/ml/training_pipeline/features.py
@@ -246,7 +246,7 @@ def _validate_and_clean_data(data: pd.DataFrame) -> pd.DataFrame:
     rows_before = len(data)
     nan_counts = data.isna().sum()
     # Avoid reassigning function parameter (CODE.md line 77)
-    cleaned_data = data.dropna()
+    cleaned_data = data.dropna().copy()
     rows_dropped = rows_before - len(cleaned_data)
 
     if rows_dropped > 0:
@@ -311,12 +311,12 @@ def _scale_technical_indicators(
         col = f"sma_{window}"
         if col in data.columns:
             scaled = f"{col}_scaled"
-            data[scaled] = MinMaxScaler().fit_transform(data[[col]])
+            data.loc[:, scaled] = MinMaxScaler().fit_transform(data[[col]])
             feature_names.append(scaled)
 
     # Scale RSI
     if "rsi" in data.columns:
-        data["rsi_scaled"] = MinMaxScaler().fit_transform(data[["rsi"]])
+        data.loc[:, "rsi_scaled"] = MinMaxScaler().fit_transform(data[["rsi"]])
         feature_names.append("rsi_scaled")
 
     return data, feature_names
@@ -342,13 +342,14 @@ def _add_sentiment_features(
     if sentiment_assessment["recommendation"] not in ["full_sentiment", "hybrid_with_fallback"]:
         return data, feature_names, scalers
 
+    data = data.copy()
     sentiment_features = ["sentiment_score", "sentiment_volume", "sentiment_momentum"]
     for feature in sentiment_features:
         if feature in data.columns:
-            data[f"{feature}_filled"] = data[feature].fillna(0)
+            data.loc[:, f"{feature}_filled"] = data[feature].fillna(0)
             scaler = MinMaxScaler()
             scaled = f"{feature}_scaled"
-            data[scaled] = scaler.fit_transform(data[[f"{feature}_filled"]])
+            data.loc[:, scaled] = scaler.fit_transform(data[[f"{feature}_filled"]])
             feature_names.append(scaled)
             scalers[feature] = scaler
 

--- a/src/performance/tracker.py
+++ b/src/performance/tracker.py
@@ -166,7 +166,7 @@ class PerformanceTracker:
                 ts_converted = ts_converted.tz_localize(UTC)
             else:
                 ts_converted = ts_converted.tz_convert(UTC)
-            return ts_converted.to_pydatetime()
+            return ts_converted.floor("us").to_pydatetime()
         if timestamp.tzinfo is None:
             return timestamp.replace(tzinfo=UTC)
         return timestamp.astimezone(UTC)


### PR DESCRIPTION
## Summary

Supersedes #667. Rebased onto `develop`, where the repo-wide static-analysis sweep (**#754**, "clear repo-wide static-analysis debt — black, ruff, mypy, bandit all green") has **already landed** the bulk of #667's work (ruff/black/isinstance/import cleanups). This PR carries only the **two runtime-warning fixes** from #667 that #754 did *not* cover, plus the ops-snapshot doc.

### Bug fixes

- **`SettingWithCopyWarning` in the ML training pipeline** (`src/ml/training_pipeline/features.py`): `_validate_and_clean_data` returned a `dropna()` view; `_scale_technical_indicators` and `_add_sentiment_features` then wrote into it, raising the warning and risking silent data corruption in future pandas releases. Fixed with `dropna().copy()`, `.loc[:, col] =` for all new-column writes, and an explicit `data = data.copy()` guard in `_add_sentiment_features`.
- **`UserWarning: Discarding nonzero nanoseconds`** (`src/performance/tracker.py`): `to_pydatetime()` silently truncated sub-microsecond precision with a warning on every call. Fixed by flooring to microseconds first: `.floor("us").to_pydatetime()`.

Also adds `docs/research/ops-snapshots/2026-06-04_1200.md`.

## Why a fresh PR instead of resolving #667 in place

Rebasing #667 onto current `develop` left only these 3 files — everything else was already on `develop` via #754. #667 also carried two now-stale edits that would have **regressed** live-trading fixes already on `develop`:
- `database/manager.py` — would have dropped the Decimal→float coercion in balance recovery.
- `order_tracker.py` — would have reintroduced treating a poll give-up as a cancel (reverting #752).

Resolving those conflicts in favour of `develop` and dropping the redundant churn is cleaner as a fresh, conflict-free PR.

## Test plan

- [x] Targeted unit tests (performance / training_pipeline / features): **419 passed, 0 failures**
- [x] `ruff check` — clean
- [x] `black --check` — clean

## Risk assessment

Pandas-idiom and datetime-precision corrections only; no trading logic altered. Behavior is identical on the current pandas 2.1.4 pin — the `.copy()` guard prevents future silent corruption.

Closes #667.

https://claude.ai/code/session_01UTpcPugqsLHN15k5GwGFqC

---
_Generated by [Claude Code](https://claude.ai/code)_