### PR TITLE
fix(backtest): guard None trailing-stop price in update_trailing_stop

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Backtest trailing-stop updates no longer crash the run when trailing
+  activates without a stop improvement (#761): `TrailingStopManager.update`
+  legitimately returns `updated=True, new_stop_price=None` (e.g. ATR
+  unavailable on the activation candle), and the backtest tracker compared
+  that `None` against the current stop (`TypeError`, unwrapped). The tracker
+  now mirrors the live tracker: flag updates apply, price comparison skipped.
 - `atb data populate-dummy` works again (#763): `log_trade` was called with the
   nonexistent `order_id` kwarg (the parameter is `exit_order_id`), so the first
   generated trade raised `TypeError` and the command always failed. Same bug

--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -279,14 +279,10 @@ class ExitHandler:
         new_activated = result.trailing_activated or trade.trailing_stop_activated
         new_breakeven = result.breakeven_triggered or trade.breakeven_triggered
 
-        # Apply update via position tracker.
-        # KNOWN LATENT BUG (typing surfaced, behavior preserved): new_stop_price can
-        # be None when result.updated is True but trailing only just activated
-        # without a stop improvement; PositionTracker.update_trailing_stop would
-        # then compare None against the current stop (TypeError if a stop exists).
-        # Guarding here would change runtime behavior; tracked for a separate fix.
+        # Apply update via position tracker (a None stop price means trailing
+        # just activated without a stop improvement; flag updates still apply).
         changed = self.position_tracker.update_trailing_stop(
-            new_stop_loss=result.new_stop_price,  # type: ignore[arg-type]
+            new_stop_loss=result.new_stop_price,
             activated=new_activated,
             breakeven_triggered=new_breakeven,
         )

--- a/src/engines/backtest/execution/position_tracker.py
+++ b/src/engines/backtest/execution/position_tracker.py
@@ -228,14 +228,17 @@ class PositionTracker:
 
     def update_trailing_stop(
         self,
-        new_stop_loss: float,
+        new_stop_loss: float | None,
         activated: bool,
         breakeven_triggered: bool,
     ) -> bool:
         """Update trailing stop state for active position.
 
         Args:
-            new_stop_loss: New stop loss price.
+            new_stop_loss: New stop loss price, or None when trailing just
+                activated without producing a stop improvement (e.g. ATR
+                unavailable on the activation candle); flag updates still
+                apply. Mirrors the live tracker's None handling.
             activated: Whether trailing stop is now activated.
             breakeven_triggered: Whether breakeven has been triggered.
 
@@ -247,18 +250,19 @@ class PositionTracker:
 
         changed = False
 
-        # Only update if new stop is better
-        current_sl = self.current_trade.stop_loss
-        side_str = to_side_string(self.current_trade.side)
-        if side_str == "long":
-            should_update = current_sl is None or new_stop_loss > float(current_sl)
-        else:
-            should_update = current_sl is None or new_stop_loss < float(current_sl)
+        if new_stop_loss is not None:
+            # Only update if new stop is better
+            current_sl = self.current_trade.stop_loss
+            side_str = to_side_string(self.current_trade.side)
+            if side_str == "long":
+                should_update = current_sl is None or new_stop_loss > float(current_sl)
+            else:
+                should_update = current_sl is None or new_stop_loss < float(current_sl)
 
-        if should_update:
-            self.current_trade.stop_loss = new_stop_loss
-            self.current_trade.trailing_stop_price = new_stop_loss
-            changed = True
+            if should_update:
+                self.current_trade.stop_loss = new_stop_loss
+                self.current_trade.trailing_stop_price = new_stop_loss
+                changed = True
 
         if activated != self.current_trade.trailing_stop_activated:
             self.current_trade.trailing_stop_activated = activated

--- a/tests/unit/backtesting/test_trailing_stop_none_guard.py
+++ b/tests/unit/backtesting/test_trailing_stop_none_guard.py
@@ -1,0 +1,101 @@
+"""Regression tests for #761: trailing-stop update with a None stop price.
+
+``TrailingStopManager.update`` can return ``updated=True`` with
+``new_stop_price=None`` (trailing just activated without a stop improvement,
+e.g. ATR unavailable on the activation candle). The backtest
+``PositionTracker.update_trailing_stop`` previously compared that ``None``
+against the current stop (``None > float`` → ``TypeError``), crashing the
+whole backtest run. It now mirrors the live tracker: flag updates apply, the
+price comparison is skipped.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.engines.backtest.execution.position_tracker import PositionTracker
+from src.engines.backtest.models import ActiveTrade
+from src.engines.shared.models import PositionSide
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _open_tracker(stop_loss: float | None) -> PositionTracker:
+    tracker = PositionTracker()
+    tracker.open_position(
+        ActiveTrade(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            entry_price=100.0,
+            entry_time=datetime(2024, 1, 1, tzinfo=UTC),
+            size=0.1,
+            stop_loss=stop_loss,
+        )
+    )
+    return tracker
+
+
+class TestUpdateTrailingStopNoneGuard:
+    def test_none_stop_with_existing_stop_does_not_raise(self):
+        """Regression: None vs existing float stop crashed with TypeError."""
+        tracker = _open_tracker(stop_loss=95.0)
+
+        changed = tracker.update_trailing_stop(
+            new_stop_loss=None, activated=True, breakeven_triggered=False
+        )
+
+        trade = tracker.current_trade
+        assert trade is not None
+        assert changed is True  # activation flag changed
+        assert trade.stop_loss == 95.0  # price untouched
+        assert trade.trailing_stop_activated is True
+
+    def test_none_stop_without_existing_stop_keeps_none(self):
+        """Activation without a price must not fabricate a stop price."""
+        tracker = _open_tracker(stop_loss=None)
+
+        changed = tracker.update_trailing_stop(
+            new_stop_loss=None, activated=True, breakeven_triggered=False
+        )
+
+        trade = tracker.current_trade
+        assert trade is not None
+        assert changed is True
+        assert trade.stop_loss is None
+        assert trade.trailing_stop_price is None
+        assert trade.trailing_stop_activated is True
+
+    def test_none_stop_with_no_flag_change_reports_unchanged(self):
+        tracker = _open_tracker(stop_loss=95.0)
+
+        changed = tracker.update_trailing_stop(
+            new_stop_loss=None, activated=False, breakeven_triggered=False
+        )
+
+        assert changed is False
+
+    def test_real_stop_improvement_still_applies(self):
+        """Existing improvement semantics are untouched."""
+        tracker = _open_tracker(stop_loss=95.0)
+
+        changed = tracker.update_trailing_stop(
+            new_stop_loss=97.0, activated=True, breakeven_triggered=False
+        )
+
+        trade = tracker.current_trade
+        assert trade is not None
+        assert changed is True
+        assert trade.stop_loss == 97.0
+        assert trade.trailing_stop_price == 97.0
+
+    def test_worse_stop_is_rejected_but_flags_apply(self):
+        tracker = _open_tracker(stop_loss=95.0)
+
+        changed = tracker.update_trailing_stop(
+            new_stop_loss=90.0, activated=True, breakeven_triggered=True
+        )
+
+        trade = tracker.current_trade
+        assert trade is not None
+        assert changed is True  # flags changed
+        assert trade.stop_loss == 95.0  # worse stop rejected for a long


### PR DESCRIPTION
## Summary

Fixes #761 — `TrailingStopManager.update` can legitimately return `TrailingStopUpdate(updated=True, new_stop_price=None)` (trailing just activated without producing a stop improvement, e.g. ATR unavailable on the activation candle). The **backtest** `PositionTracker.update_trailing_stop` then compared that `None` against the current stop — `None > float(current_sl)` raises `TypeError`, and the call is not wrapped, so it aborted the entire backtest run.

## Changes

- `src/engines/backtest/execution/position_tracker.py`: `update_trailing_stop` accepts `new_stop_loss: float | None` and skips the price comparison when `None`, while activation/breakeven **flag updates still apply** — exactly mirroring the live tracker's existing `None` handling (`engines/live/execution/position_tracker.py:787`), so this is also a backtest↔live parity alignment. Side benefit: the `None`-stop/`None`-current corner no longer books a phantom "changed" stop write.
- `src/engines/backtest/execution/exit_handler.py`: removed the `KNOWN LATENT BUG` comment and `# type: ignore[arg-type]`.
- `tests/unit/backtesting/test_trailing_stop_none_guard.py` (new): 5 tests — the regression case (None + existing stop: no raise, price untouched, flags applied), None without existing stop (no fabricated price), no-flag-change returns False, and both improvement/rejection semantics unchanged.

## Testing

- `pytest tests/unit/backtesting` — 105 passed (5 new).
- mypy / black / ruff clean on touched files.

Closes #761

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_