### PR TITLE
fix(live): recover_positions reads the real get_active_positions API

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `LivePositionTracker.recover_positions` actually recovers positions now
+  (#764): it called `DatabaseManager.get_open_positions`, a method that does
+  not exist, so the swallowed `AttributeError` made it always return `[]` —
+  a silent fail-open trap for any future recovery caller. It now maps the
+  dict rows from the real `get_active_positions` API with the same
+  normalization and hydration as the engine's `_recover_active_positions`
+  (uppercase DB side, tracker key fallback to row id, partial-op state,
+  reconciliation ids), skips invalid-entry-price rows with a CRITICAL log,
+  and isolates per-row failures.
 - `StrategyManager.update_model` with no strategy loaded now fails with the
   intended descriptive `ValueError` (#765) instead of an `AttributeError`
   raised while formatting the error message itself (`self.current_strategy.name`

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -1782,6 +1782,9 @@ class DatabaseManager:
                         # * Include exchange order IDs for live trading recovery
                         "entry_order_id": getattr(p, "entry_order_id", None),
                         "stop_loss_order_id": getattr(p, "stop_loss_order_id", None),
+                        # Idempotency key; recovery paths (engine and tracker)
+                        # hydrate LivePosition.client_order_id from this.
+                        "client_order_id": getattr(p, "client_order_id", None),
                     }
                 )
 

--- a/src/engines/live/execution/position_tracker.py
+++ b/src/engines/live/execution/position_tracker.py
@@ -883,7 +883,7 @@ class LivePositionTracker:
         try:
             db_positions = self.db_manager.get_active_positions(session_id)
         except Exception as e:
-            logger.error("Failed to load positions for recovery: %s", e)
+            logger.error("Failed to load positions for recovery: %s", e, exc_info=True)
             return []
 
         recovered: list[LivePosition] = []
@@ -959,7 +959,10 @@ class LivePositionTracker:
                 # Per-row isolation: one corrupt row must not abort recovery
                 # of the remaining positions.
                 logger.error(
-                    "Failed to recover position %s: %s", pos_data.get("symbol", "<unknown>"), e
+                    "Failed to recover position %s: %s",
+                    pos_data.get("symbol", "<unknown>"),
+                    e,
+                    exc_info=True,
                 )
 
         return recovered

--- a/src/engines/live/execution/position_tracker.py
+++ b/src/engines/live/execution/position_tracker.py
@@ -862,62 +862,91 @@ class LivePositionTracker:
         self,
         session_id: int,
     ) -> list[LivePosition]:
-        """Recover positions from database on restart.
+        """Recover open positions for a session from the database.
+
+        Maps the dict rows returned by ``DatabaseManager.get_active_positions``
+        (the same source the engine's ``_recover_active_positions`` uses) onto
+        tracked ``LivePosition`` objects. Rows with an invalid entry price are
+        skipped with a CRITICAL log; other corrupt rows are skipped per-row so
+        one bad record cannot abort recovery of the rest.
 
         Args:
             session_id: Trading session ID to recover from.
 
         Returns:
-            List of recovered positions.
+            List of recovered positions (already registered in the tracker).
         """
         if self.db_manager is None:
             logger.warning("Cannot recover positions without database manager")
             return []
 
-        recovered = []
         try:
-            # KNOWN GAP: DatabaseManager does not implement get_open_positions
-            # (it exposes get_active_positions returning dicts). Against the real
-            # manager this raises AttributeError, caught below, so recovery
-            # returns []. Kept as-is for behavior parity; engine recovery uses
-            # LiveTradingEngine._recover_active_positions instead.
-            db_positions = self.db_manager.get_open_positions(session_id)  # type: ignore[attr-defined]
-            for db_pos in db_positions:
-                entry_time = db_pos.entry_time
+            db_positions = self.db_manager.get_active_positions(session_id)
+        except Exception as e:
+            logger.error("Failed to load positions for recovery: %s", e)
+            return []
+
+        recovered: list[LivePosition] = []
+        for pos_data in db_positions:
+            try:
+                # DB enum values are uppercase ("LONG"); shared PositionSide
+                # uses lowercase — same normalization as the engine's
+                # _recover_active_positions.
+                side_value = pos_data["side"]
+                if isinstance(side_value, str):
+                    side_value = side_value.lower()
+
+                # Non-nullable column; subscript (not .get) so a missing key is
+                # a loud per-row failure rather than a None into LivePosition.
+                entry_time = pos_data["entry_time"]
                 if entry_time is not None and entry_time.tzinfo is None:
                     entry_time = entry_time.replace(tzinfo=UTC)
+
+                # Tracker key: prefer the exchange entry order id, fall back to
+                # the database row id (mirrors engine recovery).
+                entry_order_id = pos_data.get("entry_order_id")
+                tracker_key = entry_order_id or str(pos_data["id"])
+
+                entry_balance = pos_data.get("entry_balance")
+                quantity = pos_data.get("quantity")
                 position = LivePosition(
-                    symbol=db_pos.symbol,
-                    side=PositionSide(db_pos.side),
-                    size=float(db_pos.size),
-                    entry_price=float(db_pos.entry_price),
+                    symbol=pos_data["symbol"],
+                    side=PositionSide(side_value),
+                    size=float(pos_data["size"]),
+                    entry_price=float(pos_data["entry_price"]),
                     entry_time=entry_time,
-                    entry_balance=float(db_pos.entry_balance) if db_pos.entry_balance else None,
-                    quantity=float(db_pos.quantity) if db_pos.quantity is not None else None,
-                    stop_loss=float(db_pos.stop_loss) if db_pos.stop_loss else None,
-                    take_profit=float(db_pos.take_profit) if db_pos.take_profit else None,
-                    order_id=db_pos.entry_order_id,
-                    exchange_order_id=db_pos.entry_order_id,
-                    client_order_id=getattr(db_pos, "client_order_id", None),
-                    original_size=(
-                        float(db_pos.original_size) if db_pos.original_size is not None else None
-                    ),
-                    current_size=(
-                        float(db_pos.current_size) if db_pos.current_size is not None else None
-                    ),
-                    partial_exits_taken=int(db_pos.partial_exits_taken or 0),
-                    scale_ins_taken=int(db_pos.scale_ins_taken or 0),
-                    trailing_stop_activated=bool(db_pos.trailing_stop_activated),
-                    trailing_stop_price=(
-                        float(db_pos.trailing_stop_price) if db_pos.trailing_stop_price else None
-                    ),
-                    breakeven_triggered=bool(db_pos.breakeven_triggered),
+                    entry_balance=float(entry_balance) if entry_balance is not None else None,
+                    quantity=float(quantity) if quantity is not None else None,
+                    stop_loss=pos_data.get("stop_loss"),
+                    take_profit=pos_data.get("take_profit"),
+                    order_id=tracker_key,
+                    tracker_key=tracker_key,
+                    exchange_order_id=entry_order_id,
+                    client_order_id=pos_data.get("client_order_id"),
+                    db_position_id=pos_data.get("id"),
+                    stop_loss_order_id=pos_data.get("stop_loss_order_id"),
+                    original_size=pos_data.get("original_size"),
+                    current_size=pos_data.get("current_size"),
+                    partial_exits_taken=int(pos_data.get("partial_exits_taken", 0) or 0),
+                    scale_ins_taken=int(pos_data.get("scale_ins_taken", 0) or 0),
+                    trailing_stop_activated=bool(pos_data.get("trailing_stop_activated", False)),
+                    trailing_stop_price=pos_data.get("trailing_stop_price"),
+                    breakeven_triggered=bool(pos_data.get("breakeven_triggered", False)),
                 )
-                # Persisted rows carry the entry order id used as tracker key.
-                recovered_order_id = cast(str, position.order_id)
-                with self._positions_lock:
-                    self._positions[recovered_order_id] = position
-                    self._position_db_ids[recovered_order_id] = db_pos.id
+
+                # A position with an invalid entry price cannot be closed
+                # properly and would orphan in the tracker — skip loudly.
+                if position.entry_price <= 0 or not math.isfinite(position.entry_price):
+                    logger.critical(
+                        "SKIPPING recovery of position %s (%s): invalid entry_price %.8f. "
+                        "MANUAL RECONCILIATION REQUIRED.",
+                        position.symbol,
+                        tracker_key,
+                        position.entry_price,
+                    )
+                    continue
+
+                self.track_recovered_position(position, db_id=pos_data.get("id"))
                 recovered.append(position)
                 logger.info(
                     "Recovered position: %s %s @ %.2f",
@@ -926,7 +955,11 @@ class LivePositionTracker:
                     position.symbol,
                     position.entry_price,
                 )
-        except Exception as e:
-            logger.error("Failed to recover positions: %s", e)
+            except Exception as e:
+                # Per-row isolation: one corrupt row must not abort recovery
+                # of the remaining positions.
+                logger.error(
+                    "Failed to recover position %s: %s", pos_data.get("symbol", "<unknown>"), e
+                )
 
         return recovered

--- a/tests/unit/live/test_position_tracker_quantity.py
+++ b/tests/unit/live/test_position_tracker_quantity.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from types import SimpleNamespace
 
 import pytest
 
@@ -32,32 +31,107 @@ def test_open_position_persists_executed_quantity(mock_db_manager) -> None:
     assert call_kwargs["quantity"] == 10.0
 
 
+def _db_position_row(**overrides) -> dict:
+    """Dict row in the shape DatabaseManager.get_active_positions returns."""
+    row = {
+        "id": 123,
+        "symbol": "BTCUSDT",
+        "side": "LONG",  # DB enum .value is uppercase
+        "size": 0.1,
+        "entry_price": 50000.0,
+        "entry_time": datetime.now(UTC),
+        "entry_balance": 1000.0,
+        "stop_loss": 48000.0,
+        "take_profit": 55000.0,
+        "entry_order_id": "order-456",
+        "stop_loss_order_id": None,
+        "client_order_id": "atb_abc123",
+        "original_size": 0.1,
+        "current_size": 0.1,
+        "partial_exits_taken": 0,
+        "scale_ins_taken": 0,
+        "trailing_stop_activated": False,
+        "trailing_stop_price": None,
+        "breakeven_triggered": False,
+        "quantity": 0.02,
+    }
+    row.update(overrides)
+    return row
+
+
 @pytest.mark.fast
 def test_recover_positions_restores_quantity(mock_db_manager) -> None:
-    entry_time = datetime.now(UTC)
-    db_pos = SimpleNamespace(
-        id=123,
-        symbol="BTCUSDT",
-        side="long",
-        size=0.1,
-        entry_price=50000.0,
-        entry_time=entry_time,
-        entry_balance=1000.0,
-        stop_loss=48000.0,
-        take_profit=55000.0,
-        entry_order_id="order-456",
-        original_size=0.1,
-        current_size=0.1,
-        partial_exits_taken=0,
-        scale_ins_taken=0,
-        trailing_stop_activated=False,
-        trailing_stop_price=None,
-        breakeven_triggered=False,
-        quantity=0.02,
-    )
-    mock_db_manager.get_open_positions.return_value = [db_pos]
+    """Regression for #764: recovery reads get_active_positions (the real
+    DatabaseManager API — get_open_positions never existed) and hydrates the
+    persisted quantity."""
+    mock_db_manager.get_active_positions.return_value = [_db_position_row()]
 
     tracker = LivePositionTracker(db_manager=mock_db_manager)
     recovered = tracker.recover_positions(session_id=1)
 
+    mock_db_manager.get_active_positions.assert_called_once_with(1)
+    assert len(recovered) == 1
     assert recovered[0].quantity == 0.02
+
+
+@pytest.mark.fast
+def test_recover_positions_tracks_and_maps_fields(mock_db_manager) -> None:
+    """Recovered positions are registered in the tracker with the entry order
+    id as key, the uppercase DB side is normalized, and partial-op state and
+    reconciliation ids are hydrated."""
+    mock_db_manager.get_active_positions.return_value = [
+        _db_position_row(
+            original_size=0.2,
+            current_size=0.1,
+            partial_exits_taken=1,
+            stop_loss_order_id="sl-789",
+        )
+    ]
+
+    tracker = LivePositionTracker(db_manager=mock_db_manager)
+    recovered = tracker.recover_positions(session_id=1)
+
+    assert len(recovered) == 1
+    position = recovered[0]
+    assert position.side == PositionSide.LONG
+    assert position.order_id == "order-456"
+    assert position.exchange_order_id == "order-456"
+    assert position.client_order_id == "atb_abc123"
+    assert position.db_position_id == 123
+    assert position.stop_loss_order_id == "sl-789"
+    assert position.original_size == 0.2
+    assert position.current_size == 0.1
+    assert position.partial_exits_taken == 1
+    # Registered in the tracker under the entry order id
+    assert tracker.positions["order-456"] is position
+
+
+@pytest.mark.fast
+def test_recover_positions_falls_back_to_db_id_key(mock_db_manager) -> None:
+    """Without an entry order id, the database row id becomes the tracker key
+    (mirrors LiveTradingEngine._recover_active_positions)."""
+    mock_db_manager.get_active_positions.return_value = [_db_position_row(entry_order_id=None)]
+
+    tracker = LivePositionTracker(db_manager=mock_db_manager)
+    recovered = tracker.recover_positions(session_id=1)
+
+    assert len(recovered) == 1
+    assert recovered[0].order_id == "123"
+    assert "123" in tracker.positions
+
+
+@pytest.mark.fast
+def test_recover_positions_skips_corrupt_row_recovers_rest(mock_db_manager) -> None:
+    """One corrupt row (invalid entry price) must not abort recovery of the
+    remaining positions."""
+    mock_db_manager.get_active_positions.return_value = [
+        _db_position_row(id=1, entry_order_id="bad", entry_price=0.0),
+        _db_position_row(id=2, entry_order_id="good"),
+    ]
+
+    tracker = LivePositionTracker(db_manager=mock_db_manager)
+    recovered = tracker.recover_positions(session_id=1)
+
+    assert len(recovered) == 1
+    assert recovered[0].order_id == "good"
+    assert "bad" not in tracker.positions


### PR DESCRIPTION
## Summary

Fixes #764 — `LivePositionTracker.recover_positions` called `DatabaseManager.get_open_positions`, a method that **has never existed** (the real API is `get_active_positions`, returning dict rows). The `AttributeError` was swallowed by the broad except, so the method always returned `[]` while looking exactly like a clean 'no positions to recover' — a fail-open trap for any future recovery caller (LESSONS §1.8 class). The engine's own `_recover_active_positions` was unaffected (it already uses the real API).

## Changes

- `src/engines/live/execution/position_tracker.py`: `recover_positions` now maps `get_active_positions` dict rows with the **same normalization and hydration as engine recovery**: uppercase DB enum side lowercased; tracker key prefers `entry_order_id`, falls back to the DB row id; partial-operation state, reconciliation ids, and naive-entry_time→UTC coercion hydrated. Registration goes through the existing `track_recovered_position`. Invalid-entry-price rows are skipped with a CRITICAL log; other corrupt rows are isolated per-row.
- `tests/unit/live/test_position_tracker_quantity.py`: the pre-existing test mocked the **nonexistent** method (Mock auto-creates attributes, so it passed while production always failed). Rewritten against the real API shape, plus field-mapping/registration, row-id key fallback, and corrupt-row isolation tests (5 tests).

## Testing

- `pytest tests/unit/live tests/unit/engines/live` — 557 passed.
- mypy / black / ruff clean on touched files.

Closes #764

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR