### PR TITLE
feat(live): day-start balance recovery actually works across restarts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Live daily P&L survives restarts now (#766): day-start balance recovery
+  queried `DatabaseManager.get_first_snapshot_of_day`, which was never
+  implemented (`AttributeError` swallowed as a "graceful fallback"), and the
+  recovery helper itself was never invoked — so every intraday restart reset
+  the daily P&L baseline to the restart-time balance. The method now exists
+  (earliest `account_history` row of the UTC day for the session) and is
+  wired into the first snapshot after engine start. Trading-day semantics are
+  explicitly UTC throughout the event logger (was local `date.today()`,
+  skewing day boundaries on non-UTC hosts).
 - `build_time_exit_policy` (engines/shared) can now actually build a policy
   (#760): it passed `exit_time`/`exit_days` kwargs that `TimeExitPolicy` does
   not accept, so it always raised `TypeError` internally and returned `None`.

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -2269,7 +2269,10 @@ class DatabaseManager:
             return False
 
     def get_first_snapshot_of_day(
-        self, session_id: int | None = None, target_date: date | None = None
+        self,
+        session_id: int | None = None,
+        target_date: date | None = None,
+        fallback_session_id: int | None = None,
     ) -> AccountHistory | None:
         """Get the earliest account snapshot of a UTC calendar day for a session.
 
@@ -2284,10 +2287,14 @@ class DatabaseManager:
         Args:
             session_id: Trading session ID (defaults to the current session).
             target_date: UTC calendar date (defaults to today in UTC).
+            fallback_session_id: Prior session whose snapshots also count. A
+                clean restart creates a NEW session while the day's earlier
+                snapshots live under the recovered inactive session — without
+                this the primary use case (restart continuity) finds nothing.
 
         Returns:
-            The day's earliest ``AccountHistory`` row, or None when the session
-            has no snapshot that day.
+            The day's earliest ``AccountHistory`` row across the session(s),
+            or None when no snapshot exists that day.
         """
         session_id = session_id or self._current_session_id
         if not session_id:
@@ -2299,12 +2306,16 @@ class DatabaseManager:
         day_start = datetime(target_date.year, target_date.month, target_date.day, tzinfo=UTC)
         day_end = day_start + timedelta(days=1)
 
+        session_ids = [session_id]
+        if fallback_session_id is not None and fallback_session_id != session_id:
+            session_ids.append(fallback_session_id)
+
         # Use ANALYTICS timeout - day-start recovery is a non-critical read
         with self.get_session_with_timeout(QueryTimeout.ANALYTICS) as session:
             snapshot = (
                 session.query(AccountHistory)
                 .filter(
-                    AccountHistory.session_id == session_id,
+                    AccountHistory.session_id.in_(session_ids),
                     AccountHistory.timestamp >= day_start,
                     AccountHistory.timestamp < day_end,
                 )

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -9,7 +9,7 @@ import math
 import os
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any, cast
 
@@ -2264,6 +2264,54 @@ class DatabaseManager:
         except Exception as e:
             logger.error(f"Failed to update balance: {e}")
             return False
+
+    def get_first_snapshot_of_day(
+        self, session_id: int | None = None, target_date: date | None = None
+    ) -> AccountHistory | None:
+        """Get the earliest account snapshot of a UTC calendar day for a session.
+
+        Used by the live event logger to recover the day-start balance after a
+        restart, so daily P&L remains anchored to the day's first snapshot
+        rather than the restart-time balance.
+
+        Day semantics are UTC: snapshots are written with ``datetime.now(UTC)``
+        timestamps, so the day window is ``[00:00 UTC, 24:00 UTC)`` of
+        ``target_date``.
+
+        Args:
+            session_id: Trading session ID (defaults to the current session).
+            target_date: UTC calendar date (defaults to today in UTC).
+
+        Returns:
+            The day's earliest ``AccountHistory`` row, or None when the session
+            has no snapshot that day.
+        """
+        session_id = session_id or self._current_session_id
+        if not session_id:
+            return None
+
+        if target_date is None:
+            target_date = datetime.now(UTC).date()
+
+        day_start = datetime(target_date.year, target_date.month, target_date.day, tzinfo=UTC)
+        day_end = day_start + timedelta(days=1)
+
+        # Use ANALYTICS timeout - day-start recovery is a non-critical read
+        with self.get_session_with_timeout(QueryTimeout.ANALYTICS) as session:
+            snapshot = (
+                session.query(AccountHistory)
+                .filter(
+                    AccountHistory.session_id == session_id,
+                    AccountHistory.timestamp >= day_start,
+                    AccountHistory.timestamp < day_end,
+                )
+                .order_by(AccountHistory.timestamp.asc())
+                .first()
+            )
+            if snapshot is not None:
+                # Detach so attributes stay readable after the session closes.
+                session.expunge(snapshot)
+            return snapshot
 
     def get_balance_history(self, session_id: int | None = None, limit: int = 100) -> list[dict]:
         """Get balance change history"""

--- a/src/engines/live/logging/event_logger.py
+++ b/src/engines/live/logging/event_logger.py
@@ -74,16 +74,26 @@ class LiveEventLogger:
         """
         self.session_id = session_id
 
+    @staticmethod
+    def _utc_today() -> date:
+        """Current UTC calendar date.
+
+        Trading-day semantics are UTC throughout (snapshots are written with
+        ``datetime.now(UTC)`` timestamps); a local-time date here would skew
+        day boundaries on non-UTC hosts.
+        """
+        return datetime.now(UTC).date()
+
     def set_day_start_balance(self, balance: float) -> None:
         """Set the day start balance for daily P&L calculation.
 
         Called during session recovery to restore day start balance from database.
 
         Args:
-            balance: The balance at the start of the current trading day.
+            balance: The balance at the start of the current trading day (UTC).
         """
         self._day_start_balance = balance
-        self._current_trading_date = date.today()
+        self._current_trading_date = self._utc_today()
 
     def _check_and_update_trading_date(self, current_balance: float) -> None:
         """Check if the trading date has changed and update day start balance.
@@ -94,15 +104,19 @@ class LiveEventLogger:
         Args:
             current_balance: The current account balance.
         """
-        today = date.today()
+        today = self._utc_today()
         if self._current_trading_date is None:
-            # First call - initialize with current balance
+            # First call (engine start or restart): anchor to the day's first
+            # persisted snapshot when one exists, so an intraday restart does
+            # not reset the daily P&L baseline to the restart-time balance.
+            recovered = self._get_day_start_balance_from_db()
             self._current_trading_date = today
-            self._day_start_balance = current_balance
+            self._day_start_balance = recovered if recovered is not None else current_balance
             logger.debug(
-                "Initialized daily P&L tracking: date=%s, day_start_balance=%.2f",
+                "Initialized daily P&L tracking: date=%s, day_start_balance=%.2f (%s)",
                 today,
-                current_balance,
+                self._day_start_balance,
+                "recovered from DB" if recovered is not None else "current balance",
             )
         elif today != self._current_trading_date:
             # Date rolled over - log previous day and reset
@@ -121,7 +135,7 @@ class LiveEventLogger:
         """Recover day start balance from database on session restart.
 
         Enables continuous daily P&L tracking across restarts by retrieving
-        the starting balance from the first snapshot of the current trading day.
+        the starting balance from the first snapshot of the current UTC day.
 
         Returns:
             The day start balance if found, None otherwise.
@@ -130,21 +144,16 @@ class LiveEventLogger:
             return None
 
         try:
-            today = date.today()
-            # Query first snapshot of current day for this session.
-            # DatabaseManager does not implement this method yet; the
-            # AttributeError handler below provides the graceful fallback.
-            snapshot = self.db_manager.get_first_snapshot_of_day(  # type: ignore[attr-defined]
+            snapshot = self.db_manager.get_first_snapshot_of_day(
                 session_id=self.session_id,
-                target_date=today,
+                target_date=self._utc_today(),
             )
             if snapshot is not None:
                 return float(snapshot.balance)
-        except AttributeError:
-            # Method not available on db_manager - graceful fallback
-            logger.debug("get_first_snapshot_of_day not available on db_manager")
-        except (ValueError, TypeError, KeyError) as e:
-            logger.debug("Failed to recover day start balance: %s", e)
+        except Exception as e:
+            # Degraded but non-fatal: daily P&L baseline falls back to the
+            # restart-time balance.
+            logger.warning("Failed to recover day start balance: %s", e)
 
         return None
 

--- a/src/engines/live/logging/event_logger.py
+++ b/src/engines/live/logging/event_logger.py
@@ -60,6 +60,9 @@ class LiveEventLogger:
         # Daily P&L tracking state
         self._current_trading_date: date | None = None
         self._day_start_balance: float | None = None
+        # Prior session a clean restart recovered from (see
+        # set_recovery_session_id): day-start snapshots may live there.
+        self.recovery_session_id: int | None = None
 
     @property
     def enabled(self) -> bool:
@@ -131,11 +134,25 @@ class LiveEventLogger:
             self._current_trading_date = today
             self._day_start_balance = current_balance
 
+    def set_recovery_session_id(self, session_id: int | None) -> None:
+        """Record the prior session a clean restart recovered from.
+
+        A clean restart creates a NEW trading session while the day's earlier
+        snapshots live under the recovered inactive session — day-start
+        recovery must look across both (#766).
+
+        Args:
+            session_id: The recovered inactive session's ID, or None.
+        """
+        self.recovery_session_id = session_id
+
     def _get_day_start_balance_from_db(self) -> float | None:
         """Recover day start balance from database on session restart.
 
         Enables continuous daily P&L tracking across restarts by retrieving
-        the starting balance from the first snapshot of the current UTC day.
+        the starting balance from the first snapshot of the current UTC day —
+        for the current session or, on clean restarts, the prior session set
+        via ``set_recovery_session_id``.
 
         Returns:
             The day start balance if found, None otherwise.
@@ -147,13 +164,16 @@ class LiveEventLogger:
             snapshot = self.db_manager.get_first_snapshot_of_day(
                 session_id=self.session_id,
                 target_date=self._utc_today(),
+                fallback_session_id=self.recovery_session_id,
             )
             if snapshot is not None:
                 return float(snapshot.balance)
-        except Exception as e:
-            # Degraded but non-fatal: daily P&L baseline falls back to the
-            # restart-time balance.
-            logger.warning("Failed to recover day start balance: %s", e)
+        except (ValueError, TypeError, KeyError, AttributeError) as e:
+            # Data-shape failures: degraded but non-fatal — the daily P&L
+            # baseline falls back to the restart-time balance. Unexpected
+            # DB-level errors propagate to the engine's snapshot wrapper,
+            # which logs and skips the snapshot rather than crashing the loop.
+            logger.warning("Failed to recover day start balance: %s", e, exc_info=True)
 
         return None
 

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1513,6 +1513,12 @@ class LiveTradingEngine:
             self.live_execution_engine.session_id = self.trading_session_id
             self.live_execution_engine.strategy_name = self._strategy_name()
 
+            # Wire the event logger so snapshot/daily-P&L logging is session
+            # scoped; on a clean restart also point day-start recovery at the
+            # prior session, where today's earlier snapshots live (#766).
+            self.event_logger.set_session_id(self.trading_session_id)
+            self.event_logger.set_recovery_session_id(self._recovered_inactive_session_id)
+
         # Carry OPEN positions forward on a clean restart (#668). The inactive
         # session recovered above (balance only) still owns any OPEN position via
         # Position.session_id, so _recover_active_positions() at line ~1281 saw a
@@ -5163,56 +5169,26 @@ class LiveTradingEngine:
         return ml_data
 
     def _log_account_snapshot(self):
-        """Log current account state to database"""
+        """Log current account state to database via the event logger.
+
+        Routing through ``LiveEventLogger.log_account_snapshot`` keeps daily
+        P&L tracking — and its day-start recovery across restarts (#766) — on
+        the live path. The engine previously duplicated the exposure/equity/
+        drawdown math here and wrote snapshots directly with a
+        ``daily_pnl = 0`` placeholder, so live snapshots never carried daily
+        P&L and the recovery wiring was dead code.
+        """
         try:
-            # Calculate total exposure using the active fraction per position
-            positions_snapshot = self.live_position_tracker.positions
-            total_exposure = sum(
-                float(pos.current_size if pos.current_size is not None else pos.size)
-                * (
-                    float(pos.entry_balance)
-                    if pos.entry_balance is not None and pos.entry_balance > 0
-                    else float(self.current_balance)
-                )
-                for pos in positions_snapshot.values()
-            )
-
-            # Calculate equity (balance + unrealized P&L)
-            unrealized_pnl = sum(float(pos.unrealized_pnl) for pos in positions_snapshot.values())
-            equity = float(self.current_balance) + unrealized_pnl
-
-            # Calculate current drawdown percentage
-            current_drawdown: float = 0
             perf_metrics = self.performance_tracker.get_metrics()
-            if perf_metrics.peak_balance > 0:
-                current_drawdown = (
-                    (perf_metrics.peak_balance - self.current_balance)
-                    / perf_metrics.peak_balance
-                    * 100
-                )
-
-            # TODO: Calculate daily P&L (requires tracking of day start balance)
-            daily_pnl = 0  # Placeholder
-
-            # Log snapshot to database
-            if self.trading_session_id is not None:
-                self.db_manager.log_account_snapshot(
-                    balance=self.current_balance,
-                    equity=equity,
-                    total_pnl=perf_metrics.total_pnl,
-                    open_positions=self.live_position_tracker.position_count,
-                    total_exposure=total_exposure,
-                    drawdown=current_drawdown,
-                    daily_pnl=daily_pnl,
-                    session_id=self.trading_session_id,
-                )
-            else:
-                logger.warning(
-                    "⚠️ Cannot log account snapshot to database - no trading session ID available"
-                )
-
+            self.event_logger.log_account_snapshot(
+                balance=float(self.current_balance),
+                positions=self.live_position_tracker.positions,
+                total_pnl=perf_metrics.total_pnl,
+                peak_balance=perf_metrics.peak_balance,
+            )
         except Exception as e:
-            logger.error("Failed to log account snapshot: %s", e)
+            # Snapshot logging must never crash the trading loop.
+            logger.error("Failed to log account snapshot: %s", e, exc_info=True)
 
     def _log_status(self, symbol: str, current_price: float):
         """Log current trading status"""
@@ -5575,6 +5551,9 @@ class LiveTradingEngine:
                     # Wire session context to execution engine so journaling works
                     self.live_execution_engine.session_id = session_id
                     self.live_execution_engine.strategy_name = self._strategy_name()
+                    # Crash recovery reuses the session, so day-start snapshots
+                    # already live under it — no recovery fallback needed (#766).
+                    self.event_logger.set_session_id(session_id)
                 logger.info(
                     "💾 Recovered balance $%.2f from %s session #%s",
                     recovered_balance,

--- a/tests/unit/database/test_day_start_snapshot.py
+++ b/tests/unit/database/test_day_start_snapshot.py
@@ -1,0 +1,104 @@
+"""Tests for DatabaseManager.get_first_snapshot_of_day (regression for #766).
+
+The live event logger's day-start balance recovery called this method while it
+did not exist, so recovery silently never worked. These tests run against a
+real in-memory SQLite database to exercise the actual query semantics.
+"""
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.database.models import AccountHistory
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.fixture
+def db() -> DatabaseManager:
+    return DatabaseManager("sqlite:///:memory:")
+
+
+def _insert_snapshot(db: DatabaseManager, session_id: int, ts: datetime, balance: float) -> None:
+    with db.get_session() as session:
+        session.add(
+            AccountHistory(
+                timestamp=ts,
+                balance=balance,
+                equity=balance,
+                total_pnl=0.0,
+                daily_pnl=0.0,
+                drawdown=0.0,
+                open_positions=0,
+                total_exposure=0.0,
+                margin_used=0.0,
+                margin_available=balance,
+                session_id=session_id,
+            )
+        )
+        session.commit()
+
+
+class TestGetFirstSnapshotOfDay:
+    def test_returns_earliest_snapshot_of_target_day(self, db):
+        """The day's earliest row wins regardless of insert order."""
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 15, 0, tzinfo=UTC), 1100.0)
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 0, 5, tzinfo=UTC), 1000.0)
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 8, 30, tzinfo=UTC), 1050.0)
+
+        snapshot = db.get_first_snapshot_of_day(session_id=1, target_date=date(2024, 1, 2))
+
+        assert snapshot is not None
+        assert float(snapshot.balance) == 1000.0
+
+    def test_day_window_is_utc_calendar_day(self, db):
+        """Rows from the previous/next UTC day are excluded."""
+        _insert_snapshot(db, 1, datetime(2024, 1, 1, 23, 59, tzinfo=UTC), 900.0)
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 0, 0, tzinfo=UTC), 1000.0)
+        _insert_snapshot(db, 1, datetime(2024, 1, 3, 0, 0, tzinfo=UTC), 1200.0)
+
+        snapshot = db.get_first_snapshot_of_day(session_id=1, target_date=date(2024, 1, 2))
+
+        assert snapshot is not None
+        assert float(snapshot.balance) == 1000.0
+
+    def test_filters_by_session(self, db):
+        """Another session's snapshots are invisible."""
+        _insert_snapshot(db, 2, datetime(2024, 1, 2, 0, 5, tzinfo=UTC), 5000.0)
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 9, 0, tzinfo=UTC), 1000.0)
+
+        snapshot = db.get_first_snapshot_of_day(session_id=1, target_date=date(2024, 1, 2))
+
+        assert snapshot is not None
+        assert float(snapshot.balance) == 1000.0
+
+    def test_returns_none_when_day_empty(self, db):
+        """No snapshot rows on the target day returns None."""
+        _insert_snapshot(db, 1, datetime(2024, 1, 1, 12, 0, tzinfo=UTC), 900.0)
+
+        assert db.get_first_snapshot_of_day(session_id=1, target_date=date(2024, 1, 2)) is None
+
+    def test_returns_none_without_session(self, db):
+        """No session id (explicit or current) returns None."""
+        assert db.get_first_snapshot_of_day(session_id=None, target_date=date(2024, 1, 2)) is None
+
+    def test_defaults_to_current_utc_day(self, db):
+        """target_date defaults to today's UTC date."""
+        now = datetime.now(UTC)
+        _insert_snapshot(db, 1, now, 1234.0)
+
+        snapshot = db.get_first_snapshot_of_day(session_id=1)
+
+        assert snapshot is not None
+        assert float(snapshot.balance) == 1234.0
+
+    def test_attributes_readable_after_session_closes(self, db):
+        """The returned row is detached and remains readable."""
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 0, 5, tzinfo=UTC), 1000.0)
+
+        snapshot = db.get_first_snapshot_of_day(session_id=1, target_date=date(2024, 1, 2))
+
+        assert snapshot is not None
+        assert snapshot.session_id == 1
+        assert float(snapshot.equity) == 1000.0

--- a/tests/unit/database/test_day_start_snapshot.py
+++ b/tests/unit/database/test_day_start_snapshot.py
@@ -84,11 +84,16 @@ class TestGetFirstSnapshotOfDay:
         assert db.get_first_snapshot_of_day(session_id=None, target_date=date(2024, 1, 2)) is None
 
     def test_defaults_to_current_utc_day(self, db):
-        """target_date defaults to today's UTC date."""
+        """target_date defaults to today's UTC date (clock frozen: a midnight
+        tick between insert and query would otherwise split the day)."""
+        from unittest.mock import patch
+
         now = datetime.now(UTC)
         _insert_snapshot(db, 1, now, 1234.0)
 
-        snapshot = db.get_first_snapshot_of_day(session_id=1)
+        with patch("src.database.manager.datetime", wraps=datetime) as mock_dt:
+            mock_dt.now.return_value = now
+            snapshot = db.get_first_snapshot_of_day(session_id=1)
 
         assert snapshot is not None
         assert float(snapshot.balance) == 1234.0
@@ -102,3 +107,27 @@ class TestGetFirstSnapshotOfDay:
         assert snapshot is not None
         assert snapshot.session_id == 1
         assert float(snapshot.equity) == 1000.0
+
+    def test_fallback_session_covers_clean_restart(self, db):
+        """A clean restart creates a NEW session; the day's earlier snapshots
+        live under the prior session and must still be found via
+        fallback_session_id (#766 review)."""
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 0, 5, tzinfo=UTC), 1000.0)
+        _insert_snapshot(db, 2, datetime(2024, 1, 2, 12, 0, tzinfo=UTC), 1100.0)
+
+        snapshot = db.get_first_snapshot_of_day(
+            session_id=2, target_date=date(2024, 1, 2), fallback_session_id=1
+        )
+
+        assert snapshot is not None
+        assert float(snapshot.balance) == 1000.0
+
+    def test_fallback_session_ignored_when_none(self, db):
+        """Without a fallback the query stays strictly session scoped."""
+        _insert_snapshot(db, 1, datetime(2024, 1, 2, 0, 5, tzinfo=UTC), 1000.0)
+
+        snapshot = db.get_first_snapshot_of_day(
+            session_id=2, target_date=date(2024, 1, 2), fallback_session_id=None
+        )
+
+        assert snapshot is None

--- a/tests/unit/live/test_day_start_balance_recovery.py
+++ b/tests/unit/live/test_day_start_balance_recovery.py
@@ -51,15 +51,29 @@ class TestDayStartBalanceRecovery:
 
         assert event_logger._day_start_balance == 1080.0
 
-    def test_db_failure_degrades_to_current_balance(self):
-        """A DB error during recovery must not raise into the snapshot path."""
+    def test_data_shape_failure_degrades_to_current_balance(self):
+        """Data-shape errors (bad snapshot payload) degrade to the
+        restart-time balance instead of raising."""
         mock_db = create_autospec(DatabaseManager, instance=True)
-        mock_db.get_first_snapshot_of_day.side_effect = RuntimeError("db down")
+        mock_db.get_first_snapshot_of_day.side_effect = ValueError("bad balance")
 
         event_logger = _logger_with_db(mock_db)
         event_logger._check_and_update_trading_date(current_balance=1080.0)
 
         assert event_logger._day_start_balance == 1080.0
+
+    def test_unexpected_db_error_propagates(self):
+        """Unexpected DB-level errors are NOT swallowed here — they propagate
+        to the engine's snapshot wrapper, which logs with a traceback and
+        skips the snapshot (per PR review: a broad except hid connectivity
+        failures as data noise)."""
+        mock_db = create_autospec(DatabaseManager, instance=True)
+        mock_db.get_first_snapshot_of_day.side_effect = RuntimeError("db down")
+
+        event_logger = _logger_with_db(mock_db)
+
+        with pytest.raises(RuntimeError, match="db down"):
+            event_logger._check_and_update_trading_date(current_balance=1080.0)
 
     def test_no_db_or_session_returns_none(self):
         """Recovery helper degrades cleanly without a DB manager or session."""
@@ -93,9 +107,54 @@ class TestDayStartBalanceRecovery:
     def test_set_day_start_balance_uses_utc_date(self):
         """The explicit setter stamps the UTC trading date."""
         from datetime import UTC, datetime
+        from unittest.mock import patch
 
+        fixed_date = datetime.now(UTC).date()
         event_logger = _logger_with_db(Mock())
-        event_logger.set_day_start_balance(999.0)
+        with patch.object(event_logger, "_utc_today", return_value=fixed_date):
+            event_logger.set_day_start_balance(999.0)
 
         assert event_logger._day_start_balance == 999.0
-        assert event_logger._current_trading_date == datetime.now(UTC).date()
+        assert event_logger._current_trading_date == fixed_date
+
+
+class TestEngineSnapshotRouting:
+    """The live engine must route snapshots through LiveEventLogger (#766
+    review): it previously wrote snapshots directly with daily_pnl=0 and the
+    recovery wiring was dead code on the live path."""
+
+    @pytest.mark.fast
+    def test_engine_snapshot_delegates_to_event_logger(self):
+        """_log_account_snapshot forwards balance/positions/pnl/peak to the
+        event logger (which owns daily P&L tracking and recovery)."""
+        from unittest.mock import MagicMock
+
+        from src.engines.live.trading_engine import LiveTradingEngine
+
+        mock_engine = MagicMock()
+        mock_engine.current_balance = 1080.0
+        perf = MagicMock()
+        perf.total_pnl = 80.0
+        perf.peak_balance = 1100.0
+        mock_engine.performance_tracker.get_metrics.return_value = perf
+        mock_engine.live_position_tracker.positions = {}
+
+        LiveTradingEngine._log_account_snapshot(mock_engine)
+
+        kwargs = mock_engine.event_logger.log_account_snapshot.call_args.kwargs
+        assert kwargs["balance"] == 1080.0
+        assert kwargs["total_pnl"] == 80.0
+        assert kwargs["peak_balance"] == 1100.0
+        assert kwargs["positions"] == {}
+
+    @pytest.mark.fast
+    def test_engine_snapshot_failure_does_not_raise(self):
+        """Snapshot failures must never crash the trading loop."""
+        from unittest.mock import MagicMock
+
+        from src.engines.live.trading_engine import LiveTradingEngine
+
+        mock_engine = MagicMock()
+        mock_engine.performance_tracker.get_metrics.side_effect = RuntimeError("boom")
+
+        LiveTradingEngine._log_account_snapshot(mock_engine)

--- a/tests/unit/live/test_day_start_balance_recovery.py
+++ b/tests/unit/live/test_day_start_balance_recovery.py
@@ -78,10 +78,12 @@ class TestDayStartBalanceRecovery:
         event_logger._check_and_update_trading_date(current_balance=1080.0)
         assert event_logger._day_start_balance == 1000.0
 
-        # Simulate the date rolling over since the first call
-        from datetime import date, timedelta
+        # Simulate the date rolling over since the first call (UTC date —
+        # local date.today() here is flaky on UTC+N hosts during the window
+        # between local and UTC midnight, the exact skew this PR fixes)
+        from datetime import UTC, datetime, timedelta
 
-        event_logger._current_trading_date = date.today() - timedelta(days=1)
+        event_logger._current_trading_date = datetime.now(UTC).date() - timedelta(days=1)
         event_logger._check_and_update_trading_date(current_balance=1200.0)
 
         # Rollover re-anchors to the live balance; the DB is not re-queried

--- a/tests/unit/live/test_day_start_balance_recovery.py
+++ b/tests/unit/live/test_day_start_balance_recovery.py
@@ -1,0 +1,99 @@
+"""Tests for live day-start balance recovery (regression for #766).
+
+``LiveEventLogger._get_day_start_balance_from_db`` queried a DatabaseManager
+method that did not exist, and nothing invoked the recovery helper — so after
+any restart the daily P&L baseline silently reset to the restart-time balance.
+Recovery is now wired into the first ``_check_and_update_trading_date`` call.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, create_autospec
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.engines.live.logging.event_logger import LiveEventLogger
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _logger_with_db(mock_db) -> LiveEventLogger:
+    return LiveEventLogger(
+        db_manager=mock_db,
+        log_to_database=True,
+        log_trades_to_file=False,
+        session_id=7,
+    )
+
+
+class TestDayStartBalanceRecovery:
+    def test_first_check_recovers_day_start_from_db(self):
+        """An intraday restart anchors daily P&L to the day's first snapshot,
+        not the restart-time balance. Autospec enforces the real
+        get_first_snapshot_of_day signature."""
+        mock_db = create_autospec(DatabaseManager, instance=True)
+        mock_db.get_first_snapshot_of_day.return_value = SimpleNamespace(balance=1000.0)
+
+        event_logger = _logger_with_db(mock_db)
+        event_logger._check_and_update_trading_date(current_balance=1080.0)
+
+        mock_db.get_first_snapshot_of_day.assert_called_once()
+        assert mock_db.get_first_snapshot_of_day.call_args.kwargs["session_id"] == 7
+        assert event_logger._day_start_balance == 1000.0
+
+    def test_falls_back_to_current_balance_without_snapshot(self):
+        """Fresh day / fresh session (no snapshot yet) keeps old behavior."""
+        mock_db = create_autospec(DatabaseManager, instance=True)
+        mock_db.get_first_snapshot_of_day.return_value = None
+
+        event_logger = _logger_with_db(mock_db)
+        event_logger._check_and_update_trading_date(current_balance=1080.0)
+
+        assert event_logger._day_start_balance == 1080.0
+
+    def test_db_failure_degrades_to_current_balance(self):
+        """A DB error during recovery must not raise into the snapshot path."""
+        mock_db = create_autospec(DatabaseManager, instance=True)
+        mock_db.get_first_snapshot_of_day.side_effect = RuntimeError("db down")
+
+        event_logger = _logger_with_db(mock_db)
+        event_logger._check_and_update_trading_date(current_balance=1080.0)
+
+        assert event_logger._day_start_balance == 1080.0
+
+    def test_no_db_or_session_returns_none(self):
+        """Recovery helper degrades cleanly without a DB manager or session."""
+        event_logger = LiveEventLogger(
+            db_manager=None, log_to_database=False, log_trades_to_file=False, session_id=None
+        )
+
+        assert event_logger._get_day_start_balance_from_db() is None
+
+    def test_rollover_resets_to_current_balance(self):
+        """A date rollover uses the live balance, not a stale DB snapshot."""
+        mock_db = create_autospec(DatabaseManager, instance=True)
+        mock_db.get_first_snapshot_of_day.return_value = SimpleNamespace(balance=1000.0)
+
+        event_logger = _logger_with_db(mock_db)
+        event_logger._check_and_update_trading_date(current_balance=1080.0)
+        assert event_logger._day_start_balance == 1000.0
+
+        # Simulate the date rolling over since the first call
+        from datetime import date, timedelta
+
+        event_logger._current_trading_date = date.today() - timedelta(days=1)
+        event_logger._check_and_update_trading_date(current_balance=1200.0)
+
+        # Rollover re-anchors to the live balance; the DB is not re-queried
+        assert event_logger._day_start_balance == 1200.0
+        assert mock_db.get_first_snapshot_of_day.call_count == 1
+
+    def test_set_day_start_balance_uses_utc_date(self):
+        """The explicit setter stamps the UTC trading date."""
+        from datetime import UTC, datetime
+
+        event_logger = _logger_with_db(Mock())
+        event_logger.set_day_start_balance(999.0)
+
+        assert event_logger._day_start_balance == 999.0
+        assert event_logger._current_trading_date == datetime.now(UTC).date()

--- a/tests/unit/live/test_handler_bug_fixes.py
+++ b/tests/unit/live/test_handler_bug_fixes.py
@@ -617,8 +617,10 @@ class TestDailyPnLTracking:
 
     def test_daily_pnl_initialized_on_first_snapshot(self) -> None:
         """Daily P&L should be 0 on first snapshot (balance = day start balance)."""
-        # Arrange
+        # Arrange: no persisted snapshot exists for the day (#766 recovery
+        # returns None), so the first call anchors to the current balance.
         db_manager = MagicMock()
+        db_manager.get_first_snapshot_of_day.return_value = None
         logger = LiveEventLogger(
             db_manager=db_manager,
             log_to_database=True,
@@ -639,8 +641,10 @@ class TestDailyPnLTracking:
 
     def test_daily_pnl_calculated_from_day_start_balance(self) -> None:
         """Daily P&L should be calculated from day start balance."""
-        # Arrange
+        # Arrange: no persisted snapshot exists for the day (#766 recovery
+        # returns None), so the first call anchors to the current balance.
         db_manager = MagicMock()
+        db_manager.get_first_snapshot_of_day.return_value = None
         logger = LiveEventLogger(
             db_manager=db_manager,
             log_to_database=True,


### PR DESCRIPTION
## Summary

Fixes #766 — live day-start balance recovery was **doubly dead**: `LiveEventLogger._get_day_start_balance_from_db` queried `DatabaseManager.get_first_snapshot_of_day`, which was never implemented (the `AttributeError` was swallowed as a "graceful fallback"), and nothing ever invoked the recovery helper anyway. Net effect: after **any** intraday restart (deploys, WS hard reconnects — routine events) the daily P&L baseline silently reset to the restart-time balance.

## Changes

- `src/database/manager.py`: new `get_first_snapshot_of_day(session_id, target_date)` — earliest `account_history` row of the **UTC** calendar day for the session (`[00:00, 24:00) UTC` window, matching the `datetime.now(UTC)` timestamps snapshots are written with), ANALYTICS query timeout, row detached before return.
- `src/engines/live/logging/event_logger.py`:
  - Recovery is **wired in**: the first `_check_and_update_trading_date` call after engine start anchors to the day's first persisted snapshot when one exists, falling back to the current balance (fresh day/session).
  - Trading-day semantics are explicitly **UTC** throughout (`_utc_today()` helper) — previously local `date.today()`, which skews day boundaries on non-UTC hosts; behavior-neutral on UTC servers (production) and correct elsewhere.
  - The dead `except AttributeError` fallback and `# type: ignore[attr-defined]` are gone; DB failures degrade to the restart-time balance with a WARNING.
- Tests: `tests/unit/database/test_day_start_snapshot.py` (new, 7 tests, real in-memory SQLite — earliest-of-day, UTC window boundaries, session isolation, empty day, defaults, detached row) and `tests/unit/live/test_day_start_balance_recovery.py` (new, 6 tests, autospec'd DatabaseManager — restart anchoring, fallback, failure degradation, rollover semantics). Two existing daily-P&L tests updated to return `None` from the mock (their scenario is "no snapshot exists"; MagicMock's auto-`__float__` otherwise faked a 1.0 recovered balance).

## Testing

- `pytest tests/unit/database tests/unit/live` — 503 passed.
- mypy / black / ruff clean on touched files.

Closes #766

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_