### PR TITLE
fix(backtest): runtime context exposes the open position to strategies

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Backtest strategies can finally see their open position (#756):
+  `_build_runtime_context` passed the `PositionSide` enum into
+  `ComponentPosition`, whose validation expects "long"/"short" strings, so
+  construction raised `ValueError` on every candle (swallowed) and component
+  strategies always received `current_positions=None` — while live populated
+  it correctly. Position-aware logic (pyramiding guards, exposure checks) was
+  silently inert in backtests. The side now converts via `to_side_string`,
+  exactly like live.
 - `TradeProtocol` members are now read-only properties (#767), so concrete
   trade classes with narrower types (non-Optional datetimes, `PositionSide`
   enum side) conform structurally — the three `cast("TradeProtocol", ...)`

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -58,6 +58,7 @@ from src.engines.shared.risk_configuration import (
     build_trailing_stop_policy,
     merge_dynamic_risk_config,
 )
+from src.engines.shared.side_utils import to_side_string
 from src.infrastructure.logging.context import set_context, update_context
 from src.infrastructure.logging.events import log_engine_event
 from src.position_management.correlation_engine import CorrelationConfig, CorrelationEngine
@@ -746,15 +747,10 @@ class Backtester:
                 positions.append(
                     ComponentPosition(
                         symbol=trade.symbol,
-                        # KNOWN BUG (typing surfaced, behavior preserved): trade.side
-                        # is a PositionSide enum after __post_init__ normalization,
-                        # but ComponentPosition validates side against the strings
-                        # 'long'/'short', so construction always raises ValueError
-                        # and is swallowed below — the runtime context never sees
-                        # open positions (live passes side.value; parity gap).
-                        # Converting here would change strategy inputs; tracked for
-                        # a separate behavioral fix.
-                        side=trade.side,  # type: ignore[arg-type]
+                        # ComponentPosition validates side against the strings
+                        # "long"/"short"; convert the PositionSide enum exactly
+                        # like the live engine does (parity, #756).
+                        side=to_side_string(trade.side),
                         size=float(notional),
                         entry_price=float(trade.entry_price),
                         current_price=float(current_price),
@@ -763,7 +759,7 @@ class Backtester:
                 )
             except Exception as exc:
                 # Per-candle hot loop while a position is open: WARN once per
-                # engine instance so the failure (see KNOWN BUG above) is
+                # engine instance so an unexpected translation failure is
                 # visible, then drop to debug to avoid flooding the run.
                 if not getattr(self, "_runtime_position_translation_warned", False):
                     self._runtime_position_translation_warned = True

--- a/tests/unit/backtesting/test_runtime_context_positions.py
+++ b/tests/unit/backtesting/test_runtime_context_positions.py
@@ -1,0 +1,115 @@
+"""Regression tests for #756: backtest RuntimeContext must expose open positions.
+
+``Backtester._build_runtime_context`` passed the shared ``PositionSide`` enum
+into ``ComponentPosition``, whose validation expects the strings
+``"long"``/``"short"`` — construction raised ``ValueError`` on every candle,
+was swallowed, and component strategies always saw ``current_positions=None``
+while live strategies saw the real position (parity gap).
+"""
+
+import logging
+from datetime import UTC, datetime
+from unittest.mock import Mock
+
+import pytest
+
+from src.engines.backtest.engine import Backtester
+from src.engines.backtest.models import ActiveTrade
+from src.engines.shared.models import PositionSide
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.fixture
+def backtester(mock_data_provider):
+    return Backtester(
+        strategy=create_ml_basic_strategy(),
+        data_provider=mock_data_provider,
+        initial_balance=10_000,
+        log_to_database=False,
+    )
+
+
+def _open_position(backtester: Backtester, side: PositionSide) -> None:
+    backtester.position_tracker.open_position(
+        ActiveTrade(
+            symbol="BTCUSDT",
+            side=side,
+            entry_price=100.0,
+            entry_time=datetime(2024, 1, 1, tzinfo=UTC),
+            size=0.1,
+            entry_balance=10_000.0,
+        )
+    )
+
+
+class TestRuntimeContextPositions:
+    def test_open_long_position_visible_to_strategies(self, backtester, caplog):
+        """The active trade appears in RuntimeContext with a string side."""
+        _open_position(backtester, PositionSide.LONG)
+
+        with caplog.at_level(logging.WARNING):
+            ctx = backtester._build_runtime_context(
+                balance=10_000.0, current_price=110.0, current_time=datetime.now(UTC)
+            )
+
+        assert ctx.current_positions is not None
+        assert len(ctx.current_positions) == 1
+        position = ctx.current_positions[0]
+        assert position.symbol == "BTCUSDT"
+        assert position.side == "long"
+        assert position.entry_price == 100.0
+        assert position.current_price == 110.0
+        # The old bug logged a translation warning every run
+        assert "Failed to translate active trade" not in caplog.text
+
+    def test_open_short_position_visible_to_strategies(self, backtester):
+        _open_position(backtester, PositionSide.SHORT)
+
+        ctx = backtester._build_runtime_context(
+            balance=10_000.0, current_price=90.0, current_time=datetime.now(UTC)
+        )
+
+        assert ctx.current_positions is not None
+        assert ctx.current_positions[0].side == "short"
+
+    def test_no_position_yields_none(self, backtester):
+        ctx = backtester._build_runtime_context(
+            balance=10_000.0, current_price=100.0, current_time=datetime.now(UTC)
+        )
+
+        assert ctx.current_positions is None
+
+    def test_position_size_uses_notional(self, backtester):
+        """Size is the notional (fraction × balance), matching live's quantity
+        semantics for the runtime context."""
+        _open_position(backtester, PositionSide.LONG)
+
+        ctx = backtester._build_runtime_context(
+            balance=10_000.0, current_price=110.0, current_time=datetime.now(UTC)
+        )
+
+        assert ctx.current_positions is not None
+        assert ctx.current_positions[0].size == pytest.approx(0.1 * 10_000.0)
+
+
+class TestRuntimeContextTranslationFailure:
+    def test_unexpected_failure_warns_once_then_debug(self, backtester, caplog):
+        """The defensive warn-once path still guards unexpected failures."""
+        _open_position(backtester, PositionSide.LONG)
+        # Corrupt the trade so translation genuinely fails
+        backtester.position_tracker.current_trade.entry_price = Mock(side_effect=TypeError("boom"))
+        backtester.position_tracker.current_trade.symbol = None  # ComponentPosition rejects
+
+        with caplog.at_level(logging.WARNING):
+            ctx1 = backtester._build_runtime_context(
+                balance=10_000.0, current_price=110.0, current_time=datetime.now(UTC)
+            )
+            ctx2 = backtester._build_runtime_context(
+                balance=10_000.0, current_price=110.0, current_time=datetime.now(UTC)
+            )
+
+        assert ctx1.current_positions is None
+        assert ctx2.current_positions is None
+        assert caplog.text.count("Failed to translate active trade") == 1


### PR DESCRIPTION
## Summary

Fixes #756 — the highest-priority parity bug from the static-analysis sweep: **backtest strategies never saw their open position**. `Backtester._build_runtime_context` passed the shared `PositionSide` enum into `ComponentPosition`, whose `_validate_position` checks `side not in ["long", "short"]` — an enum never equals those strings, so construction raised `ValueError` on **every candle with an open position**, was swallowed by the defensive except, and component strategies always received `current_positions=None`. Live passes `position.side.value` and works, so any position-aware strategy logic (pyramiding guards, exposure checks, position-conditional sizing) was silently inert in backtests while active in live.

## Changes

- `src/engines/backtest/engine.py`: side converts via the shared `to_side_string(trade.side)` — the exact normalization live uses. `KNOWN BUG` comment and `# type: ignore[arg-type]` removed. The warn-once defensive handler stays for genuinely unexpected translation failures.
- `tests/unit/backtesting/test_runtime_context_positions.py` (new, 5 tests): long and short positions appear in the context with string sides and correct prices (and **no** translation warning — the old bug warned on every run); no-position case yields `None`; size carries the notional; the warn-once-then-debug defensive path still works when translation genuinely fails.

## Impact note for reviewers

This intentionally **changes backtest results** for strategies that read `RuntimeContext.current_positions` — they now see the position, as they always did in live. That is the fix: backtests for position-aware strategies were structurally wrong before. Strategies that ignore the context are unaffected (full backtesting suite passes unchanged).

## Testing

- `pytest tests/unit/backtesting tests/unit/engines/backtest` — 135 passed (5 new).
- mypy / black / ruff clean on touched files.

Closes #756

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_