### PR TITLE
fix(backtest): risk tracking registers next-bar entries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Backtest risk tracking now covers next-bar (pending) entries (#757):
+  the post-fill `RiskManager.update_position` call passed the `PositionSide`
+  enum, whose string validation (`side in VALID_SIDES`) raised `ValueError`
+  on every call — swallowed with a warning — so `daily_risk_used` and
+  position tracking for correlation control silently omitted every pending
+  entry. Backtests could take position sequences a correctly-accounted run
+  would have rejected. The side now converts via `to_side_string`, like the
+  immediate-entry path.
 - `TradeProtocol` members are now read-only properties (#767), so concrete
   trade classes with narrower types (non-Optional datetimes, `PositionSide`
   enum side) conform structurally — the three `cast("TradeProtocol", ...)`

--- a/src/engines/backtest/execution/entry_handler.py
+++ b/src/engines/backtest/execution/entry_handler.py
@@ -530,18 +530,12 @@ class EntryHandler:
             # Open position in tracker
             self.position_tracker.open_position(result.trade)
 
-            # Update risk manager
+            # Update risk manager (update_position validates string sides;
+            # convert the PositionSide enum like the immediate-entry path, #757)
             try:
-                # KNOWN BUG (typing surfaced, behavior preserved): result.trade.side
-                # is a PositionSide enum after __post_init__ normalization, but
-                # update_position validates `side in VALID_SIDES` (strings), so this
-                # call always raises ValueError and is swallowed by the except below,
-                # skipping risk tracking for pending (next-bar) entries. Converting
-                # via to_side_string here would change runtime behavior; tracked for
-                # a separate behavioral fix.
                 self.risk_manager.update_position(
                     symbol=symbol,
-                    side=result.trade.side,  # type: ignore[arg-type]
+                    side=to_side_string(result.trade.side),
                     size=result.trade.size,
                     entry_price=result.trade.entry_price,
                 )

--- a/src/engines/backtest/execution/entry_handler.py
+++ b/src/engines/backtest/execution/entry_handler.py
@@ -530,8 +530,8 @@ class EntryHandler:
             # Open position in tracker
             self.position_tracker.open_position(result.trade)
 
-            # Update risk manager (update_position validates string sides;
-            # convert the PositionSide enum like the immediate-entry path, #757)
+            # Update risk manager (update_position validates string sides,
+            # so the PositionSide enum must be converted)
             try:
                 self.risk_manager.update_position(
                     symbol=symbol,

--- a/tests/unit/backtesting/test_pending_entry_execution.py
+++ b/tests/unit/backtesting/test_pending_entry_execution.py
@@ -1,14 +1,17 @@
 """Tests for pending entry execution behavior."""
 
 from datetime import datetime
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, create_autospec
 
 import pandas as pd
 import pytest
 
 from src.engines.backtest.execution.entry_handler import EntryHandler
 from src.engines.backtest.execution.execution_engine import ExecutionEngine
+from src.engines.backtest.execution.position_tracker import PositionTracker
 from src.engines.shared.execution.execution_decision import ExecutionDecision
+from src.engines.shared.execution.execution_model import ExecutionModel
+from src.risk.risk_manager import RiskManager
 
 
 def test_pending_entry_no_fill_does_not_execute_trade() -> None:
@@ -62,14 +65,11 @@ def test_pending_entry_no_fill_does_not_execute_trade() -> None:
     risk_manager.update_position.assert_not_called()
 
 
+@pytest.mark.fast
 def test_pending_entry_updates_risk_tracking() -> None:
-    """Regression for #757: a filled pending (next-bar) entry must register in
-    the REAL risk manager. The handler previously passed the PositionSide enum
-    to update_position, whose `side in VALID_SIDES` (strings) check raised
-    ValueError on every call — swallowed by the except — so daily risk and
-    position tracking silently skipped all next-bar entries."""
-    from src.risk.risk_manager import RiskManager
-
+    """A filled pending (next-bar) entry registers in the real risk manager:
+    the position is tracked under a string side and its size accrues to the
+    daily risk budget — identically to an immediate entry."""
     execution_engine = ExecutionEngine()
     execution_engine.queue_entry(
         side="long",
@@ -80,9 +80,9 @@ def test_pending_entry_updates_risk_tracking() -> None:
         signal_time=datetime(2024, 1, 1),
     )
 
-    position_tracker = Mock()
+    position_tracker = create_autospec(PositionTracker, instance=True)
     risk_manager = RiskManager()
-    execution_model = Mock()
+    execution_model = create_autospec(ExecutionModel, instance=True)
     execution_model.decide_fill.return_value = ExecutionDecision(
         should_fill=True,
         fill_price=100.0,
@@ -111,6 +111,7 @@ def test_pending_entry_updates_risk_tracking() -> None:
     )
 
     assert result.executed is True
-    assert "BTCUSDT" in risk_manager.positions
-    assert risk_manager.positions["BTCUSDT"]["side"] == "long"
+    positions = risk_manager.get_positions_snapshot()
+    assert "BTCUSDT" in positions
+    assert positions["BTCUSDT"]["side"] == "long"
     assert risk_manager.daily_risk_used == pytest.approx(0.1)

--- a/tests/unit/backtesting/test_pending_entry_execution.py
+++ b/tests/unit/backtesting/test_pending_entry_execution.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, Mock
 
 import pandas as pd
+import pytest
 
 from src.engines.backtest.execution.entry_handler import EntryHandler
 from src.engines.backtest.execution.execution_engine import ExecutionEngine
@@ -59,3 +60,57 @@ def test_pending_entry_no_fill_does_not_execute_trade() -> None:
     assert execution_engine.has_pending_entry is True
     position_tracker.open_position.assert_not_called()
     risk_manager.update_position.assert_not_called()
+
+
+def test_pending_entry_updates_risk_tracking() -> None:
+    """Regression for #757: a filled pending (next-bar) entry must register in
+    the REAL risk manager. The handler previously passed the PositionSide enum
+    to update_position, whose `side in VALID_SIDES` (strings) check raised
+    ValueError on every call — swallowed by the except — so daily risk and
+    position tracking silently skipped all next-bar entries."""
+    from src.risk.risk_manager import RiskManager
+
+    execution_engine = ExecutionEngine()
+    execution_engine.queue_entry(
+        side="long",
+        size_fraction=0.1,
+        sl_pct=0.05,
+        tp_pct=0.04,
+        signal_price=100.0,
+        signal_time=datetime(2024, 1, 1),
+    )
+
+    position_tracker = Mock()
+    risk_manager = RiskManager()
+    execution_model = Mock()
+    execution_model.decide_fill.return_value = ExecutionDecision(
+        should_fill=True,
+        fill_price=100.0,
+        filled_quantity=10.0,
+        liquidity="taker",
+        reason="test fill",
+    )
+
+    handler = EntryHandler(
+        execution_engine=execution_engine,
+        position_tracker=position_tracker,
+        risk_manager=risk_manager,
+        execution_model=execution_model,
+    )
+
+    candle = pd.Series(
+        {"open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 1000.0}
+    )
+
+    result = handler.process_pending_entry(
+        symbol="BTCUSDT",
+        open_price=100.0,
+        current_time=datetime(2024, 1, 1, 1),
+        balance=10000.0,
+        candle=candle,
+    )
+
+    assert result.executed is True
+    assert "BTCUSDT" in risk_manager.positions
+    assert risk_manager.positions["BTCUSDT"]["side"] == "long"
+    assert risk_manager.daily_risk_used == pytest.approx(0.1)


### PR DESCRIPTION
## Summary

Fixes #757 — backtest risk accounting silently omitted every **next-bar (pending) entry**. After a pending entry filled, `process_pending_entry` passed the shared `PositionSide` enum to `RiskManager.update_position`, whose `side in VALID_SIDES` check compares against the strings `{"long", "short"}` — the membership test always failed, the `ValueError` was swallowed by the warning handler, and:

- `daily_risk_used` never accumulated pending-entry exposure → backtests could take position sequences a correctly-accounted run would have rejected;
- `RiskManager.positions` never tracked the symbol → correlation control never saw the exposure.

The immediate-entry sibling path passes a string side and was unaffected — making backtest results quietly depend on the execution mode.

## Changes

- `src/engines/backtest/execution/entry_handler.py`: convert via the shared `to_side_string(result.trade.side)` (already imported and used elsewhere in the file); removed the `KNOWN BUG` comment and `# type: ignore[arg-type]`. The defensive except stays for genuinely unexpected failures.
- `tests/unit/backtesting/test_pending_entry_execution.py`: regression test drives a **real** `RiskManager` through a filled pending entry — asserts the position is tracked with a string side and `daily_risk_used == size`. (Fails on the old code: the swallowed `ValueError` left both empty.)

## Impact note for reviewers

This intentionally changes backtest results for strategies using next-bar execution: risk limits (`max_daily_risk`, correlation control) now actually bind on pending entries, as they always did for immediate entries and in live. Full backtesting suite passes (106).

## Testing

- `pytest tests/unit/backtesting` — 106 passed (1 new).
- mypy / black / ruff clean on touched files.

Closes #757

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_