### PR TITLE
fix(database): normalize foreign-enum sides in log_trade

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Backtest trades persist the correct `pnl_percent` for longs (#758):
+  the backtest event logger passed the engines' `PositionSide` enum into
+  `log_trade`, which compares against the **database** `PositionSide` —
+  cross-enum equality is always False, so every long backtest trade was
+  stored with the short formula (sign-flipped). `log_trade` now normalizes
+  any Enum side/source by value before classification (hardens all callers)
+  and the backtest call site converts via `to_side_string`.
 - `TradeProtocol` members are now read-only properties (#767), so concrete
   trade classes with narrower types (non-Optional datetimes, `PositionSide`
   enum side) conform structurally — the three `cast("TradeProtocol", ...)`

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -12,7 +12,7 @@ from contextlib import ExitStack, contextmanager
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from enum import Enum
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import sqlalchemy as sa
 from sqlalchemy import and_, create_engine, text
@@ -47,6 +47,9 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Database enum type for _normalize_db_enum
+_DbEnumT = TypeVar("_DbEnumT", bound=Enum)
 
 
 # Query timeout categories for differentiated timeout handling
@@ -719,6 +722,22 @@ class DatabaseManager:
 
             logger.info(f"Ended trading session #{session_id}")
 
+    @staticmethod
+    def _normalize_db_enum(value: str | Enum, enum_cls: type[_DbEnumT]) -> _DbEnumT:
+        """Normalize a string or foreign-enum value onto a database enum.
+
+        Engines pass their own enums (e.g. ``engines/shared`` ``PositionSide``)
+        whose members never compare equal to the database enums — values are
+        therefore matched by their string value, case-insensitively (#758).
+
+        Raises:
+            KeyError: If the value does not name a member of ``enum_cls``.
+        """
+        if isinstance(value, enum_cls):
+            return value
+        raw = str(value.value) if isinstance(value, Enum) else value
+        return enum_cls[raw.upper()]
+
     def log_trade(
         self,
         symbol: str,
@@ -800,30 +819,24 @@ class DatabaseManager:
 
         # Use WRITE timeout - trade logging requires durability guarantees
         with self.get_session_with_timeout(QueryTimeout.WRITE) as session:
-            # Normalize sides/sources to the DATABASE enums. Engines pass their
-            # own PositionSide (engines/shared), and cross-enum equality is
-            # always False — that misclassified every long backtest trade onto
-            # the short pnl_percent formula (#758). Compare by value, not enum
-            # identity, so any side representation classifies correctly.
-            if isinstance(side, Enum) and not isinstance(side, PositionSide):
-                side = str(side.value)
-            if isinstance(side, str):
-                side = PositionSide[side.upper()]
-            if isinstance(source, Enum) and not isinstance(source, TradeSource):
-                source = str(source.value)
-            if isinstance(source, str):
-                source = TradeSource[source.upper()]
+            # Normalize sides/sources to the DATABASE enums (fresh locals, no
+            # argument reassignment). Engines pass their own PositionSide
+            # (engines/shared), and cross-enum equality is always False — that
+            # misclassified every long backtest trade onto the short
+            # pnl_percent formula (#758).
+            db_side = self._normalize_db_enum(side, PositionSide)
+            db_source = self._normalize_db_enum(source, TradeSource)
 
             # Calculate percentage P&L (entry_price validated positive above)
-            if side == PositionSide.LONG:
+            if db_side == PositionSide.LONG:
                 pnl_percent = ((exit_price - entry_price) / entry_price) * 100
             else:
                 pnl_percent = ((entry_price - exit_price) / entry_price) * 100
 
             trade = Trade(
                 symbol=symbol,
-                side=side,
-                source=source,
+                side=db_side,
+                source=db_source,
                 entry_price=entry_price,
                 exit_price=exit_price,
                 size=size,
@@ -904,7 +917,7 @@ class DatabaseManager:
                 raise
 
             logger.info(
-                f"Logged trade #{trade.id}: {symbol} {side.value} P&L: ${pnl:.2f} ({pnl_percent:.2f}%)"
+                f"Logged trade #{trade.id}: {symbol} {db_side.value} P&L: ${pnl:.2f} ({pnl_percent:.2f}%)"
             )
 
             # Update performance metrics - handle None session_id

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -11,6 +11,7 @@ from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
+from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
 
 import sqlalchemy as sa
@@ -799,9 +800,17 @@ class DatabaseManager:
 
         # Use WRITE timeout - trade logging requires durability guarantees
         with self.get_session_with_timeout(QueryTimeout.WRITE) as session:
-            # Convert string enums if necessary
+            # Normalize sides/sources to the DATABASE enums. Engines pass their
+            # own PositionSide (engines/shared), and cross-enum equality is
+            # always False — that misclassified every long backtest trade onto
+            # the short pnl_percent formula (#758). Compare by value, not enum
+            # identity, so any side representation classifies correctly.
+            if isinstance(side, Enum) and not isinstance(side, PositionSide):
+                side = str(side.value)
             if isinstance(side, str):
                 side = PositionSide[side.upper()]
+            if isinstance(source, Enum) and not isinstance(source, TradeSource):
+                source = str(source.value)
             if isinstance(source, str):
                 source = TradeSource[source.upper()]
 

--- a/src/engines/backtest/logging/event_logger.py
+++ b/src/engines/backtest/logging/event_logger.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
 from src.config.constants import DEFAULT_CONFIDENCE_SCORE
+from src.engines.shared.side_utils import to_side_string
 
 if TYPE_CHECKING:
     from src.database.manager import DatabaseManager
@@ -228,14 +229,12 @@ class EventLogger:
         # cast: the enabled guard above guarantees db_manager is not None
         db_manager = cast("DatabaseManager", self.db_manager)
         try:
-            # KNOWN BUG (typing surfaced, behavior preserved): trade.side is the
-            # shared engines PositionSide enum, while log_trade expects str or the
-            # database PositionSide enum. The cross-enum comparison inside log_trade
-            # misclassifies the side (see report); normalizing here would change
-            # persisted values, so it is left for a separate behavioral fix.
             db_manager.log_trade(
                 symbol=symbol,
-                side=trade.side,  # type: ignore[arg-type]
+                # log_trade expects str or the database PositionSide; convert
+                # the shared engines enum so long/short classifies correctly
+                # and pnl_percent persists with the right formula (#758).
+                side=to_side_string(trade.side),
                 entry_price=trade.entry_price,
                 exit_price=trade.exit_price,
                 size=trade.size,

--- a/tests/unit/database/test_log_trade_side_normalization.py
+++ b/tests/unit/database/test_log_trade_side_normalization.py
@@ -20,10 +20,12 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 @pytest.fixture
 def db() -> DatabaseManager:
+    """In-memory SQLite-backed manager exercising the real log_trade path."""
     return DatabaseManager("sqlite:///:memory:")
 
 
 def _log_trade(db: DatabaseManager, side, entry_price: float, exit_price: float) -> int:
+    """Log a minimal trade with the given side representation; returns row id."""
     return db.log_trade(
         symbol="BTCUSDT",
         side=side,
@@ -40,6 +42,7 @@ def _log_trade(db: DatabaseManager, side, entry_price: float, exit_price: float)
 
 
 def _fetch_trade(db: DatabaseManager, trade_id: int):
+    """Load the persisted Trade row back, detached from the session."""
     from src.database.models import Trade
 
     with db.get_session() as session:
@@ -60,6 +63,7 @@ class TestLogTradeSideNormalization:
         assert float(trade.pnl_percent) == pytest.approx(10.0)
 
     def test_shared_enum_short_uses_short_formula(self, db):
+        """A profitable short logged with the shared enum keeps the short formula."""
         trade_id = _log_trade(db, SharedPositionSide.SHORT, entry_price=100.0, exit_price=90.0)
 
         trade = _fetch_trade(db, trade_id)

--- a/tests/unit/database/test_log_trade_side_normalization.py
+++ b/tests/unit/database/test_log_trade_side_normalization.py
@@ -1,0 +1,83 @@
+"""Regression tests for #758: log_trade misclassified foreign-enum sides.
+
+The engines pass their own ``PositionSide`` enum (``engines/shared``), while
+``log_trade`` compared against the **database** ``PositionSide`` — cross-enum
+equality is always ``False``, so every long backtest trade was persisted with
+the short ``pnl_percent`` formula. ``log_trade`` now normalizes any Enum input
+by value before classification.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.database.models import PositionSide as DbPositionSide
+from src.engines.shared.models import PositionSide as SharedPositionSide
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.fixture
+def db() -> DatabaseManager:
+    return DatabaseManager("sqlite:///:memory:")
+
+
+def _log_trade(db: DatabaseManager, side, entry_price: float, exit_price: float) -> int:
+    return db.log_trade(
+        symbol="BTCUSDT",
+        side=side,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        size=0.1,
+        entry_time=datetime(2024, 1, 1, 10, tzinfo=UTC),
+        exit_time=datetime(2024, 1, 1, 12, tzinfo=UTC),
+        pnl=10.0,
+        exit_reason="test",
+        strategy_name="test",
+        source="BACKTEST",
+    )
+
+
+def _fetch_trade(db: DatabaseManager, trade_id: int):
+    from src.database.models import Trade
+
+    with db.get_session() as session:
+        trade = session.query(Trade).filter(Trade.id == trade_id).one()
+        session.expunge(trade)
+        return trade
+
+
+class TestLogTradeSideNormalization:
+    def test_shared_enum_long_uses_long_formula(self, db):
+        """Regression: a profitable long logged with the SHARED enum must
+        persist a positive pnl_percent (the old cross-enum comparison fell
+        through to the short formula and stored it negative)."""
+        trade_id = _log_trade(db, SharedPositionSide.LONG, entry_price=100.0, exit_price=110.0)
+
+        trade = _fetch_trade(db, trade_id)
+        assert trade.side == DbPositionSide.LONG
+        assert float(trade.pnl_percent) == pytest.approx(10.0)
+
+    def test_shared_enum_short_uses_short_formula(self, db):
+        trade_id = _log_trade(db, SharedPositionSide.SHORT, entry_price=100.0, exit_price=90.0)
+
+        trade = _fetch_trade(db, trade_id)
+        assert trade.side == DbPositionSide.SHORT
+        assert float(trade.pnl_percent) == pytest.approx(10.0)
+
+    def test_string_sides_still_work(self, db):
+        """Existing string-side callers are unchanged (both cases)."""
+        long_id = _log_trade(db, "long", entry_price=100.0, exit_price=105.0)
+        short_id = _log_trade(db, "SHORT", entry_price=100.0, exit_price=95.0)
+
+        assert float(_fetch_trade(db, long_id).pnl_percent) == pytest.approx(5.0)
+        assert float(_fetch_trade(db, short_id).pnl_percent) == pytest.approx(5.0)
+
+    def test_database_enum_still_works(self, db):
+        """Callers already passing the database enum are unchanged."""
+        trade_id = _log_trade(db, DbPositionSide.LONG, entry_price=100.0, exit_price=120.0)
+
+        trade = _fetch_trade(db, trade_id)
+        assert trade.side == DbPositionSide.LONG
+        assert float(trade.pnl_percent) == pytest.approx(20.0)


### PR DESCRIPTION
## Summary

Fixes #758 — every **long** backtest trade was persisted with the **short** `pnl_percent` formula (sign-flipped). The backtest event logger passed the engines' `PositionSide` enum (`engines/shared`, values `"long"/"short"`) into `DatabaseManager.log_trade`, which classifies the side against the **database** `PositionSide` enum (values `"LONG"/"SHORT"`). Two distinct enum classes never compare equal, so `side == PositionSide.LONG` was always `False` and the `else` (short) branch always ran — and the foreign enum object also reached the SQLAlchemy enum column binding.

Dashboards and any analysis built on `trades.pnl_percent` from backtest sessions were wrong for longs. Live trades were unaffected (live passes strings/the DB enum), so persisted rows were silently inconsistent between sources.

## Changes

- `src/database/manager.py`: `log_trade` now **normalizes any `Enum` side/source by value** before classification (`isinstance(side, Enum) and not isinstance(side, PositionSide)` → `str(side.value)` → existing uppercase lookup). This hardens **every** caller, present and future, against the cross-enum trap.
- `src/engines/backtest/logging/event_logger.py`: call site also converts via the shared `to_side_string(trade.side)` (belt-and-braces + removes the `# type: ignore[arg-type]` and `KNOWN BUG` comment).
- `tests/unit/database/test_log_trade_side_normalization.py` (new, 4 tests, real in-memory SQLite): shared-enum LONG persists `pnl_percent == +10%` with `trades.side == DbPositionSide.LONG` (**fails on old code**: stored −10%); shared-enum SHORT correct; string sides (both cases) and database-enum callers unchanged.

## Note for reviewers

Historical backtest rows written before this fix carry sign-flipped `pnl_percent` for longs (gross `pnl` was always correct). Happy to ship a one-off data-repair script as a follow-up if wanted — flagging rather than bundling data migration into the behavioral fix.

## Testing

- `pytest tests/unit/database tests/unit/backtesting` — 187 passed (4 new).
- mypy / black / ruff clean on touched files.

Closes #758

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR)_