### PR TITLE
fix(risk): correlation peers fetched with a real window — no silent drops

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Correlation control no longer silently drops peer symbols (#759): the
+  no-window fallback omitted the required `start` argument, so every call
+  raised `TypeError` (swallowed) and the peer vanished from correlated-
+  exposure accounting in BOTH engines. A failed window computation now falls
+  back to the default correlation window; when no time window is derivable
+  at all (non-datetime index), peers are skipped with an explicit WARNING
+  instead of fabricating a wall-clock window (backtest lookahead).
 - `TradeProtocol` members are now read-only properties (#767), so concrete
   trade classes with narrower types (non-Optional datetimes, `PositionSide`
   enum side) conform structurally — the three `cast("TradeProtocol", ...)`

--- a/src/engines/shared/correlation_handler.py
+++ b/src/engines/shared/correlation_handler.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pandas as pd
 
+from src.config.constants import DEFAULT_CORRELATION_WINDOW_DAYS
+
 if TYPE_CHECKING:
     from src.data_providers.data_provider import DataProvider
     from src.position_management.correlation_engine import CorrelationEngine
@@ -190,7 +192,7 @@ class CorrelationHandler:
                 )
             except Exception as exc:
                 # Debug level: per-candle hot loop; without start_ts the fetch
-                # below falls back to the unwindowed call.
+                # below falls back to the default correlation window.
                 logger.debug("Failed to compute correlation window start for %s: %s", symbol, exc)
 
         # Get currently open positions from snapshot (thread-safe)
@@ -203,33 +205,47 @@ class CorrelationHandler:
             # peer symbols are added to the correlation series.
             logger.debug("Failed to read open positions snapshot for %s: %s", symbol, exc)
 
+        # Peer symbols still needing a price series
+        peers = sorted(open_symbols - set(price_series.keys()) - {str(symbol)})
+        if not peers:
+            return price_series
+
+        if not isinstance(end_ts, pd.Timestamp):
+            # Without a real end timestamp (e.g. a non-datetime index) no
+            # history window can be derived. Skip peers loudly rather than
+            # fabricate a wall-clock window: in a backtest that would fetch
+            # data from the future relative to the simulated candle
+            # (lookahead). Correlation control degrades to the symbols
+            # already in the series (fail-open, but visible).
+            logger.warning(
+                "Correlation control degraded for %s: no derivable history window "
+                "(end timestamp unavailable); skipping peer symbols %s",
+                symbol,
+                peers,
+            )
+            return price_series
+
         # Fetch price series for open positions
-        for sym in open_symbols:
-            if sym == str(symbol) or sym in price_series:
-                continue
+        for sym in peers:
+            # If the configured window computation failed, fall back to the
+            # default window so the peer is still included rather than
+            # silently dropped (#759).
+            window_start = start_ts
+            if window_start is None:
+                window_start = end_ts - pd.Timedelta(days=DEFAULT_CORRELATION_WINDOW_DAYS)
 
             try:
-                if start_ts is not None and isinstance(end_ts, pd.Timestamp):
-                    hist = self.data_provider.get_historical_data(
-                        sym,
-                        timeframe=timeframe,
-                        start=start_ts.to_pydatetime(),
-                        end=end_ts.to_pydatetime(),
-                    )
-                else:
-                    # KNOWN BUG (typing surfaced, behavior preserved): DataProvider
-                    # .get_historical_data requires `start`, so this fallback call
-                    # always raises TypeError and is swallowed by the except below,
-                    # silently skipping this symbol. Passing `start` here would
-                    # change runtime behavior; tracked for a separate behavioral fix.
-                    hist = self.data_provider.get_historical_data(  # type: ignore[call-arg]
-                        sym, timeframe=timeframe
-                    )
+                hist = self.data_provider.get_historical_data(
+                    sym,
+                    timeframe=timeframe,
+                    start=window_start.to_pydatetime(),
+                    end=end_ts.to_pydatetime(),
+                )
             except Exception as exc:
                 logger.warning(
                     "Failed to fetch correlation history for %s (window %s -> %s): %s",
                     sym,
-                    start_ts,
+                    window_start,
                     end_ts,
                     exc,
                 )

--- a/tests/unit/engines/shared/test_correlation_handler_window.py
+++ b/tests/unit/engines/shared/test_correlation_handler_window.py
@@ -1,0 +1,149 @@
+"""Regression tests for #759: correlation peer-symbol history windows.
+
+The no-window fallback called ``get_historical_data(sym, timeframe=...)``
+without the **required** ``start`` argument — every call raised ``TypeError``,
+was swallowed, and the peer symbol silently dropped out of correlation
+exposure. Peers are now fetched with the default window when the configured
+window computation fails, and skipped **loudly** when no time window is
+derivable at all (non-datetime index — fabricating a wall-clock window there
+would be lookahead in a backtest).
+"""
+
+import logging
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from src.config.constants import DEFAULT_CORRELATION_WINDOW_DAYS
+from src.engines.shared.correlation_handler import CorrelationHandler
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _datetime_df(periods: int = 10) -> pd.DataFrame:
+    idx = pd.date_range("2024-01-10", periods=periods, freq="1h")
+    return pd.DataFrame({"close": [100.0 + i for i in range(periods)]}, index=idx)
+
+
+def _int_index_df(periods: int = 10) -> pd.DataFrame:
+    return pd.DataFrame({"close": [100.0 + i for i in range(periods)]})
+
+
+def _peer_history() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=10, freq="1h")
+    return pd.DataFrame({"close": [50.0 + i for i in range(10)]}, index=idx)
+
+
+def _make_handler(correlation_window_days=30) -> tuple[CorrelationHandler, Mock]:
+    risk_manager = Mock()
+    risk_manager.params.correlation_window_days = correlation_window_days
+    data_provider = Mock()
+    data_provider.get_historical_data = Mock(return_value=_peer_history())
+    handler = CorrelationHandler(
+        correlation_engine=Mock(),
+        risk_manager=risk_manager,
+        data_provider=data_provider,
+        strategy=None,
+    )
+    return handler, data_provider
+
+
+class TestCorrelationWindowFallback:
+    def test_configured_window_passes_start_and_end(self):
+        """Happy path: peer fetched with the configured window bounds."""
+        handler, provider = _make_handler(correlation_window_days=7)
+        df = _datetime_df()
+
+        series = handler._build_price_series(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            df=df,
+            index=5,
+            positions_snapshot={"ETHUSDT": {"size": 0.1}},
+        )
+
+        assert "ETHUSDT" in series
+        kwargs = provider.get_historical_data.call_args.kwargs
+        end = pd.Timestamp(kwargs["end"])
+        start = pd.Timestamp(kwargs["start"])
+        assert end == df.index[5]
+        assert (end - start) == pd.Timedelta(days=7)
+
+    def test_failed_window_computation_falls_back_to_default(self):
+        """Regression: a broken correlation_window_days no longer drops the
+        peer — the default window is used and the provider IS called with a
+        valid start."""
+        handler, provider = _make_handler(correlation_window_days=object())
+        df = _datetime_df()
+
+        series = handler._build_price_series(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            df=df,
+            index=5,
+            positions_snapshot={"ETHUSDT": {"size": 0.1}},
+        )
+
+        assert "ETHUSDT" in series
+        kwargs = provider.get_historical_data.call_args.kwargs
+        end = pd.Timestamp(kwargs["end"])
+        start = pd.Timestamp(kwargs["start"])
+        assert (end - start) == pd.Timedelta(days=DEFAULT_CORRELATION_WINDOW_DAYS)
+
+    def test_non_datetime_index_skips_peers_loudly(self, caplog):
+        """No derivable window (integer index): peers are skipped with a
+        WARNING — never fetched with a fabricated wall-clock window."""
+        handler, provider = _make_handler()
+        df = _int_index_df()
+
+        with caplog.at_level(logging.WARNING):
+            series = handler._build_price_series(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                df=df,
+                index=5,
+                positions_snapshot={"ETHUSDT": {"size": 0.1}},
+            )
+
+        assert "BTCUSDT" in series
+        assert "ETHUSDT" not in series
+        provider.get_historical_data.assert_not_called()
+        assert "Correlation control degraded" in caplog.text
+        assert "ETHUSDT" in caplog.text
+
+    def test_no_peers_no_warning(self, caplog):
+        """Without peer positions there is nothing to fetch and no noise."""
+        handler, provider = _make_handler()
+        df = _int_index_df()
+
+        with caplog.at_level(logging.WARNING):
+            series = handler._build_price_series(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                df=df,
+                index=5,
+                positions_snapshot={"BTCUSDT": {"size": 0.1}},
+            )
+
+        assert "BTCUSDT" in series
+        provider.get_historical_data.assert_not_called()
+        assert "Correlation control degraded" not in caplog.text
+
+    def test_provider_failure_still_skips_with_warning(self, caplog):
+        """A genuinely failing provider degrades loudly per peer."""
+        handler, provider = _make_handler()
+        provider.get_historical_data.side_effect = ConnectionError("api down")
+        df = _datetime_df()
+
+        with caplog.at_level(logging.WARNING):
+            series = handler._build_price_series(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                df=df,
+                index=5,
+                positions_snapshot={"ETHUSDT": {"size": 0.1}},
+            )
+
+        assert "ETHUSDT" not in series
+        assert "Failed to fetch correlation history" in caplog.text

--- a/tests/unit/engines/shared/test_correlation_handler_window.py
+++ b/tests/unit/engines/shared/test_correlation_handler_window.py
@@ -10,7 +10,7 @@ would be lookahead in a backtest).
 """
 
 import logging
-from unittest.mock import Mock
+from unittest.mock import Mock, create_autospec
 
 import pandas as pd
 import pytest
@@ -22,26 +22,36 @@ pytestmark = [pytest.mark.unit, pytest.mark.fast]
 
 
 def _datetime_df(periods: int = 10) -> pd.DataFrame:
+    """Primary-symbol frame with a datetime index (windows derivable)."""
     idx = pd.date_range("2024-01-10", periods=periods, freq="1h")
     return pd.DataFrame({"close": [100.0 + i for i in range(periods)]}, index=idx)
 
 
 def _int_index_df(periods: int = 10) -> pd.DataFrame:
+    """Primary-symbol frame with an integer index (no derivable window)."""
     return pd.DataFrame({"close": [100.0 + i for i in range(periods)]})
 
 
 def _peer_history() -> pd.DataFrame:
+    """History frame the mocked provider returns for peer symbols."""
     idx = pd.date_range("2024-01-01", periods=10, freq="1h")
     return pd.DataFrame({"close": [50.0 + i for i in range(10)]}, index=idx)
 
 
 def _make_handler(correlation_window_days=30) -> tuple[CorrelationHandler, Mock]:
-    risk_manager = Mock()
+    """Handler with autospecced collaborators and a stubbed history provider."""
+    from src.data_providers.data_provider import DataProvider
+    from src.position_management.correlation_engine import CorrelationEngine
+    from src.risk.risk_manager import RiskManager, RiskParameters
+
+    risk_manager = create_autospec(RiskManager, instance=True)
+    # params is created in __init__, invisible to autospec — attach a real one
+    risk_manager.params = RiskParameters()
     risk_manager.params.correlation_window_days = correlation_window_days
-    data_provider = Mock()
-    data_provider.get_historical_data = Mock(return_value=_peer_history())
+    data_provider = create_autospec(DataProvider, instance=True)
+    data_provider.get_historical_data.return_value = _peer_history()
     handler = CorrelationHandler(
-        correlation_engine=Mock(),
+        correlation_engine=create_autospec(CorrelationEngine, instance=True),
         risk_manager=risk_manager,
         data_provider=data_provider,
         strategy=None,


### PR DESCRIPTION
## Summary

Fixes #759 — `CorrelationHandler` (shared by **both** engines) silently dropped peer symbols from correlated-exposure accounting whenever the explicit time window was unavailable: the fallback called `get_historical_data(sym, timeframe=...)` **without the required `start` argument**, so every call raised `TypeError`, was swallowed, and correlation limits under-counted risk exactly when window metadata was degraded.

## Changes

`src/engines/shared/correlation_handler.py` (`_build_price_series`):
- **Failed window computation**: falls back to `DEFAULT_CORRELATION_WINDOW_DAYS` so the peer is **still fetched with valid bounds** instead of dropped.
- **No derivable time window at all** (non-datetime index): peers are skipped with an explicit `Correlation control degraded` WARNING. Deliberately **not** fabricating a wall-clock window — in a backtest that would be lookahead. Fail-open but visible, documented in-code.
- Loop restructured over a precomputed `peers` list (also narrows `end_ts` for mypy); happy path unchanged.

`tests/unit/engines/shared/test_correlation_handler_window.py` (new, 5 tests): happy-path bounds; regression — broken window config still fetches with default window; non-datetime index skips loudly without provider calls; no peers → no noise; provider failure degrades per-peer.

## Testing

- `pytest tests/unit/engines/shared tests/unit/live tests/unit/backtesting/test_backtesting_risk_management.py` — 666 passed (5 new).
- mypy / black / ruff clean on touched files.

Closes #759

https://claude.ai/code/session_01BmhSDCFn81xgnfNTNgEruR