### PR TITLE
refactor(live): extract stop-loss lifecycle, monitoring glue, and shared entry-handler code (#486, steps 1–3)

### DIFF
--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -23,3 +23,15 @@ Log initialized.
 3. Filed **#683** to redesign #679 as exchange-verified-before-adopt; #679 to be reverted on develop (interim parity with prod = #677-only).
 
 Refs: #668, #677, #679, #671, #648/#15, #28 (booking-while-held), #674 (margin Decimal, in prod).
+
+---
+
+## 2026-06-10 · refactor · claude(session, human-directed)
+**#486 live-engine refactor steps 1–3 landed on `claude/live-trading-engine-refactor-09koj9` (pure refactor, parity-proven).**
+- `LiveStopLossManager` (`engines/live/execution/stop_loss_manager.py`) now owns every exchange-facing stop-loss call (place/retry, cancel, fill/held queries, re-protect, offline-fill detection). Engine keeps thin wrappers; original #486 acceptance criteria met — no direct `place_stop_loss_order`/`cancel_order`/`get_open_orders`/`get_order` in the engine.
+- Monitoring glue → `engines/live/monitoring/` (`LiveAccountMonitor` + dataframe extractors). Engine 6,558 → 6,110 lines.
+- The 3 byte-identical entry-handler methods (AST-verified) → `engines/shared/execution/entry_handler_mixin.py`; divergent orchestration deliberately NOT merged.
+- Parity proof: 3,965 unit tests green; 51 parity tests green; deterministic backtest fingerprint byte-identical before/after every commit; new end-to-end paper-session smoke test (real strategy + real in-memory DB, start→entry→exit→shutdown) asserts gross P&L equals shared `pnl_percent` on recorded fills.
+- Reviews: code-reviewer (no findings), architecture-reviewer (no blockers; P2+nits applied), risk-officer **APPROVE, high confidence** (all UNPROTECTED paths verified equivalent to origin/develop).
+- Residual pre-existing risks noted by risk-officer (refactor-neutral): webhook alert delivery is fire-and-forget; SL retry budget hardcoded (3×, 1s backoff) in two places; `position_still_held` defers to ~120s reconciler on API errors.
+Commits: 0e3c0c5, 9a8a1c0, d49b3d5, a5729d3, d12eb12. Remaining #486 scope (recovery extraction, config dataclass, <1,500-line target) intentionally deferred to follow-up PRs.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Live trading engine refactor, steps 1–3 of #486 (pure refactor, no behavior
+  change; verified by the full unit suite, the parity suite, and a
+  deterministic backtest fingerprint that is byte-identical before/after):
+  - Exchange-facing stop-loss lifecycle (placement with retry, cancellation,
+    fill/held-inventory queries, re-protection, offline-fill detection for the
+    legacy reconciliation fallback) moved from `LiveTradingEngine` into
+    `src/engines/live/execution/stop_loss_manager.py` (`LiveStopLossManager`).
+    The engine no longer calls `place_stop_loss_order`, `cancel_order`,
+    `get_open_orders`, or `get_order` directly — it orchestrates via thin
+    delegating wrappers.
+  - Account monitoring glue (balance/equity snapshots, status lines,
+    performance summaries, dataframe extraction helpers) moved to
+    `src/engines/live/monitoring/` (`LiveAccountMonitor`).
+  - The three byte-identical entry-handler methods (`_extract_entry_plan`,
+    `_apply_dynamic_risk`, `get_dynamic_risk_adjustments`) now live once in
+    `src/engines/shared/execution/entry_handler_mixin.py`
+    (`SharedEntryHandlerMixin`), inherited by both the backtest and live
+    entry handlers so this slice of backtest-live parity holds by
+    construction. Divergent orchestration (`process_runtime_decision`,
+    `execute_entry`, exit checks) is intentionally left engine-specific.
+
 ### Fixed
 - `TradeProtocol` members are now read-only properties (#767), so concrete
   trade classes with narrower types (non-Optional datetimes, `PositionSide`

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -1,6 +1,6 @@
 # Live trading
 
-> **Last Updated**: 2025-12-26
+> **Last Updated**: 2026-06-10
 > **Related Documentation**: [Backtesting](backtesting.md), [Monitoring](monitoring.md), [Database](database.md)
 
 `src/engines/live/trading_engine.py` powers the real-time execution stack. It shares core building blocks with the backtester while adding
@@ -20,6 +20,21 @@ continuous polling, account synchronisation, and resilience features required fo
   known state.
 - **Sentiment and regime inputs** – pass a `SentimentDataProvider` (Fear & Greed) or enable the `RegimeStrategySwitcher` to swap
   strategies when market conditions change.
+
+## Handler decomposition & lock ownership (#486)
+
+`LiveTradingEngine` orchestrates; exchange- and observability-facing work is delegated:
+
+| Component | Module | Responsibility | Lock ownership |
+|-----------|--------|----------------|----------------|
+| `LiveStopLossManager` | `engines/live/execution/stop_loss_manager.py` | All exchange-facing stop-loss calls: placement (with retry), cancel, fill/held queries, re-protect, offline-fill detection | None — stateless; reads `enable_live_trading`/`exchange_interface`/`order_tracker` off the engine at call time; position mutations go through `LivePositionTracker`'s internal lock |
+| `LiveAccountMonitor` | `engines/live/monitoring/account_monitor.py` | Balance/equity snapshots, status lines, performance summaries | None — stateless; reads positions via `LivePositionTracker.positions` (thread-safe snapshot) |
+| `LivePositionTracker` | `engines/live/execution/position_tracker.py` | Position state | Owns `_positions_lock`; `positions` property returns a defensive copy |
+| `OrderTracker` | `engines/live/order_tracker.py` | Order fill polling + callbacks | Owns its internal lock; engine callbacks defer closes to the trading loop via `_pending_fill_exits` |
+| `SharedEntryHandlerMixin` | `engines/shared/execution/entry_handler_mixin.py` | Entry-plan extraction + dynamic-risk sizing, identical for backtest and live | None — delegates to shared `DynamicRiskHandler` |
+
+The engine itself keeps thin private wrappers (`_cancel_stop_loss_order`, `_check_stop_loss_filled`, `_log_account_snapshot`, …) so
+call sites and test mock points are stable while the implementations live in the modules above.
 
 ## State recovery & account sync
 

--- a/src/engines/backtest/execution/entry_handler.py
+++ b/src/engines/backtest/execution/entry_handler.py
@@ -24,10 +24,8 @@ from src.config.constants import (
 from src.data_providers.exchange_interface import OrderSide, OrderType
 from src.engines.backtest.models import ActiveTrade
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
-from src.engines.shared.entry_utils import (
-    extract_entry_plan,
-    resolve_stop_loss_take_profit_pct,
-)
+from src.engines.shared.entry_utils import resolve_stop_loss_take_profit_pct
+from src.engines.shared.execution.entry_handler_mixin import SharedEntryHandlerMixin
 from src.engines.shared.execution.execution_model import ExecutionModel
 from src.engines.shared.execution.market_snapshot import MarketSnapshot
 from src.engines.shared.execution.order_intent import OrderIntent
@@ -80,14 +78,14 @@ class EntryExecutionResult:
     reasons: list[str] | None = None
 
 
-class EntryHandler:
+class EntryHandler(SharedEntryHandlerMixin):
     """Processes entry signals and coordinates entry execution.
 
     This class encapsulates entry-related logic including:
     - Runtime entry signal processing
     - Position sizing with risk adjustments
     - Correlation control
-    - Dynamic risk adjustments
+    - Dynamic risk adjustments (shared with live via SharedEntryHandlerMixin)
     - Stop loss and take profit calculation
     """
 
@@ -559,25 +557,6 @@ class EntryHandler:
             executed=result.executed,
         )
 
-    def _extract_entry_plan(
-        self,
-        decision: Any,
-        balance: float,
-    ) -> tuple[PositionSide | None, float]:
-        """Extract entry side and size from runtime decision.
-
-        Args:
-            decision: Runtime decision from strategy.
-            balance: Current account balance.
-
-        Returns:
-            Tuple of (side, size_fraction).
-        """
-        plan = extract_entry_plan(decision, balance)
-        if plan is None:
-            return None, 0.0
-        return plan.side, plan.size_fraction
-
     def _calculate_sl_tp_pct(
         self,
         current_price: float,
@@ -612,44 +591,3 @@ class EntryHandler:
             max_stop_loss_pct=DEFAULT_MAX_STOP_LOSS_PCT,
             use_strategy_take_profit=True,
         )
-
-    def _apply_dynamic_risk(
-        self,
-        original_size: float,
-        current_time: datetime,
-        balance: float,
-        peak_balance: float,
-        trading_session_id: int | None,
-    ) -> float:
-        """Apply dynamic risk adjustments to position size.
-
-        Delegates to shared DynamicRiskHandler for consistent logic
-        between backtest and live engines.
-
-        Args:
-            original_size: Original position size fraction.
-            current_time: Current timestamp.
-            balance: Current account balance.
-            peak_balance: Peak account balance.
-            trading_session_id: Session ID for logging.
-
-        Returns:
-            Adjusted position size fraction.
-        """
-        # Update handler's manager in case it changed
-        self._dynamic_risk_handler.set_manager(self.dynamic_risk_manager)
-        return self._dynamic_risk_handler.apply_dynamic_risk(
-            original_size=original_size,
-            current_time=current_time,
-            balance=balance,
-            peak_balance=peak_balance,
-            trading_session_id=trading_session_id,
-        )
-
-    def get_dynamic_risk_adjustments(self) -> list[dict]:
-        """Get and clear dynamic risk adjustments tracked by this handler.
-
-        Returns:
-            List of dynamic risk adjustment records.
-        """
-        return self._dynamic_risk_handler.get_adjustments(clear=True)

--- a/src/engines/live/execution/entry_handler.py
+++ b/src/engines/live/execution/entry_handler.py
@@ -24,10 +24,8 @@ from src.data_providers.exchange_interface import OrderSide, OrderType
 from src.engines.live.execution.execution_engine import LiveExecutionEngine
 from src.engines.live.execution.position_tracker import LivePosition, PositionSide
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
-from src.engines.shared.entry_utils import (
-    extract_entry_plan,
-    resolve_stop_loss_take_profit_pct,
-)
+from src.engines.shared.entry_utils import resolve_stop_loss_take_profit_pct
+from src.engines.shared.execution.entry_handler_mixin import SharedEntryHandlerMixin
 from src.engines.shared.execution.execution_model import ExecutionModel
 from src.engines.shared.execution.market_snapshot import MarketSnapshot
 from src.engines.shared.execution.order_intent import OrderIntent
@@ -77,7 +75,7 @@ class LiveEntryResult:
     ambiguous: bool = False
 
 
-class LiveEntryHandler:
+class LiveEntryHandler(SharedEntryHandlerMixin):
     """Processes entry signals and coordinates entry execution for live trading.
 
     This class encapsulates entry-related logic including:
@@ -417,25 +415,6 @@ class LiveEntryHandler:
             ambiguous=exec_result.ambiguous,
         )
 
-    def _extract_entry_plan(
-        self,
-        decision: Any,
-        balance: float,
-    ) -> tuple[PositionSide | None, float]:
-        """Extract entry side and size from runtime decision.
-
-        Args:
-            decision: Runtime decision from strategy.
-            balance: Current account balance.
-
-        Returns:
-            Tuple of (side, size_fraction).
-        """
-        plan = extract_entry_plan(decision, balance)
-        if plan is None:
-            return None, 0.0
-        return plan.side, plan.size_fraction
-
     def _calculate_sl_tp(
         self,
         current_price: float,
@@ -488,44 +467,3 @@ class LiveEntryHandler:
         )
 
         return stop_loss, take_profit
-
-    def _apply_dynamic_risk(
-        self,
-        original_size: float,
-        current_time: datetime,
-        balance: float,
-        peak_balance: float,
-        trading_session_id: int | None,
-    ) -> float:
-        """Apply dynamic risk adjustments to position size.
-
-        Delegates to shared DynamicRiskHandler for consistent logic
-        between backtest and live engines.
-
-        Args:
-            original_size: Original position size fraction.
-            current_time: Current timestamp.
-            balance: Current account balance.
-            peak_balance: Peak account balance.
-            trading_session_id: Session ID for logging.
-
-        Returns:
-            Adjusted position size fraction.
-        """
-        # Update handler's manager in case it changed
-        self._dynamic_risk_handler.set_manager(self.dynamic_risk_manager)
-        return self._dynamic_risk_handler.apply_dynamic_risk(
-            original_size=original_size,
-            current_time=current_time,
-            balance=balance,
-            peak_balance=peak_balance,
-            trading_session_id=trading_session_id,
-        )
-
-    def get_dynamic_risk_adjustments(self) -> list[dict]:
-        """Get and clear dynamic risk adjustments tracked by this handler.
-
-        Returns:
-            List of dynamic risk adjustment records.
-        """
-        return self._dynamic_risk_handler.get_adjustments(clear=True)

--- a/src/engines/live/execution/stop_loss_manager.py
+++ b/src/engines/live/execution/stop_loss_manager.py
@@ -398,8 +398,10 @@ class LiveStopLossManager:
         tracked stop-loss id missing from the exchange, confirms via a direct
         order lookup whether it FILLED. Returns ``(position, fill_price)``
         pairs for confirmed fills; bookkeeping (balance/trade/DB updates) stays
-        with the caller. A failed ``get_open_orders`` propagates to the caller,
-        matching the original error handling.
+        with the caller. Unlike the other methods on this manager (which
+        catch-and-degrade), a failed ``get_open_orders`` PROPAGATES — the
+        caller must keep its surrounding try/except so a transient listing
+        failure degrades to a logged reconciliation error, not a startup crash.
         """
         state = self._state
         exchange_orders = state.exchange_interface.get_open_orders()

--- a/src/engines/live/execution/stop_loss_manager.py
+++ b/src/engines/live/execution/stop_loss_manager.py
@@ -1,0 +1,430 @@
+"""Exchange-facing stop-loss lifecycle for the live trading engine.
+
+Owns every direct exchange call for stop-loss protection — placement after
+entry, cancellation before a close, fill/held-inventory queries, re-protection
+after a failed close, and the offline-fill detection used by the legacy
+startup reconciliation fallback — so ``LiveTradingEngine`` orchestrates these
+operations through one handler instead of talking to the exchange directly
+(#486).
+
+Thread-safety / lock ownership: this manager holds no locks and owns no
+mutable state of its own. It reads ``enable_live_trading``,
+``exchange_interface`` and ``order_tracker`` off the engine at call time
+(tests and the engine's own startup mutate these after construction), and all
+position mutations go through ``LivePositionTracker``'s internal lock.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol
+
+from src.config.constants import BORROW_DUST_EPSILON
+from src.data_providers.exchange_interface import OrderSide, SideEffectType
+from src.data_providers.exchange_interface import (
+    OrderStatus as ExchangeOrderStatus,
+)
+from src.engines.live.execution.position_tracker import (
+    LivePosition,
+    LivePositionTracker,
+)
+from src.engines.live.order_tracker import OrderTracker
+from src.engines.shared.models import PositionSide
+from src.infrastructure.logging.events import log_order_event
+
+logger = logging.getLogger(__name__)
+
+
+class StopLossEngineState(Protocol):
+    """Live engine state the manager reads at call time.
+
+    Attributes are read dynamically (not captured at construction) because the
+    engine assigns ``exchange_interface``/``order_tracker`` during ``start()``
+    and tests swap them after the engine is built.
+    """
+
+    enable_live_trading: bool
+    exchange_interface: Any
+    order_tracker: OrderTracker | None
+    live_position_tracker: LivePositionTracker
+
+
+class LiveStopLossManager:
+    """Places, cancels, verifies and re-places server-side stop-loss orders."""
+
+    def __init__(
+        self,
+        engine_state: StopLossEngineState,
+        send_alert: Callable[[str], object],
+    ) -> None:
+        """Bind to the engine's live state and its alerting hook.
+
+        Args:
+            engine_state: Engine attributes read at call time (see protocol).
+            send_alert: Webhook alert dispatcher for UNPROTECTED escalations
+                (return value, e.g. delivery success, is ignored).
+        """
+        self._state = engine_state
+        self._send_alert = send_alert
+
+    def place_protection(
+        self,
+        position: LivePosition,
+        symbol: str,
+        side: PositionSide,
+        quantity: float,
+        stop_price: float,
+    ) -> str | None:
+        """Place a server-side stop-loss after entry, with retry/backoff.
+
+        On success the stop order id is recorded on the tracked position and
+        registered with the order tracker. Returns the stop order id, or
+        ``None`` when all attempts failed (the caller owns the emergency-close
+        escalation).
+        """
+        state = self._state
+        sl_side = OrderSide.SELL if side == PositionSide.LONG else OrderSide.BUY
+        sl_order_id = None
+        max_retries = 3
+        retry_delay = 1.0
+
+        for attempt in range(max_retries):
+            try:
+                sl_order_id = state.exchange_interface.place_stop_loss_order(
+                    symbol=symbol,
+                    side=sl_side,
+                    quantity=quantity,
+                    stop_price=stop_price,
+                    side_effect_type=SideEffectType.AUTO_REPAY,
+                )
+                if sl_order_id:
+                    break
+            except Exception as sl_err:
+                logger.warning(
+                    "Stop-loss placement attempt %s/%s failed: %s",
+                    attempt + 1,
+                    max_retries,
+                    sl_err,
+                )
+
+            if attempt < max_retries - 1:
+                time.sleep(retry_delay)
+                retry_delay *= 2
+
+        if sl_order_id:
+            logger.info(
+                "Server-side stop-loss placed: %s @ $%.2f order_id=%s",
+                symbol,
+                stop_price,
+                sl_order_id,
+            )
+            if position.order_id is not None:
+                state.live_position_tracker.set_stop_loss_order_id(position.order_id, sl_order_id)
+            if state.order_tracker:
+                state.order_tracker.track_order(sl_order_id, symbol)
+        return sl_order_id
+
+    def cancel(self, position: LivePosition) -> bool:
+        """Cancel a position's resting stop-loss order and stop tracking it.
+
+        Returns True only when the exchange confirms the cancel. The close path uses
+        this before a market exit so the stop no longer reserves the base asset
+        (otherwise the close is rejected -2010 on margin, #710). A False result means
+        the order may still rest, or may have just filled, so the caller must NOT
+        submit a close (it would -2010, or over-sell an already-closed position).
+        """
+        state = self._state
+        if not (
+            state.enable_live_trading and state.exchange_interface and position.stop_loss_order_id
+        ):
+            return False
+        cancelled = False
+        try:
+            cancelled = bool(
+                state.exchange_interface.cancel_order(position.stop_loss_order_id, position.symbol)
+            )
+            if cancelled:
+                logger.info(
+                    "Cancelled stop-loss order %s for %s before close",
+                    position.stop_loss_order_id,
+                    position.symbol,
+                )
+        except Exception as e:
+            logger.warning(
+                "Error cancelling stop-loss order %s for %s: %s",
+                position.stop_loss_order_id,
+                position.symbol,
+                e,
+            )
+        # Only stop tracking when the cancel is confirmed; otherwise the order may
+        # still be live on the exchange and must remain watched.
+        if cancelled and state.order_tracker:
+            state.order_tracker.stop_tracking(position.stop_loss_order_id)
+        return cancelled
+
+    def filled_quantity(self, position: LivePosition) -> float | None:
+        """Return the filled (executed) base quantity of a position's stop-loss order.
+
+        ``0.0`` for an unfilled stop, the filled base quantity for a partial/full fill,
+        or ``None`` if the order cannot be read (missing / API error). The close path
+        treats ``None`` and any non-zero fill as "unsafe to inline-close" and defers to
+        the reconciler — a partially-filled stop means held base != tracked size, so a
+        full-size close would over-sell (long) / over-buy (short). (#710)
+        """
+        state = self._state
+        if not (
+            state.enable_live_trading and state.exchange_interface and position.stop_loss_order_id
+        ):
+            return 0.0
+        try:
+            order = state.exchange_interface.get_order(position.stop_loss_order_id, position.symbol)
+        except Exception as e:
+            logger.warning(
+                "Could not read stop-loss order %s for %s: %s",
+                position.stop_loss_order_id,
+                position.symbol,
+                e,
+            )
+            return None
+        if order is None:
+            return None
+        return float(getattr(order, "filled_quantity", 0.0) or 0.0)
+
+    def position_still_held(self, position: LivePosition) -> bool:
+        """Whether the position's inventory is still actually held on the exchange.
+
+        Checked before an inline re-protect so a stop is not re-placed on a position an
+        ambiguous / already-executed close has actually closed (which would orphan a
+        stop). Conservative: any unreadable/uncertain state returns ``False`` (do not
+        re-place; the reconciler reconciles exchange truth). (#710)
+        """
+        state = self._state
+        if not (state.enable_live_trading and state.exchange_interface):
+            return False
+        from src.engines.live.reconciliation import PositionReconciler
+
+        base = PositionReconciler._extract_base_asset(position.symbol)
+        dust = float(BORROW_DUST_EPSILON)
+        try:
+            get_asset = getattr(state.exchange_interface, "get_margin_account_asset", None)
+            if getattr(state.exchange_interface, "is_margin_mode", False) and callable(get_asset):
+                asset = get_asset(base)
+                if not asset:
+                    return False
+                if position.side == PositionSide.SHORT:
+                    # A short is still held while base remains borrowed (owed).
+                    return float(asset.get("borrowed", 0.0) or 0.0) > dust
+                free = float(asset.get("free", 0.0) or 0.0)
+                locked = float(asset.get("locked", 0.0) or 0.0)
+                return (free + locked) > dust
+            # Spot / no margin-asset accessor: long inventory is the base balance.
+            bal = state.exchange_interface.get_balance(base)
+            if not bal:
+                return False
+            return (
+                float(getattr(bal, "free", 0.0) or 0.0) + float(getattr(bal, "locked", 0.0) or 0.0)
+            ) > dust
+        except Exception as e:
+            logger.warning("Could not confirm held inventory for %s: %s", position.symbol, e)
+            return False
+
+    @staticmethod
+    def held_protection_quantity(position: LivePosition) -> float:
+        """Base quantity to protect, scaled for any prior partial exits.
+
+        Mirrors the reconciler's re-placement sizing ``quantity * current/original`` so
+        a re-protected stop covers the *remaining* held size, not the full entry size.
+        """
+        quantity = getattr(position, "quantity", None)
+        if not quantity or quantity <= 0:
+            return 0.0
+        current = getattr(position, "current_size", None)
+        original = getattr(position, "original_size", None)
+        if current is not None and original is not None and original > 0:
+            return float(quantity) * (float(current) / float(original))
+        return float(quantity)
+
+    def reprotect(self, position: LivePosition) -> None:
+        """Re-place a stop-loss after a failed close left a position momentarily naked.
+
+        Reached only when a market close failed *after* its clean (zero-fill) resting
+        stop was cancelled to free the base balance (#710). Re-establish protection
+        immediately rather than waiting for the ~120s reconciler — but first verify the
+        position is still actually held (the close may be ambiguous / already executed)
+        to avoid orphaning a stop, and size for any prior partial exits. The reconciler
+        is the ultimate backstop if this attempt cannot run or also fails.
+        """
+        state = self._state
+        if not (state.enable_live_trading and state.exchange_interface):
+            return
+        if not self.position_still_held(position):
+            logger.warning(
+                "%s appears no longer held after a failed close — not re-placing a "
+                "stop (the reconciler will reconcile exchange state).",
+                position.symbol,
+            )
+            return
+
+        stop_price = getattr(position, "stop_loss", None)
+        quantity = self.held_protection_quantity(position)
+        if not stop_price or stop_price <= 0 or quantity <= 0:
+            logger.critical(
+                "CRITICAL: %s close failed after its stop-loss was cancelled and it "
+                "cannot be re-protected inline (stop_price=%s, quantity=%s) — position "
+                "is UNPROTECTED pending the reconciler. MANUAL REVIEW REQUIRED.",
+                position.symbol,
+                stop_price,
+                quantity,
+            )
+            self._send_alert(
+                f"🚨 {position.symbol} UNPROTECTED: close failed after stop-loss "
+                f"cancel and it could not be re-placed inline. Reconciler backstop "
+                f"engaged. MANUAL REVIEW REQUIRED."
+            )
+            return
+
+        sl_side = OrderSide.SELL if position.side == PositionSide.LONG else OrderSide.BUY
+        sl_order_id = None
+        retry_delay = 1.0
+        for attempt in range(3):
+            try:
+                sl_order_id = state.exchange_interface.place_stop_loss_order(
+                    symbol=position.symbol,
+                    side=sl_side,
+                    quantity=float(quantity),
+                    stop_price=float(stop_price),
+                    side_effect_type=SideEffectType.AUTO_REPAY,
+                )
+                if sl_order_id:
+                    break
+            except Exception as e:
+                logger.warning(
+                    "Re-protect attempt %s/3 for %s failed: %s",
+                    attempt + 1,
+                    position.symbol,
+                    e,
+                )
+            if attempt < 2:
+                time.sleep(retry_delay)
+                retry_delay *= 2
+
+        if sl_order_id:
+            if position.order_id is not None:
+                state.live_position_tracker.set_stop_loss_order_id(position.order_id, sl_order_id)
+            if state.order_tracker:
+                state.order_tracker.track_order(sl_order_id, position.symbol)
+            logger.warning(
+                "Re-protected %s after a failed close: new stop-loss %s @ $%.2f (qty=%.8f)",
+                position.symbol,
+                sl_order_id,
+                float(stop_price),
+                float(quantity),
+            )
+        else:
+            logger.critical(
+                "CRITICAL: %s close failed AND re-placing its stop-loss failed after "
+                "retries — position is UNPROTECTED pending the periodic reconciler. "
+                "MANUAL REVIEW REQUIRED.",
+                position.symbol,
+            )
+            self._send_alert(
+                f"🚨 {position.symbol} UNPROTECTED: close failed and stop-loss "
+                f"re-placement failed. Reconciler is the only backstop. REVIEW NOW."
+            )
+
+    def check_filled(self, position: LivePosition) -> tuple[bool, float | None]:
+        """Check if a stop-loss order already filled on the exchange."""
+        state = self._state
+        if (
+            not state.enable_live_trading
+            or not state.exchange_interface
+            or not position.stop_loss_order_id
+        ):
+            return False, None
+
+        max_attempts = 3
+        for attempt in range(max_attempts):
+            try:
+                sl_order = state.exchange_interface.get_order(
+                    position.stop_loss_order_id, position.symbol
+                )
+                if sl_order and sl_order.status == ExchangeOrderStatus.FILLED:
+                    logger.info(
+                        "Stop-loss order %s already filled at $%.2f - using actual fill price",
+                        position.stop_loss_order_id,
+                        sl_order.average_price,
+                    )
+                    return True, sl_order.average_price
+                return False, None
+            except (ConnectionError, TimeoutError, OSError) as e:
+                logger.warning(
+                    "Transient error checking stop-loss order %s (attempt %s/%s): %s",
+                    position.stop_loss_order_id,
+                    attempt + 1,
+                    max_attempts,
+                    e,
+                )
+                if attempt < max_attempts - 1:
+                    time.sleep(2**attempt)
+            except Exception as e:
+                logger.error(
+                    "Unexpected error checking stop-loss order %s: %s",
+                    position.stop_loss_order_id,
+                    e,
+                    exc_info=True,
+                )
+                return False, None
+
+        logger.error(
+            "Failed to check stop-loss order %s after %s attempts; assuming not filled",
+            position.stop_loss_order_id,
+            max_attempts,
+        )
+        log_order_event(
+            "sl_check_failed",
+            order_id=position.stop_loss_order_id,
+            symbol=position.symbol,
+        )
+        return False, None
+
+    def find_offline_filled_stops(
+        self, positions_snapshot: Mapping[str, LivePosition]
+    ) -> list[tuple[LivePosition, float | None]]:
+        """Detect stop-losses that filled while the engine was offline.
+
+        Legacy startup-reconciliation fallback: lists open orders, and for any
+        tracked stop-loss id missing from the exchange, confirms via a direct
+        order lookup whether it FILLED. Returns ``(position, fill_price)``
+        pairs for confirmed fills; bookkeeping (balance/trade/DB updates) stays
+        with the caller. A failed ``get_open_orders`` propagates to the caller,
+        matching the original error handling.
+        """
+        state = self._state
+        exchange_orders = state.exchange_interface.get_open_orders()
+        exchange_order_ids = {order.order_id for order in exchange_orders}
+
+        positions_to_close: list[tuple[LivePosition, float | None]] = []
+        for _order_id, position in positions_snapshot.items():
+            if position.stop_loss_order_id:
+                if position.stop_loss_order_id not in exchange_order_ids:
+                    logger.warning(
+                        "⚠️ Stop-loss order %s not found on exchange for %s - position may have closed",
+                        position.stop_loss_order_id,
+                        position.symbol,
+                    )
+                    try:
+                        sl_order = state.exchange_interface.get_order(
+                            position.stop_loss_order_id, position.symbol
+                        )
+                        if sl_order and sl_order.status == ExchangeOrderStatus.FILLED:
+                            logger.info(
+                                "✅ Confirmed: Stop-loss triggered for %s @ $%s",
+                                position.symbol,
+                                sl_order.average_price or "unknown",
+                            )
+                            positions_to_close.append((position, sl_order.average_price))
+                    except Exception as e:
+                        logger.warning("Could not verify stop-loss order status: %s", e)
+        return positions_to_close

--- a/src/engines/live/monitoring/__init__.py
+++ b/src/engines/live/monitoring/__init__.py
@@ -1,0 +1,25 @@
+"""Monitoring glue for the live trading engine.
+
+Account snapshots, status logging, performance summaries, and the
+dataframe-extraction helpers used when logging trading decisions. Extracted
+from ``LiveTradingEngine`` so the engine orchestrates and this package
+observes (#486).
+"""
+
+from src.engines.live.monitoring.account_monitor import (
+    LiveAccountMonitor,
+    MonitoringEngineState,
+)
+from src.engines.live.monitoring.dataframe_extraction import (
+    extract_indicators,
+    extract_ml_predictions,
+    extract_sentiment_data,
+)
+
+__all__ = [
+    "LiveAccountMonitor",
+    "MonitoringEngineState",
+    "extract_indicators",
+    "extract_ml_predictions",
+    "extract_sentiment_data",
+]

--- a/src/engines/live/monitoring/account_monitor.py
+++ b/src/engines/live/monitoring/account_monitor.py
@@ -1,0 +1,215 @@
+"""Account-level monitoring for the live trading engine.
+
+Balance/equity snapshots, inline status logging, performance-metric updates,
+and the end-of-session summary. Extracted from ``LiveTradingEngine`` so
+observability glue lives outside the orchestration loop (#486).
+
+Thread-safety / lock ownership: the monitor holds no locks and owns no
+mutable state. It reads balances/session ids off the engine at call time and
+position state through ``LivePositionTracker``'s thread-safe ``positions``
+snapshot property.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Protocol
+
+from src.engines.live.execution.position_tracker import LivePositionTracker
+
+if TYPE_CHECKING:
+    from src.database.manager import DatabaseManager
+    from src.engines.shared.models import BaseTrade
+    from src.performance.tracker import PerformanceTracker
+
+logger = logging.getLogger(__name__)
+
+
+class MonitoringEngineState(Protocol):
+    """Live engine state the monitor reads at call time.
+
+    Attributes are read dynamically (not captured at construction) because
+    balance, session id, and run state mutate throughout the engine lifecycle.
+    """
+
+    initial_balance: float
+    current_balance: float
+    trading_session_id: int | None
+    completed_trades: list[BaseTrade]
+    last_data_update: datetime | None
+    is_running: bool
+    live_position_tracker: LivePositionTracker
+    performance_tracker: PerformanceTracker
+    db_manager: DatabaseManager
+
+
+class LiveAccountMonitor:
+    """Snapshots, status lines, and performance summaries for a live session."""
+
+    def __init__(self, engine_state: MonitoringEngineState) -> None:
+        """Bind to the engine's live state (see protocol for what is read)."""
+        self._state = engine_state
+
+    def update_performance_metrics(self) -> None:
+        """Update performance tracking metrics"""
+        # Update performance tracker on every metric update cycle
+        # Note: Less frequent than backtest (every candle vs every update cycle)
+        # This trade-off reduces overhead while maintaining statistical validity for risk metrics
+        state = self._state
+        state.performance_tracker.update_balance(state.current_balance, timestamp=datetime.now(UTC))
+
+    def log_account_snapshot(self) -> None:
+        """Log current account state to database"""
+        state = self._state
+        try:
+            # Calculate total exposure using the active fraction per position
+            positions_snapshot = state.live_position_tracker.positions
+            total_exposure = sum(
+                float(pos.current_size if pos.current_size is not None else pos.size)
+                * (
+                    float(pos.entry_balance)
+                    if pos.entry_balance is not None and pos.entry_balance > 0
+                    else float(state.current_balance)
+                )
+                for pos in positions_snapshot.values()
+            )
+
+            # Calculate equity (balance + unrealized P&L)
+            unrealized_pnl = sum(float(pos.unrealized_pnl) for pos in positions_snapshot.values())
+            equity = float(state.current_balance) + unrealized_pnl
+
+            # Calculate current drawdown percentage
+            current_drawdown: float = 0
+            perf_metrics = state.performance_tracker.get_metrics()
+            if perf_metrics.peak_balance > 0:
+                current_drawdown = (
+                    (perf_metrics.peak_balance - state.current_balance)
+                    / perf_metrics.peak_balance
+                    * 100
+                )
+
+            # TODO: Calculate daily P&L (requires tracking of day start balance)
+            daily_pnl = 0  # Placeholder
+
+            # Log snapshot to database
+            if state.trading_session_id is not None:
+                state.db_manager.log_account_snapshot(
+                    balance=state.current_balance,
+                    equity=equity,
+                    total_pnl=perf_metrics.total_pnl,
+                    open_positions=state.live_position_tracker.position_count,
+                    total_exposure=total_exposure,
+                    drawdown=current_drawdown,
+                    daily_pnl=daily_pnl,
+                    session_id=state.trading_session_id,
+                )
+            else:
+                logger.warning(
+                    "⚠️ Cannot log account snapshot to database - no trading session ID available"
+                )
+
+        except Exception as e:
+            logger.error("Failed to log account snapshot: %s", e)
+
+    def log_status(self, symbol: str, current_price: float) -> None:
+        """Log current trading status"""
+        state = self._state
+        total_unrealized = sum(
+            float(pos.unrealized_pnl) for pos in state.live_position_tracker.positions.values()
+        )
+        perf_metrics = state.performance_tracker.get_metrics()
+        win_rate = perf_metrics.win_rate * 100
+
+        logger.info(
+            f"📊 Status: {symbol} @ ${current_price:.2f} | "
+            f"Balance: ${state.current_balance:.2f} | "
+            f"Positions: {state.live_position_tracker.position_count} | "
+            f"Unrealized: ${total_unrealized:.2f} | "
+            f"Trades: {perf_metrics.total_trades} ({win_rate:.1f}% win)"
+        )
+
+    def print_final_stats(self) -> None:
+        """Print final trading statistics"""
+        state = self._state
+        # Validate initial_balance before division to prevent crashes
+        if state.initial_balance <= 0:
+            logger.error(
+                "Cannot calculate total return - invalid initial_balance: %.8f. "
+                "Skipping final statistics.",
+                state.initial_balance,
+            )
+            return
+
+        total_return = (
+            (state.current_balance - state.initial_balance) / state.initial_balance
+        ) * 100
+        perf_metrics = state.performance_tracker.get_metrics()
+        win_rate = perf_metrics.win_rate * 100
+
+        print("\n" + "=" * 60)
+        print("🏁 FINAL TRADING STATISTICS")
+        print("=" * 60)
+        print(f"Initial Balance: ${state.initial_balance:,.2f}")
+        print(f"Final Balance: ${state.current_balance:,.2f}")
+        print(f"Total Return: {total_return:+.2f}%")
+        print(f"Total PnL: ${perf_metrics.total_pnl:+,.2f}")
+        print(f"Max Drawdown: {perf_metrics.max_drawdown * 100:.2f}%")
+        print(f"Total Trades: {perf_metrics.total_trades}")
+        print(f"Winning Trades: {perf_metrics.winning_trades}")
+        print(f"Win Rate: {win_rate:.1f}%")
+        print(f"Active Positions: {state.live_position_tracker.position_count}")
+
+        if state.completed_trades:
+            avg_trade = sum(trade.pnl for trade in state.completed_trades) / len(
+                state.completed_trades
+            )
+            print(f"Average Trade: ${avg_trade:.2f}")
+
+        print("=" * 60)
+
+    def performance_summary(self) -> dict[str, Any]:
+        """Get current performance summary"""
+        state = self._state
+        # Get comprehensive metrics from performance tracker
+        perf_metrics = state.performance_tracker.get_metrics()
+
+        # Convert to percentages for backward compatibility
+        win_rate = perf_metrics.win_rate * 100
+        current_drawdown = perf_metrics.current_drawdown * 100
+        max_drawdown_pct = perf_metrics.max_drawdown * 100
+
+        return {
+            # Core metrics from tracker
+            "initial_balance": state.initial_balance,
+            "current_balance": state.current_balance,
+            "total_return": perf_metrics.total_return_pct,
+            "total_return_pct": perf_metrics.total_return_pct,
+            "total_pnl": perf_metrics.total_pnl,
+            "current_drawdown": current_drawdown,
+            "max_drawdown_pct": max_drawdown_pct,
+            "total_trades": perf_metrics.total_trades,
+            "winning_trades": perf_metrics.winning_trades,
+            "win_rate": win_rate,
+            "win_rate_pct": win_rate,
+            # New metrics from tracker
+            "sharpe_ratio": perf_metrics.sharpe_ratio,
+            "sortino_ratio": perf_metrics.sortino_ratio,
+            "calmar_ratio": perf_metrics.calmar_ratio,
+            "var_95": perf_metrics.var_95,
+            "expectancy": perf_metrics.expectancy,
+            "profit_factor": perf_metrics.profit_factor,
+            "avg_win": perf_metrics.avg_win,
+            "avg_loss": perf_metrics.avg_loss,
+            "largest_win": perf_metrics.largest_win,
+            "largest_loss": perf_metrics.largest_loss,
+            "avg_trade_duration_hours": perf_metrics.avg_trade_duration_hours,
+            "consecutive_wins": perf_metrics.consecutive_wins,
+            "consecutive_losses": perf_metrics.consecutive_losses,
+            "total_fees_paid": perf_metrics.total_fees_paid,
+            "total_slippage_cost": perf_metrics.total_slippage_cost,
+            # Live-specific metrics
+            "active_positions": state.live_position_tracker.position_count,
+            "last_update": (state.last_data_update.isoformat() if state.last_data_update else None),
+            "is_running": state.is_running,
+        }

--- a/src/engines/live/monitoring/dataframe_extraction.py
+++ b/src/engines/live/monitoring/dataframe_extraction.py
@@ -1,0 +1,93 @@
+"""Pure helpers that pull loggable values out of a strategy dataframe.
+
+Used by the live engine when persisting trading decisions; extraction is
+best-effort — missing or NaN columns are simply omitted.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# Indicator columns commonly produced by strategy/indicator pipelines.
+INDICATOR_COLUMNS = [
+    "rsi",
+    "macd",
+    "macd_signal",
+    "macd_hist",
+    "atr",
+    "volatility",
+    "trend_ma",
+    "short_ma",
+    "long_ma",
+    "volume_ma",
+    "trend_strength",
+    "regime",
+    "body_size",
+    "upper_wick",
+    "lower_wick",
+]
+
+SENTIMENT_COLUMNS = [
+    "sentiment_primary",
+    "sentiment_momentum",
+    "sentiment_volatility",
+    "sentiment_extreme_positive",
+    "sentiment_extreme_negative",
+    "sentiment_ma_3",
+    "sentiment_ma_7",
+    "sentiment_ma_14",
+    "sentiment_confidence",
+    "sentiment_freshness",
+]
+
+ML_PREDICTION_COLUMNS = ["ml_prediction", "prediction_confidence", "onnx_pred"]
+
+
+def extract_indicators(df: pd.DataFrame, index: int) -> dict:
+    """Extract indicator values from dataframe for logging"""
+    if index >= len(df):
+        return {}
+
+    indicators = {}
+    current_row = df.iloc[index]
+
+    for col in INDICATOR_COLUMNS:
+        if col in df.columns and not pd.isna(current_row[col]):
+            indicators[col] = float(current_row[col])
+
+    # Add basic OHLCV data
+    for col in ["open", "high", "low", "close", "volume"]:
+        if col in df.columns:
+            indicators[col] = float(current_row[col])
+
+    return indicators
+
+
+def extract_sentiment_data(df: pd.DataFrame, index: int) -> dict:
+    """Extract sentiment data from dataframe for logging"""
+    if index >= len(df):
+        return {}
+
+    sentiment_data = {}
+    current_row = df.iloc[index]
+
+    for col in SENTIMENT_COLUMNS:
+        if col in df.columns and not pd.isna(current_row[col]):
+            sentiment_data[col] = float(current_row[col])
+
+    return sentiment_data
+
+
+def extract_ml_predictions(df: pd.DataFrame, index: int) -> dict:
+    """Extract ML prediction data from dataframe for logging"""
+    if index >= len(df):
+        return {}
+
+    ml_data = {}
+    current_row = df.iloc[index]
+
+    for col in ML_PREDICTION_COLUMNS:
+        if col in df.columns and not pd.isna(current_row[col]):
+            ml_data[col] = float(current_row[col])
+
+    return ml_data

--- a/src/engines/live/monitoring/dataframe_extraction.py
+++ b/src/engines/live/monitoring/dataframe_extraction.py
@@ -43,7 +43,7 @@ SENTIMENT_COLUMNS = [
 ML_PREDICTION_COLUMNS = ["ml_prediction", "prediction_confidence", "onnx_pred"]
 
 
-def extract_indicators(df: pd.DataFrame, index: int) -> dict:
+def extract_indicators(df: pd.DataFrame, index: int) -> dict[str, float]:
     """Extract indicator values from dataframe for logging"""
     if index >= len(df):
         return {}
@@ -63,7 +63,7 @@ def extract_indicators(df: pd.DataFrame, index: int) -> dict:
     return indicators
 
 
-def extract_sentiment_data(df: pd.DataFrame, index: int) -> dict:
+def extract_sentiment_data(df: pd.DataFrame, index: int) -> dict[str, float]:
     """Extract sentiment data from dataframe for logging"""
     if index >= len(df):
         return {}
@@ -78,7 +78,7 @@ def extract_sentiment_data(df: pd.DataFrame, index: int) -> dict:
     return sentiment_data
 
 
-def extract_ml_predictions(df: pd.DataFrame, index: int) -> dict:
+def extract_ml_predictions(df: pd.DataFrame, index: int) -> dict[str, float]:
     """Extract ML prediction data from dataframe for logging"""
     if index >= len(df):
         return {}

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -48,9 +48,6 @@ from src.data_providers.binance_provider import BinanceProvider, WebSocketState
 from src.data_providers.coinbase_provider import CoinbaseProvider
 from src.data_providers.data_provider import DataProvider
 from src.data_providers.exchange_interface import OrderSide, OrderType, SideEffectType
-from src.data_providers.exchange_interface import (
-    OrderStatus as ExchangeOrderStatus,
-)
 from src.data_providers.sentiment_provider import SentimentDataProvider
 from src.database.manager import DatabaseManager
 from src.database.models import EventType, TradeSource
@@ -64,6 +61,7 @@ from src.engines.live.execution.position_tracker import (
     LivePosition,
     LivePositionTracker,
 )
+from src.engines.live.execution.stop_loss_manager import LiveStopLossManager
 from src.engines.live.health.health_monitor import HealthMonitor
 from src.engines.live.logging.event_logger import LiveEventLogger
 from src.engines.live.margin_interest_tracker import MarginInterestTracker
@@ -906,6 +904,14 @@ class LiveTradingEngine:
             time_exit_policy=self.time_exit_policy,
             use_high_low_for_stops=self.use_high_low_for_stops,
             max_filled_price_deviation=self.max_filled_price_deviation,
+        )
+
+        # Stop-loss lifecycle handler — owns every exchange-facing stop-loss
+        # call (place/cancel/query/re-protect) so the engine orchestrates
+        # without touching the exchange interface directly (#486).
+        self.stop_loss_manager = LiveStopLossManager(
+            engine_state=self,
+            send_alert=self._send_alert,
         )
 
     def _apply_dynamic_risk_adjustment(
@@ -4071,10 +4077,6 @@ class LiveTradingEngine:
 
             # Place server-side stop-loss order for protection with retry logic
             if self.enable_live_trading and stop_loss and self.exchange_interface:
-                sl_side = OrderSide.SELL if side == PositionSide.LONG else OrderSide.BUY
-                sl_order_id = None
-                max_retries = 3
-                retry_delay = 1.0
                 # Use stored quantity directly to ensure stop-loss covers exact position size
                 if position.quantity is not None and position.quantity > 0:
                     quantity = position.quantity
@@ -4092,48 +4094,19 @@ class LiveTradingEngine:
                         else 0.0
                     )
 
-                for attempt in range(max_retries):
-                    try:
-                        sl_order_id = self.exchange_interface.place_stop_loss_order(
-                            symbol=symbol,
-                            side=sl_side,
-                            quantity=quantity,
-                            stop_price=stop_loss,
-                            side_effect_type=SideEffectType.AUTO_REPAY,
-                        )
-                        if sl_order_id:
-                            break
-                    except Exception as sl_err:
-                        logger.warning(
-                            "Stop-loss placement attempt %s/%s failed: %s",
-                            attempt + 1,
-                            max_retries,
-                            sl_err,
-                        )
+                sl_order_id = self.stop_loss_manager.place_protection(
+                    position=position,
+                    symbol=symbol,
+                    side=side,
+                    quantity=quantity,
+                    stop_price=stop_loss,
+                )
 
-                    if attempt < max_retries - 1:
-                        time.sleep(retry_delay)
-                        retry_delay *= 2
-
-                if sl_order_id:
-                    logger.info(
-                        "Server-side stop-loss placed: %s @ $%.2f order_id=%s",
-                        symbol,
-                        stop_loss,
-                        sl_order_id,
-                    )
-                    self.live_position_tracker.set_stop_loss_order_id(
-                        # Executed entries carry the exchange order id.
-                        cast(str, position.order_id),
-                        sl_order_id,
-                    )
-                    if self.order_tracker:
-                        self.order_tracker.track_order(sl_order_id, symbol)
-                else:
+                if not sl_order_id:
                     logger.critical(
                         "CRITICAL: Failed to place stop-loss after %s attempts for %s - "
                         "closing position on exchange to prevent unprotected exposure",
-                        max_retries,
+                        3,  # placement retry budget lives in LiveStopLossManager
                         symbol,
                     )
                     # Record the structured event and fire the alert in one call
@@ -4824,33 +4797,7 @@ class LiveTradingEngine:
         the order may still rest, or may have just filled, so the caller must NOT
         submit a close (it would -2010, or over-sell an already-closed position).
         """
-        if not (
-            self.enable_live_trading and self.exchange_interface and position.stop_loss_order_id
-        ):
-            return False
-        cancelled = False
-        try:
-            cancelled = bool(
-                self.exchange_interface.cancel_order(position.stop_loss_order_id, position.symbol)
-            )
-            if cancelled:
-                logger.info(
-                    "Cancelled stop-loss order %s for %s before close",
-                    position.stop_loss_order_id,
-                    position.symbol,
-                )
-        except Exception as e:
-            logger.warning(
-                "Error cancelling stop-loss order %s for %s: %s",
-                position.stop_loss_order_id,
-                position.symbol,
-                e,
-            )
-        # Only stop tracking when the cancel is confirmed; otherwise the order may
-        # still be live on the exchange and must remain watched.
-        if cancelled and self.order_tracker:
-            self.order_tracker.stop_tracking(position.stop_loss_order_id)
-        return cancelled
+        return self.stop_loss_manager.cancel(position)
 
     def _stop_loss_filled_quantity(self, position: Position) -> float | None:
         """Return the filled (executed) base quantity of a position's stop-loss order.
@@ -4861,23 +4808,7 @@ class LiveTradingEngine:
         the reconciler — a partially-filled stop means held base != tracked size, so a
         full-size close would over-sell (long) / over-buy (short). (#710)
         """
-        if not (
-            self.enable_live_trading and self.exchange_interface and position.stop_loss_order_id
-        ):
-            return 0.0
-        try:
-            order = self.exchange_interface.get_order(position.stop_loss_order_id, position.symbol)
-        except Exception as e:
-            logger.warning(
-                "Could not read stop-loss order %s for %s: %s",
-                position.stop_loss_order_id,
-                position.symbol,
-                e,
-            )
-            return None
-        if order is None:
-            return None
-        return float(getattr(order, "filled_quantity", 0.0) or 0.0)
+        return self.stop_loss_manager.filled_quantity(position)
 
     def _position_still_held(self, position: Position) -> bool:
         """Whether the position's inventory is still actually held on the exchange.
@@ -4887,34 +4818,7 @@ class LiveTradingEngine:
         stop). Conservative: any unreadable/uncertain state returns ``False`` (do not
         re-place; the reconciler reconciles exchange truth). (#710)
         """
-        if not (self.enable_live_trading and self.exchange_interface):
-            return False
-        from src.engines.live.reconciliation import PositionReconciler
-
-        base = PositionReconciler._extract_base_asset(position.symbol)
-        dust = float(BORROW_DUST_EPSILON)
-        try:
-            get_asset = getattr(self.exchange_interface, "get_margin_account_asset", None)
-            if getattr(self.exchange_interface, "is_margin_mode", False) and callable(get_asset):
-                asset = get_asset(base)
-                if not asset:
-                    return False
-                if position.side == PositionSide.SHORT:
-                    # A short is still held while base remains borrowed (owed).
-                    return float(asset.get("borrowed", 0.0) or 0.0) > dust
-                free = float(asset.get("free", 0.0) or 0.0)
-                locked = float(asset.get("locked", 0.0) or 0.0)
-                return (free + locked) > dust
-            # Spot / no margin-asset accessor: long inventory is the base balance.
-            bal = self.exchange_interface.get_balance(base)
-            if not bal:
-                return False
-            return (
-                float(getattr(bal, "free", 0.0) or 0.0) + float(getattr(bal, "locked", 0.0) or 0.0)
-            ) > dust
-        except Exception as e:
-            logger.warning("Could not confirm held inventory for %s: %s", position.symbol, e)
-            return False
+        return self.stop_loss_manager.position_still_held(position)
 
     def _held_protection_quantity(self, position: Position) -> float:
         """Base quantity to protect, scaled for any prior partial exits.
@@ -4922,14 +4826,7 @@ class LiveTradingEngine:
         Mirrors the reconciler's re-placement sizing ``quantity * current/original`` so
         a re-protected stop covers the *remaining* held size, not the full entry size.
         """
-        quantity = getattr(position, "quantity", None)
-        if not quantity or quantity <= 0:
-            return 0.0
-        current = getattr(position, "current_size", None)
-        original = getattr(position, "original_size", None)
-        if current is not None and original is not None and original > 0:
-            return float(quantity) * (float(current) / float(original))
-        return float(quantity)
+        return self.stop_loss_manager.held_protection_quantity(position)
 
     def _reprotect_position(self, position: Position) -> None:
         """Re-place a stop-loss after a failed close left a position momentarily naked.
@@ -4941,136 +4838,11 @@ class LiveTradingEngine:
         to avoid orphaning a stop, and size for any prior partial exits. The reconciler
         is the ultimate backstop if this attempt cannot run or also fails.
         """
-        if not (self.enable_live_trading and self.exchange_interface):
-            return
-        if not self._position_still_held(position):
-            logger.warning(
-                "%s appears no longer held after a failed close — not re-placing a "
-                "stop (the reconciler will reconcile exchange state).",
-                position.symbol,
-            )
-            return
-
-        stop_price = getattr(position, "stop_loss", None)
-        quantity = self._held_protection_quantity(position)
-        if not stop_price or stop_price <= 0 or quantity <= 0:
-            logger.critical(
-                "CRITICAL: %s close failed after its stop-loss was cancelled and it "
-                "cannot be re-protected inline (stop_price=%s, quantity=%s) — position "
-                "is UNPROTECTED pending the reconciler. MANUAL REVIEW REQUIRED.",
-                position.symbol,
-                stop_price,
-                quantity,
-            )
-            self._send_alert(
-                f"🚨 {position.symbol} UNPROTECTED: close failed after stop-loss "
-                f"cancel and it could not be re-placed inline. Reconciler backstop "
-                f"engaged. MANUAL REVIEW REQUIRED."
-            )
-            return
-
-        sl_side = OrderSide.SELL if position.side == PositionSide.LONG else OrderSide.BUY
-        sl_order_id = None
-        retry_delay = 1.0
-        for attempt in range(3):
-            try:
-                sl_order_id = self.exchange_interface.place_stop_loss_order(
-                    symbol=position.symbol,
-                    side=sl_side,
-                    quantity=float(quantity),
-                    stop_price=float(stop_price),
-                    side_effect_type=SideEffectType.AUTO_REPAY,
-                )
-                if sl_order_id:
-                    break
-            except Exception as e:
-                logger.warning(
-                    "Re-protect attempt %s/3 for %s failed: %s",
-                    attempt + 1,
-                    position.symbol,
-                    e,
-                )
-            if attempt < 2:
-                time.sleep(retry_delay)
-                retry_delay *= 2
-
-        if sl_order_id:
-            if position.order_id is not None:
-                self.live_position_tracker.set_stop_loss_order_id(position.order_id, sl_order_id)
-            if self.order_tracker:
-                self.order_tracker.track_order(sl_order_id, position.symbol)
-            logger.warning(
-                "Re-protected %s after a failed close: new stop-loss %s @ $%.2f (qty=%.8f)",
-                position.symbol,
-                sl_order_id,
-                float(stop_price),
-                float(quantity),
-            )
-        else:
-            logger.critical(
-                "CRITICAL: %s close failed AND re-placing its stop-loss failed after "
-                "retries — position is UNPROTECTED pending the periodic reconciler. "
-                "MANUAL REVIEW REQUIRED.",
-                position.symbol,
-            )
-            self._send_alert(
-                f"🚨 {position.symbol} UNPROTECTED: close failed and stop-loss "
-                f"re-placement failed. Reconciler is the only backstop. REVIEW NOW."
-            )
+        self.stop_loss_manager.reprotect(position)
 
     def _check_stop_loss_filled(self, position: Position) -> tuple[bool, float | None]:
         """Check if a stop-loss order already filled on the exchange."""
-        if (
-            not self.enable_live_trading
-            or not self.exchange_interface
-            or not position.stop_loss_order_id
-        ):
-            return False, None
-
-        max_attempts = 3
-        for attempt in range(max_attempts):
-            try:
-                sl_order = self.exchange_interface.get_order(
-                    position.stop_loss_order_id, position.symbol
-                )
-                if sl_order and sl_order.status == ExchangeOrderStatus.FILLED:
-                    logger.info(
-                        "Stop-loss order %s already filled at $%.2f - using actual fill price",
-                        position.stop_loss_order_id,
-                        sl_order.average_price,
-                    )
-                    return True, sl_order.average_price
-                return False, None
-            except (ConnectionError, TimeoutError, OSError) as e:
-                logger.warning(
-                    "Transient error checking stop-loss order %s (attempt %s/%s): %s",
-                    position.stop_loss_order_id,
-                    attempt + 1,
-                    max_attempts,
-                    e,
-                )
-                if attempt < max_attempts - 1:
-                    time.sleep(2**attempt)
-            except Exception as e:
-                logger.error(
-                    "Unexpected error checking stop-loss order %s: %s",
-                    position.stop_loss_order_id,
-                    e,
-                    exc_info=True,
-                )
-                return False, None
-
-        logger.error(
-            "Failed to check stop-loss order %s after %s attempts; assuming not filled",
-            position.stop_loss_order_id,
-            max_attempts,
-        )
-        log_order_event(
-            "sl_check_failed",
-            order_id=position.stop_loss_order_id,
-            symbol=position.symbol,
-        )
-        return False, None
+        return self.stop_loss_manager.check_filled(position)
 
     def _update_performance_metrics(self):
         """Update performance tracking metrics"""
@@ -5959,31 +5731,9 @@ class LiveTradingEngine:
             return
 
         try:
-            exchange_orders = self.exchange_interface.get_open_orders()
-            exchange_order_ids = {order.order_id for order in exchange_orders}
-
-            positions_to_close = []
-            for _order_id, position in positions_snapshot.items():
-                if position.stop_loss_order_id:
-                    if position.stop_loss_order_id not in exchange_order_ids:
-                        logger.warning(
-                            "⚠️ Stop-loss order %s not found on exchange for %s - position may have closed",
-                            position.stop_loss_order_id,
-                            position.symbol,
-                        )
-                        try:
-                            sl_order = self.exchange_interface.get_order(
-                                position.stop_loss_order_id, position.symbol
-                            )
-                            if sl_order and sl_order.status == ExchangeOrderStatus.FILLED:
-                                logger.info(
-                                    "✅ Confirmed: Stop-loss triggered for %s @ $%s",
-                                    position.symbol,
-                                    sl_order.average_price or "unknown",
-                                )
-                                positions_to_close.append((position, sl_order.average_price))
-                        except Exception as e:
-                            logger.warning("Could not verify stop-loss order status: %s", e)
+            positions_to_close = self.stop_loss_manager.find_offline_filled_stops(
+                positions_snapshot
+            )
 
             # Close positions that were stopped out
             for position, exit_price in positions_to_close:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -65,6 +65,12 @@ from src.engines.live.execution.stop_loss_manager import LiveStopLossManager
 from src.engines.live.health.health_monitor import HealthMonitor
 from src.engines.live.logging.event_logger import LiveEventLogger
 from src.engines.live.margin_interest_tracker import MarginInterestTracker
+from src.engines.live.monitoring import (
+    LiveAccountMonitor,
+    extract_indicators,
+    extract_ml_predictions,
+    extract_sentiment_data,
+)
 from src.engines.live.strategy_manager import StrategyManager
 from src.engines.shared.correlation_handler import CorrelationHandler
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
@@ -913,6 +919,9 @@ class LiveTradingEngine:
             engine_state=self,
             send_alert=self._send_alert,
         )
+
+        # Account monitor — snapshots, status lines, performance summaries.
+        self.account_monitor = LiveAccountMonitor(engine_state=self)
 
     def _apply_dynamic_risk_adjustment(
         self,
@@ -4846,161 +4855,27 @@ class LiveTradingEngine:
 
     def _update_performance_metrics(self):
         """Update performance tracking metrics"""
-        # Update performance tracker on every metric update cycle
-        # Note: Less frequent than backtest (every candle vs every update cycle)
-        # This trade-off reduces overhead while maintaining statistical validity for risk metrics
-        self.performance_tracker.update_balance(self.current_balance, timestamp=datetime.now(UTC))
+        self.account_monitor.update_performance_metrics()
 
     def _extract_indicators(self, df: pd.DataFrame, index: int) -> dict:
         """Extract indicator values from dataframe for logging"""
-        if index >= len(df):
-            return {}
-
-        indicators = {}
-        current_row = df.iloc[index]
-
-        # Common indicators to extract
-        indicator_columns = [
-            "rsi",
-            "macd",
-            "macd_signal",
-            "macd_hist",
-            "atr",
-            "volatility",
-            "trend_ma",
-            "short_ma",
-            "long_ma",
-            "volume_ma",
-            "trend_strength",
-            "regime",
-            "body_size",
-            "upper_wick",
-            "lower_wick",
-        ]
-
-        for col in indicator_columns:
-            if col in df.columns and not pd.isna(current_row[col]):
-                indicators[col] = float(current_row[col])
-
-        # Add basic OHLCV data
-        for col in ["open", "high", "low", "close", "volume"]:
-            if col in df.columns:
-                indicators[col] = float(current_row[col])
-
-        return indicators
+        return extract_indicators(df, index)
 
     def _extract_sentiment_data(self, df: pd.DataFrame, index: int) -> dict:
         """Extract sentiment data from dataframe for logging"""
-        if index >= len(df):
-            return {}
-
-        sentiment_data = {}
-        current_row = df.iloc[index]
-
-        # Sentiment columns to extract
-        sentiment_columns = [
-            "sentiment_primary",
-            "sentiment_momentum",
-            "sentiment_volatility",
-            "sentiment_extreme_positive",
-            "sentiment_extreme_negative",
-            "sentiment_ma_3",
-            "sentiment_ma_7",
-            "sentiment_ma_14",
-            "sentiment_confidence",
-            "sentiment_freshness",
-        ]
-
-        for col in sentiment_columns:
-            if col in df.columns and not pd.isna(current_row[col]):
-                sentiment_data[col] = float(current_row[col])
-
-        return sentiment_data
+        return extract_sentiment_data(df, index)
 
     def _extract_ml_predictions(self, df: pd.DataFrame, index: int) -> dict:
         """Extract ML prediction data from dataframe for logging"""
-        if index >= len(df):
-            return {}
-
-        ml_data = {}
-        current_row = df.iloc[index]
-
-        # ML prediction columns to extract
-        ml_columns = ["ml_prediction", "prediction_confidence", "onnx_pred"]
-
-        for col in ml_columns:
-            if col in df.columns and not pd.isna(current_row[col]):
-                ml_data[col] = float(current_row[col])
-
-        return ml_data
+        return extract_ml_predictions(df, index)
 
     def _log_account_snapshot(self):
         """Log current account state to database"""
-        try:
-            # Calculate total exposure using the active fraction per position
-            positions_snapshot = self.live_position_tracker.positions
-            total_exposure = sum(
-                float(pos.current_size if pos.current_size is not None else pos.size)
-                * (
-                    float(pos.entry_balance)
-                    if pos.entry_balance is not None and pos.entry_balance > 0
-                    else float(self.current_balance)
-                )
-                for pos in positions_snapshot.values()
-            )
-
-            # Calculate equity (balance + unrealized P&L)
-            unrealized_pnl = sum(float(pos.unrealized_pnl) for pos in positions_snapshot.values())
-            equity = float(self.current_balance) + unrealized_pnl
-
-            # Calculate current drawdown percentage
-            current_drawdown: float = 0
-            perf_metrics = self.performance_tracker.get_metrics()
-            if perf_metrics.peak_balance > 0:
-                current_drawdown = (
-                    (perf_metrics.peak_balance - self.current_balance)
-                    / perf_metrics.peak_balance
-                    * 100
-                )
-
-            # TODO: Calculate daily P&L (requires tracking of day start balance)
-            daily_pnl = 0  # Placeholder
-
-            # Log snapshot to database
-            if self.trading_session_id is not None:
-                self.db_manager.log_account_snapshot(
-                    balance=self.current_balance,
-                    equity=equity,
-                    total_pnl=perf_metrics.total_pnl,
-                    open_positions=self.live_position_tracker.position_count,
-                    total_exposure=total_exposure,
-                    drawdown=current_drawdown,
-                    daily_pnl=daily_pnl,
-                    session_id=self.trading_session_id,
-                )
-            else:
-                logger.warning(
-                    "⚠️ Cannot log account snapshot to database - no trading session ID available"
-                )
-
-        except Exception as e:
-            logger.error("Failed to log account snapshot: %s", e)
+        self.account_monitor.log_account_snapshot()
 
     def _log_status(self, symbol: str, current_price: float):
         """Log current trading status"""
-        total_unrealized = sum(
-            float(pos.unrealized_pnl) for pos in self.live_position_tracker.positions.values()
-        )
-        perf_metrics = self.performance_tracker.get_metrics()
-        win_rate = perf_metrics.win_rate * 100
-
-        logger.info(
-            f"📊 Status: {symbol} @ ${current_price:.2f} | "
-            f"Balance: ${self.current_balance:.2f} | "
-            f"Positions: {self.live_position_tracker.position_count} | "
-            f"Unrealized: ${total_unrealized:.2f} | "
-            f"Trades: {perf_metrics.total_trades} ({win_rate:.1f}% win)"
-        )
+        self.account_monitor.log_status(symbol, current_price)
 
     def _log_trade(self, trade: Trade):
         """Log trade to file"""
@@ -5194,84 +5069,11 @@ class LiveTradingEngine:
 
     def _print_final_stats(self):
         """Print final trading statistics"""
-        # Validate initial_balance before division to prevent crashes
-        if self.initial_balance <= 0:
-            logger.error(
-                "Cannot calculate total return - invalid initial_balance: %.8f. "
-                "Skipping final statistics.",
-                self.initial_balance,
-            )
-            return
-
-        total_return = ((self.current_balance - self.initial_balance) / self.initial_balance) * 100
-        perf_metrics = self.performance_tracker.get_metrics()
-        win_rate = perf_metrics.win_rate * 100
-
-        print("\n" + "=" * 60)
-        print("🏁 FINAL TRADING STATISTICS")
-        print("=" * 60)
-        print(f"Initial Balance: ${self.initial_balance:,.2f}")
-        print(f"Final Balance: ${self.current_balance:,.2f}")
-        print(f"Total Return: {total_return:+.2f}%")
-        print(f"Total PnL: ${perf_metrics.total_pnl:+,.2f}")
-        print(f"Max Drawdown: {perf_metrics.max_drawdown * 100:.2f}%")
-        print(f"Total Trades: {perf_metrics.total_trades}")
-        print(f"Winning Trades: {perf_metrics.winning_trades}")
-        print(f"Win Rate: {win_rate:.1f}%")
-        print(f"Active Positions: {self.live_position_tracker.position_count}")
-
-        if self.completed_trades:
-            avg_trade = sum(trade.pnl for trade in self.completed_trades) / len(
-                self.completed_trades
-            )
-            print(f"Average Trade: ${avg_trade:.2f}")
-
-        print("=" * 60)
+        self.account_monitor.print_final_stats()
 
     def get_performance_summary(self) -> dict[str, Any]:
         """Get current performance summary"""
-        # Get comprehensive metrics from performance tracker
-        perf_metrics = self.performance_tracker.get_metrics()
-
-        # Convert to percentages for backward compatibility
-        win_rate = perf_metrics.win_rate * 100
-        current_drawdown = perf_metrics.current_drawdown * 100
-        max_drawdown_pct = perf_metrics.max_drawdown * 100
-
-        return {
-            # Core metrics from tracker
-            "initial_balance": self.initial_balance,
-            "current_balance": self.current_balance,
-            "total_return": perf_metrics.total_return_pct,
-            "total_return_pct": perf_metrics.total_return_pct,
-            "total_pnl": perf_metrics.total_pnl,
-            "current_drawdown": current_drawdown,
-            "max_drawdown_pct": max_drawdown_pct,
-            "total_trades": perf_metrics.total_trades,
-            "winning_trades": perf_metrics.winning_trades,
-            "win_rate": win_rate,
-            "win_rate_pct": win_rate,
-            # New metrics from tracker
-            "sharpe_ratio": perf_metrics.sharpe_ratio,
-            "sortino_ratio": perf_metrics.sortino_ratio,
-            "calmar_ratio": perf_metrics.calmar_ratio,
-            "var_95": perf_metrics.var_95,
-            "expectancy": perf_metrics.expectancy,
-            "profit_factor": perf_metrics.profit_factor,
-            "avg_win": perf_metrics.avg_win,
-            "avg_loss": perf_metrics.avg_loss,
-            "largest_win": perf_metrics.largest_win,
-            "largest_loss": perf_metrics.largest_loss,
-            "avg_trade_duration_hours": perf_metrics.avg_trade_duration_hours,
-            "consecutive_wins": perf_metrics.consecutive_wins,
-            "consecutive_losses": perf_metrics.consecutive_losses,
-            "total_fees_paid": perf_metrics.total_fees_paid,
-            "total_slippage_cost": perf_metrics.total_slippage_cost,
-            # Live-specific metrics
-            "active_positions": self.live_position_tracker.position_count,
-            "last_update": self.last_data_update.isoformat() if self.last_data_update else None,
-            "is_running": self.is_running,
-        }
+        return self.account_monitor.performance_summary()
 
     def _recover_existing_session(self) -> float | None:
         """Try to recover balance from an existing session.

--- a/src/engines/shared/execution/entry_handler_mixin.py
+++ b/src/engines/shared/execution/entry_handler_mixin.py
@@ -1,0 +1,90 @@
+"""Entry-handler behavior shared verbatim by the backtest and live engines.
+
+These methods were byte-identical copies in ``EntryHandler`` (backtest) and
+``LiveEntryHandler`` (live). Hosting them here makes backtest-live parity for
+entry-plan extraction and dynamic-risk sizing hold by construction instead of
+by code review (#486, CODE.md Backtest-Live Parity).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from src.engines.shared.entry_utils import extract_entry_plan
+from src.engines.shared.models import PositionSide
+
+if TYPE_CHECKING:
+    from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
+    from src.position_management.dynamic_risk import DynamicRiskManager
+
+
+class SharedEntryHandlerMixin:
+    """Entry-plan extraction and dynamic-risk sizing common to both engines.
+
+    The inheriting handler must set ``dynamic_risk_manager`` and
+    ``_dynamic_risk_handler`` in its ``__init__``.
+    """
+
+    dynamic_risk_manager: DynamicRiskManager | None
+    _dynamic_risk_handler: DynamicRiskHandler
+
+    def _extract_entry_plan(
+        self,
+        decision: Any,
+        balance: float,
+    ) -> tuple[PositionSide | None, float]:
+        """Extract entry side and size from runtime decision.
+
+        Args:
+            decision: Runtime decision from strategy.
+            balance: Current account balance.
+
+        Returns:
+            Tuple of (side, size_fraction).
+        """
+        plan = extract_entry_plan(decision, balance)
+        if plan is None:
+            return None, 0.0
+        return plan.side, plan.size_fraction
+
+    def _apply_dynamic_risk(
+        self,
+        original_size: float,
+        current_time: datetime,
+        balance: float,
+        peak_balance: float,
+        trading_session_id: int | None,
+    ) -> float:
+        """Apply dynamic risk adjustments to position size.
+
+        Delegates to shared DynamicRiskHandler for consistent logic
+        between backtest and live engines.
+
+        Args:
+            original_size: Original position size fraction.
+            current_time: Current timestamp.
+            balance: Current account balance.
+            peak_balance: Peak account balance.
+            trading_session_id: Session ID for logging.
+
+        Returns:
+            Adjusted position size fraction.
+        """
+        # Update handler's manager in case it changed
+        self._dynamic_risk_handler.set_manager(self.dynamic_risk_manager)
+        return self._dynamic_risk_handler.apply_dynamic_risk(
+            original_size=original_size,
+            current_time=current_time,
+            balance=balance,
+            peak_balance=peak_balance,
+            trading_session_id=trading_session_id,
+        )
+
+    def get_dynamic_risk_adjustments(self) -> list[dict]:
+        """Get and clear dynamic risk adjustments tracked by this handler.
+
+        Returns:
+            List of dynamic risk adjustment records.
+        """
+        return self._dynamic_risk_handler.get_adjustments(clear=True)

--- a/tests/integration/live/test_paper_session_smoke.py
+++ b/tests/integration/live/test_paper_session_smoke.py
@@ -45,14 +45,17 @@ def _make_market_data(periods: int = 200) -> pd.DataFrame:
 
 @pytest.fixture
 def paper_engine():
-    """Real engine in paper mode with a real in-memory DB and mocked provider."""
+    """Real engine in paper mode with a real DB and mocked provider."""
     df = _make_market_data()
     provider = MagicMock()
     provider.get_live_data.return_value = df
     provider.get_historical_data.return_value = df
     provider.get_current_price.return_value = float(df["close"].iloc[-1])
 
-    db = DatabaseManager("sqlite:///:memory:")
+    # DATABASE_URL is provisioned by conftest: CI Postgres service for
+    # integration runs, in-memory SQLite locally. A hardcoded SQLite URL is
+    # rejected by DatabaseManager in CI.
+    db = DatabaseManager()
     with (
         patch("src.engines.live.trading_engine.DatabaseManager"),
         patch("src.engines.live.trading_engine.get_config", return_value={}),
@@ -70,7 +73,16 @@ def paper_engine():
     engine.live_position_tracker.db_manager = db
     engine.live_execution_engine.db_manager = db
     engine.event_logger.db_manager = db
-    yield engine, df
+    # The CI Postgres DB is shared across the sequential integration run;
+    # other tests may leave active sessions/positions behind. Disable session
+    # recovery so this smoke always starts a fresh session (recovery has its
+    # own dedicated coverage in tests/unit/engines/live/test_session_recovery.py
+    # and test_clean_restart_readoption.py).
+    with (
+        patch.object(db, "get_active_session_id", return_value=None),
+        patch.object(db, "get_last_session_id", return_value=None),
+    ):
+        yield engine, df
     if engine.is_running:
         engine.stop()
 

--- a/tests/integration/live/test_paper_session_smoke.py
+++ b/tests/integration/live/test_paper_session_smoke.py
@@ -1,0 +1,149 @@
+"""End-to-end paper-trading session smoke (#486 refactor).
+
+Drives the REAL LiveTradingEngine — real ml_basic strategy, real in-memory
+DatabaseManager — through start -> trading loop -> paper entry -> monitoring
+-> paper exit -> shutdown. Exercises the post-refactor wiring end to end:
+handler construction (LiveStopLossManager, LiveAccountMonitor), the bounded
+trading loop, entry/exit through the live handlers, and the shared
+backtest-parity P&L formula on the recorded fills.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.engines.live.trading_engine import LiveTradingEngine, PositionSide
+from src.performance.metrics import Side, pnl_percent
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = pytest.mark.integration
+
+SYMBOL = "BTCUSDT"
+
+
+def _make_market_data(periods: int = 200) -> pd.DataFrame:
+    idx = pd.date_range(
+        datetime.now(UTC) - pd.Timedelta(hours=periods - 1), periods=periods, freq="1h"
+    )
+    base = [100.0 + 0.1 * i for i in range(periods)]
+    return pd.DataFrame(
+        {
+            "open": base,
+            "high": [p + 1.0 for p in base],
+            "low": [p - 1.0 for p in base],
+            "close": [p + 0.5 for p in base],
+            "volume": [1000.0] * periods,
+        },
+        index=idx,
+    )
+
+
+@pytest.fixture
+def paper_engine():
+    """Real engine in paper mode with a real in-memory DB and mocked provider."""
+    df = _make_market_data()
+    provider = MagicMock()
+    provider.get_live_data.return_value = df
+    provider.get_historical_data.return_value = df
+    provider.get_current_price.return_value = float(df["close"].iloc[-1])
+
+    db = DatabaseManager("sqlite:///:memory:")
+    with (
+        patch("src.engines.live.trading_engine.DatabaseManager"),
+        patch("src.engines.live.trading_engine.get_config", return_value={}),
+    ):
+        engine = LiveTradingEngine(
+            strategy=create_ml_basic_strategy(),
+            data_provider=provider,
+            enable_live_trading=False,
+            initial_balance=10_000.0,
+            check_interval=0.01,
+            log_trades=False,
+        )
+    # Rewire every handler to the real DB (construction used the patched class).
+    engine.db_manager = db
+    engine.live_position_tracker.db_manager = db
+    engine.live_execution_engine.db_manager = db
+    engine.event_logger.db_manager = db
+    yield engine, df
+    if engine.is_running:
+        engine.stop()
+
+
+def test_paper_session_start_entry_exit_shutdown(paper_engine):
+    engine, df = paper_engine
+
+    # --- start(): session creation, handler wiring, three real loop iterations.
+    # Close-only mode keeps the real strategy from opening its own positions
+    # during the loop (its signals depend on wall-clock-anchored data and would
+    # make the scripted entry/exit below nondeterministic); exits still run.
+    engine._close_only_mode = True
+    engine.start(symbol=SYMBOL, timeframe="1h", max_steps=3)
+    assert engine.trading_session_id is not None
+    assert engine.stop_loss_manager is not None
+    assert engine.account_monitor is not None
+    assert engine._loop_crashed is False
+    assert engine.live_position_tracker.position_count == 0
+
+    baseline_positions = set(engine.live_position_tracker.positions)
+    baseline_trades = len(engine.completed_trades)
+    engine.resume_trading()
+
+    # --- paper entry through the real entry path
+    entry_price = float(df["close"].iloc[-1])
+    engine._execute_entry(
+        symbol=SYMBOL,
+        side=PositionSide.LONG,
+        size=0.05,
+        price=entry_price,
+        stop_loss=entry_price * 0.95,
+        take_profit=entry_price * 1.10,
+        signal_strength=0.9,
+        signal_confidence=0.9,
+    )
+    new_position_ids = set(engine.live_position_tracker.positions) - baseline_positions
+    assert len(new_position_ids) == 1
+
+    # --- monitoring through LiveAccountMonitor
+    engine._log_account_snapshot()
+    engine._log_status(SYMBOL, entry_price)
+    summary = engine.get_performance_summary()
+    assert summary["current_balance"] == engine.current_balance
+    assert summary["active_positions"] == engine.live_position_tracker.position_count
+
+    # --- paper exit through the real exit path
+    position = engine.live_position_tracker.positions[next(iter(new_position_ids))]
+    entry_balance = float(position.entry_balance)  # P&L basis: balance at entry
+    exit_price = entry_price * 1.05
+    engine._execute_exit(
+        position=position,
+        reason="smoke_exit",
+        limit_price=None,
+        current_price=exit_price,
+        candle_high=None,
+        candle_low=None,
+        candle=None,
+    )
+    assert next(iter(new_position_ids)) not in engine.live_position_tracker.positions
+    assert len(engine.completed_trades) == baseline_trades + 1
+
+    # Gross P&L must equal the shared pnl_percent formula on the RECORDED fill
+    # prices (slippage included) times the entry balance — the same arithmetic
+    # the backtest engine uses (backtest-live parity).
+    trade = engine.completed_trades[-1]
+    expected_gross = (
+        pnl_percent(trade.entry_price, trade.exit_price, Side.LONG, 0.05) * entry_balance
+    )
+    assert trade.pnl == pytest.approx(expected_gross, abs=1e-9)
+    # Default execution model applies 5bps slippage to both fills.
+    assert trade.entry_price == pytest.approx(entry_price * 1.0005, abs=1e-9)
+    assert trade.exit_price == pytest.approx(exit_price * 0.9995, abs=1e-9)
+
+    # --- clean shutdown (final stats via LiveAccountMonitor)
+    engine.stop()
+    assert engine.is_running is False

--- a/tests/unit/engines/live/test_stop_loss_manager.py
+++ b/tests/unit/engines/live/test_stop_loss_manager.py
@@ -1,0 +1,218 @@
+"""Unit tests for LiveStopLossManager (#486 handler extraction).
+
+Behavioral coverage of the cancel/fill/reprotect paths already exists in
+test_close_cancel_stop_710.py and test_stop_loss_cancel_escalation_741.py via
+the engine wrappers; these tests cover the manager's own contract — dynamic
+engine-state reads, placement retry/registration, and offline-fill detection.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.data_providers.exchange_interface import OrderSide, SideEffectType
+from src.data_providers.exchange_interface import OrderStatus as ExchangeOrderStatus
+from src.engines.live.execution.stop_loss_manager import LiveStopLossManager
+from src.engines.shared.models import PositionSide
+
+pytestmark = pytest.mark.fast
+
+
+def make_state(**overrides):
+    """Engine-state stand-in with the attributes the manager reads at call time."""
+    state = SimpleNamespace(
+        enable_live_trading=True,
+        exchange_interface=Mock(),
+        order_tracker=Mock(),
+        live_position_tracker=Mock(),
+    )
+    for key, value in overrides.items():
+        setattr(state, key, value)
+    return state
+
+
+def make_position(**overrides):
+    position = SimpleNamespace(
+        symbol="BTCUSDT",
+        side=PositionSide.LONG,
+        order_id="entry-1",
+        stop_loss_order_id="sl-1",
+        stop_loss=48000.0,
+        quantity=0.5,
+        current_size=0.02,
+        original_size=0.02,
+    )
+    for key, value in overrides.items():
+        setattr(position, key, value)
+    return position
+
+
+class TestDynamicStateReads:
+    def test_reads_exchange_interface_assigned_after_construction(self):
+        # Arrange: manager built before the exchange exists (engine startup order)
+        state = make_state(exchange_interface=None, enable_live_trading=False)
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        # Act: engine assigns exchange + flips live flag later (start() / tests)
+        state.exchange_interface = Mock()
+        state.exchange_interface.cancel_order.return_value = True
+        state.enable_live_trading = True
+        result = manager.cancel(make_position())
+
+        # Assert: the late-bound exchange was used
+        assert result is True
+        state.exchange_interface.cancel_order.assert_called_once_with("sl-1", "BTCUSDT")
+
+
+class TestPlaceProtection:
+    def test_success_registers_stop_with_tracker_and_order_tracker(self):
+        state = make_state()
+        state.exchange_interface.place_stop_loss_order.return_value = "sl-99"
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+        position = make_position(stop_loss_order_id=None)
+
+        sl_order_id = manager.place_protection(
+            position=position,
+            symbol="BTCUSDT",
+            side=PositionSide.LONG,
+            quantity=0.5,
+            stop_price=48000.0,
+        )
+
+        assert sl_order_id == "sl-99"
+        state.exchange_interface.place_stop_loss_order.assert_called_once_with(
+            symbol="BTCUSDT",
+            side=OrderSide.SELL,
+            quantity=0.5,
+            stop_price=48000.0,
+            side_effect_type=SideEffectType.AUTO_REPAY,
+        )
+        state.live_position_tracker.set_stop_loss_order_id.assert_called_once_with(
+            "entry-1", "sl-99"
+        )
+        state.order_tracker.track_order.assert_called_once_with("sl-99", "BTCUSDT")
+
+    def test_short_position_uses_buy_side(self):
+        state = make_state()
+        state.exchange_interface.place_stop_loss_order.return_value = "sl-2"
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        manager.place_protection(
+            position=make_position(side=PositionSide.SHORT),
+            symbol="BTCUSDT",
+            side=PositionSide.SHORT,
+            quantity=0.5,
+            stop_price=52000.0,
+        )
+
+        call = state.exchange_interface.place_stop_loss_order.call_args
+        assert call.kwargs["side"] == OrderSide.BUY
+
+    @patch("src.engines.live.execution.stop_loss_manager.time.sleep")
+    def test_retries_on_exception_then_succeeds(self, mock_sleep):
+        state = make_state()
+        state.exchange_interface.place_stop_loss_order.side_effect = [
+            ConnectionError("boom"),
+            "sl-after-retry",
+        ]
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        sl_order_id = manager.place_protection(
+            position=make_position(),
+            symbol="BTCUSDT",
+            side=PositionSide.LONG,
+            quantity=0.5,
+            stop_price=48000.0,
+        )
+
+        assert sl_order_id == "sl-after-retry"
+        assert state.exchange_interface.place_stop_loss_order.call_count == 2
+
+    @patch("src.engines.live.execution.stop_loss_manager.time.sleep")
+    def test_returns_none_after_exhausting_retries_without_registration(self, mock_sleep):
+        state = make_state()
+        state.exchange_interface.place_stop_loss_order.return_value = None
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        sl_order_id = manager.place_protection(
+            position=make_position(),
+            symbol="BTCUSDT",
+            side=PositionSide.LONG,
+            quantity=0.5,
+            stop_price=48000.0,
+        )
+
+        assert sl_order_id is None
+        assert state.exchange_interface.place_stop_loss_order.call_count == 3
+        state.live_position_tracker.set_stop_loss_order_id.assert_not_called()
+        state.order_tracker.track_order.assert_not_called()
+
+
+class TestCheckFilled:
+    def test_filled_order_returns_fill_price(self):
+        state = make_state()
+        state.exchange_interface.get_order.return_value = SimpleNamespace(
+            status=ExchangeOrderStatus.FILLED, average_price=47950.0
+        )
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        filled, price = manager.check_filled(make_position())
+
+        assert filled is True
+        assert price == 47950.0
+
+    def test_paper_mode_short_circuits_without_exchange_call(self):
+        state = make_state(enable_live_trading=False)
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        filled, price = manager.check_filled(make_position())
+
+        assert filled is False
+        assert price is None
+        state.exchange_interface.get_order.assert_not_called()
+
+
+class TestFindOfflineFilledStops:
+    def test_detects_filled_stop_missing_from_open_orders(self):
+        state = make_state()
+        state.exchange_interface.get_open_orders.return_value = [
+            SimpleNamespace(order_id="other-order")
+        ]
+        state.exchange_interface.get_order.return_value = SimpleNamespace(
+            status=ExchangeOrderStatus.FILLED, average_price=47900.0
+        )
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+        position = make_position()
+
+        result = manager.find_offline_filled_stops({"entry-1": position})
+
+        assert result == [(position, 47900.0)]
+
+    def test_resting_stop_is_not_flagged(self):
+        state = make_state()
+        state.exchange_interface.get_open_orders.return_value = [SimpleNamespace(order_id="sl-1")]
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        result = manager.find_offline_filled_stops({"entry-1": make_position()})
+
+        assert result == []
+        state.exchange_interface.get_order.assert_not_called()
+
+    def test_unverifiable_order_is_skipped_not_closed(self):
+        state = make_state()
+        state.exchange_interface.get_open_orders.return_value = []
+        state.exchange_interface.get_order.side_effect = ConnectionError("api down")
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        result = manager.find_offline_filled_stops({"entry-1": make_position()})
+
+        assert result == []
+
+    def test_open_orders_failure_propagates_to_caller(self):
+        state = make_state()
+        state.exchange_interface.get_open_orders.side_effect = ConnectionError("api down")
+        manager = LiveStopLossManager(engine_state=state, send_alert=Mock())
+
+        with pytest.raises(ConnectionError):
+            manager.find_offline_filled_stops({"entry-1": make_position()})


### PR DESCRIPTION
## Summary

Steps 1–3 of #486: a **pure refactor** of `LiveTradingEngine` that completes the handler-only approach for exchange-facing stop-loss operations, extracts monitoring glue, and consolidates the genuinely duplicated backtest/live entry-handler code into `engines/shared/`. No behavior change.

### What moved

| Commit | Extraction |
|--------|-----------|
| `0e3c0c5` | **`LiveStopLossManager`** (`engines/live/execution/stop_loss_manager.py`) — owns every exchange-facing stop-loss call: placement after entry (retry/backoff), cancellation before close, fill/held-inventory queries, re-protection after failed closes, and offline-fill detection for the legacy reconciliation fallback. The engine no longer calls `place_stop_loss_order`, `cancel_order`, `get_open_orders`, or `get_order` directly (the issue's acceptance criteria). |
| `9a8a1c0` | **`LiveAccountMonitor`** + dataframe extractors (`engines/live/monitoring/`) — balance/equity snapshots, status lines, final stats, performance summaries. Engine: 6,558 → 6,110 lines. |
| `d49b3d5` | **`SharedEntryHandlerMixin`** (`engines/shared/execution/entry_handler_mixin.py`) — the three AST-verified byte-identical methods (`_extract_entry_plan`, `_apply_dynamic_risk`, `get_dynamic_risk_adjustments`) now live once, inherited by both engines' entry handlers, so this slice of backtest-live parity holds by construction. Divergent orchestration (`process_runtime_decision`, `execute_entry`, exit checks) was deliberately **not** force-merged. |
| `d12eb12` | End-to-end **paper-session smoke test** + review polish. |
| `a5729d3` | Changelog + handler/lock-ownership table in `docs/live_trading.md`. |

### Design notes

- The engine keeps thin delegating wrappers (`_cancel_stop_loss_order`, `_log_account_snapshot`, …) so every existing call site and test mock point is unchanged.
- The new components hold **no locks and no mutable state**; they read `enable_live_trading` / `exchange_interface` / `order_tracker` / balances off the engine at call time via narrow `Protocol`s (these attributes are assigned during `start()` and swapped by tests after construction).
- All log messages, retry budgets, and exception scopes moved verbatim.

## Parity evidence

- Full unit suite green before and after every commit (3,953 → 3,965 tests, 0 failures).
- Parity suite (`tests/integration/parity/`, 51 tests) green throughout.
- A deterministic backtest fingerprint (ml_basic over a fixed synthetic series: 49 trades, final balance $9,919.054250535286, full trade-by-trade JSON) is **byte-identical** before/after every commit.
- New `tests/integration/live/test_paper_session_smoke.py`: real engine + real ml_basic strategy + real in-memory DB through start → bounded loop → paper entry → monitoring → paper exit → shutdown; asserts gross P&L on the recorded fills equals the shared `pnl_percent` formula on the entry balance.

## Reviews performed

- **code-reviewer**: line-by-line comparison against deleted code — no findings.
- **architecture-reviewer**: no blockers; P2 (caller-contract note on `find_offline_filled_stops`) and type-hint nit applied in `d12eb12`.
- **risk-officer**: APPROVE (high confidence) — every UNPROTECTED-position path verified equivalent to `origin/develop`; the #710 cancel/close/re-protect invariants preserved; flagged three pre-existing, refactor-neutral risks for follow-up (fire-and-forget webhook alerts, hardcoded SL retry budget, reconciler-deferral window in `position_still_held`).

## Testing

- `python tests/run_tests.py unit` — 3,965 passed, 103 skipped.
- `pytest tests/integration/parity tests/integration/live` — 82 passed.
- `atb dev quality` equivalents on touched files: black, ruff, mypy, bandit clean.

## Remaining #486 scope (follow-up PRs, per the issue's "one PR each" sequencing)

- (c) session/crash-recovery startup sequence → `engines/live/recovery.py`
- (d) config/feature-flag resolution → constructor-injected dataclass
- the <1,500-line engine target

Closes nothing yet — partial progress on #486.

https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa

---
_Generated by [Claude Code](https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa)_