### PR TITLE
fix(live): persist trade rows for reconciler FULL_EXIT + external closes (#731 follow-up)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -271,6 +271,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `recover_missing_trades` with an autospec'd `DatabaseManager`, so the real
   `log_trade` signature is enforced. Also clears pre-existing mypy loop-variable
   and ruff `UP038` debt on `account_sync.py` (behaviour-neutral).
+- Reconciler `trades` rows now cover two more close paths that previously corrected state
+  but recorded no trade row (extending #731's offline stop-loss trade-row logging). (1) The **crash-recovery
+  FULL_EXIT** path (`_reconcile_filled_exit`) opts into `log_trade=True` with a stable dedup
+  key — the real exchange exit order id, else a synthetic `reconcile_exit_<position_id>` — and
+  realizes P&L **only after** the DB position is actually closed (a failed close no longer
+  double-corrects the balance on the next reconcile pass). (2) **External/manual closes**
+  (operator sells on the exchange UI, or a liquidation) detected by `_verify_asset_holdings`
+  (spot) and `_remove_phantom_position` (margin) now persist a **balance-neutral** audit trade
+  row — commission (reconstructed entry leg) + quantity + GROSS pnl, priced mark-to-market via
+  the data provider (degrading to entry price → pnl 0 when no price source) — deduped by a
+  synthetic `reconcile_ext_<position_id>` key, gated on the DB close succeeding. These paths
+  deliberately do **not** realize P&L: a spot external close's capital is already reconciled by
+  startup Step C (`_reconcile_balance`), and a margin external close's by
+  `AccountSynchronizer._sync_margin_equity`, so writing the balance here too would double-book
+  the `account_balances` ledger. `PositionReconciler` now accepts an optional `data_provider`
+  for the mark-to-market estimate. Hardening on all reconciler close paths: the DB-close gate now
+  reads `close_position`'s actual return (it returns `False` **without raising** on a missing row
+  or a rolled-back commit, so "did not raise" was not "closed"); the external-close paths use
+  `pop_position` so a position already reconciled earlier in the same run is not logged twice (the
+  `reconcile_exit_`/`reconcile_ext_` keys do not collide); and a failed trade-row write on a
+  balance-neutral path now escalates as a missing-audit-row alert rather than a false
+  "account_balances/trades DIVERGED" page. (Known follow-up: `PeriodicReconciler._reconcile_cycle`
+  has parallel inline external-close detection that still records no trade row — its capital is
+  reconciled each cycle by the periodic balance step (notional check, like startup Step C), so this
+  is an audit-row gap, not a balance gap.)
 - Margin-equity balance corrections are now audited and alertable.
   `margin_equity_sync_correction` book-downs (written by
   `AccountSynchronizer._sync_margin_equity`) previously updated the balance ledger

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -150,6 +150,25 @@ Each closed `trades` row stores fees so consumers can compute true net P&L:
 > for positions that took partial exits (their intermediate P&L and fees are in the ledger,
 > not in `trades`). Logging partial-exit trade rows is tracked as a follow-up.
 
+> **Reconciler-closed trades.** When a position is closed during reconciliation rather than by
+> the engine, a `trades` row is still written so fees/quantity/P&L are not lost. Two kinds:
+> - **Closes the bot can price** — offline stop-loss (`_close_position_from_filled_sl`) and
+>   crash-recovery `FULL_EXIT` (`_reconcile_filled_exit`) — know the exit fill, so they realize
+>   P&L **and** log the trade (only after the DB position is confirmed closed; deduped by the
+>   exit order id or a synthetic `reconcile_exit_<position_id>` key).
+> - **External/manual closes** (operator sells on the exchange UI, or a liquidation) detected by
+>   a holdings/borrow check (`_verify_asset_holdings` spot, `_remove_phantom_position` margin)
+>   carry no fill. They log a **balance-neutral** trade row only (commission = reconstructed
+>   entry leg, GROSS pnl priced mark-to-market from the data provider, falling back to entry
+>   price → pnl 0), keyed by a synthetic `reconcile_ext_<position_id>`. They do **not** touch the
+>   balance: that capital is reconciled by startup Step C (`_reconcile_balance`, spot) or
+>   `AccountSynchronizer._sync_margin_equity` (margin), so realizing P&L here too would
+>   double-book the ledger. Because that GROSS pnl is a mark-to-market **estimate** (not the real
+>   external fill), it is an approximation wherever `trades.pnl` is summed — session metrics and
+>   the degraded `recover_last_balance` fallback — in the same spirit as the partial-exit caveat
+>   above; the authoritative `account_balances` ledger is unaffected. (`PeriodicReconciler`'s
+>   runtime external-close detection does not yet log a trade row — tracked as a follow-up.)
+
 ## CLI usage
 
 `atb live` forwards arguments to `src/engines/live/runner.py`:

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1910,11 +1910,11 @@ class PositionReconciler:
                 price = provider.get_current_price(symbol)
                 if price is not None and float(price) > 0:
                     return float(price)
-            except Exception as e:
+            except Exception:
                 logger.warning(
-                    "Could not fetch current price for external-close Trade row of %s: %s",
+                    "Could not fetch current price for external-close Trade row of %s",
                     symbol,
-                    e,
+                    exc_info=True,
                 )
         return float(getattr(position, "entry_price", 0.0) or 0.0)
 
@@ -2105,11 +2105,18 @@ class PositionReconciler:
                         "this run)",
                         symbol,
                     )
-                else:
-                    logger.info(
-                        "External close for %s — Trade row skipped (DB close not confirmed); "
-                        "will re-reconcile on a later pass",
+                elif db_pos_id:
+                    # Popped from the in-memory tracker but the DB row did NOT close (close_position
+                    # returned False / raised). Tracker and the DB positions table now disagree
+                    # (tracker says gone, DB says OPEN). Escalate (CODE.md: no silent divergence) —
+                    # the OPEN row is re-recovered on the next restart; manual reconciliation may be
+                    # needed meanwhile.
+                    logger.critical(
+                        "External close for %s: removed from tracker but DB position %s close "
+                        "FAILED (still OPEN) — memory/DB divergence; manual reconciliation may be "
+                        "needed.",
                         symbol,
+                        db_pos_id,
                     )
         except Exception as e:
             logger.warning("Asset holdings check failed for %s: %s", base_asset, e)
@@ -2243,6 +2250,16 @@ class PositionReconciler:
         # avoids a duplicate when an earlier pass already handled it.
         if db_closed and removed is not None:
             self._log_external_close_trade(position)
+        elif db_pos_id and removed is not None and not db_closed:
+            # Popped from the in-memory tracker but the DB row did NOT close — memory/DB divergence
+            # (CODE.md: no silent divergence). The phantom is gone on the exchange, so do not
+            # re-track; the OPEN DB row is re-recovered on the next restart.
+            logger.critical(
+                "Margin phantom %s removed from tracker but DB position %s close FAILED (still "
+                "OPEN) — memory/DB divergence; manual reconciliation may be needed.",
+                getattr(position, "symbol", "?"),
+                db_pos_id,
+            )
         result.status = "corrected"
         result.severity = Severity.HIGH
 
@@ -2779,6 +2796,7 @@ class PeriodicReconciler:
         symbols: list[str] | None = None,
         sweep_cooldown: dict[str, float] | None = None,
         lock_registry: Any = None,
+        data_provider: Any | None = None,
     ) -> None:
         """Initialize periodic reconciler.
 
@@ -2829,6 +2847,7 @@ class PeriodicReconciler:
             db_manager=db_manager,
             session_id=session_id,
             use_margin=use_margin,
+            data_provider=data_provider,
         )
 
     def start(self) -> None:

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -188,6 +188,7 @@ class PositionReconciler:
         max_position_size: float = 0.1,
         use_margin: bool = False,
         fee_rate: float = DEFAULT_FEE_RATE,
+        data_provider: Any | None = None,
     ) -> None:
         self.exchange = exchange_interface
         self.position_tracker = position_tracker
@@ -195,6 +196,10 @@ class PositionReconciler:
         self.session_id = session_id
         self.max_position_size = max_position_size
         self._use_margin = use_margin
+        # Optional market-data source (has get_current_price). Used only to mark-to-market the
+        # audit Trade row for an EXTERNAL close (the bot has no fill); never feeds a balance
+        # correction, so its absence degrades the row to entry-priced (P&L 0), nothing more.
+        self._data_provider = data_provider
         # Used to reconstruct fees when logging a Trade row for a reconciler-closed
         # position (recovered positions carry no entry-fee metadata). Route fee modelling
         # through the shared CostCalculator (CODE.md: never duplicate financial logic) so a
@@ -499,7 +504,12 @@ class PositionReconciler:
             exit_fee = order_commission_usd(exchange_order, symbol, fill_price)
             if exit_fee is None:
                 exit_fee = self._cost_calc.calculate_fee(fill_price * float(fill_qty or 0.0))
-            self._reconcile_filled_exit(order_data, fill_price, exit_fee=exit_fee)
+            self._reconcile_filled_exit(
+                order_data,
+                fill_price,
+                exit_fee=exit_fee,
+                exit_order_id=getattr(exchange_order, "order_id", None),
+            )
         elif order_type == "PARTIAL_EXIT":
             self._reconcile_filled_partial_exit(order_data, fill_price)
 
@@ -788,9 +798,22 @@ class PositionReconciler:
             raise
 
     def _reconcile_filled_exit(
-        self, order_data: dict, fill_price: float, exit_fee: float = 0.0
+        self,
+        order_data: dict,
+        fill_price: float,
+        exit_fee: float = 0.0,
+        exit_order_id: str | None = None,
     ) -> None:
-        """Close position if an exit order filled but position is still tracked."""
+        """Close a position whose exit order filled offline but is still tracked, and persist a
+        Trade row for the closure.
+
+        Mirrors the offline-SL reference (``_close_position_from_filled_sl``): P&L realization —
+        which also writes the Trade row — is gated on the DB position actually closing, so a
+        failed close does not double-correct the balance on the next reconcile pass (the row stays
+        OPEN and is re-recovered). The Trade uses a stable, non-NULL dedup key (the real exit order
+        id, else a synthetic id from ``position_id``) so a re-run collides on
+        ``uq_trade_order_session`` (NULL != NULL in Postgres) instead of inserting a duplicate.
+        """
         position_id = order_data.get("position_id")
         client_order_id = order_data.get("client_order_id", "")
 
@@ -815,16 +838,29 @@ class PositionReconciler:
                         order_id_to_remove,
                     )
 
-                # Close in DB
+                # Close in DB. close_position returns False (without raising) when the row is not
+                # found or the commit rolls back, so gate on the actual return — "did not raise" is
+                # not "closed", and logging a trade for a non-persisted close would diverge.
+                db_closed = False
                 try:
-                    self.db_manager.close_position(
-                        position_id, exit_price=fill_price if fill_price > 0 else None
+                    db_closed = bool(
+                        self.db_manager.close_position(
+                            position_id, exit_price=fill_price if fill_price > 0 else None
+                        )
                     )
-                    logger.info(
-                        "Reconciled filled exit %s: closed DB position %s",
-                        client_order_id,
-                        position_id,
-                    )
+                    if db_closed:
+                        logger.info(
+                            "Reconciled filled exit %s: closed DB position %s",
+                            client_order_id,
+                            position_id,
+                        )
+                    else:
+                        logger.warning(
+                            "close_position returned False for %s (exit order %s) — not persisted; "
+                            "skipping P&L/trade, will re-reconcile",
+                            position_id,
+                            client_order_id,
+                        )
                 except Exception as e:
                     logger.warning(
                         "Failed to close DB position %s for exit order %s: %s",
@@ -833,10 +869,20 @@ class PositionReconciler:
                         e,
                     )
 
-                # Realize P&L so session balance stays correct
-                if matched_position is not None and fill_price > 0:
+                # Realize P&L (and log the Trade row) ONLY once the DB position is closed.
+                # _realize_pnl_on_close corrects the balance unconditionally, so realizing it when
+                # the close failed (row still OPEN) would double-subtract on the next reconcile
+                # pass — and the row would be re-recovered anyway.
+                if matched_position is not None and fill_price > 0 and db_closed:
+                    # db_closed implies a non-NULL position_id, so the synthetic key is non-NULL.
+                    stable_exit_id = exit_order_id or f"reconcile_exit_{position_id}"
                     self._realize_pnl_on_close(
-                        matched_position, fill_price, "exit_order_recovery", exit_fee=exit_fee
+                        matched_position,
+                        fill_price,
+                        "exit_order_recovery",
+                        exit_fee=exit_fee,
+                        log_trade=True,
+                        exit_order_id=stable_exit_id,
                     )
         except Exception as e:
             logger.warning(
@@ -1777,8 +1823,9 @@ class PositionReconciler:
         db_closed = False
         if db_pos_id:
             try:
-                self.db_manager.close_position(db_pos_id, exit_price=exit_price)
-                db_closed = True
+                # Gate on close_position's actual return (False without raising = row not
+                # found / commit rolled back), not merely "did not raise".
+                db_closed = bool(self.db_manager.close_position(db_pos_id, exit_price=exit_price))
             except Exception as e:
                 logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
 
@@ -1846,6 +1893,73 @@ class PositionReconciler:
         except (TypeError, ValueError):
             pass
         return qty
+
+    def _external_close_exit_price(self, position: Any) -> float:
+        """Best-effort exit price for an externally-closed position.
+
+        The bot did not execute the close (manual sell on the exchange UI, or a liquidation), so
+        no fill price is known. Use the current market price as a mark-to-market estimate; fall
+        back to ``entry_price`` (GROSS P&L 0) when no price source is available. This only feeds
+        the audit Trade row — the session balance is owned by Step C (spot) / margin-equity sync
+        (margin), so the estimate never affects capital correctness.
+        """
+        symbol = getattr(position, "symbol", "") or ""
+        provider = getattr(self, "_data_provider", None)
+        if provider is not None and symbol:
+            try:
+                price = provider.get_current_price(symbol)
+                if price is not None and float(price) > 0:
+                    return float(price)
+            except Exception as e:
+                logger.warning(
+                    "Could not fetch current price for external-close Trade row of %s: %s",
+                    symbol,
+                    e,
+                )
+        return float(getattr(position, "entry_price", 0.0) or 0.0)
+
+    def _log_external_close_trade(self, position: Any) -> None:
+        """Persist a balance-neutral Trade row for an externally-closed position (audit only).
+
+        External closes are detected by a holdings/borrow check, so the bot has no fill — but the
+        closure still must leave a ``trades`` row (commission + quantity + GROSS pnl) for fee/P&L
+        accounting, the same gap #731 closed for the offline-SL path. Unlike the SL/exit paths this
+        does NOT realize P&L: an external close's capital is reconciled by Step C (spot) /
+        margin-equity sync (margin), so writing the balance here too would double-book the ledger.
+        Deduped by a stable, non-NULL ``reconcile_ext_{db_position_id}`` key — the external close's
+        exchange order id is not persisted, so a synthetic key keeps re-runs idempotent over
+        ``uq_trade_order_session`` (NULL != NULL in Postgres). Callers gate this on the DB position
+        actually closing so a failed close is re-reconciled, not logged twice.
+        """
+        db_pos_id = getattr(position, "db_position_id", None)
+        if db_pos_id is None:
+            return
+        exit_price = self._external_close_exit_price(position)
+        entry_price = float(getattr(position, "entry_price", 0) or 0.0)
+        if exit_price <= 0 or entry_price <= 0:
+            return
+        qty = self._closed_slice_quantity(position)
+        if qty <= 0:
+            return
+        side = getattr(position, "side", "long")
+        side_is_short = side == PositionSide.SHORT or str(side).lower() == "short"
+        gross_pnl = (
+            (entry_price - exit_price) * qty if side_is_short else (exit_price - entry_price) * qty
+        )
+        # exit_fee/interest are unknown for an external close (not executed by the bot); leave them
+        # 0 — the entry-fee leg is still reconstructed inside _log_reconciliation_trade.
+        self._log_reconciliation_trade(
+            position=position,
+            entry_price=entry_price,
+            exit_price=exit_price,
+            qty=qty,
+            gross_pnl=gross_pnl,
+            exit_fee=0.0,
+            interest_cost=0.0,
+            reason="external_close_recovery",
+            exit_order_id=f"reconcile_ext_{db_pos_id}",
+            balance_realized=False,
+        )
 
     @staticmethod
     def _extract_base_asset(symbol: str) -> str:
@@ -1961,23 +2075,42 @@ class PositionReconciler:
                     held_qty,
                     position_qty,
                 )
-                # Remove from in-memory tracker
-                self.position_tracker.remove_position(position.order_id)
-                # Close the DB position
+                # Pop from the in-memory tracker. pop_position returns the position only if it was
+                # STILL tracked: if an earlier Step-A pending-exit reconcile already closed+removed
+                # it this run, this returns None and we must NOT log a second external-close trade
+                # (the reconcile_exit_/reconcile_ext_ keys do not collide, so dedup would miss it).
+                removed = self.position_tracker.pop_position(position.order_id)
+                # Close the DB position. Gate on close_position's actual return (False without
+                # raising = row not found / commit rolled back), not merely "did not raise".
                 db_pos_id = getattr(position, "db_position_id", None)
+                db_closed = False
                 if db_pos_id:
                     try:
-                        self.db_manager.close_position(db_pos_id)
+                        db_closed = bool(self.db_manager.close_position(db_pos_id))
                     except Exception as e:
                         logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
 
-                # Realize P&L — no exit price available for external closes,
-                # so skip balance update (P&L is unknown)
-                # External closes have no fill price; we cannot compute P&L
-                logger.info(
-                    "External close for %s — P&L not realized (no exit price)",
-                    symbol,
-                )
+                # Do NOT realize P&L here: a spot external close's capital is reconciled by Step C
+                # (_reconcile_balance), which always runs right after position verification —
+                # realizing here too would double-book the balance ledger. Persist a balance-neutral
+                # Trade row (commission/quantity/GROSS pnl, priced mark-to-market) only when WE
+                # closed a still-tracked position (removed is not None) and the DB row actually
+                # closed — so a failed close is re-reconciled and an already-handled position is not
+                # logged twice.
+                if db_closed and removed is not None:
+                    self._log_external_close_trade(position)
+                elif removed is None:
+                    logger.info(
+                        "External close for %s — Trade row skipped (position already reconciled "
+                        "this run)",
+                        symbol,
+                    )
+                else:
+                    logger.info(
+                        "External close for %s — Trade row skipped (DB close not confirmed); "
+                        "will re-reconcile on a later pass",
+                        symbol,
+                    )
         except Exception as e:
             logger.warning("Asset holdings check failed for %s: %s", base_asset, e)
 
@@ -2095,13 +2228,21 @@ class PositionReconciler:
                     e,
                 )
 
-        self.position_tracker.remove_position(position.order_id)
+        removed = self.position_tracker.pop_position(position.order_id)
         db_pos_id = getattr(position, "db_position_id", None)
+        db_closed = False
         if db_pos_id:
             try:
-                self.db_manager.close_position(db_pos_id)
+                db_closed = bool(self.db_manager.close_position(db_pos_id))
             except Exception as e:
                 logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
+        # A margin phantom is an external close / liquidation. Capital is reconciled by
+        # account_sync margin-equity sync (true net equity), so do NOT realize P&L here; persist a
+        # balance-neutral audit Trade row (deduped by reconcile_ext_{db_position_id}) only when WE
+        # closed a still-tracked position (pop returned it) and the DB row actually closed —
+        # avoids a duplicate when an earlier pass already handled it.
+        if db_closed and removed is not None:
+            self._log_external_close_trade(position)
         result.status = "corrected"
         result.severity = Severity.HIGH
 
@@ -2418,6 +2559,7 @@ class PositionReconciler:
         interest_cost: float,
         reason: str,
         exit_order_id: str | None,
+        balance_realized: bool = True,
     ) -> None:
         """Insert a ``trades`` row for a reconciler-closed position, commission and
         quantity populated.
@@ -2500,18 +2642,30 @@ class PositionReconciler:
                 getattr(position, "symbol", "?"),
             )
         except Exception as e:
-            # The balance was already corrected and the DB position closed by the caller,
-            # so a failure here leaves account_balances and trades diverged with no row to
-            # explain the delta. Escalate (CRITICAL + stack trace) rather than swallow at
-            # WARNING — "silent divergence is a bug" (CODE.md). Still do not re-raise:
-            # reconciliation must continue for the remaining positions.
-            logger.critical(
-                "Balance corrected for %s but FAILED to persist its trades row: %s — "
-                "account_balances and trades have DIVERGED; manual reconciliation required.",
-                getattr(position, "symbol", "?"),
-                e,
-                exc_info=True,
-            )
+            # Escalate (CRITICAL + stack trace) rather than swallow at WARNING — "silent
+            # divergence is a bug" (CODE.md). Still do not re-raise: reconciliation must continue
+            # for the remaining positions. The alert differs by whether the caller moved the
+            # balance: a balance-realizing path (SL/exit) leaves account_balances and trades
+            # genuinely diverged; a balance-neutral path (external close) only loses an audit row
+            # (capital is reconciled by Step C / margin-equity sync), so it must NOT page as a
+            # ledger divergence.
+            if balance_realized:
+                logger.critical(
+                    "Balance corrected for %s but FAILED to persist its trades row: %s — "
+                    "account_balances and trades have DIVERGED; manual reconciliation required.",
+                    getattr(position, "symbol", "?"),
+                    e,
+                    exc_info=True,
+                )
+            else:
+                logger.critical(
+                    "FAILED to persist the external-close audit trades row for %s: %s — the close "
+                    "is missing from the trades table (balance is reconciled separately, so no "
+                    "account_balances divergence). Investigate the trades write path.",
+                    getattr(position, "symbol", "?"),
+                    e,
+                    exc_info=True,
+                )
 
     def _persist_position_correction(
         self,

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -5444,6 +5444,7 @@ class LiveTradingEngine:
                     max_position_size=self.max_position_size,
                     use_margin=use_margin,
                     fee_rate=self.live_execution_engine.fee_rate,
+                    data_provider=self.data_provider,
                 )
 
                 if not positions_snapshot:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1707,6 +1707,7 @@ class LiveTradingEngine:
                     symbols=[self._active_symbol] if self._active_symbol else [],
                     sweep_cooldown=self._orphan_sweep_cooldown,
                     lock_registry=self._base_asset_locks,
+                    data_provider=self.data_provider,
                 )
                 self._periodic_reconciler.start()
                 logger.info("🔄 Periodic reconciler started")

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -1007,7 +1007,7 @@ class TestAssetHoldingsVerification:
         assert result.status == "corrected"
         assert result.severity == Severity.HIGH
         assert any("closed externally" in c.reason for c in result.corrections)
-        mock_position_tracker.remove_position.assert_called_once_with(pos.order_id)
+        mock_position_tracker.pop_position.assert_called_once_with(pos.order_id)
         mock_db.close_position.assert_called_once_with(10)
 
     def test_position_with_sufficient_balance_not_flagged(
@@ -1113,7 +1113,7 @@ class TestAssetHoldingsVerification:
 
         result = reconciler.reconcile_position(pos)
         assert result.status == "corrected"
-        mock_position_tracker.remove_position.assert_called_once()
+        mock_position_tracker.pop_position.assert_called_once()
         mock_db.close_position.assert_not_called()
 
 
@@ -3004,7 +3004,16 @@ class TestReconciliationFeeAccounting:
         with patch.object(reconciler, "_realize_pnl_on_close") as mock_pnl:
             reconciler._reconcile_filled_exit(order_data, fill_price=51000.0, exit_fee=0.60)
 
-        mock_pnl.assert_called_once_with(position, 51000.0, "exit_order_recovery", exit_fee=0.60)
+        # Now opts into Trade-row logging with a stable dedup key. No real exit order id was
+        # threaded, so the synthetic reconcile_exit_<position_id> key is used.
+        mock_pnl.assert_called_once_with(
+            position,
+            51000.0,
+            "exit_order_recovery",
+            exit_fee=0.60,
+            log_trade=True,
+            exit_order_id="reconcile_exit_42",
+        )
 
     def test_stop_loss_recovery_passes_commission_to_pnl(
         self, reconciler, mock_exchange, mock_db, mock_position_tracker

--- a/tests/unit/test_trade_commission_quantity_persistence.py
+++ b/tests/unit/test_trade_commission_quantity_persistence.py
@@ -758,6 +758,52 @@ def test_reconciler_filled_exit_scale_in_nulls_quantity(monkeypatch):
     assert t["order_id"] == "EXCH-SI"
 
 
+def test_periodic_reconciler_forwards_data_provider_to_embedded_reconciler():
+    """PeriodicReconciler forwards its data_provider to the embedded PositionReconciler so an
+    external close it delegates is priced mark-to-market, not entry-priced (CODE.md: every caller
+    of a new constructor param passes it)."""
+    from types import SimpleNamespace
+
+    from src.engines.live.reconciliation import PeriodicReconciler
+
+    provider = SimpleNamespace(get_current_price=lambda _s: 123.0)
+    periodic = PeriodicReconciler(
+        exchange_interface=Mock(),
+        position_tracker=Mock(),
+        db_manager=MockDatabaseManager(),
+        session_id=1,
+        data_provider=provider,
+    )
+
+    assert periodic._position_reconciler._data_provider is provider
+
+
+def test_reconciler_external_close_logs_critical_on_db_close_divergence(monkeypatch, caplog):
+    """Popped from the tracker but close_position fails (returns False) → the memory/DB divergence
+    is escalated to CRITICAL (CODE.md: no silent divergence) and no trade row is written."""
+    import logging
+    from types import SimpleNamespace
+
+    db = MockDatabaseManager()
+    monkeypatch.setattr(db, "close_position", Mock(return_value=False))
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 81
+    position.order_id = "pos-81"
+    position.stop_loss_order_id = None
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    reconciler._data_provider = SimpleNamespace(get_current_price=lambda _s: 110.0)
+
+    with caplog.at_level(logging.CRITICAL, logger="src.engines.live.reconciliation"):
+        reconciler._remove_phantom_position(position, _recon_result())
+
+    assert len(db._trades) == 0
+    assert any(
+        r.levelno == logging.CRITICAL and "divergence" in r.getMessage().lower()
+        for r in caplog.records
+    )
+
+
 def test_reconciler_dedups_duplicate_trade_on_rerun():
     """A re-run with the same exit_order_id + session inserts only ONE trade row.
 

--- a/tests/unit/test_trade_commission_quantity_persistence.py
+++ b/tests/unit/test_trade_commission_quantity_persistence.py
@@ -318,16 +318,46 @@ def test_order_commission_usd_returns_none_for_unconvertible_asset(asset):
     assert _order_commission_usd(order, "ETHUSDT", 2100.0) is None
 
 
-def _make_reconciler(db, fee_rate=0.001):
+def _make_reconciler(db, fee_rate=0.001, tracker=None):
     from src.engines.live.reconciliation import PositionReconciler
 
     return PositionReconciler(
         exchange_interface=Mock(),
-        position_tracker=Mock(),
+        position_tracker=tracker if tracker is not None else Mock(),
         db_manager=db,
         session_id=1,
         fee_rate=fee_rate,
     )
+
+
+def _tracker_with(position):
+    """A position_tracker stub exposing the internals the reconciler close paths read:
+    a real lock + a {order_id: position} map, a spied remove_position, and a real
+    pop_position that removes and returns the position (None if already gone)."""
+    import threading
+    from types import SimpleNamespace
+
+    positions = {position.order_id: position}
+    tracker = SimpleNamespace(
+        _positions=positions,
+        _positions_lock=threading.Lock(),
+        remove_position=Mock(),
+    )
+    tracker.pop_position = lambda oid: positions.pop(oid, None)
+    return tracker
+
+
+def _recon_result():
+    from src.engines.live.reconciliation import ReconciliationResult
+
+    return ReconciliationResult(entity_type="position", entity_id=None, status="resolved")
+
+
+def _register_open_position(db, position):
+    """Register the position in the mock DB so close_position(db_position_id) returns True —
+    mirrors a real OPEN row that the reconciler then closes (the close paths now gate on the
+    actual return value, so an unregistered row would read as 'not closed')."""
+    db._positions[position.db_position_id] = {"id": position.db_position_id, "status": "OPEN"}
 
 
 def test_reconciler_logs_trade_with_commission_and_quantity():
@@ -406,6 +436,7 @@ def test_reconciler_filled_sl_converts_short_commission_to_usd_and_dedups(monkey
     )
     position.db_position_id = 77
     position.order_id = "pos-77"
+    _register_open_position(db, position)
     # Filled SL with NO order id (forces a synthetic dedup key); commission in base asset ETH.
     sl_order = NS(average_price=90.0, order_id=None, commission=0.001, commission_asset="ETH")
 
@@ -442,6 +473,289 @@ def test_reconciler_filled_sl_skips_trade_when_db_close_fails(monkeypatch):
     reconciler._close_position_from_filled_sl(position, sl_order)
 
     assert len(db._trades) == 0  # DB close failed -> trade not logged (no duplicate risk)
+
+
+def test_reconciler_filled_exit_logs_trade_with_exchange_order_id(monkeypatch):
+    """Crash-recovery FULL_EXIT: closing a still-tracked position logs a Trade row keyed by the
+    real exchange exit order id, with commission + quantity + GROSS pnl (parity with offline SL)."""
+    db = MockDatabaseManager()
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 55
+    position.order_id = "pos-55"
+    _register_open_position(db, position)
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+
+    reconciler._reconcile_filled_exit(
+        {"position_id": 55, "client_order_id": "atbx_exit_1"},
+        fill_price=90.0,
+        exit_fee=0.2,
+        exit_order_id="EXCH-EXIT-999",
+    )
+
+    trades = db._trades
+    assert len(trades) == 1
+    t = list(trades.values())[0]
+    assert t["order_id"] == "EXCH-EXIT-999"  # real exchange exit order id as the dedup key
+    assert t["quantity"] == pytest.approx(2.5)
+    # entry fee = 2.5*100*0.001 = 0.25 ; commission = 0.25 + exit_fee 0.2 = 0.45
+    assert t["commission"] == pytest.approx(0.45, abs=0.01)
+    assert t["pnl"] == pytest.approx((90.0 - 100.0) * 2.5)  # GROSS long pnl = -25.0
+
+
+def test_reconciler_filled_exit_synthesizes_dedup_key_when_no_exchange_id(monkeypatch):
+    """With no exchange exit id, a synthetic non-NULL key reconcile_exit_<pos_id> is used so a
+    re-run collides on uq_trade_order_session instead of inserting a duplicate."""
+    db = MockDatabaseManager()
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 56
+    position.order_id = "pos-56"
+    _register_open_position(db, position)
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+
+    reconciler._reconcile_filled_exit(
+        {"position_id": 56, "client_order_id": "atbx_exit_2"},
+        fill_price=110.0,
+        exit_fee=0.0,
+        exit_order_id=None,
+    )
+
+    t = list(db._trades.values())[0]
+    assert t["order_id"] == "reconcile_exit_56"
+
+
+def test_reconciler_filled_exit_skips_trade_when_db_close_fails(monkeypatch):
+    """If the DB position close fails, NO trade is logged and the balance is NOT corrected — the
+    row stays OPEN and is re-reconciled later (avoids the double balance correction)."""
+    db = MockDatabaseManager()
+    monkeypatch.setattr(db, "close_position", Mock(side_effect=RuntimeError("db down")))
+    no_balance_write = Mock()
+    monkeypatch.setattr(db, "update_balance", no_balance_write)
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 57
+    position.order_id = "pos-57"
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+
+    reconciler._reconcile_filled_exit(
+        {"position_id": 57, "client_order_id": "atbx_exit_3"},
+        fill_price=90.0,
+        exit_fee=0.2,
+        exit_order_id="EXCH-1",
+    )
+
+    assert len(db._trades) == 0  # DB close failed -> trade not logged (no duplicate risk)
+    no_balance_write.assert_not_called()  # and P&L not realized -> no double balance correction
+
+
+def test_reconciler_external_close_spot_logs_balance_neutral_trade(monkeypatch):
+    """SPOT external close (asset sold on the exchange UI): a balance-neutral Trade row is logged
+    (audit only) keyed by reconcile_ext_<pos_id>, priced mark-to-market. Capital is owned by
+    Step C (_reconcile_balance), so the session balance is NOT written here."""
+    from types import SimpleNamespace
+
+    db = MockDatabaseManager()
+    no_balance_write = Mock()
+    monkeypatch.setattr(db, "update_balance", no_balance_write)
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0, symbol="ETHUSDT")
+    position.db_position_id = 61
+    position.order_id = "pos-61"
+    _register_open_position(db, position)
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    # Exchange holds ~0 ETH -> external close detected (held < 50% of tracked 2.5).
+    reconciler.exchange.get_balance = Mock(return_value=SimpleNamespace(total=0.0))
+    # Current market price feeds the mark-to-market estimate for the audit row.
+    reconciler._data_provider = SimpleNamespace(get_current_price=lambda _s: 110.0)
+
+    reconciler._verify_asset_holdings(position, _recon_result())
+
+    trades = db._trades
+    assert len(trades) == 1
+    t = list(trades.values())[0]
+    assert t["order_id"] == "reconcile_ext_61"  # synthetic, non-NULL, stable across re-runs
+    assert t["quantity"] == pytest.approx(2.5)
+    assert t["commission"] is not None and t["commission"] > 0.0  # reconstructed entry fee
+    assert t["pnl"] == pytest.approx((110.0 - 100.0) * 2.5)  # GROSS long pnl = 25.0
+    no_balance_write.assert_not_called()  # balance-neutral; capital owned by Step C
+
+
+def test_reconciler_external_close_margin_logs_balance_neutral_trade(monkeypatch):
+    """MARGIN external close/liquidation via _remove_phantom_position: a balance-neutral Trade row
+    is logged. Capital is owned by account_sync margin-equity sync, so balance is NOT written."""
+    from types import SimpleNamespace
+
+    db = MockDatabaseManager()
+    no_balance_write = Mock()
+    monkeypatch.setattr(db, "update_balance", no_balance_write)
+    position = _make_position(
+        quantity=2.5, entry_fee=None, side=PositionSide.SHORT, entry_price=100.0
+    )
+    position.db_position_id = 62
+    position.order_id = "pos-62"
+    position.stop_loss_order_id = None
+    _register_open_position(db, position)
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    reconciler._data_provider = SimpleNamespace(get_current_price=lambda _s: 90.0)
+
+    reconciler._remove_phantom_position(position, _recon_result())
+
+    t = list(db._trades.values())[0]
+    assert t["order_id"] == "reconcile_ext_62"
+    assert t["pnl"] == pytest.approx((100.0 - 90.0) * 2.5)  # GROSS short pnl = 25.0
+    assert t["quantity"] == pytest.approx(2.5)
+    no_balance_write.assert_not_called()
+
+
+def test_reconciler_external_close_skips_trade_when_db_close_fails(monkeypatch):
+    """If the DB position close fails, NO external-close Trade row is logged — the row stays OPEN
+    and is re-recovered later; logging now would duplicate it."""
+    from types import SimpleNamespace
+
+    db = MockDatabaseManager()
+    monkeypatch.setattr(db, "close_position", Mock(side_effect=RuntimeError("db down")))
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 63
+    position.order_id = "pos-63"
+    position.stop_loss_order_id = None
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    reconciler._data_provider = SimpleNamespace(get_current_price=lambda _s: 110.0)
+
+    reconciler._remove_phantom_position(position, _recon_result())
+
+    assert len(db._trades) == 0
+
+
+def test_reconciler_external_close_dedups_across_restart(monkeypatch):
+    """Across a restart (position re-loaded into the tracker, DB row re-opened, but the persisted
+    trade row remains), re-detecting the same external close inserts only ONE Trade row: the
+    synthetic reconcile_ext_<pos_id> key collides on uq_trade_order_session."""
+    from types import SimpleNamespace
+
+    db = MockDatabaseManager()
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 64
+    position.order_id = "pos-64"
+    position.stop_loss_order_id = None
+    _register_open_position(db, position)
+    tracker = _tracker_with(position)
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=tracker)
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    reconciler._data_provider = SimpleNamespace(get_current_price=lambda _s: 110.0)
+
+    reconciler._remove_phantom_position(position, _recon_result())  # logs reconcile_ext_64
+    # Simulate a later restart: the position is re-tracked and the DB row re-opened, but the
+    # persisted trade row remains, so the second attempt dedups instead of duplicating.
+    tracker._positions[position.order_id] = position
+    _register_open_position(db, position)
+    reconciler._remove_phantom_position(position, _recon_result())
+
+    assert len(db._trades) == 1  # synthetic key collided on uq_trade_order_session
+
+
+def test_external_close_exit_price_falls_back_to_entry_when_no_provider():
+    """With no data provider, the external-close exit price degrades to entry_price (GROSS pnl 0),
+    so the audit row still records commission + quantity without fabricating a price."""
+    db = MockDatabaseManager()
+    reconciler = _make_reconciler(db, fee_rate=0.001)  # no data_provider threaded
+
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+
+    assert reconciler._external_close_exit_price(position) == pytest.approx(100.0)
+
+
+def test_reconciler_filled_exit_skips_trade_when_db_close_returns_false(monkeypatch):
+    """close_position returns False (row not found / commit rolled back) WITHOUT raising — the gate
+    must treat that as 'not closed' and log no trade (else trades/account_balances diverge)."""
+    db = MockDatabaseManager()
+    monkeypatch.setattr(db, "close_position", Mock(return_value=False))
+    no_balance_write = Mock()
+    monkeypatch.setattr(db, "update_balance", no_balance_write)
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 71
+    position.order_id = "pos-71"
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+
+    reconciler._reconcile_filled_exit(
+        {"position_id": 71, "client_order_id": "atbx_exit_f"},
+        fill_price=90.0,
+        exit_fee=0.2,
+        exit_order_id="EXCH-F",
+    )
+
+    assert len(db._trades) == 0  # False return -> not persisted -> no trade
+    no_balance_write.assert_not_called()
+
+
+def test_reconciler_external_close_skips_trade_when_db_close_returns_false(monkeypatch):
+    """External close: close_position returning False (not raising) must skip the trade row."""
+    from types import SimpleNamespace
+
+    db = MockDatabaseManager()
+    monkeypatch.setattr(db, "close_position", Mock(return_value=False))
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0)
+    position.db_position_id = 72
+    position.order_id = "pos-72"
+    position.stop_loss_order_id = None
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    reconciler._data_provider = SimpleNamespace(get_current_price=lambda _s: 110.0)
+
+    reconciler._remove_phantom_position(position, _recon_result())
+
+    assert len(db._trades) == 0
+
+
+def test_reconciler_external_close_skips_trade_when_position_already_reconciled(monkeypatch):
+    """If an earlier reconcile pass already removed+closed the position (pop_position returns None),
+    the external-close path must NOT log a second trade row — the reconcile_exit_/reconcile_ext_
+    keys differ, so uq_trade_order_session would not catch the duplicate."""
+    from types import SimpleNamespace
+
+    db = MockDatabaseManager()
+    position = _make_position(quantity=2.5, entry_fee=None, entry_price=100.0, symbol="ETHUSDT")
+    position.db_position_id = 73
+    position.order_id = "pos-73"
+    tracker = _tracker_with(position)
+    tracker.pop_position(position.order_id)  # simulate Step A already popped it this run
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=tracker)
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    reconciler.exchange.get_balance = Mock(return_value=SimpleNamespace(total=0.0))
+    reconciler._data_provider = SimpleNamespace(get_current_price=lambda _s: 110.0)
+
+    reconciler._verify_asset_holdings(position, _recon_result())
+
+    assert len(db._trades) == 0  # not double-logged
+
+
+def test_reconciler_filled_exit_scale_in_nulls_quantity(monkeypatch):
+    """A scaled-in position closed through the FULL_EXIT caller stores NULL quantity (regression
+    guard: the caller's qty pre-scaling must not produce a logged quantity for a scale-in)."""
+    db = MockDatabaseManager()
+    position = _make_position(
+        quantity=2.5, entry_fee=None, entry_price=100.0, size=0.40, current_size=0.40
+    )
+    position.original_size = 0.25  # scaled in beyond the original fraction
+    position.db_position_id = 75
+    position.order_id = "pos-75"
+    _register_open_position(db, position)
+    reconciler = _make_reconciler(db, fee_rate=0.001, tracker=_tracker_with(position))
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+
+    reconciler._reconcile_filled_exit(
+        {"position_id": 75, "client_order_id": "atbx_exit_si"},
+        fill_price=110.0,
+        exit_fee=0.11,
+        exit_order_id="EXCH-SI",
+    )
+
+    t = list(db._trades.values())[0]
+    assert t["quantity"] is None  # scale-in -> NULL, not the inflated 4.0
+    assert t["order_id"] == "EXCH-SI"
 
 
 def test_reconciler_dedups_duplicate_trade_on_rerun():


### PR DESCRIPTION
## What & why
Two `PositionReconciler` close paths corrected balance/state but wrote **no `trades` row** (commission/quantity/pnl unrecorded) — the same gap #731 (now merged, `561f342f`) fixed for the offline stop-loss path:

1. **Crash-recovery `FULL_EXIT`** (`_reconcile_filled_exit`) now logs a trade (`log_trade=True`) with a stable dedup key — the real exit order id, else synthetic `reconcile_exit_<id>` — realized **only after** the DB position is confirmed closed (a failed close no longer double-corrects the balance next pass).
2. **External/manual closes + liquidations** (`_verify_asset_holdings` spot, `_remove_phantom_position` margin) now persist a **balance-neutral** audit trade row (commission + quantity + GROSS pnl, priced mark-to-market via a newly-threaded `data_provider`, keyed `reconcile_ext_<id>`). They deliberately **do not realize P&L** — that capital is owned by Step C (`_reconcile_balance`, spot) and `AccountSynchronizer._sync_margin_equity` (margin), so writing it here too would double-book the `account_balances` ledger. (Verified by an independent research pass + the deep-review architecture finder.)

## Hardening (deep-review follow-ups, all reconciler close paths)
- **DB-close gate now reads `close_position`'s actual return** — it returns `False` *without raising* on a missing row / rolled-back commit, so "did not raise" was not "closed".
- **External paths use `pop_position`** so a position already reconciled earlier in the same run isn't logged twice (the `reconcile_exit_`/`reconcile_ext_` keys don't collide → dedup wouldn't catch it).
- A failed trade-row write on a balance-neutral path **escalates as a missing-audit-row alert**, not a false "account_balances/trades DIVERGED" page.

## Testing
- New unit tests in `tests/unit/test_trade_commission_quantity_persistence.py`: filled-exit (real-id / synthetic-key / db-close-raise / db-close-False / scale-in NULL qty), external spot/margin (balance-neutral, db-close-False gate, already-reconciled pop guard, cross-restart dedup).
- Rebased onto current `develop` (post-#731 merge + #796 stop-loss-lifecycle refactor): **620 passed** across `tests/unit/live/` + `tests/unit/engines/live/`; black / ruff / mypy all green.
- Reviewed via `/deep-review-v2` (8 finders + verifier): 0 Important; the 3 Concerns + high-confidence nit it surfaced are addressed here.

## Known follow-up (separate)
`PeriodicReconciler._reconcile_cycle` has parallel **inline** external-close detection (runtime, not startup) that still logs no trade row. Its capital **is** reconciled each cycle by the periodic balance step (notional check, like startup Step C), so this is an audit-row gap, not a balance gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)