### PR TITLE
refactor(live): resolve construction-time settings via LiveEngineSettings (#486, step d)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # System Architecture
 
-> **Last Updated**: 2026-02-18
+> **Last Updated**: 2026-06-10
 > **Maintainer Note**: This is a living document. Update after major architectural changes or new component additions. Use the `/update-docs` command to keep this in sync.
 
 ---
@@ -293,6 +293,7 @@ Real-time execution with safety controls.
 - `recovery.py` - Startup recovery: session balance, persisted-position reload, exchange reconciliation (`LiveSessionRecoverer`)
 - `trade_close_accounting.py` - Close-accounting helpers (closed quantity, entry-fee USD, position portion) shared by exit and recovery paths
 - `monitoring/` - Account snapshots, status lines, performance summaries (`LiveAccountMonitor`)
+- `config.py` - Construction-time settings resolution (`LiveEngineSettings`): the #734 partial-ops feature gate, regime-detection env flag, and execution fill policy. `runner.py` resolves and injects `settings=LiveEngineSettings.resolve()`; the engine self-resolves when not injected. Runtime-dynamic flags stay runtime reads.
 
 The engine delegates to these handlers through thin private wrappers; see the
 handler decomposition and lock-ownership table in `docs/live_trading.md` (#486).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `LiveTradingEngine` construction-time settings resolution (feature flags /
+  env / app config) moved to `src/engines/live/config.py`
+  (`LiveEngineSettings`, #486 step d): the #734 `live_partial_operations`
+  gate, the `FEATURE_ENABLE_REGIME_DETECTION` env flag, and the
+  `EXECUTION_FILL_POLICY` fill-policy read. `runner.py` resolves and injects
+  settings explicitly; the engine self-resolves when not injected (using its
+  module-level lookups so existing test patch points keep working).
+  Runtime-dynamic flag reads (`ws_user_hard_reconnect`, hot-swap partial-ops
+  re-check, heartbeat steps) intentionally stay runtime.
 - Live trading engine refactor, steps 1–3 of #486 (pure refactor, no behavior
   change; verified by the full unit suite, the parity suite, and a
   deterministic backtest fingerprint that is byte-identical before/after):

--- a/src/engines/live/config.py
+++ b/src/engines/live/config.py
@@ -18,20 +18,14 @@ import logging
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Protocol
 
 from src.config import get_config
 from src.config.constants import DEFAULT_EXECUTION_FILL_POLICY
 from src.config.feature_flags import is_enabled
+from src.engines.live.config_source import ConfigSource
 from src.engines.shared.execution.fill_policy import FillPolicy, resolve_fill_policy
 
 logger = logging.getLogger(__name__)
-
-
-class ConfigSource(Protocol):
-    """Key-value app-config reader (structural match for ``ConfigManager``)."""
-
-    def get(self, key: str, default: str | None = None) -> str | None: ...
 
 
 @dataclass(frozen=True)

--- a/src/engines/live/config.py
+++ b/src/engines/live/config.py
@@ -1,0 +1,82 @@
+"""Construction-time settings resolution for the live trading engine.
+
+``LiveEngineSettings`` captures the feature-flag / environment / app-config
+reads the engine performs exactly once at construction, so the resolution
+logic lives outside ``LiveTradingEngine`` and the runner can build and inject
+settings explicitly (#486 step d).
+
+Deliberately NOT captured here: flags the engine re-reads at runtime because
+they may change mid-process and tests pin that dynamism —
+``ws_user_hard_reconnect`` (read per reconnect decision),
+``live_partial_operations`` re-checks on strategy hot-swap, and
+``ENGINE_HEARTBEAT_STEPS`` (read at loop start).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.config import get_config
+from src.config.constants import DEFAULT_EXECUTION_FILL_POLICY
+from src.config.feature_flags import is_enabled
+from src.engines.shared.execution.fill_policy import FillPolicy, resolve_fill_policy
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigSource(Protocol):
+    """Key-value app-config reader (structural match for ``ConfigManager``)."""
+
+    def get(self, key: str, default: str | None = None) -> str | None: ...
+
+
+@dataclass(frozen=True)
+class LiveEngineSettings:
+    """Resolved construction-time settings for ``LiveTradingEngine``.
+
+    Attributes:
+        partial_operations_allowed: ``live_partial_operations`` feature flag.
+            Hard gate for the #734 bookkeeping-only partial-ops hazard; the
+            engine disables partial exits/scale-ins when False.
+        regime_detection_enabled: ``FEATURE_ENABLE_REGIME_DETECTION`` env flag
+            gating the optional ``RegimeDetector``.
+        execution_fill_policy: Fill policy resolved from the
+            ``EXECUTION_FILL_POLICY`` app-config key.
+    """
+
+    partial_operations_allowed: bool
+    regime_detection_enabled: bool
+    execution_fill_policy: FillPolicy
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        flag_lookup: Callable[[str, bool], bool] = is_enabled,
+        env_lookup: Callable[[str, str], str] = os.getenv,
+        config_lookup: Callable[[], ConfigSource] = get_config,
+    ) -> LiveEngineSettings:
+        """Resolve settings from feature flags, environment, and app config.
+
+        The source callables default to the real lookups; the engine passes
+        its own module-level names so existing test patch points
+        (``trading_engine.is_enabled``, ``trading_engine.get_config``) keep
+        intercepting resolution.
+        """
+        policy_name: str | None = DEFAULT_EXECUTION_FILL_POLICY
+        try:
+            cfg = config_lookup()
+            policy_name = cfg.get("EXECUTION_FILL_POLICY", DEFAULT_EXECUTION_FILL_POLICY)
+        except Exception as exc:
+            logger.warning("Failed to read execution fill policy config: %s", exc)
+
+        return cls(
+            partial_operations_allowed=flag_lookup("live_partial_operations", False),
+            regime_detection_enabled=env_lookup("FEATURE_ENABLE_REGIME_DETECTION", "").lower()
+            == "true",
+            execution_fill_policy=resolve_fill_policy(policy_name),
+        )

--- a/src/engines/live/config.py
+++ b/src/engines/live/config.py
@@ -52,6 +52,11 @@ class LiveEngineSettings:
     regime_detection_enabled: bool
     execution_fill_policy: FillPolicy
 
+    def __post_init__(self) -> None:
+        """Reject invalid settings at construction (CODE.md Input Validation)."""
+        if self.execution_fill_policy is None:
+            raise ValueError("execution_fill_policy must not be None")
+
     @classmethod
     def resolve(
         cls,

--- a/src/engines/live/config_source.py
+++ b/src/engines/live/config_source.py
@@ -1,0 +1,16 @@
+"""Structural type for key-value app-config readers.
+
+``ConfigSource`` is the duck type ``ConfigManager`` satisfies; settings
+resolution depends on this protocol rather than the concrete config class so
+tests can substitute plain mappings or specced mocks.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ConfigSource(Protocol):
+    """Key-value app-config reader (structural match for ``ConfigManager``)."""
+
+    def get(self, key: str, default: str | None = None) -> str | None: ...

--- a/src/engines/live/runner.py
+++ b/src/engines/live/runner.py
@@ -20,6 +20,7 @@ from src.config.constants import (
 )
 from src.data_providers.data_provider import DataProvider
 from src.data_providers.mock_data_provider import MockDataProvider
+from src.engines.live.config import LiveEngineSettings
 from src.engines.live.trading_engine import LiveTradingEngine
 from src.infrastructure.logging.config import configure_logging
 from src.risk.risk_manager import RiskParameters
@@ -259,7 +260,9 @@ def main():
             max_drawdown=args.max_drawdown,
         )
 
-        # Create trading engine
+        # Create trading engine. Settings are resolved here (feature flags /
+        # env / app config) and injected so the engine constructor stays free
+        # of config resolution (#486).
         logger.info("Creating live trading engine...")
         engine = LiveTradingEngine(
             strategy=strategy,
@@ -275,6 +278,7 @@ def main():
             account_snapshot_interval=args.snapshot_interval,
             provider=args.provider,
             testnet=args.testnet,
+            settings=LiveEngineSettings.resolve(),
         )
 
         # Final safety check for live trading

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -27,7 +27,6 @@ from src.config.constants import (
     DEFAULT_DYNAMIC_RISK_ENABLED,
     DEFAULT_END_OF_DAY_FLAT,
     DEFAULT_ERROR_COOLDOWN,
-    DEFAULT_EXECUTION_FILL_POLICY,
     DEFAULT_FEE_RATE,
     DEFAULT_INITIAL_BALANCE,
     DEFAULT_MARKET_TIMEZONE,
@@ -51,6 +50,7 @@ from src.data_providers.exchange_interface import OrderSide, OrderType, SideEffe
 from src.data_providers.sentiment_provider import SentimentDataProvider
 from src.database.manager import DatabaseManager
 from src.database.models import EventType, TradeSource
+from src.engines.live.config import LiveEngineSettings
 
 # Modular handlers (optional injection for testability)
 from src.engines.live.data.market_data_handler import MarketDataHandler
@@ -84,7 +84,6 @@ from src.engines.live.trade_close_accounting import (
 from src.engines.shared.correlation_handler import CorrelationHandler
 from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
 from src.engines.shared.execution.execution_model import ExecutionModel
-from src.engines.shared.execution.fill_policy import FillPolicy, resolve_fill_policy
 from src.engines.shared.models import (
     BaseTrade,
     PositionSide,
@@ -219,6 +218,7 @@ class LiveTradingEngine:
         market_data_handler: MarketDataHandler | None = None,
         event_logger: LiveEventLogger | None = None,
         health_monitor: HealthMonitor | None = None,
+        settings: LiveEngineSettings | None = None,
     ):
         """
         Initialize the live trading engine.
@@ -234,6 +234,10 @@ class LiveTradingEngine:
         account_snapshot_interval : int, optional
             How often to log account snapshots to database in seconds.
             Defaults to 1800 (30 minutes). Set to 0 to disable snapshots.
+        settings : LiveEngineSettings, optional
+            Pre-resolved construction-time settings (feature flags / env /
+            app config). The runner builds these explicitly; when omitted the
+            engine resolves them itself (#486).
         """
 
         # Validate inputs
@@ -245,6 +249,15 @@ class LiveTradingEngine:
             raise ValueError("Check interval must be positive")
         if account_snapshot_interval < 0:
             raise ValueError("Account snapshot interval must be non-negative")
+
+        # Construction-time settings. Pass this module's lookups so test
+        # patches on trading_engine.is_enabled / trading_engine.get_config
+        # keep intercepting resolution.
+        self.settings = settings or LiveEngineSettings.resolve(
+            flag_lookup=is_enabled,
+            env_lookup=os.getenv,
+            config_lookup=get_config,
+        )
 
         self._runtime_dataset = None
         self._runtime_warmup = 0
@@ -338,9 +351,9 @@ class LiveTradingEngine:
         # failures), books phantom realized PnL, and frees risk budget that is
         # still deployed. The flag exists only for development of the proper
         # fix; do NOT enable it for live capital until #734 is resolved.
-        if (enable_partial_operations or partial_manager is not None) and not is_enabled(
-            "live_partial_operations", False
-        ):
+        if (
+            enable_partial_operations or partial_manager is not None
+        ) and not self.settings.partial_operations_allowed:
             logger.warning(
                 "Partial exits/scale-ins are DISABLED (#734): the live engine "
                 "executes them as bookkeeping only (no exchange order, mismatched "
@@ -642,7 +655,7 @@ class LiveTradingEngine:
         # Optional regime detector (feature-gated)
         self.regime_detector = None
         try:
-            if os.getenv("FEATURE_ENABLE_REGIME_DETECTION", "").lower() == "true":
+            if self.settings.regime_detection_enabled:
                 self.regime_detector = RegimeDetector()
         except Exception:
             self.regime_detector = None
@@ -655,7 +668,7 @@ class LiveTradingEngine:
             logger.debug("Skipping signal handler registration outside main thread")
 
         # Execution modeling
-        self.execution_fill_policy = self._resolve_execution_fill_policy()
+        self.execution_fill_policy = self.settings.execution_fill_policy
         self.execution_model = ExecutionModel(self.execution_fill_policy)
 
         # Initialize modular handlers (use injected or create defaults)
@@ -3637,17 +3650,6 @@ class LiveTradingEngine:
             return float(value)
         except (TypeError, ValueError):
             return DEFAULT_TAKE_PROFIT_PCT
-
-    def _resolve_execution_fill_policy(self) -> FillPolicy:
-        """Resolve execution fill policy from configuration."""
-        policy_name: str | None = DEFAULT_EXECUTION_FILL_POLICY
-        try:
-            cfg = get_config()
-            policy_name = cfg.get("EXECUTION_FILL_POLICY", DEFAULT_EXECUTION_FILL_POLICY)
-        except Exception as exc:
-            logger.warning("Failed to read execution fill policy config: %s", exc)
-
-        return resolve_fill_policy(policy_name)
 
     def _execute_entry(
         self,

--- a/tests/unit/engines/live/test_engine_settings.py
+++ b/tests/unit/engines/live/test_engine_settings.py
@@ -10,7 +10,8 @@ from unittest.mock import MagicMock, create_autospec, patch
 import pytest
 
 from src.data_providers.data_provider import DataProvider
-from src.engines.live.config import ConfigSource, LiveEngineSettings
+from src.engines.live.config import LiveEngineSettings
+from src.engines.live.config_source import ConfigSource
 from src.engines.shared.execution.fill_policy import resolve_fill_policy
 from src.strategies.ml_basic import create_ml_basic_strategy
 
@@ -72,7 +73,7 @@ class TestEngineInjection:
     def _make_engine(self, **kwargs):
         from src.engines.live.trading_engine import LiveTradingEngine
 
-        with patch("src.engines.live.trading_engine.DatabaseManager"):
+        with patch("src.engines.live.trading_engine.DatabaseManager", autospec=True):
             return LiveTradingEngine(
                 strategy=create_ml_basic_strategy(),
                 data_provider=create_autospec(DataProvider, instance=True),

--- a/tests/unit/engines/live/test_engine_settings.py
+++ b/tests/unit/engines/live/test_engine_settings.py
@@ -1,0 +1,99 @@
+"""Unit tests for LiveEngineSettings (#486 step d).
+
+The dataclass owns the engine's construction-time feature-flag / env /
+app-config resolution; the engine accepts it injected (runner path) or
+resolves it with its own module-level lookups (test patch points).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.engines.live.config import LiveEngineSettings
+from src.engines.shared.execution.fill_policy import resolve_fill_policy
+
+pytestmark = pytest.mark.fast
+
+
+class TestResolve:
+    def test_defaults_with_quiet_sources(self):
+        settings = LiveEngineSettings.resolve(
+            flag_lookup=lambda name, default: default,
+            env_lookup=lambda key, default: default,
+            config_lookup=lambda: {},  # dict satisfies the ConfigSource protocol
+        )
+
+        assert settings.partial_operations_allowed is False
+        assert settings.regime_detection_enabled is False
+        assert settings.execution_fill_policy == resolve_fill_policy(None)
+
+    def test_flag_and_env_sources_are_consulted(self):
+        flags = {"live_partial_operations": True}
+        env = {"FEATURE_ENABLE_REGIME_DETECTION": "TRUE"}
+
+        settings = LiveEngineSettings.resolve(
+            flag_lookup=lambda name, default: flags.get(name, default),
+            env_lookup=lambda key, default: env.get(key, default),
+            config_lookup=lambda: {},
+        )
+
+        assert settings.partial_operations_allowed is True
+        assert settings.regime_detection_enabled is True
+
+    def test_config_read_failure_falls_back_to_default_policy(self):
+        def boom():
+            raise RuntimeError("config unavailable")
+
+        settings = LiveEngineSettings.resolve(
+            flag_lookup=lambda name, default: default,
+            env_lookup=lambda key, default: default,
+            config_lookup=boom,
+        )
+
+        assert settings.execution_fill_policy == resolve_fill_policy(None)
+
+    def test_fill_policy_read_from_config(self):
+        cfg = MagicMock()
+        cfg.get.return_value = "next_open"
+
+        settings = LiveEngineSettings.resolve(
+            flag_lookup=lambda name, default: default,
+            env_lookup=lambda key, default: default,
+            config_lookup=lambda: cfg,
+        )
+
+        assert settings.execution_fill_policy == resolve_fill_policy("next_open")
+        assert cfg.get.call_args[0][0] == "EXECUTION_FILL_POLICY"
+
+
+class TestEngineInjection:
+    def _make_engine(self, **kwargs):
+        from src.engines.live.trading_engine import LiveTradingEngine
+
+        with patch("src.engines.live.trading_engine.DatabaseManager"):
+            return LiveTradingEngine(
+                strategy=MagicMock(),
+                data_provider=MagicMock(),
+                initial_balance=1000.0,
+                **kwargs,
+            )
+
+    def test_injected_settings_are_used_verbatim(self):
+        injected = LiveEngineSettings(
+            partial_operations_allowed=False,
+            regime_detection_enabled=False,
+            execution_fill_policy=resolve_fill_policy(None),
+        )
+
+        engine = self._make_engine(settings=injected)
+
+        assert engine.settings is injected
+        assert engine.execution_fill_policy is injected.execution_fill_policy
+
+    def test_self_resolution_respects_trading_engine_patch_point(self):
+        # The #734 gate tests patch trading_engine.is_enabled around
+        # construction; self-resolution must keep honoring that.
+        with patch("src.engines.live.trading_engine.is_enabled", return_value=True):
+            engine = self._make_engine()
+
+        assert engine.settings.partial_operations_allowed is True

--- a/tests/unit/engines/live/test_engine_settings.py
+++ b/tests/unit/engines/live/test_engine_settings.py
@@ -97,3 +97,13 @@ class TestEngineInjection:
             engine = self._make_engine()
 
         assert engine.settings.partial_operations_allowed is True
+
+
+class TestPostInitValidation:
+    def test_none_fill_policy_rejected_at_construction(self):
+        with pytest.raises(ValueError, match="execution_fill_policy"):
+            LiveEngineSettings(
+                partial_operations_allowed=False,
+                regime_detection_enabled=False,
+                execution_fill_policy=None,  # type: ignore[arg-type]
+            )

--- a/tests/unit/engines/live/test_engine_settings.py
+++ b/tests/unit/engines/live/test_engine_settings.py
@@ -5,12 +5,14 @@ app-config resolution; the engine accepts it injected (runner path) or
 resolves it with its own module-level lookups (test patch points).
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
-from src.engines.live.config import LiveEngineSettings
+from src.data_providers.data_provider import DataProvider
+from src.engines.live.config import ConfigSource, LiveEngineSettings
 from src.engines.shared.execution.fill_policy import resolve_fill_policy
+from src.strategies.ml_basic import create_ml_basic_strategy
 
 pytestmark = pytest.mark.fast
 
@@ -53,7 +55,7 @@ class TestResolve:
         assert settings.execution_fill_policy == resolve_fill_policy(None)
 
     def test_fill_policy_read_from_config(self):
-        cfg = MagicMock()
+        cfg = MagicMock(spec=ConfigSource)
         cfg.get.return_value = "next_open"
 
         settings = LiveEngineSettings.resolve(
@@ -72,8 +74,8 @@ class TestEngineInjection:
 
         with patch("src.engines.live.trading_engine.DatabaseManager"):
             return LiveTradingEngine(
-                strategy=MagicMock(),
-                data_provider=MagicMock(),
+                strategy=create_ml_basic_strategy(),
+                data_provider=create_autospec(DataProvider, instance=True),
                 initial_balance=1000.0,
                 **kwargs,
             )


### PR DESCRIPTION
## Summary

Step (d) of #486 (follows #796 and #798): extract `LiveTradingEngine`'s **construction-time** config/feature-flag resolution into a frozen dataclass, `LiveEngineSettings` (`src/engines/live/config.py`), built explicitly in `runner.py` and constructor-injected.

### What moved

Three resolutions the engine performed exactly once at construction:
- the **#734 `live_partial_operations` gate** (hard-disables bookkeeping-only partial ops),
- the **`FEATURE_ENABLE_REGIME_DETECTION`** env flag gating the optional `RegimeDetector`,
- the **`EXECUTION_FILL_POLICY`** app-config read (absorbing `_resolve_execution_fill_policy`, including its failure-fallback warning).

### Design notes

- `runner.py` resolves and injects `settings=LiveEngineSettings.resolve()`; when omitted (every existing constructor call site, including all tests) the engine self-resolves **using its own module-level lookups**, so existing patch points (`trading_engine.is_enabled`, `trading_engine.get_config`) keep intercepting resolution — the #734 gate tests pass unchanged.
- **Deliberately NOT moved**: flags the engine re-reads at runtime because tests pin that dynamism — `ws_user_hard_reconnect` (read per reconnect decision), the hot-swap partial-ops re-check, and `ENGINE_HEARTBEAT_STEPS` (read at loop start). Capturing those at construction would be a behavior change.
- Constructor surface is otherwise untouched (no churn across the ~hundreds of engine construction sites in tests).

## Testing

- 6 new unit tests for `LiveEngineSettings` (default resolution, source consultation, config-failure fallback, fill-policy read, verbatim injection, and the `trading_engine.is_enabled` patch-point contract).
- Full unit suite green (4,016 passed), parity + live integration green (82), and the deterministic backtest fingerprint remains byte-identical to the original pre-refactor baseline.
- black, ruff, mypy clean on touched files.

## Remaining #486 scope

Only the long-term <1,500-line engine target remains (next candidates: WebSocket health management, strategy-runtime integration, locked entry/exit orchestration). Partial progress on #486 — does not close it.

https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa

---
_Generated by [Claude Code](https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa)_