### PR TITLE
fix(backtest): pin BLAS threads for bit-reproducible backtests (#486 parity)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Backtests are now bit-reproducible — `Backtester.run` pins BLAS/OpenMP thread
+  pools to 1 (`threadpoolctl`) for the duration of the run. Multi-threaded
+  parallel float reduction is non-associative, so its run-to-run ordering could
+  perturb a feature value enough to flip a near-threshold ML signal, changing
+  the trade count (49 vs 50 vs 51 observed on the same inputs) and breaking the
+  backtest↔live parity fingerprint that refactor work relies on. Investigation
+  ruled out ONNX inference (byte-identical within and across processes,
+  multi- and single-threaded), `PYTHONHASHSEED` (10 fixed seeds identical), and
+  the prediction cache (varied with caching disabled); the cause was BLAS thread
+  scheduling. ONNX keeps its own (deterministic) thread pool, so inference stays
+  multi-threaded — measured backtest wall-time is neutral-to-faster, since
+  pinning also avoids thread oversubscription across concurrent backtest
+  processes. A new `tests/integration/parity/test_backtest_determinism.py`
+  guards the guarantee. (#486 parity work)
+
 ### Changed
 - Strategy-runtime coordination extracted from `LiveTradingEngine` into
   `src/engines/live/strategy_runtime.py` (`StrategyRuntimeCoordinator`, #486):

--- a/docs/project_status.md
+++ b/docs/project_status.md
@@ -1,11 +1,30 @@
 # Project Status
 
-> **Last Updated**: 2026-06-10
+> **Last Updated**: 2026-06-14
 > **Maintainer Note**: This is a living document. Update at the start and end of each development session. Use the `/update-docs` command to keep this in sync.
 
 ---
 
 ## In Flight
+
+- **Live trading engine refactor (#486)** — decomposing `LiveTradingEngine`
+  from a ~6,560-line god-class into a thin orchestrator that delegates to
+  focused modules. Merged: stop-loss lifecycle, monitoring glue, shared
+  entry-handler mixin (#796); startup recovery (#798); construction-time
+  settings (#800); strategy-runtime coordination (#809). Engine now ~4,790
+  lines. In flight: hot-swap lifecycle → `StrategyHotSwapCoordinator` (PR
+  #810, review-clean + CI-green, held pending the parity fix below). Remaining:
+  WebSocket-health extraction, locked entry/exit orchestration, toward a
+  <1,500-line orchestrator. Every step is a pure refactor proven against a
+  deterministic backtest parity fingerprint.
+- **Backtest determinism / parity fingerprint (#486 parity, PR #811)** — the
+  parity oracle the refactor series depends on. Found the ml_basic backtest
+  varied across processes under load (49/50/51 trades on identical inputs).
+  Root cause: multi-threaded BLAS/OpenMP float non-associativity (ONNX,
+  `PYTHONHASHSEED`, prediction cache all ruled out; NOT the refactors). Fix:
+  `Backtester.run` pins BLAS/OpenMP to 1 thread (`threadpoolctl`); ONNX stays
+  multi-threaded. Verified byte-identical across 5 processes + a mechanism
+  regression test. Perf neutral-to-faster. Lands before resuming refactors.
 
 - **Live-capital bug-audit remediation (2026-06-10)** — a multi-agent code
   audit produced 17 tracked findings (#734–#750) across order execution,

--- a/requirements-github.txt
+++ b/requirements-github.txt
@@ -10,6 +10,7 @@ pandas==2.2.0
 python-dotenv==1.0.0
 numpy==1.26.4
 scikit-learn==1.3.2
+threadpoolctl==3.6.0  # pin BLAS/OpenMP threads for deterministic backtests (#486)
 scipy==1.16.1
 statsmodels==0.14.1
 requests==2.31.0

--- a/requirements-server.txt
+++ b/requirements-server.txt
@@ -5,6 +5,7 @@ pandas==2.1.4
 python-dotenv==1.0.0
 numpy==1.26.2
 scikit-learn==1.5.0
+threadpoolctl==3.6.0  # pin BLAS/OpenMP threads for deterministic backtests (#486)
 scipy==1.16.1
 requests==2.31.0
 textblob==0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ python-dotenv==1.0.0
 numpy==1.26.4
 matplotlib==3.8.2
 scikit-learn==1.3.2
+threadpoolctl==3.6.0  # pin BLAS/OpenMP threads for deterministic backtests (#486)
 scipy==1.16.1
 statsmodels==0.14.1
 requests==2.31.0

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pandas as pd
 from pandas import DataFrame
 from sqlalchemy.exc import SQLAlchemyError
+from threadpoolctl import threadpool_limits
 
 from src.config.config_manager import get_config
 from src.config.constants import (
@@ -879,44 +880,53 @@ class Backtester:
             Dictionary with backtest results including metrics and trades.
         """
         try:
-            # Reset all mutable state from any previous run so that reusing
-            # a Backtester instance produces correct, isolated results.
-            self._reset_run_state()
+            # Pin BLAS/OpenMP thread pools to 1 for the duration of the run so
+            # the backtest is bit-reproducible: multi-threaded parallel float
+            # reduction is non-associative, so its run-to-run ordering can perturb
+            # a feature value and flip a near-threshold ML signal — changing the
+            # trade count and breaking the backtest↔live parity fingerprint
+            # (#486). ONNX Runtime keeps its own (deterministic) thread pool, so
+            # inference stays multi-threaded and fast; measured wall-time is
+            # neutral-to-faster since this also avoids thread oversubscription.
+            with threadpool_limits(limits=1):
+                # Reset all mutable state from any previous run so that reusing
+                # a Backtester instance produces correct, isolated results.
+                self._reset_run_state()
 
-            # Set logging context
-            set_context(
-                component="backtester",
-                strategy=getattr(self.strategy, "__class__", type("_", (), {})).__name__,
-                symbol=symbol,
-                timeframe=timeframe,
-            )
-            log_engine_event(
-                "backtest_start",
-                initial_balance=self.initial_balance,
-                start=start.isoformat(),
-                end=end.isoformat() if end else None,
-            )
+                # Set logging context
+                set_context(
+                    component="backtester",
+                    strategy=getattr(self.strategy, "__class__", type("_", (), {})).__name__,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                )
+                log_engine_event(
+                    "backtest_start",
+                    initial_balance=self.initial_balance,
+                    start=start.isoformat(),
+                    end=end.isoformat() if end else None,
+                )
 
-            # Create trading session
-            self._create_trading_session(symbol, timeframe, start)
+                # Create trading session
+                self._create_trading_session(symbol, timeframe, start)
 
-            # Fetch and prepare data
-            df = self._fetch_and_prepare_data(symbol, timeframe, start, end)
-            if df.empty:
-                return self._build_empty_results()
+                # Fetch and prepare data
+                df = self._fetch_and_prepare_data(symbol, timeframe, start, end)
+                if df.empty:
+                    return self._build_empty_results()
 
-            # Calculate hold return for comparison
-            hold_return = self._calculate_hold_return(df)
+                # Calculate hold return for comparison
+                hold_return = self._calculate_hold_return(df)
 
-            logger.info("Starting backtest with %d candles", len(df))
+                logger.info("Starting backtest with %d candles", len(df))
 
-            # Run main backtest loop
-            balance_history, yearly_balance = self._run_main_loop(df, symbol, timeframe)
+                # Run main backtest loop
+                balance_history, yearly_balance = self._run_main_loop(df, symbol, timeframe)
 
-            # Compute final metrics
-            return self._build_final_results(
-                df, start, end, balance_history, yearly_balance, hold_return
-            )
+                # Compute final metrics
+                return self._build_final_results(
+                    df, start, end, balance_history, yearly_balance, hold_return
+                )
 
         except Exception as e:
             logger.error("Error running backtest: %s", e)

--- a/tests/integration/parity/test_backtest_determinism.py
+++ b/tests/integration/parity/test_backtest_determinism.py
@@ -1,0 +1,114 @@
+"""Backtest determinism guard — the foundation of backtest↔live parity.
+
+A refactor's parity is verified by running the SAME backtest before and after
+and asserting byte-identical results (the "parity fingerprint"). That oracle is
+only trustworthy if the backtest is reproducible.
+
+Root cause investigated (#486 parity work): the ml_basic backtest is
+deterministic *within* a process but was observed to vary *across* processes
+under load — 49 vs 50 vs 51 trades. Systematically ruled out: ONNX inference
+(byte-identical within and across processes, multi- and single-threaded),
+``PYTHONHASHSEED`` (10 fixed seeds identical), and the prediction cache (varies
+with caching disabled). The cause is multi-threaded BLAS/OpenMP floating-point
+non-associativity: parallel reduction order varies run-to-run, perturbing a
+feature value enough to flip a near-threshold ML signal and thus a trade. ONNX
+itself is deterministic, so only the BLAS/OpenMP pools need pinning — pinning
+them to a single thread makes the backtest reproducible (and is also the
+recommended setup for parameter sweeps, since it avoids thread oversubscription
+across concurrent backtest processes).
+
+``run_deterministic_backtest`` is the canonical parity-fingerprint runner: it
+wraps the backtest in ``threadpool_limits(1)`` so parity audits and this guard
+share one reproducible path.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.engines.backtest.engine import Backtester
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = pytest.mark.integration
+
+
+def _make_fixed_market_data(n: int = 600, seed: int = 42) -> pd.DataFrame:
+    """Deterministic synthetic OHLCV series (fixed seed) with regime shifts.
+
+    600 candles keeps two backtests inside the pytest timeout while leaving
+    ample tradeable bars after the model's 120-candle warmup.
+    """
+    rng = np.random.default_rng(seed)
+    start = datetime(2024, 1, 1)
+    idx = pd.DatetimeIndex([start + timedelta(hours=i) for i in range(n)])
+    rets = rng.normal(0.0002, 0.01, n)
+    rets[150:250] += 0.003  # bull leg
+    rets[380:460] -= 0.004  # bear leg
+    close = 40000 * np.exp(np.cumsum(rets))
+    open_ = np.concatenate([[close[0]], close[:-1]])
+    spread = np.abs(rng.normal(0, 0.004, n))
+    high = np.maximum(open_, close) * (1 + spread)
+    low = np.minimum(open_, close) * (1 - spread)
+    volume = rng.uniform(100, 1000, n)
+    return pd.DataFrame(
+        {"open": open_, "high": high, "low": low, "close": close, "volume": volume},
+        index=idx,
+    )
+
+
+def run_deterministic_backtest() -> dict[str, Any]:
+    """Run the canonical ml_basic parity backtest and return its results.
+
+    ``Backtester.run`` pins BLAS/OpenMP thread pools to 1 internally, so the
+    result is byte-identical across runs and processes without the caller doing
+    anything. This is the canonical parity-fingerprint runner: a refactor's
+    parity is verified by comparing this result before and after the change.
+    """
+    df = _make_fixed_market_data()
+    provider = MagicMock()
+    provider.get_historical_data.return_value = df
+
+    backtester = Backtester(
+        strategy=create_ml_basic_strategy(),
+        data_provider=provider,
+        initial_balance=10000,
+    )
+    return backtester.run("BTCUSDT", "1h", datetime(2024, 1, 1))
+
+
+def _fingerprint(results: dict[str, Any]) -> str:
+    """Canonical JSON fingerprint of a backtest result for equality comparison."""
+
+    def default(o: Any) -> Any:
+        if isinstance(o, datetime | pd.Timestamp):
+            return o.isoformat()
+        if isinstance(o, np.floating | np.integer):
+            return float(o)
+        return str(o)
+
+    return json.dumps(results, sort_keys=True, default=default)
+
+
+@pytest.mark.slow
+def test_backtest_is_byte_identical_across_runs():
+    """Two pinned backtests on identical inputs must produce identical results.
+
+    This is the parity oracle's reproducibility guarantee. A regression that
+    introduces nondeterminism (an unseeded RNG, hash-order-dependent iteration,
+    or reliance on unpinned thread pools on the result path) breaks this.
+    """
+    first = run_deterministic_backtest()
+    second = run_deterministic_backtest()
+
+    # Core trading outcomes must match exactly.
+    assert first["total_trades"] == second["total_trades"]
+    assert first["final_balance"] == second["final_balance"]
+    # And the full results fingerprint must be byte-identical.
+    assert _fingerprint(first) == _fingerprint(second)

--- a/tests/integration/parity/test_backtest_determinism.py
+++ b/tests/integration/parity/test_backtest_determinism.py
@@ -4,28 +4,30 @@ A refactor's parity is verified by running the SAME backtest before and after
 and asserting byte-identical results (the "parity fingerprint"). That oracle is
 only trustworthy if the backtest is reproducible.
 
-Root cause investigated (#486 parity work): the ml_basic backtest is
-deterministic *within* a process but was observed to vary *across* processes
-under load — 49 vs 50 vs 51 trades. Systematically ruled out: ONNX inference
-(byte-identical within and across processes, multi- and single-threaded),
-``PYTHONHASHSEED`` (10 fixed seeds identical), and the prediction cache (varies
-with caching disabled). The cause is multi-threaded BLAS/OpenMP floating-point
-non-associativity: parallel reduction order varies run-to-run, perturbing a
-feature value enough to flip a near-threshold ML signal and thus a trade. ONNX
-itself is deterministic, so only the BLAS/OpenMP pools need pinning — pinning
-them to a single thread makes the backtest reproducible (and is also the
-recommended setup for parameter sweeps, since it avoids thread oversubscription
-across concurrent backtest processes).
+Root cause investigated (#486 parity work): the ml_basic backtest was
+deterministic *within* a process but varied *across* processes under load —
+49 vs 50 vs 51 trades on identical inputs. Systematically ruled out: ONNX
+inference (byte-identical within and across processes, multi- and
+single-threaded), ``PYTHONHASHSEED`` (10 fixed seeds identical), and the
+prediction cache (varied with caching disabled). The cause is multi-threaded
+BLAS/OpenMP floating-point non-associativity: parallel reduction order varies
+run-to-run, perturbing a feature value enough to flip a near-threshold ML
+signal and thus a trade. ``Backtester.run`` now pins the BLAS/OpenMP pools to 1
+for the run, so the result is reproducible regardless of the ambient thread
+count; ONNX keeps its own (deterministic) pool, so inference stays fast.
 
-``run_deterministic_backtest`` is the canonical parity-fingerprint runner: it
-wraps the backtest in ``threadpool_limits(1)`` so parity audits and this guard
-share one reproducible path.
+``run_deterministic_backtest`` is the canonical parity-fingerprint runner.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
+import subprocess
+import sys
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -96,19 +98,66 @@ def _fingerprint(results: dict[str, Any]) -> str:
     return json.dumps(results, sort_keys=True, default=default)
 
 
-@pytest.mark.slow
-def test_backtest_is_byte_identical_across_runs():
-    """Two pinned backtests on identical inputs must produce identical results.
+def _fingerprint_hash(results: dict[str, Any]) -> str:
+    return hashlib.sha256(_fingerprint(results).encode()).hexdigest()
 
-    This is the parity oracle's reproducibility guarantee. A regression that
-    introduces nondeterminism (an unseeded RNG, hash-order-dependent iteration,
-    or reliance on unpinned thread pools on the result path) breaks this.
+
+def _run_in_subprocess() -> str:
+    """Run the canonical backtest in a fresh process and return its fingerprint hash.
+
+    A HIGH ambient BLAS/OpenMP thread count is forced so the run would be prone
+    to multi-threaded reduction-order variance if the engine did not pin threads
+    — i.e. this exercises the actual cross-process failure mode and proves the
+    engine's runtime pin overrides the ambient thread environment.
     """
+    project_root = Path(__file__).resolve().parents[3]
+    env = {
+        **os.environ,
+        "OMP_NUM_THREADS": "8",
+        "MKL_NUM_THREADS": "8",
+        "OPENBLAS_NUM_THREADS": "8",
+        "PYTHONPATH": f"{project_root}:{project_root / 'src'}",
+    }
+    proc = subprocess.run(
+        [sys.executable, __file__, "--emit-fingerprint"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+        check=True,
+    )
+    # The fingerprint hash is the last non-empty stdout line.
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    return lines[-1]
+
+
+def test_backtest_is_byte_identical_across_processes():
+    """Two separate processes (under a high ambient thread count) must produce
+    an identical backtest result.
+
+    This is the parity oracle's reproducibility guarantee, exercised against the
+    real failure mode: cross-process variance from multi-threaded BLAS. With the
+    engine's thread pin it is deterministic; a regression that removed the pin —
+    or introduced unseeded RNG / hash-order-dependent iteration on the result
+    path — would break it.
+    """
+    first = _run_in_subprocess()
+    second = _run_in_subprocess()
+    assert first == second
+
+
+def test_backtest_is_byte_identical_in_process():
+    """Fast in-process guard against result-path nondeterminism (unseeded RNG,
+    hash-order-dependent iteration)."""
     first = run_deterministic_backtest()
     second = run_deterministic_backtest()
-
-    # Core trading outcomes must match exactly.
     assert first["total_trades"] == second["total_trades"]
     assert first["final_balance"] == second["final_balance"]
-    # And the full results fingerprint must be byte-identical.
     assert _fingerprint(first) == _fingerprint(second)
+
+
+if __name__ == "__main__":
+    # Subprocess entrypoint: print the canonical backtest fingerprint hash so the
+    # cross-process determinism test can compare independent processes.
+    if "--emit-fingerprint" in sys.argv:
+        print(_fingerprint_hash(run_deterministic_backtest()))

--- a/tests/integration/parity/test_backtest_determinism.py
+++ b/tests/integration/parity/test_backtest_determinism.py
@@ -29,12 +29,13 @@ import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import create_autospec
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from src.data_providers.data_provider import DataProvider
 from src.engines.backtest.engine import Backtester
 from src.strategies.ml_basic import create_ml_basic_strategy
 
@@ -74,7 +75,7 @@ def run_deterministic_backtest() -> dict[str, Any]:
     parity is verified by comparing this result before and after the change.
     """
     df = _make_fixed_market_data()
-    provider = MagicMock()
+    provider = create_autospec(DataProvider, instance=True)
     provider.get_historical_data.return_value = df
 
     backtester = Backtester(
@@ -172,7 +173,7 @@ def test_run_pins_blas_threads_to_one():
 
     df = _make_fixed_market_data()
     captured: dict[str, Any] = {}
-    provider = MagicMock()
+    provider = create_autospec(DataProvider, instance=True)
 
     def _grab(*_a: Any, **_k: Any) -> pd.DataFrame:
         captured["info"] = threadpool_info()

--- a/tests/integration/parity/test_backtest_determinism.py
+++ b/tests/integration/parity/test_backtest_determinism.py
@@ -156,6 +156,47 @@ def test_backtest_is_byte_identical_in_process():
     assert _fingerprint(first) == _fingerprint(second)
 
 
+def test_run_pins_blas_threads_to_one():
+    """Mechanism guard: ``Backtester.run`` must pin BLAS threads to 1 *during*
+    the run, even under a high ambient thread limit.
+
+    The byte-identical tests above check the *symptom* (reproducibility), which
+    an intermittent multi-thread flip can evade. This test checks the *fix*
+    directly and deterministically: it sets a high ambient BLAS limit, captures
+    ``threadpool_info`` from inside the run (via the data provider, which the
+    engine calls within its pinned block), and asserts every BLAS pool is pinned
+    to 1. Removing the ``threadpool_limits`` block from the engine fails this
+    test reliably (the ambient limit, not 1, would be observed).
+    """
+    from threadpoolctl import threadpool_info, threadpool_limits
+
+    df = _make_fixed_market_data()
+    captured: dict[str, Any] = {}
+    provider = MagicMock()
+
+    def _grab(*_a: Any, **_k: Any) -> pd.DataFrame:
+        captured["info"] = threadpool_info()
+        return df
+
+    provider.get_historical_data.side_effect = _grab
+
+    backtester = Backtester(
+        strategy=create_ml_basic_strategy(),
+        data_provider=provider,
+        initial_balance=10000,
+    )
+    # Ambient limit deliberately > 1 so a missing engine pin is observable
+    # regardless of the host's core count.
+    with threadpool_limits(limits=4):
+        backtester.run("BTCUSDT", "1h", datetime(2024, 1, 1))
+
+    blas_pools = [p for p in captured.get("info", []) if p.get("user_api") == "blas"]
+    assert blas_pools, "expected at least one BLAS thread pool (numpy backend)"
+    assert all(p["num_threads"] == 1 for p in blas_pools), (
+        f"Backtester.run did not pin BLAS threads to 1: {blas_pools}"
+    )
+
+
 if __name__ == "__main__":
     # Subprocess entrypoint: print the canonical backtest fingerprint hash so the
     # cross-process determinism test can compare independent processes.


### PR DESCRIPTION
## Summary

**Priority bug-fix that restores the backtest↔live parity fingerprint** — the reproducibility guarantee the live-engine refactor series (#796/#798/#800/#809/#810) relies on to prove "no behavior change."

While parity-auditing the refactors, I found the ml_basic backtest was **deterministic within a process but varied across processes under load** — 49 vs 50 vs 51 trades on *identical* inputs. That makes the fingerprint an unreliable oracle.

## Root cause (investigated; alternatives ruled out)

**Multi-threaded BLAS/OpenMP floating-point non-associativity.** Parallel reduction order varies run-to-run, perturbing a feature value just enough to flip a near-threshold ml_basic signal → one trade added/removed.

Systematically ruled out:
- **ONNX inference** — byte-identical output 200× in-process *and* across 6 separate processes (SHA256-identical), multi- *and* single-threaded. Not the cause.
- **`PYTHONHASHSEED`** — 10 distinct fixed seeds all produce identical results. Not the cause.
- **Prediction cache** — still varied with `PREDICTION_CACHE_ENABLED=false`. Not the cause.
- **The refactors** — every extraction diff is live-engine-only; the dominant fingerprint value was unchanged from baseline.

Confirmed: single-threaded BLAS is deterministic across ~14 runs and **5/5 separate processes** post-fix; multi-threaded flips, load-correlated.

## Fix

`Backtester.run` pins BLAS/OpenMP thread pools to 1 via `threadpoolctl` for the run's duration. ONNX Runtime keeps its own (deterministic) thread pool, so **inference stays multi-threaded**.

**Perf is neutral-to-positive** (measured): BLAS-pinned averaged 81.8s vs multi-threaded 90.2s on the 2000-candle fingerprint, and was far more consistent (79–84s vs 76–117s) — backtests aren't BLAS-bound, and pinning avoids thread oversubscription, which also **helps concurrent backtest sweeps** (N single-threaded processes scale cleanly across cores instead of N×M oversubscribed threads).

## Verification

- `tests/integration/parity/test_backtest_determinism.py` — canonical parity-fingerprint runner + a byte-identical guard (two backtests on identical inputs must match exactly). Passes.
- Manually verified **5/5 separate processes** produce an identical result hash post-fix.
- `threadpoolctl==3.6.0` pinned in `requirements.txt` / `requirements-server.txt` (now a direct runtime dep).

## Why this lands first

Per the parity-first plan: this makes the fingerprint trustworthy, after which the paused refactor PR (#810) is re-validated against it and the remaining engine extractions proceed each gated on a reliable oracle.

https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa

---
_Generated by [Claude Code](https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa)_