### PR TITLE
fix(live): harden LiveEntryCoordinator CODE.md compliance + add unit tests (#486)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Live entry stop-loss gate no longer silently skips a misconfigured `0.0`
+  stop. `LiveEntryCoordinator.execute_entry_locked` now keys the server-side
+  stop-loss placement on `stop_loss is not None` (was a truthy check), so a
+  `0.0` stop enters the placement path and fails there → emergency-close,
+  rather than leaving the position open and unprotected. Also hardened the
+  surrounding CODE.md issues carried over in the #486 entry extraction: the
+  stop-loss-calc and risk-override failure paths now log at WARNING (were
+  silent / `debug`), the emergency-close error log uses lazy `%s` formatting,
+  and the entry-reason `stop_loss`/`take_profit` checks use `is not None`.
+  Adds direct `LiveEntryCoordinator.execute_entry_locked` unit-test coverage
+  for the guard, tracking-failure, balance-failure, risk-failure, ambiguous,
+  and stop-loss-placement branches. (#486 follow-up)
 - Backtests are now bit-reproducible — `Backtester.run` pins BLAS/OpenMP thread
   pools to 1 (`threadpoolctl`) for the duration of the run. Multi-threaded
   parallel float reduction is non-associative, so its run-to-run ordering could

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -567,6 +567,7 @@ class LiveEntryCoordinator:
                         "Failed to update balance for entry fee %s: %s. Aborting entry.",
                         symbol,
                         balance_err,
+                        exc_info=True,
                     )
                     # Critical: Entry executed but balance update failed
                     # Attempt emergency close to maintain consistency
@@ -582,6 +583,7 @@ class LiveEntryCoordinator:
                                     "entry_price %s for %s",
                                     position.entry_price,
                                     symbol,
+                                    exc_info=True,
                                 )
                             else:
                                 # Use quantity from position - LiveEntryResult.position.quantity

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -347,7 +347,10 @@ class LiveEntryCoordinator:
                         runtime_decision.signal if runtime_decision else None,
                         runtime_decision.regime if runtime_decision else None,
                     )
-            except Exception:
+            except Exception as e:
+                logger.warning(
+                    "Stop loss price calculation failed for %s, using default: %s", symbol, e
+                )
                 if stop_loss is None:
                     stop_loss = float(current_price) * (
                         (1 - DEFAULT_STOP_LOSS_PCT)
@@ -379,7 +382,7 @@ class LiveEntryCoordinator:
                     float(current_price), signal, None  # regime context
                 )
             except Exception as e:
-                logger.debug("Component stop loss calculation failed: %s", e)
+                logger.warning("Component stop loss calculation failed for %s: %s", symbol, e)
                 stop_loss = float(current_price) * (
                     (1 - DEFAULT_STOP_LOSS_PCT)
                     if entry_side == PositionSide.LONG
@@ -398,7 +401,8 @@ class LiveEntryCoordinator:
                     if hasattr(state.strategy, "get_risk_overrides")
                     else None
                 )
-            except Exception:
+            except Exception as e:
+                logger.warning("Failed to get risk overrides for %s: %s", symbol, e)
                 overrides = None
 
             if overrides and ("stop_loss_pct" in overrides or "take_profit_pct" in overrides):
@@ -518,9 +522,9 @@ class LiveEntryCoordinator:
                 f"strength_{signal_strength:.2f}",
                 f"confidence_{signal_confidence:.2f}",
             ]
-            if stop_loss:
+            if stop_loss is not None:
                 entry_reasons.append(f"sl_{stop_loss:.2f}")
-            if take_profit:
+            if take_profit is not None:
                 entry_reasons.append(f"tp_{take_profit:.2f}")
 
             entry_signal = LiveEntrySignal(
@@ -558,7 +562,7 @@ class LiveEntryCoordinator:
                         correlation_id=position.order_id,
                     ) as balance_result:
                         state.current_balance = balance_result["new_balance"]
-                except (ValueError, Exception) as balance_err:
+                except Exception as balance_err:
                     logger.error(
                         "Failed to update balance for entry fee %s: %s. Aborting entry.",
                         symbol,
@@ -574,8 +578,10 @@ class LiveEntryCoordinator:
                             # Validate entry_price to prevent division by zero
                             if position.entry_price <= 0:
                                 logger.error(
-                                    f"Cannot calculate emergency close quantity - invalid entry_price "
-                                    f"{position.entry_price} for {symbol}"
+                                    "Cannot calculate emergency close quantity - invalid "
+                                    "entry_price %s for %s",
+                                    position.entry_price,
+                                    symbol,
                                 )
                             else:
                                 # Use quantity from position - LiveEntryResult.position.quantity
@@ -769,7 +775,7 @@ class LiveEntryCoordinator:
                 return
 
             # Place server-side stop-loss order for protection with retry logic
-            if state.enable_live_trading and stop_loss and state.exchange_interface:
+            if state.enable_live_trading and stop_loss is not None and state.exchange_interface:
                 # Use stored quantity directly to ensure stop-loss covers exact position size
                 if position.quantity is not None and position.quantity > 0:
                     quantity = position.quantity
@@ -783,7 +789,7 @@ class LiveEntryCoordinator:
                     position_value = size * entry_balance
                     quantity = (
                         position_value / float(position.entry_price)
-                        if position.entry_price
+                        if position.entry_price is not None and position.entry_price > 0
                         else 0.0
                     )
 

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -82,6 +82,7 @@ def _make_state(position: MagicMock, result: MagicMock, **overrides) -> MagicMoc
 
 
 def _call(state: MagicMock, *, side=PositionSide.LONG, stop_loss=49000.0, take_profit=51000.0):
+    """Drive execute_entry_locked on a fresh LiveEntryCoordinator with BTCUSDT defaults."""
     coordinator = LiveEntryCoordinator(engine_state=state)
     coordinator.execute_entry_locked(
         symbol="BTCUSDT",

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -1,0 +1,265 @@
+"""Unit tests for LiveEntryCoordinator.execute_entry_locked branches (#486).
+
+The entry pipeline was extracted from LiveTradingEngine into
+``LiveEntryCoordinator`` (the engine keeps thin delegating wrappers). These
+tests target the real-money execution branches directly on the coordinator,
+driving it with a mocked engine-state backref. They also pin the CODE.md
+hardening applied after the extraction: the stop-loss gate now keys on
+``stop_loss is not None`` (so a misconfigured ``0.0`` stop is no longer
+silently skipped), and the SL-calc / risk-override failure paths log.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.engines.live.execution.entry_coordinator import (
+    LiveEntryCoordinator,
+    LiveEntryEngineState,
+)
+from src.engines.shared.models import PositionSide
+
+pytestmark = pytest.mark.fast
+
+
+def _make_position() -> MagicMock:
+    position = MagicMock()
+    position.order_id = "order-1"
+    position.entry_price = 50000.0
+    position.quantity = 0.01
+    position.entry_balance = 1000.0
+    position.metadata = {}
+    return position
+
+
+def _make_result(position: MagicMock, **overrides) -> MagicMock:
+    result = MagicMock()
+    result.executed = True
+    result.position = position
+    result.entry_fee = 1.0
+    result.slippage_cost = 0.5
+    result.ambiguous = False
+    result.error = None
+    for k, v in overrides.items():
+        setattr(result, k, v)
+    return result
+
+
+def _make_state(position: MagicMock, result: MagicMock, **overrides) -> MagicMock:
+    """Build a mocked engine-state backref with sane happy-path defaults.
+
+    Spec'd against the coordinator's protocol so method-name drift is caught;
+    every attribute the execution path reads is set explicitly (protocol
+    attributes are annotation-only, so they must be assigned to be readable).
+    """
+    state = MagicMock(spec=LiveEntryEngineState)
+    state.enable_live_trading = False
+    state.current_balance = 1000.0
+    state.max_position_size = 1.0
+    state.trading_session_id = None
+    # Protocol attributes are annotation-only (not in dir()), so a spec'd mock
+    # won't auto-create them — assign each object attribute the path reads.
+    state.exchange_interface = MagicMock()
+    state.order_tracker = MagicMock()
+    state.live_position_tracker = MagicMock()
+    state.risk_manager = MagicMock()
+    state.live_entry_handler = MagicMock()
+    state.stop_loss_manager = MagicMock()
+    state.db_manager = MagicMock()
+
+    state.live_position_tracker.has_position_for_symbol.return_value = False
+    state.live_position_tracker.position_count = 0
+    state.risk_manager.get_max_concurrent_positions.return_value = 1
+    state.live_entry_handler.execute_entry.return_value = result
+    state.stop_loss_manager.place_protection.return_value = "sl-order-1"
+    state._strategy_name.return_value = "test_strategy"
+
+    for k, v in overrides.items():
+        setattr(state, k, v)
+    return state
+
+
+def _call(state: MagicMock, *, side=PositionSide.LONG, stop_loss=49000.0, take_profit=51000.0):
+    coordinator = LiveEntryCoordinator(engine_state=state)
+    coordinator.execute_entry_locked(
+        symbol="BTCUSDT",
+        side=side,
+        size=0.1,
+        price=50000.0,
+        stop_loss=stop_loss,
+        take_profit=take_profit,
+        signal_strength=0.8,
+        signal_confidence=0.7,
+    )
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# Pre-execution guards
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_position_guard_skips_execution():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.live_position_tracker.has_position_for_symbol.return_value = True
+
+    _call(state)
+
+    state.live_entry_handler.execute_entry.assert_not_called()
+
+
+def test_max_concurrent_positions_guard_skips_execution():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.live_position_tracker.position_count = 1
+    state.risk_manager.get_max_concurrent_positions.return_value = 1
+
+    _call(state)
+
+    state.live_entry_handler.execute_entry.assert_not_called()
+
+
+def test_size_capped_at_max_position_size():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.max_position_size = 0.05  # below the requested 0.1
+
+    coordinator = LiveEntryCoordinator(engine_state=state)
+    coordinator.execute_entry_locked(
+        symbol="BTCUSDT",
+        side=PositionSide.LONG,
+        size=0.1,
+        price=50000.0,
+        stop_loss=49000.0,
+        take_profit=51000.0,
+        signal_strength=0.8,
+        signal_confidence=0.7,
+    )
+
+    # The handler is called with the capped size, not the requested 0.1.
+    _, kwargs = state.live_entry_handler.execute_entry.call_args
+    assert kwargs["signal"].size_fraction == pytest.approx(0.05)
+
+
+# ---------------------------------------------------------------------------
+# Happy path + tracking
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_tracks_position_and_registers_risk():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+
+    _call(state)
+
+    state.live_position_tracker.open_position.assert_called_once()
+    state.risk_manager.update_position.assert_called_once()
+    # No-session path deducts the fee directly.
+    assert state.current_balance == pytest.approx(1000.0 - 1.0)
+
+
+def test_failed_execution_returns_without_tracking():
+    position = _make_position()
+    result = _make_result(position, executed=False, error="boom")
+    result.position = None
+    state = _make_state(position, result)
+
+    _call(state)
+
+    state.live_position_tracker.open_position.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Failure / emergency-close paths
+# ---------------------------------------------------------------------------
+
+
+def test_position_tracking_failure_triggers_emergency_close_and_refund():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True
+    state.live_position_tracker.open_position.side_effect = RuntimeError("tracker down")
+
+    _call(state)
+
+    # Emergency close placed with AUTO_REPAY; fee refunded directly (no session).
+    state.exchange_interface.place_order.assert_called_once()
+    assert state.current_balance == pytest.approx(1000.0)  # -1.0 fee then +1.0 refund
+
+
+def test_risk_manager_failure_closes_position():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.risk_manager.update_position.side_effect = ValueError("risk sync failed")
+
+    _call(state)
+
+    state._execute_exit.assert_called_once()
+
+
+def test_balance_update_failure_emergency_closes_with_session():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True
+    state.trading_session_id = 42
+    state.db_manager.atomic_balance_update.side_effect = RuntimeError("db down")
+
+    _call(state)
+
+    # Balance update failed before tracking → emergency close, never tracks.
+    state.exchange_interface.place_order.assert_called_once()
+    state.live_position_tracker.open_position.assert_not_called()
+
+
+def test_ambiguous_submission_enters_close_only_mode_without_stop_loss():
+    position = _make_position()
+    state = _make_state(position, _make_result(position, ambiguous=True))
+    state.enable_live_trading = True
+
+    _call(state)
+
+    state._enter_close_only_mode.assert_called_once()
+    state.stop_loss_manager.place_protection.assert_not_called()
+
+
+def test_stop_loss_placement_failure_triggers_emergency_exit():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True
+    state.stop_loss_manager.place_protection.return_value = None  # placement failed
+
+    _call(state)
+
+    state._record_event.assert_called_once()
+    state._execute_exit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CODE.md hardening: stop-loss gate keys on `is not None` (#813 follow-up)
+# ---------------------------------------------------------------------------
+
+
+def test_zero_stop_loss_is_not_silently_skipped():
+    """A 0.0 stop must enter the placement path (and fail there → emergency
+    close) rather than being silently treated as "no stop-loss" and leaving the
+    position unprotected. Regression guard for the truthy-check fix."""
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True
+
+    _call(state, stop_loss=0.0)
+
+    state.stop_loss_manager.place_protection.assert_called_once()
+
+
+def test_none_stop_loss_skips_placement():
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True
+
+    _call(state, stop_loss=None)
+
+    state.stop_loss_manager.place_protection.assert_not_called()

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -25,6 +25,7 @@ pytestmark = pytest.mark.fast
 
 
 def _make_position() -> MagicMock:
+    """Return a minimal position mock for use in coordinator tests."""
     position = MagicMock()
     position.order_id = "order-1"
     position.entry_price = 50000.0
@@ -35,6 +36,7 @@ def _make_position() -> MagicMock:
 
 
 def _make_result(position: MagicMock, **overrides) -> MagicMock:
+    """Return a successful entry-result mock wrapping the given position."""
     result = MagicMock()
     result.executed = True
     result.position = position


### PR DESCRIPTION
## What & why

Follow-up to #813 (entry-pipeline extraction into `LiveEntryCoordinator`). That PR was an intentionally **verbatim** behavior-preserving move, so it carried over several pre-existing CODE.md violations and didn't add direct unit tests for the new module. This PR fixes both — keeping the behavior change isolated and reviewable, per the project's bug protocol.

Addresses the claude[bot] review findings on #813.

## Behavior fix (real-money path)

- **Stop-loss gate** in `execute_entry_locked` now keys on `stop_loss is not None` instead of a truthy check (CODE.md "Position Fields"). A misconfigured `0.0` stop was silently treated as "no stop-loss" and the whole SL block was skipped, leaving the position **open and unprotected**. It now enters the placement path; since `0.0` is an invalid stop price, placement fails → the existing emergency-close fires. New regression test pins this.

## Logging / hygiene (no behavior change)

- Stop-loss-calc and risk-override failure paths now log at **WARNING** (were silent / `debug`), so a broken SL calculator or strategy misconfig is visible at `LOG_LEVEL=INFO`.
- Emergency-close "invalid entry_price" error log uses lazy `%s` formatting (no f-string in logging).
- entry-reason `stop_loss`/`take_profit` appends use `is not None`.
- entry_price quantity-fallback guard made explicit (`is not None and > 0`).
- Dropped the redundant `except (ValueError, Exception)` tuple.

## Tests (the 95% live-engine coverage ask)

New `tests/unit/engines/live/test_entry_coordinator.py` drives `LiveEntryCoordinator.execute_entry_locked` directly via a mocked engine-state backref, covering:
- duplicate-position / max-concurrent / size-cap guards
- happy-path position tracking + risk registration
- the tracking-failure (+ fee refund), balance-update-failure, risk-manager-failure, ambiguous-submission, and stop-loss-placement-failure emergency-close branches
- a regression guard for the `0.0`-stop fix (and that `None` still skips placement)

## Verification

- New tests: 12 passed. Full live-engine unit suite: 617 passed, 0 failed.
- ruff / black / mypy clean on the changed files.
- **Parity:** backtest fingerprint byte-identical (the entry path is live-only, not exercised by the backtest).

https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa

---
_Generated by [Claude Code](https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa)_