### PR TITLE
fix(live): harden LiveOrderFillCoordinator CODE.md compliance + add unit tests (#486)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3,574 → ~3,130 lines. (#486)
 
 ### Fixed
+- Hardened `LiveOrderFillCoordinator` CODE.md compliance after the #486
+  order-fill extraction (issues carried over verbatim from the engine): the
+  order-fill `logger.info` uses lazy `%s` formatting (was an f-string); the
+  cancel-refund's original-quantity fallback uses an explicit
+  `quantity is not None` check instead of `or 0.0` (Position-Fields rule — a
+  legitimate `0.0` is valid state, not "unset"; behaviour-neutral here given
+  the downstream `> 0` guard); and the entry-fee-refund-failure
+  `logger.critical` now passes `exc_info=True` (balance-integrity failure
+  where the traceback matters most). Adds direct `LiveOrderFillCoordinator`
+  unit tests covering the deferred stop-loss-close queue handoff, the
+  stop-loss-cancel escalation seam, the cancel-refund full/partial/`None`-qty
+  branches, and the fail-closed tracking-lost contract. (#486 follow-up)
 - Hardened `LiveExitCoordinator` CODE.md compliance after the #486 exit
   extraction (issues carried over verbatim from the engine): the exit-logging
   `logger.error` calls use lazy `%s` formatting (were f-strings); the

--- a/src/engines/live/execution/order_fill_coordinator.py
+++ b/src/engines/live/execution/order_fill_coordinator.py
@@ -97,7 +97,11 @@ class LiveOrderFillCoordinator:
         """
         state = self._state
         logger.info(
-            f"Order fill confirmed: {order_id} {symbol} qty={filled_qty} @ ${avg_price:.2f}"
+            "Order fill confirmed: %s %s qty=%s @ $%.2f",
+            order_id,
+            symbol,
+            filled_qty,
+            avg_price,
         )
         log_order_event(
             "order_filled",
@@ -266,7 +270,9 @@ class LiveOrderFillCoordinator:
             # full entry_fee would over-credit the balance and corrupt P&L accounting.
             entry_fee = float(removed_position.metadata.get("entry_fee", 0.0))
             if entry_fee > 0:
-                original_qty = removed_position.quantity or 0.0
+                original_qty = (
+                    removed_position.quantity if removed_position.quantity is not None else 0.0
+                )
                 if original_qty > 0 and filled_qty > 0:
                     # Compute the fraction of the order that was NOT filled.
                     unfilled_fraction = max(0.0, (original_qty - filled_qty) / original_qty)
@@ -310,6 +316,7 @@ class LiveOrderFillCoordinator:
                                 order_id,
                                 symbol,
                                 refund_err,
+                                exc_info=True,
                             )
                     else:
                         state.current_balance += refund_amount

--- a/tests/unit/engines/live/test_order_fill_coordinator.py
+++ b/tests/unit/engines/live/test_order_fill_coordinator.py
@@ -13,7 +13,7 @@ hardening applied after the extraction (the cancel-refund uses an explicit
 from __future__ import annotations
 
 import queue
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
@@ -22,6 +22,7 @@ from src.engines.live.execution.order_fill_coordinator import (
     LiveOrderFillCoordinator,
     LiveOrderFillEngineState,
 )
+from src.engines.live.execution.position_tracker import LivePositionTracker
 
 pytestmark = pytest.mark.fast
 
@@ -36,11 +37,16 @@ def _make_position(*, stop_loss_order_id: str | None = None, entry_fee: float = 
 
 
 def _make_state(*, positions: dict | None = None, session_id=None, balance: float = 1000.0):
-    """Build a mocked engine-state backref with a real fill-exit queue."""
-    state = MagicMock(spec=LiveOrderFillEngineState)
+    """Build a mocked engine-state backref with a real fill-exit queue.
+
+    ``state`` and ``live_position_tracker`` are autospec'd so call-signature
+    drift on the coordinator's protocol / the tracker is caught; ``db_manager``
+    is protocol-typed ``Any``, so a plain mock matches the surface.
+    """
+    state = create_autospec(LiveOrderFillEngineState, instance=True)
     state.current_balance = balance
     state.trading_session_id = session_id
-    state.live_position_tracker = MagicMock()
+    state.live_position_tracker = create_autospec(LivePositionTracker, instance=True)
     state.db_manager = MagicMock()
     state._pending_fill_exits = queue.SimpleQueue()
     state.live_position_tracker.positions = positions or {}
@@ -126,7 +132,7 @@ def test_order_cancel_removes_phantom_and_refunds_full_fee_sessionless():
     # filled_qty=0.0 -> fully unfilled -> full fee refunded; sessionless -> direct balance add.
     LiveOrderFillCoordinator(state).handle_order_cancel("entry-order", "BTCUSDT", filled_qty=0.0)
 
-    assert state.current_balance == 1005.0
+    assert state.current_balance == pytest.approx(1005.0)
 
 
 def test_order_cancel_partial_fill_refunds_only_unfilled_fraction_sessionless():
@@ -150,7 +156,7 @@ def test_order_cancel_none_quantity_does_not_crash_and_refunds_full_fee():
     LiveOrderFillCoordinator(state).handle_order_cancel("entry-order", "BTCUSDT", filled_qty=0.5)
 
     # original_qty resolves to 0.0 (not >0), so the full fee is refunded.
-    assert state.current_balance == 1003.0
+    assert state.current_balance == pytest.approx(1003.0)
 
 
 def test_tracking_lost_keeps_position_and_escalates():

--- a/tests/unit/engines/live/test_order_fill_coordinator.py
+++ b/tests/unit/engines/live/test_order_fill_coordinator.py
@@ -1,0 +1,167 @@
+"""Unit tests for LiveOrderFillCoordinator (#486).
+
+The OrderTracker callbacks were extracted from LiveTradingEngine into
+``LiveOrderFillCoordinator`` (the engine keeps thin delegating wrappers and
+still registers those wrappers with OrderTracker). These tests drive the
+coordinator directly via a mocked engine-state backref, covering the
+deferred-close handoff, the stop-loss-cancel escalation seam, the cancel-refund
+math, and the fail-closed tracking-lost contract. They also pin the CODE.md
+hardening applied after the extraction (the cancel-refund uses an explicit
+``quantity is not None`` guard rather than ``or 0.0``).
+"""
+
+from __future__ import annotations
+
+import queue
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.database.models import EventType
+from src.engines.live.execution.order_fill_coordinator import (
+    LiveOrderFillCoordinator,
+    LiveOrderFillEngineState,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def _make_position(*, stop_loss_order_id: str | None = None, entry_fee: float = 0.0, quantity=1.0):
+    """Return a minimal tracked-position mock for callback tests."""
+    pos = MagicMock()
+    pos.stop_loss_order_id = stop_loss_order_id
+    pos.quantity = quantity
+    pos.metadata = {"entry_fee": entry_fee}
+    return pos
+
+
+def _make_state(*, positions: dict | None = None, session_id=None, balance: float = 1000.0):
+    """Build a mocked engine-state backref with a real fill-exit queue."""
+    state = MagicMock(spec=LiveOrderFillEngineState)
+    state.current_balance = balance
+    state.trading_session_id = session_id
+    state.live_position_tracker = MagicMock()
+    state.db_manager = MagicMock()
+    state._pending_fill_exits = queue.SimpleQueue()
+    state.live_position_tracker.positions = positions or {}
+    return state
+
+
+def test_order_fill_enqueues_stop_loss_close_for_the_loop():
+    """A stop-loss full fill is deferred to the loop via the queue, not closed inline."""
+    pos = _make_position(stop_loss_order_id="sl1")
+    state = _make_state(positions={"pos1": pos})
+
+    LiveOrderFillCoordinator(state).handle_order_fill("sl1", "BTCUSDT", 0.5, 100.0)
+
+    assert state._pending_fill_exits.get_nowait() == ("pos1", 100.0)
+
+
+def test_order_fill_non_stop_loss_enqueues_nothing():
+    pos = _make_position(stop_loss_order_id="sl1")
+    state = _make_state(positions={"pos1": pos})
+
+    LiveOrderFillCoordinator(state).handle_order_fill("some-entry-order", "BTCUSDT", 0.5, 100.0)
+
+    assert state._pending_fill_exits.empty()
+
+
+def test_partial_stop_loss_fill_raises_critical_alert():
+    pos = _make_position(stop_loss_order_id="sl1")
+    state = _make_state(positions={"pos1": pos})
+
+    LiveOrderFillCoordinator(state).handle_partial_fill("sl1", "BTCUSDT", 0.25, 100.0)
+
+    state._send_alert.assert_called_once()
+
+
+def test_partial_fill_non_stop_loss_no_alert():
+    pos = _make_position(stop_loss_order_id="sl1")
+    state = _make_state(positions={"pos1": pos})
+
+    LiveOrderFillCoordinator(state).handle_partial_fill("entry-order", "BTCUSDT", 0.25, 100.0)
+
+    state._send_alert.assert_not_called()
+
+
+def test_stop_loss_cancelled_clears_id_and_escalates():
+    pos = _make_position(stop_loss_order_id="sl1")
+    state = _make_state(positions={"pos1": pos})
+
+    matched = LiveOrderFillCoordinator(state).handle_stop_loss_cancelled("sl1", "BTCUSDT")
+
+    assert matched is True
+    state.live_position_tracker.set_stop_loss_order_id.assert_called_once_with("pos1", None)
+    state._record_event.assert_called_once()
+    assert state._record_event.call_args.kwargs["error_code"] == "STOP_LOSS_CANCELLED"
+    assert state._record_event.call_args.kwargs["alert"] is True
+
+
+def test_stop_loss_cancelled_no_match_returns_false():
+    state = _make_state(positions={})
+
+    matched = LiveOrderFillCoordinator(state).handle_stop_loss_cancelled("sl-unknown", "BTCUSDT")
+
+    assert matched is False
+    state.live_position_tracker.set_stop_loss_order_id.assert_not_called()
+    state._record_event.assert_not_called()
+
+
+def test_order_cancel_routes_stop_loss_escalation_and_returns_early():
+    """If the cancelled order is a tracked stop-loss, escalate and do NOT pop a position."""
+    pos = _make_position(stop_loss_order_id="sl1")
+    state = _make_state(positions={"pos1": pos})
+
+    LiveOrderFillCoordinator(state).handle_order_cancel("sl1", "BTCUSDT")
+
+    state.live_position_tracker.set_stop_loss_order_id.assert_called_once_with("pos1", None)
+    state.live_position_tracker.pop_position.assert_not_called()
+
+
+def test_order_cancel_removes_phantom_and_refunds_full_fee_sessionless():
+    removed = _make_position(entry_fee=5.0, quantity=1.0)
+    state = _make_state(positions={}, session_id=None, balance=1000.0)
+    state.live_position_tracker.pop_position.return_value = removed
+
+    # filled_qty=0.0 -> fully unfilled -> full fee refunded; sessionless -> direct balance add.
+    LiveOrderFillCoordinator(state).handle_order_cancel("entry-order", "BTCUSDT", filled_qty=0.0)
+
+    assert state.current_balance == 1005.0
+
+
+def test_order_cancel_partial_fill_refunds_only_unfilled_fraction_sessionless():
+    removed = _make_position(entry_fee=10.0, quantity=1.0)
+    state = _make_state(positions={}, session_id=None, balance=1000.0)
+    state.live_position_tracker.pop_position.return_value = removed
+
+    # 0.4 of 1.0 filled -> 60% unfilled -> refund 6.0 of the 10.0 fee.
+    LiveOrderFillCoordinator(state).handle_order_cancel("entry-order", "BTCUSDT", filled_qty=0.4)
+
+    assert state.current_balance == pytest.approx(1006.0)
+
+
+def test_order_cancel_none_quantity_does_not_crash_and_refunds_full_fee():
+    """Regression for the `or 0.0` -> `is not None` hardening: a None quantity
+    must not raise and falls back to the full-fee refund path."""
+    removed = _make_position(entry_fee=3.0, quantity=None)
+    state = _make_state(positions={}, session_id=None, balance=1000.0)
+    state.live_position_tracker.pop_position.return_value = removed
+
+    LiveOrderFillCoordinator(state).handle_order_cancel("entry-order", "BTCUSDT", filled_qty=0.5)
+
+    # original_qty resolves to 0.0 (not >0), so the full fee is refunded.
+    assert state.current_balance == 1003.0
+
+
+def test_tracking_lost_keeps_position_and_escalates():
+    """Fail-closed: tracking-lost must NOT pop/refund; it keeps the position tracked."""
+    state = _make_state(positions={})
+    state.live_position_tracker.get_position.return_value = _make_position()
+
+    LiveOrderFillCoordinator(state).handle_order_tracking_lost("order-1", "BTCUSDT", 3)
+
+    state.live_position_tracker.pop_position.assert_not_called()
+    state._record_event.assert_called_once()
+    assert state._record_event.call_args.args[0] == EventType.ERROR
+    assert state._record_event.call_args.kwargs["error_code"] == "ORDER_TRACKING_LOST"
+    assert state._record_event.call_args.kwargs["alert"] is True


### PR DESCRIPTION
## What & why

Follow-up to #817 (order-fill callback extraction into `LiveOrderFillCoordinator`). That PR was an intentionally **verbatim** move and carried over pre-existing CODE.md violations from the deleted engine methods. This PR fixes them in isolation, per the bug protocol, so the extraction itself stayed a clean diff. Addresses the `claude[bot]` review on #817 (all 3 inline findings).

## Fixes (all behaviour-neutral)

- **Lazy `%s` logging** — `handle_order_fill`'s `logger.info` was an f-string; now `%s`.
- **Position-Fields rule** — `handle_order_cancel`'s original-quantity fallback was `removed_position.quantity or 0.0`; now `removed_position.quantity if ... is not None else 0.0`. A legitimate `0.0` quantity is valid state, not "unset". **Behaviour-neutral**: the value is immediately gated by `original_qty > 0`, so `0.0` vs `None` was already indistinguishable downstream — but the explicit form is correct and matches CODE.md.
- **`exc_info=True`** on the entry-fee-refund-failure `logger.critical` — a balance-integrity failure where the full traceback matters most for manual reconciliation.

## Tests

New `tests/unit/engines/live/test_order_fill_coordinator.py` (11 tests) drives the coordinator directly via a mocked engine-state backref with a real `SimpleQueue`:
- stop-loss full fill **enqueues** `(pos_order_id, avg_price)` for the loop (deferred close, #631); non-SL fill enqueues nothing
- partial stop-loss fill raises the critical `_send_alert`; non-SL partial does not
- stop-loss-cancel escalation clears the in-memory SL id + emits `STOP_LOSS_CANCELLED` (match) / no-ops (no match)
- `handle_order_cancel` routes a tracked-SL cancel to escalation and returns early (no `pop_position`)
- cancel-refund: full fee (fully unfilled), partial fraction (60% unfilled → 6.0 of 10.0), and the **`None`-quantity regression** (no crash, full-fee fallback)
- fail-closed `handle_order_tracking_lost`: keeps the position (no `pop_position`), emits `ORDER_TRACKING_LOST`

## Verification

- New tests: 11 passed. Existing callback suites (`test_order_execution`, `test_order_tracking_lost`, `test_stop_loss_cancel_escalation_741`, `test_db_resilience`) green.
- ruff / black / mypy clean.
- **Parity:** determinism fingerprint **byte-identical** (`ee76fd68…03a87`) — logging/typing changes don't touch the backtest path.

https://claude.ai/code/session_0188LNSixYW9Fa5hrJ7YWJoa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GW2sLEPVxrQQ6sUXDzrFRB)_