### PR TITLE
refactor(live): decompose LiveTradingEngine.start() into phase helpers (#486)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `LiveTradingEngine.start()` decomposed from a ~327-line bootstrap monolith into
+  a thin ~18-line phase orchestrator that calls cohesive, single-purpose private
+  helpers (`_begin_session_runtime`, `_bootstrap_trading_session`,
+  `_carry_forward_open_positions`, `_self_heal_terminal_positions`,
+  `_synchronize_account_on_start`, `_start_runtime_services`,
+  `_run_main_loop_until_stopped`). Each block moved verbatim — the
+  capital-critical startup ordering (recover → create session → #668
+  carry-forward → #657 self-heal → account sync → runtime services → loop
+  kickoff) and the public `start()` signature are preserved exactly. Pure
+  refactor — backtest determinism fingerprint byte-identical. (#486)
 - `LiveTradingEngine.__init__` decomposed from a ~534-line monolith into a thin
   ~110-line orchestrator that calls cohesive, single-purpose private
   initializer helpers (`_validate_inputs`, `_resolve_settings`,

--- a/docs/refactor/live_engine_modularization.md
+++ b/docs/refactor/live_engine_modularization.md
@@ -54,7 +54,7 @@ engine keeps thin delegating wrappers (so call sites and test mock points are un
 |---|---|---|
 | ~~`__init__`~~ | ~~~534~~ → ~110 | **DONE (Step A).** Decomposed into 15 cohesive private initializer helpers; now a thin phase orchestrator. |
 | `_trading_loop` | ~390 | **Orchestrator core — stays.** Readability-only improvements optional (Step C). |
-| `start` | ~326 | Bootstrap sequence (session recover/create, #668 carry-forward, #657 self-heal, account sync, WS streams, reconciler, loop kickoff) — **next: Step B**. |
+| ~~`start`~~ | ~~~326~~ → ~18 | **DONE (Step B).** Decomposed into 7 cohesive phase helpers; now a thin orchestrator. |
 | `_init_modular_handlers` | ~112 | Default-vs-injected handler construction. Could fold into the Step A helper family or a builder later. |
 | `stop` | ~86 | Lifecycle teardown. |
 | `_is_transient_db_error`, `_record_event`, `_send_alert`, `_create_exchange_provider` | small | Cross-cutting infra. |
@@ -163,12 +163,20 @@ lower-risk first move and still hits the goal.
 - Consider moving OS **signal registration** out of `__init__` into `start()` (it's a side
   effect that complicates construction) — but only if behavior/tests allow; verify.
 
-### Step B — `start()` bootstrap slim-down
-Move the startup sequence into `LiveSessionRecoverer` and/or a new `LiveStartupSequencer`,
-leaving `start()` a thin phase orchestration. Watch the capital-critical ordering: session
-recover → create session → wire session/strategy/execution-engine/event-logger → #668
-open-position carry-forward → #657 self-heal → account sync / exchange reconciliation → WS
-streams → WS health monitor → periodic reconciler → loop kickoff.
+### Step B — `start()` bootstrap slim-down (DONE)
+Decomposed `start()` (~327 → ~18 lines) into 7 cohesive private phase helpers
+(`_begin_session_runtime`, `_bootstrap_trading_session`,
+`_carry_forward_open_positions`, `_self_heal_terminal_positions`,
+`_synchronize_account_on_start`, `_start_runtime_services`,
+`_run_main_loop_until_stopped`) — Step-A-style verbatim moves on the engine
+(the recovery primitives already live in `LiveSessionRecoverer`, so no
+duplication). The capital-critical ordering is preserved exactly: session
+recover → create session → wire session/strategy/execution-engine/event-logger →
+#668 open-position carry-forward → #657 self-heal → account sync / exchange
+reconciliation → runtime services (order tracker → periodic reconciler → WS
+streams) → loop kickoff. Parity byte-identical. (A future `LiveStartupSequencer`
+coordinator is the more-architectural end-state, mirroring the builder-vs-
+phase-helper trade-off noted in Step A.)
 
 ### Step C (optional, behavior-preserving) — `_trading_loop` readability
 Extract per-iteration phases (data fetch → freshness/context gate → entry/exit eval →
@@ -319,7 +327,8 @@ The bot reviews each PR and flags carried-over CODE.md nits: f-strings in loggin
 | #820 | loop-timing → `LiveLoopTimingCoordinator` (+ hardening folded in) |
 | #821 | dynamic-risk → `LiveDynamicRiskCoordinator` (+ tests folded in) |
 | #822 | this handover doc |
-| (this branch) | **Step A** — `__init__` decomposed into 15 cohesive private initializer helpers; engine `__init__` ~534 → ~110 lines. Also aligned `LiveLoopTimingEngineState.data_freshness_threshold` to `int`. |
+| #823 | **Step A** — `__init__` decomposed into 15 cohesive private initializer helpers; engine `__init__` ~534 → ~110 lines. Also aligned `LiveLoopTimingEngineState.data_freshness_threshold` to `int`. |
+| (this branch) | **Step B** — `start()` decomposed into 7 cohesive private phase helpers; ~327 → ~18 lines. |
 
 Engine: **6,558 → 2,493 lines** through #821; Step A keeps the engine's total
 line count roughly flat (the slim `__init__` is offset by per-helper

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1098,6 +1098,26 @@ class LiveTradingEngine:
             logger.warning("Trading engine is already running")
             return
 
+        self._begin_session_runtime(symbol, timeframe)
+        self._bootstrap_trading_session(symbol, timeframe)
+        self._carry_forward_open_positions()
+        self._self_heal_terminal_positions()
+        self._synchronize_account_on_start()
+
+        # Set session ID on strategy for logging
+        if hasattr(self.strategy, "session_id"):
+            self.strategy.session_id = self.trading_session_id
+
+        self._start_runtime_services(symbol, timeframe)
+        self._run_main_loop_until_stopped(symbol, timeframe, max_steps)
+
+        # After a clean stop this is a no-op; after an abnormal loop death it
+        # exits the process non-zero (when opted in) so the orchestrator
+        # restarts it (#630).
+        self._exit_if_loop_crashed(exit_on_crash)
+
+    def _begin_session_runtime(self, symbol: str, timeframe: str) -> None:
+        """Set runtime flags + logging context and emit the startup banner."""
         self.is_running = True
         self._active_symbol = symbol
         self.timeframe = timeframe  # Store the trading timeframe
@@ -1123,6 +1143,8 @@ class LiveTradingEngine:
         if not self.enable_live_trading:
             logger.warning("⚠️  PAPER TRADING MODE - No real orders will be executed")
 
+    def _bootstrap_trading_session(self, symbol: str, timeframe: str) -> None:
+        """Recover prior balance/positions and create + wire the trading session."""
         # Try to recover from existing session first
         if self.resume_from_last_balance:
             recovered_balance = self._recover_existing_session()
@@ -1194,6 +1216,8 @@ class LiveTradingEngine:
             self.event_logger.set_session_id(self.trading_session_id)
             self.event_logger.set_recovery_session_id(self._recovered_inactive_session_id)
 
+    def _carry_forward_open_positions(self) -> None:
+        """Carry OPEN positions forward from a recovered inactive session (#668)."""
         # Carry OPEN positions forward on a clean restart (#668). The inactive
         # session recovered above (balance only) still owns any OPEN position via
         # Position.session_id, so _recover_active_positions() at line ~1281 saw a
@@ -1238,6 +1262,8 @@ class LiveTradingEngine:
                 # stale-session reassign (#668, P3).
                 self._recovered_inactive_session_id = None
 
+    def _self_heal_terminal_positions(self) -> None:
+        """Close any OPEN position in this session that already has a terminal Trade (#657)."""
         # Startup self-heal (#657): close any OPEN position in this session that
         # already has a terminal Trade. Deliberately NOT gated behind
         # enable_live_trading/exchange — the whole bug was that closing was
@@ -1260,6 +1286,8 @@ class LiveTradingEngine:
             except Exception as heal_err:
                 logger.warning("Startup position self-heal failed (continuing): %s", heal_err)
 
+    def _synchronize_account_on_start(self) -> None:
+        """Sync balance/positions with the exchange and persist any balance correction."""
         # Perform account synchronization if available
         self._pending_balance_correction = False
         self._pending_corrected_balance = None
@@ -1342,10 +1370,8 @@ class LiveTradingEngine:
                 self._pending_balance_correction = False
                 self._pending_corrected_balance = None
 
-        # Set session ID on strategy for logging
-        if hasattr(self.strategy, "session_id"):
-            self.strategy.session_id = self.trading_session_id
-
+    def _start_runtime_services(self, symbol: str, timeframe: str) -> None:
+        """Start the order tracker, periodic reconciler, and WebSocket streams."""
         # Start order tracker for monitoring order fills (live trading only)
         if self.order_tracker and self.enable_live_trading:
             self.order_tracker.start()
@@ -1387,6 +1413,10 @@ class LiveTradingEngine:
         # Try to start WebSocket streams for reduced API weight
         self._start_websocket_streams(symbol, timeframe)
 
+    def _run_main_loop_until_stopped(
+        self, symbol: str, timeframe: str, max_steps: int | None
+    ) -> None:
+        """Launch the trading-loop thread and block until it stops, then tear down."""
         # Start main trading loop in separate thread
         self.main_thread = threading.Thread(
             target=self._run_trading_loop, args=(symbol, timeframe, max_steps)
@@ -1402,11 +1432,6 @@ class LiveTradingEngine:
             logger.info("Received interrupt signal")
         finally:
             self.stop()
-
-        # After a clean stop this is a no-op; after an abnormal loop death it
-        # exits the process non-zero (when opted in) so the orchestrator
-        # restarts it (#630).
-        self._exit_if_loop_crashed(exit_on_crash)
 
     def _enter_close_only_mode(self) -> None:
         """Enter close-only mode: no new entries, exits/stops/trailing still active."""


### PR DESCRIPTION
## Summary

**Step B** of the live-engine modularization (#486): the ~327-line `LiveTradingEngine.start()` bootstrap monolith is now a thin **~18-line phase orchestrator** delegating to 7 cohesive, single-purpose private helpers:

`_begin_session_runtime` · `_bootstrap_trading_session` · `_carry_forward_open_positions` · `_self_heal_terminal_positions` · `_synchronize_account_on_start` · `_start_runtime_services` · `_run_main_loop_until_stopped`

Every block was moved **verbatim**. The recovery primitives already live in `LiveSessionRecoverer`, so there's no duplication — these helpers orchestrate the existing engine wrappers.

### Capital-critical ordering preserved exactly
recover → create session → wire session/strategy/execution-engine/event-logger → **#668** open-position carry-forward → **#657** self-heal → account sync / exchange reconciliation + risk re-registration → pending-balance-correction persist → order tracker → periodic reconciler → WS streams → loop kickoff → `_exit_if_loop_crashed`.

The public `start(symbol, timeframe, max_steps, exit_on_crash)` signature is unchanged.

## User-facing impact
None. Pure internal refactor — no behavior change.

## Testing
- **Backtest determinism: byte-identical** — `sha256=ee76fd681362f5a251f9bd34ee40c7177ca8697e9b29e70b2c0d1ed2afd03a87`, `trades=14`, `final_balance=9964.469867425983`.
- Full fast suite green: **4094 passed**, 103 skipped.
- Live-engine targeted tests (incl. `test_engine_core.py`, clean-restart/#668 carry-forward, reconciler startup branch): 668 passed.
- `mypy` (`-p` package form), `ruff`, `black`, `bandit` all clean.

Refs #486. Follows #823 (Step A).

https://claude.ai/code/session_01GM3triPGTm6bqpP9xBVWh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM3triPGTm6bqpP9xBVWh4)_