### PR TITLE
refactor(live): extract _trading_loop short-entry + periodic-account blocks (#486)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `LiveTradingEngine._trading_loop` readability: extracted the ~100-line legacy
+  duck-typed short-entry path into `_process_legacy_short_entry()` and the
+  periodic account snapshot + exchange-sync block into
+  `_log_periodic_account_state()`. Both are behavior-preserving moves (the loop
+  body shrinks ~390 → ~250 lines); the loop, its per-iteration control flow, and
+  the capital-critical error-handling/backoff block stay inline on the engine.
+  Pure refactor — backtest determinism fingerprint byte-identical. (#486)
 - `LiveTradingEngine.start()` decomposed from a ~327-line bootstrap monolith into
   a thin ~18-line phase orchestrator that calls cohesive, single-purpose private
   helpers (`_begin_session_runtime`, `_bootstrap_trading_session`,

--- a/docs/refactor/live_engine_modularization.md
+++ b/docs/refactor/live_engine_modularization.md
@@ -53,7 +53,7 @@ engine keeps thin delegating wrappers (so call sites and test mock points are un
 | Method | Lines (develop) | Nature |
 |---|---|---|
 | ~~`__init__`~~ | ~~~534~~ → ~110 | **DONE (Step A).** Decomposed into 15 cohesive private initializer helpers; now a thin phase orchestrator. |
-| `_trading_loop` | ~390 | **Orchestrator core — stays.** Readability-only improvements optional (Step C). |
+| `_trading_loop` | ~390 → ~250 | **Orchestrator core — stays.** Step C extracted the legacy short-entry + periodic-account-state blocks; remaining per-iteration flow + error handling kept inline by design. |
 | ~~`start`~~ | ~~~326~~ → ~18 | **DONE (Step B).** Decomposed into 7 cohesive phase helpers; now a thin orchestrator. |
 | `_init_modular_handlers` | ~112 | Default-vs-injected handler construction. Could fold into the Step A helper family or a builder later. |
 | `stop` | ~86 | Lifecycle teardown. |
@@ -178,9 +178,17 @@ streams) → loop kickoff. Parity byte-identical. (A future `LiveStartupSequence
 coordinator is the more-architectural end-state, mirroring the builder-vs-
 phase-helper trade-off noted in Step A.)
 
-### Step C (optional, behavior-preserving) — `_trading_loop` readability
-Extract per-iteration phases (data fetch → freshness/context gate → entry/exit eval →
-cadence/sleep → error handling) into named private helpers. The loop **stays** on the engine.
+### Step C (optional, behavior-preserving) — `_trading_loop` readability (DONE)
+Extracted the two largest **pure-sequential** blocks into named private helpers:
+the ~100-line legacy duck-typed short-entry path (`_process_legacy_short_entry`)
+and the periodic account snapshot + exchange-sync block
+(`_log_periodic_account_state`). The loop dropped ~390 → ~250 lines and now reads
+as named phases. **Deliberately left inline:** the early-`continue` data-fetch /
+freshness / context-readiness guards (already terse) and the capital-critical
+error-handling/backoff block — its `continue`/`break` control flow is clearer in
+place than behind a returns-a-signal helper, and the loop is **not** parity-
+guarded (live-only), so minimizing control-flow transforms there is the safer
+call. The loop **stays** on the engine.
 
 ### Step D — Protocol-tightening + test-consistency sweep (tracked)
 The **entry** and **exit** coordinators still use bare `Any` for some `Protocol` attrs
@@ -328,7 +336,8 @@ The bot reviews each PR and flags carried-over CODE.md nits: f-strings in loggin
 | #821 | dynamic-risk → `LiveDynamicRiskCoordinator` (+ tests folded in) |
 | #822 | this handover doc |
 | #823 | **Step A** — `__init__` decomposed into 15 cohesive private initializer helpers; engine `__init__` ~534 → ~110 lines. Also aligned `LiveLoopTimingEngineState.data_freshness_threshold` to `int`. |
-| (this branch) | **Step B** — `start()` decomposed into 7 cohesive private phase helpers; ~327 → ~18 lines. |
+| #824 | **Step B** — `start()` decomposed into 7 cohesive private phase helpers; ~327 → ~18 lines. |
+| (this branch) | **Step C** — `_trading_loop` short-entry + periodic-account blocks extracted; ~390 → ~250 lines. |
 
 Engine: **6,558 → 2,493 lines** through #821; Step A keeps the engine's total
 line count roughly flat (the slim `__init__` is offset by per-helper

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1993,7 +1993,8 @@ class LiveTradingEngine:
                     else:
                         # All strategies should be component-based
                         logger.error(
-                            f"Strategy {self.strategy.name} does not support component-based stop loss calculation"
+                            "Strategy %s does not support component-based stop loss calculation",
+                            self.strategy.name,
                         )
                         short_stop_loss = current_price * (
                             1 + DEFAULT_STOP_LOSS_PCT

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1830,146 +1830,12 @@ class LiveTradingEngine:
                         runtime_decision=runtime_decision,
                     )
                     # Check for short entry via legacy hook when available
-                    if (not self._is_runtime_strategy()) and callable(
-                        getattr(self.strategy, "check_short_entry_conditions", None)
-                    ):
-                        # Legacy duck-typed hook; presence is verified by the
-                        # callable(getattr(...)) guard above.
-                        short_entry_signal = cast(Any, self.strategy).check_short_entry_conditions(
-                            df, current_index
-                        )
-                        if short_entry_signal:
-                            try:
-                                overrides = (
-                                    self.strategy.get_risk_overrides()
-                                    if hasattr(self.strategy, "get_risk_overrides")
-                                    else None
-                                )
-                            except Exception:
-                                overrides = None
-                            indicators = self._extract_indicators(df, current_index)
-                            # Correlation context for short entries
-                            short_correlation_ctx = self._get_correlation_context(
-                                symbol,
-                                df,
-                                overrides,
-                                index=current_index,
-                            )
-                            if overrides and overrides.get("position_sizer"):
-                                short_fraction = self.risk_manager.calculate_position_fraction(
-                                    df=df,
-                                    index=current_index,
-                                    balance=self.current_balance,
-                                    price=current_price,
-                                    indicators=indicators,
-                                    strategy_overrides=overrides,
-                                    correlation_ctx=short_correlation_ctx,
-                                )
-                                short_fraction = min(short_fraction, self.max_position_size)
-                                short_position_size = short_fraction
-                            else:
-                                # All strategies should be component-based
-                                logger.error(
-                                    "Strategy %s does not support component-based position sizing",
-                                    self.strategy.name,
-                                )
-                                short_position_size = 0.0
-
-                            # Apply dynamic risk adjustments
-                            short_position_size = self._apply_dynamic_risk_adjustment(
-                                short_position_size,
-                                current_time,
-                            )
-                            if short_position_size > 0:
-                                if overrides and (
-                                    ("stop_loss_pct" in overrides)
-                                    or ("take_profit_pct" in overrides)
-                                ):
-                                    short_stop_loss, short_take_profit = (
-                                        self.risk_manager.compute_sl_tp(
-                                            df=df,
-                                            index=current_index,
-                                            entry_price=current_price,
-                                            side="short",
-                                            strategy_overrides=overrides,
-                                        )
-                                    )
-                                    if short_take_profit is None:
-                                        short_take_profit = current_price * (
-                                            1
-                                            - getattr(
-                                                self.strategy,
-                                                "take_profit_pct",
-                                                DEFAULT_TAKE_PROFIT_PCT,
-                                            )
-                                        )
-                                else:
-                                    # All strategies should be component-based
-                                    logger.error(
-                                        f"Strategy {self.strategy.name} does not support component-based stop loss calculation"
-                                    )
-                                    short_stop_loss = current_price * (
-                                        1 + DEFAULT_STOP_LOSS_PCT
-                                    )  # Default 5% stop for short
-                                    short_take_profit = current_price * (
-                                        1
-                                        - getattr(
-                                            self.strategy,
-                                            "take_profit_pct",
-                                            DEFAULT_TAKE_PROFIT_PCT,
-                                        )
-                                    )
-                                self._execute_entry(
-                                    symbol=symbol,
-                                    side=PositionSide.SHORT,
-                                    size=short_position_size,
-                                    price=float(current_price),
-                                    stop_loss=short_stop_loss,
-                                    take_profit=short_take_profit,
-                                    signal_strength=0.0,
-                                    signal_confidence=0.0,
-                                )
+                    self._process_legacy_short_entry(
+                        df, current_index, symbol, current_price, current_time
+                    )
                 # Update performance metrics
                 self._update_performance_metrics()
-                # Log account snapshot to database periodically (configurable interval)
-                now = datetime.now(UTC)
-                if self.account_snapshot_interval > 0 and (
-                    self.last_account_snapshot is None
-                    or (now - self.last_account_snapshot).seconds >= self.account_snapshot_interval
-                ):
-                    self._log_account_snapshot()
-                    self.last_account_snapshot = now
-
-                    # Perform periodic account synchronization
-                    if self.account_synchronizer and self.enable_live_trading:
-                        try:
-                            sync_result = self.account_synchronizer.sync_account_data(
-                                symbol=self._active_symbol
-                            )
-                            if sync_result.success:
-                                logger.debug("Periodic account sync completed")
-                                # Apply any balance correction to the in-memory balance
-                                # that drives sizing (the DB is already updated inside the
-                                # sync). Without this a mid-session margin-equity
-                                # correction would not reach live sizing until restart.
-                                balance_sync = sync_result.data.get("balance_sync", {})
-                                if balance_sync.get("corrected", False):
-                                    corrected = balance_sync.get("new_balance")
-                                    if corrected is not None:
-                                        with self._balance_lock:
-                                            self.current_balance = corrected
-                                        logger.info(
-                                            "💰 Balance corrected mid-session from "
-                                            "exchange: $%.2f",
-                                            corrected,
-                                        )
-                            else:
-                                logger.warning(
-                                    "Periodic account sync failed: %s",
-                                    sync_result.message,
-                                )
-                        except Exception as e:
-                            logger.error("Periodic account sync error: %s", e)
+                self._log_periodic_account_state()
                 # Log status periodically
                 if (
                     self.performance_tracker.get_metrics().total_trades % 10 == 0
@@ -2044,6 +1910,153 @@ class LiveTradingEngine:
 
         logger.info("Trading loop ended")
         self._finalize_runtime()
+
+    def _process_legacy_short_entry(
+        self,
+        df: pd.DataFrame,
+        current_index: int,
+        symbol: str,
+        current_price: float,
+        current_time: datetime,
+    ) -> None:
+        """Evaluate and execute a legacy duck-typed short entry (non-runtime strategies)."""
+        if (not self._is_runtime_strategy()) and callable(
+            getattr(self.strategy, "check_short_entry_conditions", None)
+        ):
+            # Legacy duck-typed hook; presence is verified by the
+            # callable(getattr(...)) guard above.
+            short_entry_signal = cast(Any, self.strategy).check_short_entry_conditions(
+                df, current_index
+            )
+            if short_entry_signal:
+                try:
+                    overrides = (
+                        self.strategy.get_risk_overrides()
+                        if hasattr(self.strategy, "get_risk_overrides")
+                        else None
+                    )
+                except Exception:
+                    overrides = None
+                indicators = self._extract_indicators(df, current_index)
+                # Correlation context for short entries
+                short_correlation_ctx = self._get_correlation_context(
+                    symbol,
+                    df,
+                    overrides,
+                    index=current_index,
+                )
+                if overrides and overrides.get("position_sizer"):
+                    short_fraction = self.risk_manager.calculate_position_fraction(
+                        df=df,
+                        index=current_index,
+                        balance=self.current_balance,
+                        price=current_price,
+                        indicators=indicators,
+                        strategy_overrides=overrides,
+                        correlation_ctx=short_correlation_ctx,
+                    )
+                    short_fraction = min(short_fraction, self.max_position_size)
+                    short_position_size = short_fraction
+                else:
+                    # All strategies should be component-based
+                    logger.error(
+                        "Strategy %s does not support component-based position sizing",
+                        self.strategy.name,
+                    )
+                    short_position_size = 0.0
+
+                # Apply dynamic risk adjustments
+                short_position_size = self._apply_dynamic_risk_adjustment(
+                    short_position_size,
+                    current_time,
+                )
+                if short_position_size > 0:
+                    if overrides and (
+                        ("stop_loss_pct" in overrides) or ("take_profit_pct" in overrides)
+                    ):
+                        short_stop_loss, short_take_profit = self.risk_manager.compute_sl_tp(
+                            df=df,
+                            index=current_index,
+                            entry_price=current_price,
+                            side="short",
+                            strategy_overrides=overrides,
+                        )
+                        if short_take_profit is None:
+                            short_take_profit = current_price * (
+                                1
+                                - getattr(
+                                    self.strategy,
+                                    "take_profit_pct",
+                                    DEFAULT_TAKE_PROFIT_PCT,
+                                )
+                            )
+                    else:
+                        # All strategies should be component-based
+                        logger.error(
+                            f"Strategy {self.strategy.name} does not support component-based stop loss calculation"
+                        )
+                        short_stop_loss = current_price * (
+                            1 + DEFAULT_STOP_LOSS_PCT
+                        )  # Default 5% stop for short
+                        short_take_profit = current_price * (
+                            1
+                            - getattr(
+                                self.strategy,
+                                "take_profit_pct",
+                                DEFAULT_TAKE_PROFIT_PCT,
+                            )
+                        )
+                    self._execute_entry(
+                        symbol=symbol,
+                        side=PositionSide.SHORT,
+                        size=short_position_size,
+                        price=float(current_price),
+                        stop_loss=short_stop_loss,
+                        take_profit=short_take_profit,
+                        signal_strength=0.0,
+                        signal_confidence=0.0,
+                    )
+
+    def _log_periodic_account_state(self) -> None:
+        """Log the periodic account snapshot and run periodic exchange account sync."""
+        # Log account snapshot to database periodically (configurable interval)
+        now = datetime.now(UTC)
+        if self.account_snapshot_interval > 0 and (
+            self.last_account_snapshot is None
+            or (now - self.last_account_snapshot).seconds >= self.account_snapshot_interval
+        ):
+            self._log_account_snapshot()
+            self.last_account_snapshot = now
+
+            # Perform periodic account synchronization
+            if self.account_synchronizer and self.enable_live_trading:
+                try:
+                    sync_result = self.account_synchronizer.sync_account_data(
+                        symbol=self._active_symbol
+                    )
+                    if sync_result.success:
+                        logger.debug("Periodic account sync completed")
+                        # Apply any balance correction to the in-memory balance
+                        # that drives sizing (the DB is already updated inside the
+                        # sync). Without this a mid-session margin-equity
+                        # correction would not reach live sizing until restart.
+                        balance_sync = sync_result.data.get("balance_sync", {})
+                        if balance_sync.get("corrected", False):
+                            corrected = balance_sync.get("new_balance")
+                            if corrected is not None:
+                                with self._balance_lock:
+                                    self.current_balance = corrected
+                                logger.info(
+                                    "💰 Balance corrected mid-session from " "exchange: $%.2f",
+                                    corrected,
+                                )
+                    else:
+                        logger.warning(
+                            "Periodic account sync failed: %s",
+                            sync_result.message,
+                        )
+                except Exception as e:
+                    logger.error("Periodic account sync error: %s", e)
 
     @staticmethod
     def _is_transient_db_error(exc: BaseException) -> bool:


### PR DESCRIPTION
## Summary

**Step C** of the live-engine modularization (#486) — optional, behavior-preserving readability. Two large **pure-sequential** blocks are lifted out of the ~390-line `_trading_loop`:

- **`_process_legacy_short_entry()`** — the ~100-line legacy duck-typed short-entry path (non-runtime strategies).
- **`_log_periodic_account_state()`** — the periodic account snapshot + exchange account-sync block.

The loop body shrinks ~390 → ~250 lines and now reads as named phases.

### Deliberately left inline
- The early-`continue` data-fetch / freshness / context-readiness guards (already terse).
- The **capital-critical error-handling / backoff** block — its `continue`/`break` control flow is clearer in place than behind a returns-a-signal helper, and the loop is **live-only (not parity-guarded)**, so I avoided control-flow transforms there. (Documented in `docs/refactor/live_engine_modularization.md`.)

> Note: `black` re-wrapped the moved code at its new shallower indentation (the deep-indent line breaks are no longer needed). Logic is unchanged.

## User-facing impact
None. Pure internal refactor.

## Testing
- **Backtest determinism: byte-identical** — `sha256=ee76fd681362f5a251f9bd34ee40c7177ca8697e9b29e70b2c0d1ed2afd03a87`.
- Full fast suite green: **4094 passed**, 103 skipped.
- Live-engine + `test_db_resilience` (error-path) targeted tests: 707 passed.
- `mypy` (`-p` package form), `ruff`, `black`, `bandit` all clean.

Refs #486. Follows #824 (Step B).

https://claude.ai/code/session_01GM3triPGTm6bqpP9xBVWh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM3triPGTm6bqpP9xBVWh4)_