### PR TITLE
refactor(live): tighten entry/exit coordinator Protocols + autospec tests (#486)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Live entry/exit coordinator `Protocol` types tightened (#486 Step D): the
+  engine-state backref `Protocol`s (`LiveEntryEngineState`,
+  `LiveExitEngineState`) now declare `data_provider: DataProvider`,
+  `db_manager: DatabaseManager`, `_base_asset_locks: BaseAssetLockRegistry`, and
+  `_component_strategy: ComponentStrategy | None` (were bare `Any`), matching the
+  concrete-typing standard set by the later coordinators / `LiveSessionRecoverer`.
+  `exchange_interface` / `strategy` stay `Any` (genuinely duck-typed). Their unit
+  tests now build the mocked backref with `create_autospec(..., instance=True)`
+  instead of `MagicMock(spec=...)`, so call-signature drift on the spec'd engine
+  helpers is caught, not just attribute-name drift. Typing/test-only — no runtime
+  change; backtest determinism fingerprint byte-identical. (#486)
 - `LiveTradingEngine._trading_loop` readability: extracted the ~100-line legacy
   duck-typed short-entry path into `_process_legacy_short_entry()` and the
   periodic account snapshot + exchange-sync block into

--- a/docs/project_status.md
+++ b/docs/project_status.md
@@ -1,22 +1,12 @@
 # Project Status
 
-> **Last Updated**: 2026-06-14
+> **Last Updated**: 2026-06-15
 > **Maintainer Note**: This is a living document. Update at the start and end of each development session. Use the `/update-docs` command to keep this in sync.
 
 ---
 
 ## In Flight
 
-- **Live trading engine refactor (#486)** — decomposing `LiveTradingEngine`
-  from a ~6,560-line god-class into a thin orchestrator that delegates to
-  focused modules. Merged: stop-loss lifecycle, monitoring glue, shared
-  entry-handler mixin (#796); startup recovery (#798); construction-time
-  settings (#800); strategy-runtime coordination (#809). Engine now ~4,790
-  lines. In flight: hot-swap lifecycle → `StrategyHotSwapCoordinator` (PR
-  #810, review-clean + CI-green, held pending the parity fix below). Remaining:
-  WebSocket-health extraction, locked entry/exit orchestration, toward a
-  <1,500-line orchestrator. Every step is a pure refactor proven against a
-  deterministic backtest parity fingerprint.
 - **Backtest determinism / parity fingerprint (#486 parity, PR #811)** — the
   parity oracle the refactor series depends on. Found the ml_basic backtest
   varied across processes under load (49/50/51 trades on identical inputs).
@@ -84,6 +74,7 @@ warning, per-trade sequence tie-break.
 - [x] **Feature Schema Saving** - ML models save feature schemas for validation (#530)
 - [x] **Cloud Training Automation** - Auto data download/upload for cloud training (#532)
 - [x] **CI/CD Pipeline** - Claude Code GitHub Workflow with tests (#551)
+- [x] **Live Trading Engine Modularization (#486)** - Decomposed the `LiveTradingEngine` god-class (~6,560 lines at the start of the effort) into a thin orchestrator over a coordinator family. The handover-doc plan (Steps A–E) landed via #823–#826: `__init__` 534→~110 lines (15 phase helpers), `start()` 327→~18 lines (7 phase helpers), `_trading_loop` 390→~250 lines (short-entry + periodic-account extracted), and entry/exit coordinator `Protocol`s tightened to concrete types. Every step proven byte-identical against the deterministic backtest parity fingerprint. Engine now ~2,620 lines; optional further extraction (e.g. `LiveEngineBuilder`, `LiveStartupSequencer`) remains as future polish. Plan: `docs/refactor/live_engine_modularization.md`.
 
 ### In Progress
 
@@ -134,19 +125,23 @@ warning, per-trade sequence tie-break.
 
 ## Last Session Summary
 
-**Date**: 2026-02-18
+**Date**: 2026-06-15
 
 **Work Completed**:
-- Implemented PSB high-priority improvements: updated changelog, project status, architecture docs
-- Added `#` hashtag regression prevention pattern to CLAUDE.md
-- Verified `/update-docs` slash command is complete
+- Completed the #486 live-engine modularization plan (Steps A–E) across four
+  PRs (#823–#826): decomposed `__init__`, `start()`, and `_trading_loop` into
+  cohesive helpers; tightened the entry/exit coordinator `Protocol`s to concrete
+  types and moved their tests to `create_autospec`; documented the deliberate
+  non-extractions. Every PR proven byte-identical against the backtest parity
+  fingerprint and merged CI-green.
 
 **Ended At**:
-- PSB high-priority documentation improvements
+- #486 modularization plan complete; engine is a thin ~2,620-line orchestrator.
 
 **Next Steps**:
-- Implement PSB medium-priority items (feature reference docs, additional slash commands)
-- Continue performance optimization work
+- Optional further extraction if pursued: `_process_legacy_short_entry` →
+  `LiveEntryCoordinator`; a `LiveEngineBuilder` for construction; a
+  `LiveStartupSequencer` for the bootstrap sequence.
 
 ---
 

--- a/docs/refactor/live_engine_modularization.md
+++ b/docs/refactor/live_engine_modularization.md
@@ -127,6 +127,14 @@ Use this for every extraction. It is the established pattern across all coordina
 
 ## 5. Remaining work — prioritized plan
 
+> **Status: all planned steps (A–E) complete** as of 2026-06-15 (PRs #823–#825 +
+> the Step D/E PR). The big methods are decomposed (`__init__` 534→~110,
+> `start()` 327→~18, `_trading_loop` 390→~250), the entry/exit `Protocol`s are
+> concretely typed, and the deliberate non-extractions are documented below.
+> Remaining ideas are explicitly *optional* future polish (e.g. a
+> `LiveEngineBuilder` / `LiveStartupSequencer`, folding `_init_modular_handlers`
+> into the builder) — none required for the #486 goal.
+
 Each item is its own PR with the full workflow in §6. Re-grep line numbers first.
 
 ### Step A (highest value) — Construction slim-down (DONE)
@@ -190,20 +198,30 @@ place than behind a returns-a-signal helper, and the loop is **not** parity-
 guarded (live-only), so minimizing control-flow transforms there is the safer
 call. The loop **stays** on the engine.
 
-### Step D — Protocol-tightening + test-consistency sweep (tracked)
-The **entry** and **exit** coordinators still use bare `Any` for some `Protocol` attrs
-(e.g. `db_manager`) and their tests use `MagicMock(spec=...)`. Align them to the
-concrete-typing + `create_autospec` standard the later coordinators set. (`create_autospec`
-works fine on these `Protocol`s — verified — and enforces call-signature drift, not just
-attribute names.)
+### Step D — Protocol-tightening + test-consistency sweep (DONE)
+The **entry** and **exit** coordinator `Protocol`s (`LiveEntryEngineState`,
+`LiveExitEngineState`) now declare concrete types — `data_provider: DataProvider`,
+`db_manager: DatabaseManager`, `_base_asset_locks: BaseAssetLockRegistry`,
+`_component_strategy: ComponentStrategy | None` — matching the standard set by the
+later coordinators / `LiveSessionRecoverer`. `exchange_interface` and `strategy`
+stay `Any` (genuinely duck-typed — the engine itself types `exchange_interface: Any`).
+Their unit tests build the backref with `create_autospec(..., instance=True)`
+instead of `MagicMock(spec=...)` (verified to work on these `Protocol`s; enforces
+call-signature drift, not just attribute names).
 
-### Step E — Document deliberate non-extractions
+### Step E — Document deliberate non-extractions (DONE)
 - **Keep `_record_event` / `_send_alert` on the engine.** They are cross-cutting infra used
   by *every* coordinator via `state.`; extracting them adds indirection without cohesion
   benefit. (A tiny `LiveEventEmitter` is possible but low value.)
-- Record the **one-class-per-file** decision: the engine-state `Protocol`s are co-located
-  with their coordinator. This is consistent across the family and acceptable; document it
-  rather than churn.
+- **Keep the per-iteration data/freshness/context guards and the error-handling
+  /backoff block inline in `_trading_loop`** (see Step C): terse early-`continue`
+  guards and capital-critical `continue`/`break` control flow are clearer in place,
+  and the loop is live-only (not parity-guarded).
+- **One-class-per-file is not enforced for the coordinator family:** each engine-state
+  `Protocol` is co-located with its coordinator (e.g. `LiveEntryEngineState` lives in
+  `entry_coordinator.py`). This is consistent across the family and intentional — the
+  `Protocol` is the coordinator's own narrow view of the engine and has no independent
+  reuse — so it is documented here rather than churned into separate modules.
 
 ---
 
@@ -337,7 +355,8 @@ The bot reviews each PR and flags carried-over CODE.md nits: f-strings in loggin
 | #822 | this handover doc |
 | #823 | **Step A** — `__init__` decomposed into 15 cohesive private initializer helpers; engine `__init__` ~534 → ~110 lines. Also aligned `LiveLoopTimingEngineState.data_freshness_threshold` to `int`. |
 | #824 | **Step B** — `start()` decomposed into 7 cohesive private phase helpers; ~327 → ~18 lines. |
-| (this branch) | **Step C** — `_trading_loop` short-entry + periodic-account blocks extracted; ~390 → ~250 lines. |
+| #825 | **Step C** — `_trading_loop` short-entry + periodic-account blocks extracted; ~390 → ~250 lines. |
+| (this branch) | **Steps D + E** — entry/exit coordinator `Protocol`s tightened to concrete types + tests moved to `create_autospec`; deliberate non-extractions documented. |
 
 Engine: **6,558 → 2,493 lines** through #821; Step A keeps the engine's total
 line count roughly flat (the slim `__init__` is offset by per-helper

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -38,10 +38,13 @@ from src.strategies.components import Signal, SignalDirection
 from src.strategies.components import Strategy as ComponentStrategy
 
 if TYPE_CHECKING:
+    from src.data_providers.data_provider import DataProvider
+    from src.database.manager import DatabaseManager
     from src.engines.live.execution.entry_handler import LiveEntryHandler
     from src.engines.live.execution.position_tracker import LivePosition, LivePositionTracker
     from src.engines.live.execution.stop_loss_manager import LiveStopLossManager
     from src.engines.live.order_tracker import OrderTracker
+    from src.engines.live.reconciliation import BaseAssetLockRegistry
     from src.risk.risk_manager import RiskManager
     from src.trading.performance import PerformanceTracker
 
@@ -68,12 +71,14 @@ class LiveEntryEngineState(Protocol):
     live_position_tracker: LivePositionTracker
     stop_loss_manager: LiveStopLossManager
     order_tracker: OrderTracker | None
+    # Genuinely loose: concrete providers expose duck-typed margin/WS extensions
+    # beyond the base interface (matches the engine's own ``exchange_interface: Any``).
     exchange_interface: Any
-    data_provider: Any
-    db_manager: Any
-    _component_strategy: Any
+    data_provider: DataProvider
+    db_manager: DatabaseManager
+    _component_strategy: ComponentStrategy | None
     _close_only_mode: bool
-    _base_asset_locks: Any
+    _base_asset_locks: BaseAssetLockRegistry
 
     # Engine helpers that stay on the engine; the coordinator calls them via
     # this backref (so subclass/test overrides on the engine still apply).

--- a/src/engines/live/execution/exit_coordinator.py
+++ b/src/engines/live/execution/exit_coordinator.py
@@ -46,10 +46,14 @@ from src.infrastructure.logging.events import log_order_event
 from src.performance.metrics import Side, pnl_percent
 
 if TYPE_CHECKING:
+    from src.data_providers.data_provider import DataProvider
+    from src.database.manager import DatabaseManager
     from src.engines.live.execution.execution_engine import LiveExecutionEngine
     from src.engines.live.execution.exit_handler import LiveExitHandler
     from src.engines.live.execution.position_tracker import LivePosition as Position
     from src.engines.live.execution.position_tracker import LivePositionTracker
+    from src.engines.live.reconciliation import BaseAssetLockRegistry
+    from src.strategies.components import Strategy as ComponentStrategy
     from src.trading.performance import PerformanceTracker
 
 logger = logging.getLogger(__name__)
@@ -68,15 +72,17 @@ class LiveExitEngineState(Protocol):
     log_trades: bool
     trading_session_id: int | None
     completed_trades: list[Trade]
-    _component_strategy: Any
-    _base_asset_locks: Any
+    _component_strategy: ComponentStrategy | None
+    _base_asset_locks: BaseAssetLockRegistry
     live_position_tracker: LivePositionTracker
     live_exit_handler: LiveExitHandler
     live_execution_engine: LiveExecutionEngine
     performance_tracker: PerformanceTracker
+    # Genuinely loose: concrete providers expose duck-typed margin/WS extensions
+    # beyond the base interface (matches the engine's own ``exchange_interface: Any``).
     exchange_interface: Any
-    data_provider: Any
-    db_manager: Any
+    data_provider: DataProvider
+    db_manager: DatabaseManager
 
     # Engine helpers that stay on the engine; the coordinator calls them via this
     # backref (so subclass/test overrides on the engine still apply).

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -11,7 +11,7 @@ silently skipped), and the SL-calc / risk-override failure paths log.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 
@@ -56,7 +56,7 @@ def _make_state(position: MagicMock, result: MagicMock, **overrides) -> MagicMoc
     every attribute the execution path reads is set explicitly (protocol
     attributes are annotation-only, so they must be assigned to be readable).
     """
-    state = MagicMock(spec=LiveEntryEngineState)
+    state = create_autospec(LiveEntryEngineState, instance=True)
     state.enable_live_trading = False
     state.current_balance = 1000.0
     state.max_position_size = 1.0

--- a/tests/unit/engines/live/test_exit_coordinator.py
+++ b/tests/unit/engines/live/test_exit_coordinator.py
@@ -14,7 +14,7 @@ which must not raise on an aware ``entry_time``).
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import pandas as pd
 import pytest
@@ -70,7 +70,7 @@ def _make_state(position: MagicMock, exit_check: MagicMock, **overrides) -> Magi
     protocol attributes are annotation-only, so each one the path reads is
     assigned explicitly.
     """
-    state = MagicMock(spec=LiveExitEngineState)
+    state = create_autospec(LiveExitEngineState, instance=True)
     state.enable_live_trading = False
     state.current_balance = 1000.0
     state.trading_session_id = None

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, call, create_autospec, patch
 
 import pytest
 
@@ -744,7 +744,7 @@ class TestCloseOnlyMode:
             LiveEntryEngineState,
         )
 
-        state = MagicMock(spec=LiveEntryEngineState)
+        state = create_autospec(LiveEntryEngineState, instance=True)
         state._close_only_mode = True
         coordinator = LiveEntryCoordinator(engine_state=state)
         coordinator.check_entry_conditions(
@@ -764,7 +764,7 @@ class TestCloseOnlyMode:
             LiveEntryEngineState,
         )
 
-        state = MagicMock(spec=LiveEntryEngineState)
+        state = create_autospec(LiveEntryEngineState, instance=True)
         state._close_only_mode = False
         # The method will proceed past the guard and call _is_runtime_strategy.
         # Let it raise to short-circuit the rest — we only care that the guard


### PR DESCRIPTION
## Summary

**Steps D + E** (final) of the live-engine modularization (#486).

### Step D — Protocol-tightening + test consistency
The entry/exit coordinator engine-state backref `Protocol`s now use concrete types instead of bare `Any`, matching the standard set by the later coordinators / `LiveSessionRecoverer`:

| Attr | Before | After |
|---|---|---|
| `data_provider` | `Any` | `DataProvider` |
| `db_manager` | `Any` | `DatabaseManager` |
| `_base_asset_locks` | `Any` | `BaseAssetLockRegistry` |
| `_component_strategy` | `Any` | `ComponentStrategy \| None` |

`exchange_interface` and `strategy` deliberately stay `Any` — genuinely duck-typed (the engine itself types `exchange_interface: Any`).

The entry/exit coordinator unit tests (and the two `test_reconciliation.py` close-only tests) now build the mocked backref with `create_autospec(..., instance=True)` instead of `MagicMock(spec=...)`, so **call-signature** drift on the spec'd engine helpers is caught, not just attribute-name drift.

### Step E — Document deliberate non-extractions
Documented in `docs/refactor/live_engine_modularization.md`: `_record_event`/`_send_alert` stay on the engine (cross-cutting infra); the loop's terse early-`continue` guards + capital-critical error/backoff block stay inline; the engine-state `Protocol`s are intentionally co-located with their coordinators.

This PR completes the #486 plan (Steps A–E). Status block added to the handover doc.

## User-facing impact
None. Typing / test / docs only — no runtime change.

## Testing
- **Backtest determinism: byte-identical** — `sha256=ee76fd681362f5a251f9bd34ee40c7177ca8697e9b29e70b2c0d1ed2afd03a87`.
- Full fast suite green: **4094 passed**, 103 skipped.
- Entry/exit coordinator tests under `create_autospec`: 21 passed; reconciliation close-only tests: green.
- `mypy` (`-p` package form), `ruff`, `black`, `bandit` clean (only the pre-existing, env-dependent `import requests` `type: ignore` remains — per handover doc §6.3, not in scope).

Refs #486. Follows #825 (Step C).

https://claude.ai/code/session_01GM3triPGTm6bqpP9xBVWh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM3triPGTm6bqpP9xBVWh4)_