### PR TITLE
Sync staging to develop (pick up prod review fixes)

### DIFF
--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -592,17 +592,34 @@ class LiveEntryCoordinator:
                                 )
                             else:
                                 # Use quantity from position - LiveEntryResult.position.quantity
-                                state.exchange_interface.place_order(
+                                emergency_order = state.exchange_interface.place_order(
                                     symbol=symbol,
                                     side=close_side,
                                     order_type=OrderType.MARKET,
                                     quantity=result.position.quantity,
                                     side_effect_type=SideEffectType.AUTO_REPAY,
                                 )
-                            logger.warning(
-                                "Emergency close placed for %s due to balance update failure",
-                                symbol,
-                            )
+                                if emergency_order is None:
+                                    # None is an ambiguous/failed placement, NOT a
+                                    # confirmed close: the position may still be open
+                                    # and unprotected on the exchange. Escalate to
+                                    # close-only instead of logging a false success;
+                                    # the reconciler resolves it on restart.
+                                    logger.critical(
+                                        "CRITICAL: Emergency close for %s UNCONFIRMED "
+                                        "(place_order returned None) after balance update "
+                                        "failure — position may remain open on the exchange. "
+                                        "Entering close-only mode until restart reconciles. "
+                                        "MANUAL INTERVENTION REQUIRED.",
+                                        symbol,
+                                    )
+                                    state._enter_close_only_mode()
+                                else:
+                                    logger.warning(
+                                        "Emergency close placed for %s due to balance "
+                                        "update failure",
+                                        symbol,
+                                    )
                         except Exception as close_err:
                             logger.critical(
                                 "CRITICAL: Emergency close FAILED after balance update failure for %s. "
@@ -644,7 +661,9 @@ class LiveEntryCoordinator:
                     symbol,
                     tracker_err,
                 )
-                if state.enable_live_trading and state.exchange_interface:
+                emergency_close_confirmed = False
+                live_emergency_path = bool(state.enable_live_trading and state.exchange_interface)
+                if live_emergency_path:
                     try:
                         close_side = OrderSide.SELL if side == PositionSide.LONG else OrderSide.BUY
 
@@ -659,16 +678,32 @@ class LiveEntryCoordinator:
                                 result.position.quantity,
                             )
                         else:
-                            state.exchange_interface.place_order(
+                            emergency_order = state.exchange_interface.place_order(
                                 symbol=symbol,
                                 side=close_side,
                                 order_type=OrderType.MARKET,
                                 quantity=result.position.quantity,
                                 side_effect_type=SideEffectType.AUTO_REPAY,
                             )
-                            logger.info(
-                                "Emergency close order placed for orphaned position %s", symbol
-                            )
+                            if emergency_order is None:
+                                # Ambiguous/failed placement (not a confirmed close):
+                                # the orphaned position may still be open on the
+                                # exchange. Escalate to close-only; the reconciler
+                                # resolves the untracked position on restart.
+                                logger.critical(
+                                    "CRITICAL: Emergency close for orphaned position %s "
+                                    "UNCONFIRMED (place_order returned None) — position may "
+                                    "remain open on the exchange. Entering close-only mode "
+                                    "until restart reconciles. MANUAL INTERVENTION REQUIRED.",
+                                    symbol,
+                                )
+                                state._enter_close_only_mode()
+                            else:
+                                emergency_close_confirmed = True
+                                logger.info(
+                                    "Emergency close order placed for orphaned position %s",
+                                    symbol,
+                                )
                     except Exception as close_err:
                         logger.critical(
                             "CRITICAL: Emergency close FAILED for %s. "
@@ -676,26 +711,32 @@ class LiveEntryCoordinator:
                             symbol,
                             close_err,
                         )
-                # Restore balance since position tracking failed (atomic refund)
-                if state.trading_session_id is not None:
-                    try:
-                        with state.db_manager.atomic_balance_update(
-                            balance_change=entry_fee,
-                            reason=f"refund_entry_fee_{symbol}_tracking_failed",
-                            updated_by="live_engine",
-                            correlation_id=position.order_id,
-                        ) as balance_result:
-                            state.current_balance = balance_result["new_balance"]
-                    except Exception as refund_err:
-                        logger.critical(
-                            "CRITICAL: Failed to refund entry fee after position tracking failure for %s. "
-                            "Balance state inconsistent. Error: %s",
-                            symbol,
-                            refund_err,
-                        )
-                else:
-                    # No trading session - update balance directly
-                    state.current_balance += entry_fee
+                # Refund the entry fee only when no possibly-open live position was left
+                # behind: paper (no live path) always refunds; a live path refunds only
+                # on a CONFIRMED close. On an unconfirmed/failed live close the position
+                # may still be open, so keep the fee charged (the reconciler resolves the
+                # real state on restart) rather than optimistically crediting the balance.
+                should_refund = (not live_emergency_path) or emergency_close_confirmed
+                if should_refund:
+                    if state.trading_session_id is not None:
+                        try:
+                            with state.db_manager.atomic_balance_update(
+                                balance_change=entry_fee,
+                                reason=f"refund_entry_fee_{symbol}_tracking_failed",
+                                updated_by="live_engine",
+                                correlation_id=position.order_id,
+                            ) as balance_result:
+                                state.current_balance = balance_result["new_balance"]
+                        except Exception as refund_err:
+                            logger.critical(
+                                "CRITICAL: Failed to refund entry fee after position tracking "
+                                "failure for %s. Balance state inconsistent. Error: %s",
+                                symbol,
+                                refund_err,
+                            )
+                    else:
+                        # No trading session - update balance directly
+                        state.current_balance += entry_fee
                 return
 
             # Update risk manager tracking for new position.
@@ -834,7 +875,14 @@ class LiveEntryCoordinator:
                     # exchange - a critical fund loss risk.
                     try:
                         emergency_price = state.data_provider.get_current_price(symbol)
-                    except Exception:
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to fetch current price for emergency close of %s; "
+                            "falling back to entry price %s for exit pricing: %s",
+                            symbol,
+                            price,
+                            exc,
+                        )
                         emergency_price = price
                     state._execute_exit(
                         position,

--- a/src/engines/live/execution/exit_coordinator.py
+++ b/src/engines/live/execution/exit_coordinator.py
@@ -536,8 +536,16 @@ class LiveExitCoordinator:
             # the persisted trades.commission below.
             entry_fee = _close_entry_fee_usd(position, state.live_execution_engine)
             entry_slippage_cost = float(position.metadata.get("entry_slippage_cost", 0.0))
-            total_fee = entry_fee + exit_fee
-            total_slippage = entry_slippage_cost + exit_slippage_cost
+            # This close is only the remaining slice of a partially-exited position
+            # (1.0 for a full close). The Trade above is portion-level (size =
+            # current_size), so the entry leg must be scaled to the same portion or
+            # the performance metrics over-attribute the entry fee/slippage by
+            # 1/portion — and diverge from the DB ledger, which already scales the
+            # entry fee (see commission= below).
+            close_portion = _close_position_portion(position)
+            scaled_entry_fee = entry_fee * close_portion
+            total_fee = scaled_entry_fee + exit_fee
+            total_slippage = entry_slippage_cost * close_portion + exit_slippage_cost
 
             # Store GROSS P&L in Trade.pnl for parity with backtest engine
             # Fees are tracked separately via performance_tracker.record_trade()
@@ -627,8 +635,10 @@ class LiveExitCoordinator:
                     # reconciliation, so unit-ambiguous and unreliable at close time).
                     # The entry leg is scaled to the closed portion so a partial final
                     # close's commission matches its portion-level size/quantity/pnl
-                    # (ratio is 1.0 for a full close).
-                    commission=entry_fee * _close_position_portion(position) + exit_fee,
+                    # (ratio is 1.0 for a full close). Reuses the same scaled total fed
+                    # to performance_tracker.record_trade above so the metrics and the
+                    # DB ledger never diverge.
+                    commission=total_fee,
                     quantity=_closed_base_quantity(position),
                     margin_interest_cost=interest_cost,
                 )

--- a/src/engines/live/execution/market_data_coordinator.py
+++ b/src/engines/live/execution/market_data_coordinator.py
@@ -117,7 +117,11 @@ class LiveMarketDataCoordinator:
 
             return True, ""
         except Exception as e:
-            logger.debug("Context readiness check failed: %s", e)
+            # Catch-all for unexpected readiness-check errors (the expected
+            # NaN/missing/stale cases are handled above and return their own
+            # reason). Warning-level so an unexpected failure here is visible in
+            # production rather than silently freezing trading.
+            logger.warning("Context readiness check failed: %s", e)
             return False, "readiness_check_error"
 
     def get_latest_data(self, symbol: str, timeframe: str) -> pd.DataFrame | None:

--- a/src/engines/live/recovery.py
+++ b/src/engines/live/recovery.py
@@ -258,8 +258,10 @@ class LiveSessionRecoverer:
                     try:
                         state.risk_manager.close_position(position.symbol)
                     except (KeyError, ValueError, AttributeError) as drain_err:
-                        logger.debug(
-                            "Risk manager close_position drain skipped for %s: %s",
+                        logger.warning(
+                            "Risk manager close_position drain skipped for %s: %s — "
+                            "daily_risk_used may stay inflated and per-symbol caps stale "
+                            "for this session",
                             position.symbol,
                             drain_err,
                         )

--- a/src/engines/live/startup.py
+++ b/src/engines/live/startup.py
@@ -24,10 +24,10 @@ if TYPE_CHECKING:
     from src.database.manager import DatabaseManager
     from src.engines.live.execution.execution_engine import LiveExecutionEngine
     from src.engines.live.execution.position_tracker import LivePositionTracker
+    from src.engines.live.logging.event_logger import LiveEventLogger
     from src.engines.live.order_tracker import OrderTracker
     from src.engines.live.reconciliation import BaseAssetLockRegistry, PeriodicReconciler
-    from src.position_management.time_exit_policy import TimeExitPolicy
-    from src.trading.live_event_logger import LiveEventLogger
+    from src.position_management.time_exits import TimeExitPolicy
 
 logger = logging.getLogger(__name__)
 

--- a/src/engines/live/strategy_runtime.py
+++ b/src/engines/live/strategy_runtime.py
@@ -201,7 +201,9 @@ class StrategyRuntimeCoordinator:
             try:
                 previous_component.set_additional_risk_context_provider(None)
             except Exception as exc:  # pragma: no cover - defensive cleanup
-                logger.debug("Failed to clear risk context provider on previous strategy: %s", exc)
+                logger.warning(
+                    "Failed to clear risk context provider on previous strategy: %s", exc
+                )
 
         if runtime is not None:
             state._runtime = runtime
@@ -269,7 +271,7 @@ class StrategyRuntimeCoordinator:
             try:
                 overrides = strategy.get_risk_overrides()
             except Exception as exc:  # pragma: no cover - defensive logging
-                logger.debug(
+                logger.warning(
                     "Failed to fetch component risk overrides for correlation context: %s",
                     exc,
                 )
@@ -343,9 +345,11 @@ class StrategyRuntimeCoordinator:
                         state._component_dynamic_risk_config = dynamic_descriptor.to_config()
                 except Exception as exc:
                     # Benign: shared hydration above already applied the policy;
-                    # only the live-engine state cache misses this descriptor.
-                    # Debug level: runs per decision in the trading loop.
-                    logger.debug("Dynamic risk config cache update skipped: %s", exc)
+                    # only the live-engine state cache misses this descriptor. The
+                    # except only fires on an actual error (not every decision), so
+                    # warning-level here surfaces a real, repeating failure rather
+                    # than hiding it at debug.
+                    logger.warning("Dynamic risk config cache update skipped: %s", exc)
 
     # Runtime integration helpers -------------------------------------------------
 
@@ -417,7 +421,14 @@ class StrategyRuntimeCoordinator:
                 )
                 positions.append(component_position)
             except Exception as exc:
-                logger.debug("Failed to translate live position for runtime: %s", exc)
+                # Warning-level: a dropped position means the strategy runtime sees
+                # an incomplete open-position set and could make an unintended entry,
+                # so this must be visible rather than silently swallowed at debug.
+                logger.warning(
+                    "Failed to translate live position %s for runtime: %s",
+                    getattr(position, "symbol", "?"),
+                    exc,
+                )
         return positions
 
     def build_runtime_context(

--- a/src/engines/shared/correlation_handler.py
+++ b/src/engines/shared/correlation_handler.py
@@ -93,9 +93,12 @@ class CorrelationHandler:
                 corr_cfg = overrides.get("correlation_control", {})
                 max_exposure_override = corr_cfg.get("max_correlated_exposure")
             except Exception as exc:
-                # Debug level: runs on every entry evaluation (per-candle hot loop
-                # in backtests); malformed overrides fall back to engine defaults.
-                logger.debug("Failed to read correlation_control overrides for %s: %s", symbol, exc)
+                # Fires only on malformed overrides (not the normal per-candle path);
+                # falls back to engine defaults. Warning-level so a real, repeating
+                # config problem is visible rather than hidden at debug.
+                logger.warning(
+                    "Failed to read correlation_control overrides for %s: %s", symbol, exc
+                )
 
         # Build price series for correlation calculation
         price_series = self._build_price_series(symbol, timeframe, df, index, positions_snapshot)
@@ -135,9 +138,10 @@ class CorrelationHandler:
             if hasattr(self.strategy, "get_risk_overrides"):
                 return self.strategy.get_risk_overrides()
         except Exception as exc:
-            # Debug level: called on every entry evaluation (per-candle hot loop
-            # in backtests); a failing override hook falls back to engine defaults.
-            logger.debug("Strategy get_risk_overrides() failed: %s", exc)
+            # Fires only when the strategy override hook raises (not the normal
+            # per-candle path); falls back to engine defaults. Warning-level so a
+            # consistently failing hook is visible rather than hidden at debug.
+            logger.warning("Strategy get_risk_overrides() failed: %s", exc)
 
         return None
 
@@ -180,9 +184,10 @@ class CorrelationHandler:
             try:
                 end_ts = df.index[-1]
             except Exception as exc:
-                # Debug level: per-candle hot loop; missing index bounds simply
-                # skip the windowed history fetch below.
-                logger.debug("Failed to resolve end timestamp for %s: %s", symbol, exc)
+                # Fires only when both index lookups fail (not the normal path);
+                # the windowed history fetch below is simply skipped. Warning-level
+                # so a real, repeating bounds problem is visible.
+                logger.warning("Failed to resolve end timestamp for %s: %s", symbol, exc)
 
         start_ts = None
         if isinstance(end_ts, pd.Timestamp):
@@ -191,9 +196,10 @@ class CorrelationHandler:
                     days=self.risk_manager.params.correlation_window_days
                 )
             except Exception as exc:
-                # Debug level: per-candle hot loop; without start_ts the fetch
-                # below falls back to the default correlation window.
-                logger.debug("Failed to compute correlation window start for %s: %s", symbol, exc)
+                # Fires only on a Timedelta/arithmetic failure (not the normal
+                # path); the fetch below falls back to the default correlation
+                # window. Warning-level so a real, repeating problem is visible.
+                logger.warning("Failed to compute correlation window start for %s: %s", symbol, exc)
 
         # Get currently open positions from snapshot (thread-safe)
         open_symbols = set()
@@ -201,9 +207,10 @@ class CorrelationHandler:
             if positions_snapshot:
                 open_symbols = set(map(str, positions_snapshot.keys()))
         except Exception as exc:
-            # Debug level: per-candle hot loop; unreadable snapshot means no
-            # peer symbols are added to the correlation series.
-            logger.debug("Failed to read open positions snapshot for %s: %s", symbol, exc)
+            # Fires only on an unreadable snapshot (not the normal path); no peer
+            # symbols are added to the correlation series. Warning-level so a real,
+            # repeating problem is visible rather than hidden at debug.
+            logger.warning("Failed to read open positions snapshot for %s: %s", symbol, exc)
 
         # Peer symbols still needing a price series
         peers = sorted(open_symbols - set(price_series.keys()) - {str(symbol)})

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -242,6 +242,61 @@ def test_stop_loss_placement_failure_triggers_emergency_exit():
     state._execute_exit.assert_called_once()
 
 
+def test_balance_update_failure_unconfirmed_emergency_close_enters_close_only():
+    """Site 1: post-entry balance update fails, then the emergency close placement
+    returns None (ambiguous — NOT a confirmed close). The position may remain open
+    and unprotected on the exchange, so the engine must escalate to close-only
+    rather than log a false success."""
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True
+    state.trading_session_id = 42
+    state.db_manager.atomic_balance_update.side_effect = RuntimeError("db down")
+    state.exchange_interface.place_order.return_value = None  # ambiguous placement
+
+    _call(state)
+
+    state.exchange_interface.place_order.assert_called_once()
+    state._enter_close_only_mode.assert_called_once()
+
+
+def test_tracking_failure_unconfirmed_emergency_close_enters_close_only_no_refund():
+    """Site 2: position tracking fails and the emergency close returns None
+    (ambiguous). The orphaned position may still be open on the exchange, so the
+    engine must escalate to close-only and must NOT optimistically refund the entry
+    fee (which would overstate the balance). No-session path: balance is the fee-
+    deducted 999.0 (not the 1000.0 it would be if refunded)."""
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True  # no trading_session_id → direct balance math
+    state.live_position_tracker.open_position.side_effect = RuntimeError("tracker down")
+    state.exchange_interface.place_order.return_value = None  # ambiguous placement
+
+    _call(state)
+
+    state.exchange_interface.place_order.assert_called_once()
+    state._enter_close_only_mode.assert_called_once()
+    # Unconfirmed close → entry fee stays charged (deducted, not refunded).
+    assert state.current_balance == pytest.approx(999.0)
+
+
+def test_tracking_failure_confirmed_emergency_close_refunds_fee():
+    """Site 2 contrast: a CONFIRMED emergency close (place_order returns an order)
+    refunds the entry fee as before — balance returns to 1000.0 — and does not
+    enter close-only."""
+    position = _make_position()
+    state = _make_state(position, _make_result(position))
+    state.enable_live_trading = True
+    state.live_position_tracker.open_position.side_effect = RuntimeError("tracker down")
+    state.exchange_interface.place_order.return_value = MagicMock()  # confirmed
+
+    _call(state)
+
+    state.exchange_interface.place_order.assert_called_once()
+    state._enter_close_only_mode.assert_not_called()
+    assert state.current_balance == pytest.approx(1000.0)  # -1.0 fee then +1.0 refund
+
+
 # ---------------------------------------------------------------------------
 # CODE.md hardening: stop-loss gate keys on `is not None` (#813 follow-up)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_trade_commission_quantity_persistence.py
+++ b/tests/unit/test_trade_commission_quantity_persistence.py
@@ -279,12 +279,25 @@ def test_commission_scales_entry_fee_for_partial_close():
     # current_size 0.10 of original 0.25 -> entry leg scaled to 0.40 of the full entry fee.
     position = _make_position(quantity=2.5, entry_fee=0.25, size=0.25, current_size=0.10)
 
+    # Spy on the performance-metric fee so we can assert it does NOT diverge from
+    # the DB ledger commission for a partial final close (the entry leg must be
+    # scaled in both, not full in the metrics and scaled in the DB).
+    rec = Mock(wraps=engine.performance_tracker.record_trade)
+    engine.performance_tracker.record_trade = rec
+
     trade = _close(engine, position, exit_price=110.0)
 
     # entry leg = 0.25 * (0.10 / 0.25) = 0.10 ; exit notional = 1000 * 0.10 * 1.1 = 110,
     # exit_fee = 0.11 ; commission = 0.10 + 0.11 = 0.21 (NOT the full 0.25 + 0.11 = 0.36).
     assert trade["commission"] == pytest.approx(0.21, abs=0.01)
     assert trade["commission"] < 0.25  # entry leg scaled below the full entry fee
+
+    # Performance metrics must use the SAME scaled fee (no interest in paper mode),
+    # i.e. match the DB ledger rather than the full unscaled 0.36.
+    rec.assert_called_once()
+    perf_fee = rec.call_args.kwargs["fee"]
+    assert perf_fee == pytest.approx(trade["commission"], abs=1e-9)
+    assert perf_fee < 0.36  # regression guard: not the full unscaled entry fee
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Syncs the **staging** environment to the current `develop` release line so all three envs (develop / staging / production) carry the same code.

`staging` currently runs `develop`@`61597b4` (the tree from the original soak). `develop` has since advanced to `25da4b19` with the CODE.md review fixes that already shipped to production (`main`@`102c5d76`): emergency-close `place_order()` None-escalation, partial-close commission/slippage alignment, and `debug→warning` log levels. This brings staging up to the same tree.

Clean promotion: `develop` shares history with `staging` (staging was cut from `develop`@`61597b4`), so this merges without conflicts; the resulting `staging` tree == `develop` tree == `main` tree.

Paper environment — no capital at risk. Railway will redeploy staging on merge.

(Force-push sync per the deploy-staging skill is blocked by the environment's git proxy on protected branches, so using an additive promotion PR instead.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWyqVZuBzeHXfsm9Zu4R3w)_