### PR TITLE
feat(live): enforce max-drawdown hard cap with close-only halt

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Live enforcement of the portfolio max-drawdown hard cap** (risk-officer
+  2026-07-04 finding, corroborating the 2026-06-08 observability audit —
+  `RiskManager.check_drawdown()` had zero callers, so nothing halted the live
+  engine at `max_drawdown_pct`): new `MaxDrawdownGuard` + `MaxDrawdownEnforcer`
+  (`src/engines/live/monitoring/drawdown_guard.py`) measure drawdown from the
+  session peak balance on every trading-loop iteration and, at the cap (0.20),
+  trip the existing close-only mode — entries stop, exits/stop-losses keep
+  running, nothing is liquidated. Emits a CRITICAL `system_events` row
+  (`MAX_DRAWDOWN_BREACH`), a structured `risk_event`, and the alert webhook;
+  latched (no re-trigger spam) and restart-safe (peak recomputed from
+  `account_history` on boot via `DatabaseManager.get_session_peak_balance`).
+  Warning tiers per risk-limits.json escalation: WARNING at 50% of the cap,
+  CRITICAL at 80%, rate-limited. Operators clear a trip by restarting with
+  `FEATURE_MAX_DRAWDOWN_RESET_PEAK=true` (re-baselines the peak; remove the
+  flag afterwards). See `docs/live_trading.md` → "Max-drawdown hard cap".
 - `FEATURE_ENTRY_PAUSE` feature flag: when truthy the live engine blocks all
   exposure INCREASES — new positions (long, short, and the legacy duck-typed
   short path) AND scale-ins — while exits, partial exits, stop-loss

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,8 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   engine at `max_drawdown_pct`): new `MaxDrawdownGuard` + `MaxDrawdownEnforcer`
   (`src/engines/live/monitoring/drawdown_guard.py`) measure drawdown from the
   session peak balance on every trading-loop iteration and, at the cap (0.20),
-  trip the existing close-only mode — entries stop, exits/stop-losses keep
-  running, nothing is liquidated. Emits a CRITICAL `system_events` row
+  trip the existing close-only mode — entries, legacy shorts, and scale-ins
+  stop (close-only now also gates the `execute_entry_locked` chokepoint and
+  the scale-in branch); exits/stop-losses keep running, nothing is
+  liquidated. Peak baseline = peak true equity since the last reconciled
+  reset (session-scoped; phantom-era ledger history deliberately excluded;
+  durable cross-session peak tracked in #847). Emits a CRITICAL `system_events` row
   (`MAX_DRAWDOWN_BREACH`), a structured `risk_event`, and the alert webhook;
   latched (no re-trigger spam) and restart-safe (peak recomputed from
   `account_history` on boot via `DatabaseManager.get_session_peak_balance`).

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -64,6 +64,33 @@ call sites and test mock points are stable while the implementations live in the
     sync.emergency_sync()
     ```
 
+## Max-drawdown hard cap (close-only halt)
+
+The live engine enforces `portfolio.max_drawdown_pct` from `.claude/state/risk-limits.json`
+(0.20, mirrored by `DEFAULT_MAX_DRAWDOWN` / `RiskParameters.max_drawdown`). On every
+trading-loop iteration `MaxDrawdownEnforcer` (`src/engines/live/monitoring/drawdown_guard.py`)
+measures the drawdown of the current balance from the **session peak balance** — the same
+numbers `account_history.drawdown` is derived from.
+
+- **Peak baseline**: seeded on boot from the max of `account_history` balances for the active
+  session (plus the recovered inactive session on clean restarts), the performance tracker's
+  peak, and the current balance. A restart therefore never resets the drawdown baseline.
+- **Escalation tiers** (risk-limits.json `escalation`): WARNING log at 50% of the cap
+  (10% drawdown), CRITICAL log at 80% (16% drawdown). Tier logs are rate-limited
+  (`DRAWDOWN_GUARD_LOG_INTERVAL_SECONDS`) but escalations log immediately.
+- **Breach (drawdown >= cap)**: the engine enters the existing **close-only mode** — the same
+  gate `FEATURE_ENTRY_PAUSE` uses at the entry seams. New entries and scale-ins stop; exits,
+  partial exits, stop-loss management, and reconciliation keep running. Nothing is liquidated.
+  A CRITICAL `system_events` row (`error_code=MAX_DRAWDOWN_BREACH`), a structured
+  `risk_event`, and the alert webhook (if configured) fire once. The trip is **latched**: it
+  survives balance recovery below the cap, does not re-spam, and re-trips on restart via the
+  boot-time peak recompute.
+- **Clearing a trip (operator only)**: `resume_trading()` alone will not stick — the guard
+  re-trips on the next iteration while the breach persists. To accept the loss and resume,
+  restart with `FEATURE_MAX_DRAWDOWN_RESET_PEAK=true`, which re-baselines the peak to the
+  current balance (the guard stays armed from the new baseline). **Remove the flag after the
+  restart** — leaving it set re-baselines the peak on every future restart, weakening the cap.
+
 ## Position management features
 
 - Dynamic risk adjustment (`DynamicRiskManager`) tapers exposure after drawdowns and relaxes limits during recoveries. Configure

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -75,12 +75,19 @@ numbers `account_history.drawdown` is derived from.
 - **Peak baseline**: seeded on boot from the max of `account_history` balances for the active
   session (plus the recovered inactive session on clean restarts), the performance tracker's
   peak, and the current balance. A restart therefore never resets the drawdown baseline.
+  By policy the baseline is the peak **true equity since the last reconciled reset** —
+  pre-reset ledger history is excluded because the Mar–Jun 2026 rows carry a phantom-era
+  book peak (see the capital-erosion postmortem; measuring from it would falsely report an
+  immediate breach on deploy). Known limitation: a clean restart that creates a NEW session
+  re-baselines the peak ("20% per session", not rolling); dormant while prod reuses the
+  active session across restarts — a durable cross-session peak is tracked in #847.
 - **Escalation tiers** (risk-limits.json `escalation`): WARNING log at 50% of the cap
   (10% drawdown), CRITICAL log at 80% (16% drawdown). Tier logs are rate-limited
   (`DRAWDOWN_GUARD_LOG_INTERVAL_SECONDS`) but escalations log immediately.
-- **Breach (drawdown >= cap)**: the engine enters the existing **close-only mode** — the same
-  gate `FEATURE_ENTRY_PAUSE` uses at the entry seams. New entries and scale-ins stop; exits,
-  partial exits, stop-loss management, and reconciliation keep running. Nothing is liquidated.
+- **Breach (drawdown >= cap)**: the engine enters the existing **close-only mode**. The flag
+  gates every exposure increase: entry evaluation, the `execute_entry_locked` chokepoint
+  (covers the legacy short path and any direct caller), and scale-ins. Exits, partial exits,
+  stop-loss management, and reconciliation keep running. Nothing is liquidated.
   A CRITICAL `system_events` row (`error_code=MAX_DRAWDOWN_BREACH`), a structured
   `risk_event`, and the alert webhook (if configured) fire once. The trip is **latched**: it
   survives balance recovery below the cap, does not re-spam, and re-trips on restart via the

--- a/feature_flags.json
+++ b/feature_flags.json
@@ -3,5 +3,6 @@
   "enable_regime_detection": false,
   "optimizer_canary_fraction": "0.1",
   "optimizer_auto_apply": false,
-  "entry_pause": false
+  "entry_pause": false,
+  "max_drawdown_reset_peak": false
 }

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -99,6 +99,11 @@ DEFAULT_MAX_RISK_PER_TRADE = 0.03  # 3% maximum risk per trade
 DEFAULT_MAX_DAILY_RISK = 0.06  # 6% maximum daily risk
 DEFAULT_MAX_CORRELATED_RISK = 0.10  # 10% maximum risk for correlated positions
 DEFAULT_MAX_DRAWDOWN = 0.20  # 20% maximum drawdown (fraction)
+# Escalation tiers as fractions of the max-drawdown limit.
+# Must match .claude/state/risk-limits.json escalation.{warning,critical}_at_pct_of_limit.
+DRAWDOWN_WARNING_AT_PCT_OF_LIMIT = 0.50  # WARNING at 50% of the cap (10% drawdown at 0.20)
+DRAWDOWN_CRITICAL_AT_PCT_OF_LIMIT = 0.80  # CRITICAL at 80% of the cap (16% drawdown at 0.20)
+DRAWDOWN_GUARD_LOG_INTERVAL_SECONDS = 900  # Min seconds between repeated drawdown-tier logs
 DEFAULT_FEE_RATE = 0.001  # 0.1% trading fee
 DEFAULT_SLIPPAGE_RATE = 0.0005  # 0.05% slippage
 

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -2290,6 +2290,45 @@ class DatabaseManager:
             logger.error(f"Failed to update balance: {e}")
             return False
 
+    def get_session_peak_balance(
+        self,
+        session_id: int | None = None,
+        fallback_session_id: int | None = None,
+    ) -> float | None:
+        """Get the highest account_history balance recorded for the session(s).
+
+        Re-seeds the live max-drawdown guard's peak after a restart so the
+        hard cap keeps measuring from the true session peak — a restart must
+        not reset the drawdown baseline. Mirrors ``get_first_snapshot_of_day``
+        fallback semantics: a clean restart creates a NEW session while the
+        earlier snapshots live under the recovered inactive session.
+
+        Args:
+            session_id: Trading session ID (defaults to the current session).
+            fallback_session_id: Prior session whose snapshots also count.
+
+        Returns:
+            The peak balance across the session(s), or None when no snapshot
+            exists yet.
+        """
+        session_id = session_id or self._current_session_id
+        if not session_id:
+            return None
+
+        session_ids = [session_id]
+        if fallback_session_id is not None and fallback_session_id != session_id:
+            session_ids.append(fallback_session_id)
+
+        # Use ANALYTICS timeout - one-shot boot-time read, not in the critical path
+        with self.get_session_with_timeout(QueryTimeout.ANALYTICS) as session:
+            peak = (
+                session.query(sa.func.max(AccountHistory.balance))
+                .filter(AccountHistory.session_id.in_(session_ids))
+                .scalar()
+            )
+        # Numeric columns load as Decimal; coerce before mixing with floats
+        return float(peak) if peak is not None else None
+
     def get_first_snapshot_of_day(
         self,
         session_id: int | None = None,

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -503,6 +503,11 @@ class LiveEntryCoordinator:
         """Execute a new trading position using shared execution modules."""
         state = self._state
         # Defense-in-depth: refuse any entry routed around check_entry_conditions.
+        # Close-only mode gates the chokepoint too, so the legacy short path and
+        # any direct caller can never add exposure while halted.
+        if state._close_only_mode:
+            logger.debug("Close-only mode active — refusing entry execution for %s", symbol)
+            return
         if self._entry_paused(f"entry execution for {symbol}"):
             return
         try:
@@ -933,6 +938,10 @@ class LiveEntryCoordinator:
     ) -> None:
         """Evaluate and execute a legacy duck-typed short entry (non-runtime strategies)."""
         state = self._state
+        # Close-only mode: skip legacy short evaluation, exits/stops still active
+        if state._close_only_mode:
+            logger.debug("Close-only mode active — skipping legacy short entry check")
+            return
         if self._entry_paused(f"legacy short entry for {symbol}"):
             return
         if (not state._is_runtime_strategy()) and callable(

--- a/src/engines/live/execution/exit_handler.py
+++ b/src/engines/live/execution/exit_handler.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
@@ -105,6 +106,7 @@ class LiveExitHandler:
         use_high_low_for_stops: bool = True,
         max_position_size: float = DEFAULT_MAX_POSITION_SIZE,
         max_filled_price_deviation: float = DEFAULT_MAX_FILLED_PRICE_DEVIATION,
+        close_only_provider: Callable[[], bool] | None = None,
     ) -> None:
         """Initialize exit handler.
 
@@ -119,6 +121,9 @@ class LiveExitHandler:
             use_high_low_for_stops: Use candle high/low for SL/TP detection.
             max_position_size: Maximum position size for scale-ins.
             max_filled_price_deviation: Threshold for logging suspicious fill prices.
+            close_only_provider: Reads the engine's close-only flag at call
+                time; scale-ins (exposure increases) are suppressed while it
+                returns True. Exits and partial exits are never gated.
         """
         self.execution_engine = execution_engine
         self.position_tracker = position_tracker
@@ -130,6 +135,7 @@ class LiveExitHandler:
         self.use_high_low_for_stops = use_high_low_for_stops
         self.max_position_size = max_position_size
         self.max_filled_price_deviation = max_filled_price_deviation
+        self._close_only_provider = close_only_provider
         # Use shared managers for consistent logic across engines
         self._trailing_stop_manager = TrailingStopManager(trailing_stop_policy)
         self._strategy_exit_checker = StrategyExitChecker()
@@ -847,9 +853,16 @@ class LiveExitHandler:
                 )
 
                 if scale_result.should_scale:
-                    # Scale-ins INCREASE exposure, so the entry-pause flag
-                    # suppresses them just like new entries. Partial exits and
-                    # full exits above keep running — they reduce risk.
+                    # Scale-ins INCREASE exposure, so close-only mode and the
+                    # entry-pause flag suppress them just like new entries.
+                    # Partial exits and full exits above keep running — they
+                    # reduce risk.
+                    if self._close_only_provider is not None and self._close_only_provider():
+                        logger.debug(
+                            "Close-only mode active — skipping scale-in for %s",
+                            position.symbol,
+                        )
+                        continue
                     if self._entry_pause.paused(f"scale-in for {position.symbol}"):
                         continue
 

--- a/src/engines/live/monitoring/drawdown_guard.py
+++ b/src/engines/live/monitoring/drawdown_guard.py
@@ -1,0 +1,370 @@
+"""Portfolio max-drawdown hard-cap enforcement for the live engine.
+
+``MaxDrawdownGuard`` tracks the session peak balance and classifies the
+current drawdown into escalation tiers (risk-limits.json ``escalation``):
+WARNING at 50% of the cap, CRITICAL at 80%, and a latched BREACH at the cap
+itself (``portfolio.max_drawdown_pct``).
+
+``MaxDrawdownEnforcer`` runs the guard on every trading-loop iteration and, on
+breach, trips the EXISTING close-only mode: no new entries, while exits,
+partial exits, stop-loss management, and reconciliation keep running. It never
+liquidates anything — it only stops new risk.
+
+Peak-equity source: the same numbers ``account_history.drawdown`` is derived
+from (session balance vs the session peak balance). On boot the peak is
+recomputed from ``account_history`` (active session plus the recovered
+inactive session on clean restarts), so a restart cannot reset the drawdown
+baseline — a bot restarted mid-breach re-trips naturally on its first loop
+iteration.
+
+Clearing a trip is an operator decision: restart with
+``FEATURE_MAX_DRAWDOWN_RESET_PEAK=true`` to re-baseline the peak to the
+current balance (the guard stays armed from the new baseline; remove the flag
+afterwards so later restarts don't silently re-baseline). ``resume_trading()``
+alone does not clear it — the guard re-trips on the next iteration while the
+drawdown persists.
+
+Thread-safety: all state is read and mutated on the trading-loop thread only,
+matching the loop-owned close-only flag it drives.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import TYPE_CHECKING, Protocol
+
+from src.config.constants import (
+    DRAWDOWN_CRITICAL_AT_PCT_OF_LIMIT,
+    DRAWDOWN_GUARD_LOG_INTERVAL_SECONDS,
+    DRAWDOWN_WARNING_AT_PCT_OF_LIMIT,
+)
+from src.config.feature_flags import is_enabled
+from src.database.models import EventType
+from src.infrastructure.logging.events import log_risk_event
+
+if TYPE_CHECKING:
+    from src.database.manager import DatabaseManager
+    from src.trading.performance import PerformanceTracker
+
+logger = logging.getLogger(__name__)
+
+# Tier thresholds are products of two config floats (e.g. 0.20 * 0.80); binary
+# float rounding can land the product 1 ulp above the intended boundary, so an
+# exact drawdown reading at the boundary would spuriously miss the tier.
+_TIER_EPSILON = 1e-12
+
+RESET_PEAK_FLAG = "max_drawdown_reset_peak"
+
+
+class DrawdownTier(IntEnum):
+    """Escalation tier for the current drawdown, ordered by severity."""
+
+    NONE = 0
+    WARNING = 1
+    CRITICAL = 2
+    BREACH = 3
+
+
+@dataclass(frozen=True)
+class DrawdownAssessment:
+    """One drawdown reading: level, peak it was measured from, and tier."""
+
+    drawdown: float  # fraction of peak (0..1)
+    peak_balance: float
+    tier: DrawdownTier
+    tripped: bool  # latched hard-cap breach
+
+
+class MaxDrawdownGuard:
+    """Rolling drawdown-from-peak tracker with latched hard-cap breach.
+
+    Pure state machine plus rate-limited tier logging; taking action on a
+    breach is the enforcer's job. The trip latches for the process lifetime:
+    a partial balance recovery below the cap does not silently re-enable
+    entries — that is an operator decision.
+    """
+
+    def __init__(
+        self,
+        max_drawdown_pct: float,
+        *,
+        warning_at_pct_of_limit: float = DRAWDOWN_WARNING_AT_PCT_OF_LIMIT,
+        critical_at_pct_of_limit: float = DRAWDOWN_CRITICAL_AT_PCT_OF_LIMIT,
+        log_interval_seconds: float = DRAWDOWN_GUARD_LOG_INTERVAL_SECONDS,
+    ) -> None:
+        """Configure thresholds; the guard is inert until ``seed_peak``."""
+        if not (0 < max_drawdown_pct <= 1):
+            raise ValueError("max_drawdown_pct must be in (0, 1]")
+        self.max_drawdown_pct = float(max_drawdown_pct)
+        self._warning_threshold = self.max_drawdown_pct * warning_at_pct_of_limit
+        self._critical_threshold = self.max_drawdown_pct * critical_at_pct_of_limit
+        self._log_interval = log_interval_seconds
+        self._peak = 0.0
+        self._seeded = False
+        self._tripped = False
+        self._last_tier_log: float | None = None
+        self._last_logged_tier = DrawdownTier.NONE
+
+    @property
+    def seeded(self) -> bool:
+        """Whether the peak baseline has been established."""
+        return self._seeded
+
+    @property
+    def tripped(self) -> bool:
+        """Whether the hard cap has been breached (latched)."""
+        return self._tripped
+
+    @property
+    def peak_balance(self) -> float:
+        """Current peak balance the drawdown is measured from."""
+        return self._peak
+
+    def seed_peak(self, current_balance: float, *history_candidates: float | None) -> None:
+        """Establish the peak baseline from boot-time candidates.
+
+        Takes the max of the current balance and any finite positive
+        candidates (persisted account_history peak, performance-tracker peak).
+        Under ``FEATURE_MAX_DRAWDOWN_RESET_PEAK`` the history is ignored and
+        the peak re-baselines to the current balance — the documented operator
+        override for clearing a drawdown halt.
+        """
+        if is_enabled(RESET_PEAK_FLAG, default=False):
+            self._peak = max(self._as_valid(current_balance) or 0.0, 0.0)
+            logger.critical(
+                "FEATURE_MAX_DRAWDOWN_RESET_PEAK active — drawdown peak re-baselined "
+                "to current balance $%.2f (historical peak ignored). Remove the flag "
+                "after recovery or every restart will silently re-baseline.",
+                self._peak,
+            )
+        else:
+            valid = [
+                v
+                for v in (self._as_valid(c) for c in (current_balance, *history_candidates))
+                if v is not None
+            ]
+            self._peak = max(valid, default=0.0)
+        self._seeded = True
+
+    @staticmethod
+    def _as_valid(candidate: float | None) -> float | None:
+        """Coerce a peak candidate to a finite positive float, else None."""
+        if candidate is None:
+            return None
+        try:
+            value = float(candidate)
+        except (TypeError, ValueError):
+            return None
+        if not math.isfinite(value) or value <= 0:
+            return None
+        return value
+
+    def observe(self, balance: float) -> DrawdownAssessment:
+        """Record a balance sample; ratchet the peak and classify the tier."""
+        if not self._seeded:
+            self.seed_peak(balance)
+        if not math.isfinite(balance):
+            # A garbage sample must neither move the peak nor trip the cap.
+            logger.warning("Non-finite balance in drawdown check: %s — sample ignored", balance)
+            tier = DrawdownTier.BREACH if self._tripped else DrawdownTier.NONE
+            return DrawdownAssessment(0.0, self._peak, tier, self._tripped)
+
+        if balance > self._peak:
+            self._peak = balance
+        drawdown = (self._peak - balance) / self._peak if self._peak > 0 else 0.0
+
+        tier = DrawdownTier.NONE
+        if drawdown + _TIER_EPSILON >= self.max_drawdown_pct:
+            tier = DrawdownTier.BREACH
+            self._tripped = True
+        elif drawdown + _TIER_EPSILON >= self._critical_threshold:
+            tier = DrawdownTier.CRITICAL
+        elif drawdown + _TIER_EPSILON >= self._warning_threshold:
+            tier = DrawdownTier.WARNING
+        if self._tripped:
+            tier = DrawdownTier.BREACH  # latched: recovery below the cap does not un-trip
+
+        self._log_tier(tier, drawdown, balance)
+        return DrawdownAssessment(drawdown, self._peak, tier, self._tripped)
+
+    def _log_tier(self, tier: DrawdownTier, drawdown: float, balance: float) -> None:
+        """Log the active tier: immediately on escalation, else rate-limited."""
+        if tier is DrawdownTier.NONE:
+            if self._last_logged_tier is not DrawdownTier.NONE:
+                logger.info(
+                    "Drawdown receded below warning tier (%.2f%% of peak $%.2f)",
+                    drawdown * 100,
+                    self._peak,
+                )
+                self._last_logged_tier = DrawdownTier.NONE
+                self._last_tier_log = None
+            return
+
+        now = time.monotonic()
+        escalated = tier > self._last_logged_tier
+        rate_limit_elapsed = (
+            self._last_tier_log is None or now - self._last_tier_log >= self._log_interval
+        )
+        if not escalated and not rate_limit_elapsed:
+            return
+        self._last_logged_tier = tier
+        self._last_tier_log = now
+
+        detail = (
+            f"drawdown {drawdown * 100:.2f}% of peak ${self._peak:,.2f} "
+            f"(balance ${balance:,.2f}, hard cap {self.max_drawdown_pct * 100:.1f}%)"
+        )
+        if tier is DrawdownTier.BREACH:
+            logger.critical(
+                "🛑 Max-drawdown hard cap breached — close-only mode in force: %s", detail
+            )
+        elif tier is DrawdownTier.CRITICAL:
+            logger.critical(
+                "🚨 Drawdown CRITICAL (>= %.1f%% of the cap): %s",
+                self._critical_threshold / self.max_drawdown_pct * 100,
+                detail,
+            )
+        else:
+            logger.warning(
+                "⚠️ Drawdown warning (>= %.1f%% of the cap): %s",
+                self._warning_threshold / self.max_drawdown_pct * 100,
+                detail,
+            )
+
+
+class DrawdownEngineState(Protocol):
+    """Live engine state the drawdown enforcer reads and acts through.
+
+    Accessed dynamically (not captured at construction) because balance and
+    session ids mutate throughout the engine lifecycle.
+    """
+
+    current_balance: float
+    trading_session_id: int | None
+    _recovered_inactive_session_id: int | None
+    db_manager: DatabaseManager
+    performance_tracker: PerformanceTracker
+    _close_only_mode: bool
+
+    def _enter_close_only_mode(self) -> None: ...
+
+    def _record_event(
+        self,
+        event_type: EventType,
+        message: str,
+        *,
+        severity: str = ...,
+        component: str | None = ...,
+        error_code: str | None = ...,
+        exc: BaseException | None = ...,
+        alert: bool = ...,
+    ) -> None: ...
+
+
+class MaxDrawdownEnforcer:
+    """Runs the guard on the trading loop and trips close-only mode on breach.
+
+    Fault-isolated: a failing check can never crash the trading loop. The
+    protective action (close-only) is taken before observability so an event
+    failure cannot leave the account unprotected.
+    """
+
+    def __init__(self, engine_state: DrawdownEngineState, guard: MaxDrawdownGuard) -> None:
+        """Bind to the engine's live state (see protocol for the surface)."""
+        self._state = engine_state
+        self._guard = guard
+        self._breach_notified = False
+
+    @property
+    def guard(self) -> MaxDrawdownGuard:
+        """The underlying drawdown guard (exposed for status/diagnostics)."""
+        return self._guard
+
+    def check(self) -> None:
+        """Assess current drawdown; enforce the hard cap on breach."""
+        state = self._state
+        try:
+            balance = float(state.current_balance)
+            if not self._guard.seeded:
+                self._seed_guard(balance)
+            assessment = self._guard.observe(balance)
+        except Exception as e:
+            # Monitoring must never take down the trading loop.
+            logger.error("Max-drawdown check failed: %s", e, exc_info=True)
+            return
+
+        if not assessment.tripped:
+            return
+        if self._breach_notified and state._close_only_mode:
+            return  # already tripped and halted; guard logs rate-limited reminders
+
+        # Protective action first (idempotent), then page the operator. This
+        # also re-fires if close-only is cleared while the breach persists, so
+        # resume_trading() alone cannot silently restart entries mid-breach.
+        try:
+            state._enter_close_only_mode()
+            self._breach_notified = True
+            message = (
+                f"MAX DRAWDOWN HARD CAP BREACHED: drawdown {assessment.drawdown * 100:.2f}% "
+                f">= limit {self._guard.max_drawdown_pct * 100:.1f}% "
+                f"(peak ${assessment.peak_balance:,.2f} → balance ${balance:,.2f}). "
+                "Close-only mode in force — no new entries; exits and stop-losses remain "
+                "active. Operator action required: see docs/live_trading.md "
+                "(max-drawdown hard cap) to review and clear."
+            )
+            logger.critical("🛑 %s", message)
+            log_risk_event(
+                "max_drawdown_breach",
+                drawdown=assessment.drawdown,
+                peak_balance=assessment.peak_balance,
+                balance=balance,
+                max_drawdown_pct=self._guard.max_drawdown_pct,
+            )
+            state._record_event(
+                EventType.ALERT,
+                message,
+                severity="critical",
+                component="risk",
+                error_code="MAX_DRAWDOWN_BREACH",
+                alert=True,
+            )
+        except Exception as e:
+            logger.critical(
+                "Max-drawdown breach handling failed after close-only trip: %s",
+                e,
+                exc_info=True,
+            )
+
+    def _seed_guard(self, balance: float) -> None:
+        """Establish the peak baseline: persisted session peak > in-memory."""
+        state = self._state
+        db_peak: float | None = None
+        session_id = state.trading_session_id
+        if state.db_manager is not None and session_id is not None:
+            try:
+                db_peak = state.db_manager.get_session_peak_balance(
+                    session_id,
+                    fallback_session_id=state._recovered_inactive_session_id,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Could not recompute session peak from account_history: %s — "
+                    "seeding max-drawdown guard from in-memory state only",
+                    e,
+                )
+        tracker_peak: float | None = None
+        try:
+            tracker_peak = state.performance_tracker.get_metrics().peak_balance
+        except Exception as e:
+            logger.warning("Could not read performance-tracker peak balance: %s", e)
+        self._guard.seed_peak(balance, db_peak, tracker_peak)
+        logger.info(
+            "Max-drawdown guard armed: peak=$%.2f, hard cap=%.1f%% (session %s)",
+            self._guard.peak_balance,
+            self._guard.max_drawdown_pct * 100,
+            session_id,
+        )

--- a/src/engines/live/monitoring/drawdown_guard.py
+++ b/src/engines/live/monitoring/drawdown_guard.py
@@ -6,7 +6,9 @@ WARNING at 50% of the cap, CRITICAL at 80%, and a latched BREACH at the cap
 itself (``portfolio.max_drawdown_pct``).
 
 ``MaxDrawdownEnforcer`` runs the guard on every trading-loop iteration and, on
-breach, trips the EXISTING close-only mode: no new entries, while exits,
+breach, trips the EXISTING close-only mode, which gates every exposure
+increase: entry evaluation, the ``execute_entry_locked`` chokepoint (covers
+the legacy duck-typed short path and any direct caller), and scale-ins. Exits,
 partial exits, stop-loss management, and reconciliation keep running. It never
 liquidates anything — it only stops new risk.
 
@@ -16,6 +18,22 @@ recomputed from ``account_history`` (active session plus the recovered
 inactive session on clean restarts), so a restart cannot reset the drawdown
 baseline — a bot restarted mid-breach re-trips naturally on its first loop
 iteration.
+
+Baseline policy (PM decision, 2026-07-04): the peak baseline is the peak TRUE
+equity since the last reconciled reset — i.e. session-scoped history, NOT
+all-time book value. Pre-reset ledger history is deliberately excluded: the
+Mar–Jun 2026 rows carry a phantom-era book peak (a software-held $100.00
+while true equity was ~$84; ``margin_equity_sync`` wrote the books down to
+true equity on 2026-06-03/05 — see the capital-erosion postmortem). Measuring
+drawdown from that phantom peak would falsely report an immediate >20% breach
+on deploy.
+
+Known limitation (accepted, follow-up #847): because the peak is
+session-scoped, a future CLEAN restart that creates a NEW session
+re-baselines the peak — the cap degrades to "20% per session" rather than a
+rolling 20%. Dormant today: prod reuses the active session across restarts.
+The follow-up proposal is a durable cross-session peak anchored to the last
+human-verified reconciliation marker.
 
 Clearing a trip is an operator decision: restart with
 ``FEATURE_MAX_DRAWDOWN_RESET_PEAK=true`` to re-baseline the peak to the

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -931,6 +931,9 @@ class LiveTradingEngine:
             use_high_low_for_stops=self.use_high_low_for_stops,
             max_position_size=self.max_position_size,
             max_filled_price_deviation=self.max_filled_price_deviation,
+            # Close-only mode must block ALL exposure increases, including
+            # scale-ins; read at call time so mid-session trips take effect.
+            close_only_provider=lambda: self._close_only_mode,
         )
 
         # Stop-loss lifecycle handler — owns every exchange-facing stop-loss

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -70,6 +70,7 @@ from src.engines.live.monitoring import (
     extract_ml_predictions,
     extract_sentiment_data,
 )
+from src.engines.live.monitoring.drawdown_guard import MaxDrawdownEnforcer, MaxDrawdownGuard
 from src.engines.live.recovery import LiveSessionRecoverer
 from src.engines.live.startup import LiveStartupSequencer
 from src.engines.live.strategy_hot_swap import StrategyHotSwapCoordinator
@@ -943,6 +944,14 @@ class LiveTradingEngine:
         # Account monitor — snapshots, status lines, performance summaries.
         self.account_monitor = LiveAccountMonitor(engine_state=self)
 
+        # Max-drawdown hard cap (risk-limits.json portfolio.max_drawdown_pct):
+        # trips close-only mode when drawdown from the session peak reaches
+        # params.max_drawdown. Checked every trading-loop iteration.
+        self._drawdown_enforcer = MaxDrawdownEnforcer(
+            engine_state=self,
+            guard=MaxDrawdownGuard(self.risk_manager.params.max_drawdown),
+        )
+
         # Startup recovery — session balance, persisted positions, exchange
         # reconciliation. Reads/writes engine state at call time (#486).
         self.session_recoverer = LiveSessionRecoverer(engine_state=self)
@@ -1518,6 +1527,8 @@ class LiveTradingEngine:
                     )
                 # Update performance metrics
                 self._update_performance_metrics()
+                # Enforce the portfolio max-drawdown hard cap (close-only on breach)
+                self._check_max_drawdown()
                 self._log_periodic_account_state()
                 # Log status periodically
                 if (
@@ -1957,6 +1968,10 @@ class LiveTradingEngine:
     def _update_performance_metrics(self):
         """Update performance tracking metrics"""
         self.account_monitor.update_performance_metrics()
+
+    def _check_max_drawdown(self) -> None:
+        """Enforce the max-drawdown hard cap (delegated to MaxDrawdownEnforcer)."""
+        self._drawdown_enforcer.check()
 
     def _extract_indicators(self, df: pd.DataFrame, index: int) -> dict:
         """Extract indicator values from dataframe for logging"""

--- a/src/risk/risk_manager.py
+++ b/src/risk/risk_manager.py
@@ -846,6 +846,11 @@ class PortfolioRiskManager:
     def check_drawdown(self, current_balance: float, peak_balance: float) -> bool:
         """Check if maximum drawdown has been exceeded.
 
+        Note: live enforcement of the hard cap (close-only halt, escalation
+        tiers, restart-safe peak) lives in
+        ``src.engines.live.monitoring.drawdown_guard`` — this predicate is a
+        stateless point-in-time check (strictly greater than the limit).
+
         Parameters
         ----------
         current_balance : float

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -64,6 +64,7 @@ def _make_state(position: MagicMock, result: MagicMock, **overrides) -> MagicMoc
     state.current_balance = 1000.0
     state.max_position_size = 1.0
     state.trading_session_id = None
+    state._close_only_mode = False
     # Protocol attributes are annotation-only (not in dir()), so a spec'd mock
     # won't auto-create them — assign each object attribute the path reads.
     state.exchange_interface = MagicMock()
@@ -334,6 +335,7 @@ def test_none_stop_loss_skips_placement():
 def _make_short_state(*, is_runtime: bool, short_signal, overrides):
     """Minimal backref for the legacy short-entry path."""
     state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = False
     state._is_runtime_strategy.return_value = is_runtime
     state.current_balance = 1000.0
     state.max_position_size = 1.0

--- a/tests/unit/engines/live/test_entry_pause.py
+++ b/tests/unit/engines/live/test_entry_pause.py
@@ -106,6 +106,7 @@ def test_pause_skips_entry_check_before_strategy_evaluation(entry_pause_on):
 def test_pause_blocks_execute_entry_locked_defense_in_depth(entry_pause_on):
     """Even a direct entry-execution call is refused while paused."""
     state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = False
     state.live_entry_handler = MagicMock()
     state.live_position_tracker = MagicMock()
     state.live_position_tracker.has_position_for_symbol.return_value = False
@@ -131,6 +132,7 @@ def test_pause_blocks_execute_entry_locked_defense_in_depth(entry_pause_on):
 
 def test_pause_blocks_legacy_short_entry(entry_pause_on):
     state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = False
     state._is_runtime_strategy.return_value = False
     strategy = MagicMock()
     strategy.check_short_entry_conditions.return_value = True

--- a/tests/unit/engines/live/test_max_drawdown_guard.py
+++ b/tests/unit/engines/live/test_max_drawdown_guard.py
@@ -1,0 +1,430 @@
+"""Live enforcement of the portfolio max-drawdown hard cap.
+
+`RiskManager.check_drawdown()` had zero callers, so nothing halted the live
+engine when account drawdown reached ``max_drawdown_pct`` (0.20 in
+risk-limits.json / constants). The MaxDrawdownGuard + MaxDrawdownEnforcer pair
+computes rolling drawdown from the session peak balance on every trading-loop
+iteration and trips the EXISTING close-only mode at the cap: entries stop,
+exits/stop-losses keep running, and the trip is latched until an operator
+intervenes (restart with FEATURE_MAX_DRAWDOWN_RESET_PEAK to re-baseline).
+
+Peak equity source: same numbers account_history.drawdown is derived from
+(balance vs session peak balance), recomputed from account_history on boot so
+restarts don't reset the baseline.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from unittest.mock import MagicMock, create_autospec
+
+import pytest
+
+from src.config.constants import (
+    DEFAULT_MAX_DRAWDOWN,
+    DRAWDOWN_CRITICAL_AT_PCT_OF_LIMIT,
+    DRAWDOWN_GUARD_LOG_INTERVAL_SECONDS,
+    DRAWDOWN_WARNING_AT_PCT_OF_LIMIT,
+)
+from src.database.models import EventType
+from src.engines.live.monitoring.drawdown_guard import (
+    DrawdownTier,
+    MaxDrawdownEnforcer,
+    MaxDrawdownGuard,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# Guard: tier + trip arithmetic
+# ---------------------------------------------------------------------------
+
+
+def _seeded_guard(peak: float = 100.0, **kwargs) -> MaxDrawdownGuard:
+    guard = MaxDrawdownGuard(DEFAULT_MAX_DRAWDOWN, **kwargs)
+    guard.seed_peak(peak)
+    return guard
+
+
+def test_trips_at_exactly_the_cap():
+    guard = _seeded_guard(peak=100.0)
+
+    assessment = guard.observe(80.0)  # exactly 20% drawdown
+
+    assert assessment.tier is DrawdownTier.BREACH
+    assert assessment.tripped is True
+    assert guard.tripped is True
+
+
+def test_no_trip_just_below_the_cap():
+    guard = _seeded_guard(peak=100.0)
+
+    assessment = guard.observe(80.1)  # 19.9% drawdown
+
+    assert assessment.tier is DrawdownTier.CRITICAL
+    assert assessment.tripped is False
+    assert guard.tripped is False
+
+
+def test_warning_tier_at_half_of_limit():
+    guard = _seeded_guard(peak=100.0)
+
+    # exactly limit * warning fraction = 10% drawdown
+    assessment = guard.observe(
+        100.0 * (1 - DEFAULT_MAX_DRAWDOWN * DRAWDOWN_WARNING_AT_PCT_OF_LIMIT)
+    )
+
+    assert assessment.tier is DrawdownTier.WARNING
+    assert assessment.tripped is False
+
+
+def test_critical_tier_at_eighty_pct_of_limit():
+    guard = _seeded_guard(peak=100.0)
+
+    # exactly limit * critical fraction = 16% drawdown; float products like
+    # 0.20 * 0.80 land 1 ulp off, so an exact reading must still register.
+    assessment = guard.observe(
+        100.0 * (1 - DEFAULT_MAX_DRAWDOWN * DRAWDOWN_CRITICAL_AT_PCT_OF_LIMIT)
+    )
+
+    assert assessment.tier is DrawdownTier.CRITICAL
+    assert assessment.tripped is False
+
+
+def test_no_tier_below_warning_threshold():
+    guard = _seeded_guard(peak=100.0)
+
+    assessment = guard.observe(95.0)  # 5% drawdown
+
+    assert assessment.tier is DrawdownTier.NONE
+
+
+def test_trip_latches_even_if_balance_recovers():
+    guard = _seeded_guard(peak=100.0)
+    guard.observe(80.0)  # trip
+
+    assessment = guard.observe(95.0)  # recovered to 5% drawdown
+
+    assert assessment.tripped is True
+    assert assessment.tier is DrawdownTier.BREACH
+
+
+def test_peak_ratchets_up_with_new_highs():
+    guard = _seeded_guard(peak=100.0)
+
+    guard.observe(120.0)
+    assert guard.peak_balance == pytest.approx(120.0)
+
+    # 20% off the NEW peak trips, even though it is only 4% off the old one
+    assessment = guard.observe(96.0)
+    assert assessment.tripped is True
+
+
+def test_seed_peak_takes_max_of_valid_candidates():
+    guard = MaxDrawdownGuard(DEFAULT_MAX_DRAWDOWN)
+
+    guard.seed_peak(80.0, 100.0, None, float("nan"), -5.0, 90.0)
+
+    assert guard.peak_balance == pytest.approx(100.0)
+
+
+def test_non_finite_balance_sample_is_ignored():
+    guard = _seeded_guard(peak=100.0)
+
+    assessment = guard.observe(float("nan"))
+
+    assert assessment.tripped is False
+    assert guard.peak_balance == pytest.approx(100.0)
+
+    # A garbage sample must not have corrupted subsequent arithmetic.
+    assert guard.observe(80.0).tripped is True
+
+
+def test_reset_peak_flag_rebaselines_to_current_balance(monkeypatch):
+    monkeypatch.setenv("FEATURE_MAX_DRAWDOWN_RESET_PEAK", "true")
+    guard = MaxDrawdownGuard(DEFAULT_MAX_DRAWDOWN)
+
+    guard.seed_peak(80.0, 100.0)  # historical peak 100 ignored under override
+
+    assert guard.peak_balance == pytest.approx(80.0)
+    assert guard.observe(80.0).tripped is False
+    # Still armed from the new baseline: a further 20% drawdown trips.
+    assert guard.observe(64.0).tripped is True
+
+
+def test_tier_logs_are_rate_limited(caplog):
+    guard = _seeded_guard(peak=100.0)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            guard.observe(90.0)  # warning tier every iteration
+
+    warnings = [r for r in caplog.records if "drawdown" in r.message.lower()]
+    assert len(warnings) == 1
+
+    # After the rate-limit window elapses the tier logs again.
+    guard._last_tier_log = time.monotonic() - DRAWDOWN_GUARD_LOG_INTERVAL_SECONDS - 1
+    with caplog.at_level(logging.WARNING):
+        guard.observe(90.0)
+    warnings = [r for r in caplog.records if "drawdown" in r.message.lower()]
+    assert len(warnings) == 2
+
+
+def test_tier_escalation_logs_immediately_despite_rate_limit(caplog):
+    guard = _seeded_guard(peak=100.0)
+
+    with caplog.at_level(logging.WARNING):
+        guard.observe(90.0)  # WARNING tier
+        guard.observe(83.0)  # CRITICAL tier — escalation logs immediately
+
+    criticals = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+    assert len(criticals) == 1
+
+
+def test_invalid_limit_rejected():
+    with pytest.raises(ValueError):
+        MaxDrawdownGuard(0.0)
+    with pytest.raises(ValueError):
+        MaxDrawdownGuard(1.5)
+
+
+# ---------------------------------------------------------------------------
+# Enforcer: engine integration (close-only trip, events, idempotence)
+# ---------------------------------------------------------------------------
+
+
+def _make_state(
+    *,
+    balance: float = 80.0,
+    db_peak: float | None = 100.0,
+    tracker_peak: float = 80.0,
+    session_id: int | None = 7,
+) -> MagicMock:
+    from src.engines.live.monitoring.drawdown_guard import DrawdownEngineState
+
+    state = create_autospec(DrawdownEngineState, instance=True)
+    state.current_balance = balance
+    state.trading_session_id = session_id
+    state._recovered_inactive_session_id = None
+    state._close_only_mode = False
+    state.db_manager = MagicMock()
+    state.db_manager.get_session_peak_balance.return_value = db_peak
+    state.performance_tracker = MagicMock()
+    metrics = MagicMock()
+    metrics.peak_balance = tracker_peak
+    state.performance_tracker.get_metrics.return_value = metrics
+
+    def _enter():
+        state._close_only_mode = True
+
+    state._enter_close_only_mode.side_effect = _enter
+    return state
+
+
+def _make_enforcer(state: MagicMock) -> MaxDrawdownEnforcer:
+    return MaxDrawdownEnforcer(engine_state=state, guard=MaxDrawdownGuard(DEFAULT_MAX_DRAWDOWN))
+
+
+def test_breach_enters_close_only_and_pages_operator():
+    state = _make_state(balance=80.0, db_peak=100.0)
+    enforcer = _make_enforcer(state)
+
+    enforcer.check()
+
+    state._enter_close_only_mode.assert_called_once()
+    state._record_event.assert_called_once()
+    args, kwargs = state._record_event.call_args
+    assert args[0] is EventType.ALERT
+    assert kwargs["severity"] == "critical"
+    assert kwargs["component"] == "risk"
+    assert kwargs["error_code"] == "MAX_DRAWDOWN_BREACH"
+    assert kwargs["alert"] is True
+
+
+def test_no_trip_below_cap():
+    state = _make_state(balance=80.1, db_peak=100.0)
+    enforcer = _make_enforcer(state)
+
+    enforcer.check()
+
+    state._enter_close_only_mode.assert_not_called()
+    state._record_event.assert_not_called()
+
+
+def test_trip_is_idempotent_across_loop_iterations():
+    state = _make_state(balance=80.0, db_peak=100.0)
+    enforcer = _make_enforcer(state)
+
+    for _ in range(5):
+        enforcer.check()
+
+    state._enter_close_only_mode.assert_called_once()
+    state._record_event.assert_called_once()
+
+
+def test_retrips_if_resumed_without_operator_override():
+    """resume_trading() alone cannot clear the halt while still in breach."""
+    state = _make_state(balance=80.0, db_peak=100.0)
+    enforcer = _make_enforcer(state)
+    enforcer.check()
+
+    state._close_only_mode = False  # human called resume_trading()
+    enforcer.check()
+
+    assert state._enter_close_only_mode.call_count == 2
+    assert state._record_event.call_count == 2
+
+
+def test_restart_recompute_re_trips_from_persisted_peak():
+    """A restart mid-breach recomputes the peak from account_history and
+    re-trips naturally — the halt survives restarts without persisted flags."""
+    state = _make_state(balance=78.0, db_peak=100.0, tracker_peak=78.0)
+    enforcer = _make_enforcer(state)  # fresh process: guard has no memory
+
+    enforcer.check()
+
+    state.db_manager.get_session_peak_balance.assert_called_once_with(7, fallback_session_id=None)
+    state._enter_close_only_mode.assert_called_once()
+
+
+def test_restart_with_reset_peak_override_stays_trading(monkeypatch):
+    """Documented clear procedure: restart with FEATURE_MAX_DRAWDOWN_RESET_PEAK
+    re-baselines the peak to the current balance instead of halting."""
+    monkeypatch.setenv("FEATURE_MAX_DRAWDOWN_RESET_PEAK", "true")
+    state = _make_state(balance=78.0, db_peak=100.0, tracker_peak=78.0)
+    enforcer = _make_enforcer(state)
+
+    enforcer.check()
+
+    state._enter_close_only_mode.assert_not_called()
+    assert enforcer.guard.peak_balance == pytest.approx(78.0)
+
+
+def test_breach_already_in_close_only_still_records_cause():
+    """If close-only was entered for another reason (e.g. DB outage) the
+    drawdown breach must still be recorded as a cause, exactly once."""
+    state = _make_state(balance=80.0, db_peak=100.0)
+    state._close_only_mode = True
+    enforcer = _make_enforcer(state)
+
+    enforcer.check()
+    enforcer.check()
+
+    state._record_event.assert_called_once()
+
+
+def test_db_seed_failure_fails_soft_to_in_memory_peak():
+    state = _make_state(balance=90.0, db_peak=None, tracker_peak=90.0)
+    state.db_manager.get_session_peak_balance.side_effect = RuntimeError("db down")
+
+    enforcer = _make_enforcer(state)
+    enforcer.check()  # must not raise; seeds from tracker/balance → 0% drawdown
+
+    state._enter_close_only_mode.assert_not_called()
+
+
+def test_check_never_raises_into_the_trading_loop():
+    state = _make_state()
+    state.performance_tracker.get_metrics.side_effect = RuntimeError("boom")
+    state.current_balance = "not-a-number"  # type: ignore[assignment]
+
+    enforcer = _make_enforcer(state)
+    enforcer.check()  # swallowed + logged
+
+
+def test_no_db_session_seeds_from_in_memory_only():
+    state = _make_state(balance=100.0, session_id=None, tracker_peak=100.0)
+    enforcer = _make_enforcer(state)
+
+    enforcer.check()
+
+    state.db_manager.get_session_peak_balance.assert_not_called()
+    state._enter_close_only_mode.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# While tripped: entries blocked, exits/stop-loss calls pass through
+# ---------------------------------------------------------------------------
+
+
+def test_close_only_mode_blocks_entry_evaluation():
+    """The enforcer reuses the existing close-only gate at the entry seam."""
+    from datetime import UTC, datetime
+
+    import pandas as pd
+
+    from src.engines.live.execution.entry_coordinator import (
+        LiveEntryCoordinator,
+        LiveEntryEngineState,
+    )
+
+    state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = True  # what the drawdown trip sets
+    strategy = MagicMock()
+    state.strategy = strategy
+
+    coordinator = LiveEntryCoordinator(engine_state=state)
+    coordinator.execute_entry = MagicMock()  # type: ignore[method-assign]
+    coordinator.check_entry_conditions(
+        df=pd.DataFrame({"close": [50000.0]}),
+        current_index=0,
+        symbol="BTCUSDT",
+        current_price=50000.0,
+        current_time=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+    coordinator.execute_entry.assert_not_called()
+    strategy.process_candle.assert_not_called()
+
+
+def test_exits_still_execute_while_tripped():
+    """Close-only must never block risk-reducing exits or stop-loss handling."""
+    from types import SimpleNamespace
+
+    from src.engines.live.execution.exit_handler import LiveExitHandler
+    from src.engines.shared.models import PositionSide
+
+    execution_engine = MagicMock()
+    execution_engine.fee_rate = 0.0
+    execution_engine.slippage_rate = 0.0
+    execution_engine.execute_exit.return_value = SimpleNamespace(
+        success=True, executed_price=51000.0, exit_fee=0.0, slippage_cost=0.0, error=None
+    )
+    execution_model = MagicMock()
+    execution_model.decide_fill.return_value = SimpleNamespace(
+        should_fill=True, fill_price=51000.0, liquidity=None, reason=""
+    )
+
+    position = MagicMock()
+    position.symbol = "BTCUSDT"
+    position.side = PositionSide.LONG
+    position.order_id = "order-1"
+    position.current_size = 0.1
+    position.size = 0.1
+    position.original_size = 0.1
+    position.entry_price = 50000.0
+    position.entry_balance = 1000.0
+    position.stop_loss = 49000.0
+    position.take_profit = None
+    position.quantity = 0.002
+
+    handler = LiveExitHandler(
+        execution_engine=execution_engine,
+        position_tracker=MagicMock(),
+        execution_model=execution_model,
+    )
+
+    # The exit path has no dependency on close-only state or the guard at all:
+    # this exit executes exactly as it would in normal mode.
+    result = handler.execute_exit(
+        position=position,
+        exit_reason="Stop loss",
+        current_price=51000.0,
+        limit_price=None,
+        current_balance=800.0,  # tripped account, 20% down
+    )
+
+    assert result.success is True
+    execution_engine.execute_exit.assert_called_once()

--- a/tests/unit/engines/live/test_max_drawdown_guard.py
+++ b/tests/unit/engines/live/test_max_drawdown_guard.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
@@ -377,6 +378,144 @@ def test_close_only_mode_blocks_entry_evaluation():
 
     coordinator.execute_entry.assert_not_called()
     strategy.process_candle.assert_not_called()
+
+
+def test_close_only_mode_blocks_entry_execution_chokepoint():
+    """execute_entry_locked refuses while close-only — covers legacy shorts
+    and any caller that routes around check_entry_conditions."""
+    from src.engines.live.execution.entry_coordinator import (
+        LiveEntryCoordinator,
+        LiveEntryEngineState,
+    )
+    from src.engines.shared.models import PositionSide
+
+    state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = True
+    state.live_entry_handler = MagicMock()
+
+    coordinator = LiveEntryCoordinator(engine_state=state)
+    coordinator.execute_entry_locked(
+        symbol="BTCUSDT",
+        side=PositionSide.LONG,
+        size=0.1,
+        price=50000.0,
+        stop_loss=49000.0,
+        take_profit=51000.0,
+        signal_strength=0.8,
+        signal_confidence=0.7,
+    )
+
+    state.live_entry_handler.execute_entry.assert_not_called()
+
+
+def test_close_only_mode_blocks_legacy_short_entry():
+    from src.engines.live.execution.entry_coordinator import (
+        LiveEntryCoordinator,
+        LiveEntryEngineState,
+    )
+
+    state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = True
+    strategy = MagicMock()
+    strategy.check_short_entry_conditions.return_value = True
+    state.strategy = strategy
+
+    coordinator = LiveEntryCoordinator(engine_state=state)
+    coordinator.execute_entry = MagicMock()  # type: ignore[method-assign]
+    coordinator.process_legacy_short_entry(
+        df=MagicMock(),
+        current_index=0,
+        symbol="BTCUSDT",
+        current_price=50000.0,
+        current_time=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+    coordinator.execute_entry.assert_not_called()
+    strategy.check_short_entry_conditions.assert_not_called()
+
+
+def _make_partial_ops_handler(*, close_only: bool, should_exit: bool = False):
+    """LiveExitHandler wired for check_partial_operations with one position."""
+    from types import SimpleNamespace
+
+    from src.engines.live.execution.exit_handler import LiveExitHandler
+
+    position = MagicMock()
+    position.symbol = "BTCUSDT"
+    position.order_id = "order-1"
+    position.entry_time = datetime(2024, 1, 1, tzinfo=UTC)
+    position.current_size = 0.08
+    position.original_size = 0.08
+    position.size = 0.08
+
+    execution_engine = MagicMock()
+    execution_engine.fee_rate = 0.0
+    execution_engine.slippage_rate = 0.0
+    position_tracker = MagicMock()
+    position_tracker.positions = {"order-1": position}
+    position_tracker.apply_partial_exit.return_value = SimpleNamespace(
+        realized_pnl=1.0, new_current_size=0.04, partial_exits_taken=1
+    )
+    partial_manager = MagicMock()
+    partial_manager.check_partial_exit.side_effect = [
+        SimpleNamespace(should_exit=should_exit, exit_fraction=0.5, target_index=0),
+        SimpleNamespace(should_exit=False, exit_fraction=None, target_index=None),
+    ]
+    partial_manager.check_scale_in.return_value = SimpleNamespace(
+        should_scale=True, scale_fraction=0.05, target_index=0
+    )
+    handler = LiveExitHandler(
+        execution_engine=execution_engine,
+        position_tracker=position_tracker,
+        execution_model=MagicMock(),
+        risk_manager=None,
+        partial_manager=partial_manager,
+        max_position_size=0.5,
+        close_only_provider=lambda: close_only,
+    )
+    return handler, position_tracker
+
+
+def test_close_only_mode_suppresses_scale_in():
+    """Scale-ins increase exposure, so a drawdown trip blocks them too."""
+    handler, tracker = _make_partial_ops_handler(close_only=True)
+
+    handler.check_partial_operations(
+        df=MagicMock(),
+        current_index=0,
+        current_price=51000.0,
+        current_balance=800.0,
+    )
+
+    tracker.apply_scale_in.assert_not_called()
+
+
+def test_close_only_mode_keeps_partial_exits_running():
+    """Partial exits reduce risk and must keep firing while tripped."""
+    handler, tracker = _make_partial_ops_handler(close_only=True, should_exit=True)
+
+    handler.check_partial_operations(
+        df=MagicMock(),
+        current_index=0,
+        current_price=51000.0,
+        current_balance=800.0,
+    )
+
+    tracker.apply_partial_exit.assert_called_once()
+    tracker.apply_scale_in.assert_not_called()
+
+
+def test_scale_in_proceeds_when_not_close_only():
+    handler, tracker = _make_partial_ops_handler(close_only=False)
+
+    handler.check_partial_operations(
+        df=MagicMock(),
+        current_index=0,
+        current_price=51000.0,
+        current_balance=800.0,
+    )
+
+    tracker.apply_scale_in.assert_called_once()
 
 
 def test_exits_still_execute_while_tripped():


### PR DESCRIPTION
## Summary

Wires live enforcement of `risk-limits.json`'s 20% max-drawdown hard cap — previously **dead code** (`RiskManager.check_drawdown()` had zero callers; flagged by the 2026-06-08 observability audit and the 2026-07-04 risk-officer review after HyperGrowth's honest 365d backtest showed 21.84% MaxDD).

- **`MaxDrawdownGuard`** (`engines/live/monitoring/drawdown_guard.py`): samples balance each monitoring cycle, ratchets peak, classifies WARNING (10% DD) / CRITICAL (16%) / BREACH (≥20%, float-boundary-exact).
- **On breach**: enters the existing close-only mode (idempotent latch, re-fires if resumed while still breached), emits CRITICAL system_event + risk event + alert webhook, logs unmissably. **Never liquidates** — exits/partial-exits/SL management/reconciliation unaffected.
- **Close-only gates hardened** (second commit): `execute_entry_locked` chokepoint + scale-in branch now honor close-only, closing a pre-existing gap where scale-ins and the (dormant) legacy short path could add exposure during any close-only condition.
- **Restart-safe**: peak recomputed from `account_history` on boot (session-scoped) — a mid-breach restart re-trips naturally. `FEATURE_MAX_DRAWDOWN_RESET_PEAK` gives operators an explicit re-baseline override.
- **Baseline policy (PM decision, documented in module)**: peak = true equity since the last reconciled reset (2026-06-05). Phantom-era book values (Mar–Jun $100 software-held balance, written down Jun 3/5 by `margin_equity_sync`) are excluded — an apparent April "$103.82 peak / 20.33% breach" is phantom-money accounting, not a real loss. Session-scoped peak implements this; the "20%-per-session on new-session restarts" residual is documented with a follow-up issue.

## Reviews
- architecture-reviewer: sound; P1 (close-only seam gaps) → fixed in ef5bb80a.
- code-reviewer: CORRECT, no blocking issues; boundary math, latch semantics, fault isolation, DB Decimal handling all verified.

## Testing
- 25 guard tests (exact-cap trip, no-trip at 19.9%, latch/idempotence/re-fire, restart recompute, reset-peak override, fail-soft seeding, never-raises into the loop, entries-blocked/exits-pass integration) + close-only gating tests; 48 targeted green; full unit suite green (42.7s).

## Deploy
Board waived the weekend freeze — promote to prod planned immediately after merge so cap enforcement is live before the Jul 8 FOMC window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)