### PR TITLE
Promote to production: drawdown-guard seed fix (#850)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default (`"entry_pause": false`) lives in `feature_flags.json`; the
   `FEATURE_ENTRY_PAUSE` env var remains the override path.
 
+### Fixed
+- **Max-drawdown guard mis-seeded its peak from the configured balance**
+  (prod 2026-07-04: guard armed at $100.00 vs true session equity $84.42 and
+  immediately warned at a phantom 15.60% drawdown): the seed took
+  `max(db_peak, tracker_peak, balance)` and the PerformanceTracker peak
+  initializes from `INITIAL_BALANCE` (the optimistic book value from the June
+  phantom-balance pathology). The `account_history` session max is now
+  authoritative — the tracker peak is no longer a seed candidate; fallback is
+  the current recovered balance. A failed DB read now defers seeding to the
+  next loop cycle (bounded by `MAX_SEED_ATTEMPTS`) instead of latching a
+  half-seeded baseline. Deeper fix included: the live engine now constructs
+  `PerformanceTracker` from the RESUMED session balance rather than the
+  configured amount, which also fixes the phantom ~15% in
+  `account_history.drawdown` and dynamic-risk drawdown after restarts.
+
 ### Changed
 - HyperGrowth default sizing raised: `risk_fraction` / `base_fraction`
   0.20 → 0.25 (`stop_loss_pct` stays 0.10). Board-approved 2026-07-03 with the

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -72,9 +72,15 @@ trading-loop iteration `MaxDrawdownEnforcer` (`src/engines/live/monitoring/drawd
 measures the drawdown of the current balance from the **session peak balance** — the same
 numbers `account_history.drawdown` is derived from.
 
-- **Peak baseline**: seeded on boot from the max of `account_history` balances for the active
-  session (plus the recovered inactive session on clean restarts), the performance tracker's
-  peak, and the current balance. A restart therefore never resets the drawdown baseline.
+- **Peak baseline**: the `account_history` session max is **authoritative** — seeded on boot
+  from `max(account_history.balance)` for the active session (plus the recovered inactive
+  session on clean restarts), never below the current recovered balance. The in-memory
+  performance-tracker peak is deliberately **not** a seed candidate: it can initialize from
+  the configured `INITIAL_BALANCE` book value, which mis-seeded the prod guard at $100 vs
+  true equity ~$84 (2026-07-04) and produced a phantom 15.6% drawdown warning. A failed DB
+  read defers seeding to the next loop cycle (bounded by `MAX_SEED_ATTEMPTS`, then falls
+  back to the current balance with a WARNING). A restart therefore never resets — or
+  inflates — the drawdown baseline.
   By policy the baseline is the peak **true equity since the last reconciled reset** —
   pre-reset ledger history is excluded because the Mar–Jun 2026 rows carry a phantom-era
   book peak (see the capital-erosion postmortem; measuring from it would falsely report an

--- a/src/engines/live/monitoring/drawdown_guard.py
+++ b/src/engines/live/monitoring/drawdown_guard.py
@@ -12,12 +12,16 @@ the legacy duck-typed short path and any direct caller), and scale-ins. Exits,
 partial exits, stop-loss management, and reconciliation keep running. It never
 liquidates anything — it only stops new risk.
 
-Peak-equity source: the same numbers ``account_history.drawdown`` is derived
-from (session balance vs the session peak balance). On boot the peak is
-recomputed from ``account_history`` (active session plus the recovered
-inactive session on clean restarts), so a restart cannot reset the drawdown
-baseline — a bot restarted mid-breach re-trips naturally on its first loop
-iteration.
+Peak-equity source: the AUTHORITATIVE baseline is the ``account_history``
+session max (active session plus the recovered inactive session on clean
+restarts), recomputed on boot so a restart cannot reset the drawdown baseline
+— a bot restarted mid-breach re-trips naturally on its first loop iteration.
+Fallback order is DB session max → current recovered balance; the in-memory
+PerformanceTracker peak is NEVER a seed candidate (it can initialize from the
+CONFIGURED balance — the optimistic book value that mis-seeded prod at $100
+vs true equity ~$84 on 2026-07-04). A failed DB read defers seeding to the
+next cycle (bounded by ``MAX_SEED_ATTEMPTS``) instead of latching a
+half-seeded baseline.
 
 Baseline policy (PM decision, 2026-07-04): the peak baseline is the peak TRUE
 equity since the last reconciled reset — i.e. session-scoped history, NOT
@@ -66,7 +70,6 @@ from src.infrastructure.logging.events import log_risk_event
 
 if TYPE_CHECKING:
     from src.database.manager import DatabaseManager
-    from src.trading.performance import PerformanceTracker
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +79,12 @@ logger = logging.getLogger(__name__)
 _TIER_EPSILON = 1e-12
 
 RESET_PEAK_FLAG = "max_drawdown_reset_peak"
+
+# Bounded seeding deferrals: a failed/unavailable account_history read defers
+# seeding to the next loop cycle rather than latching a half-seeded baseline;
+# after this many attempts the guard arms from the current balance so the cap
+# is never left unarmed indefinitely.
+MAX_SEED_ATTEMPTS = 10
 
 
 class DrawdownTier(IntEnum):
@@ -265,7 +274,6 @@ class DrawdownEngineState(Protocol):
     trading_session_id: int | None
     _recovered_inactive_session_id: int | None
     db_manager: DatabaseManager
-    performance_tracker: PerformanceTracker
     _close_only_mode: bool
 
     def _enter_close_only_mode(self) -> None: ...
@@ -296,6 +304,7 @@ class MaxDrawdownEnforcer:
         self._state = engine_state
         self._guard = guard
         self._breach_notified = False
+        self._seed_attempts = 0
 
     @property
     def guard(self) -> MaxDrawdownGuard:
@@ -307,8 +316,8 @@ class MaxDrawdownEnforcer:
         state = self._state
         try:
             balance = float(state.current_balance)
-            if not self._guard.seeded:
-                self._seed_guard(balance)
+            if not self._guard.seeded and not self._try_seed(balance):
+                return  # seeding deferred (DB/session not ready); retry next cycle
             assessment = self._guard.observe(balance)
         except Exception as e:
             # Monitoring must never take down the trading loop.
@@ -357,32 +366,76 @@ class MaxDrawdownEnforcer:
                 exc_info=True,
             )
 
-    def _seed_guard(self, balance: float) -> None:
-        """Establish the peak baseline: persisted session peak > in-memory."""
+    def _try_seed(self, balance: float) -> bool:
+        """Seed the peak baseline; the DB session max is AUTHORITATIVE.
+
+        Returns False when seeding must be deferred to the next loop cycle
+        (session id not resolved yet, or the account_history read failed).
+        After ``MAX_SEED_ATTEMPTS`` deferrals the guard falls back to the
+        current balance with a WARNING so the cap is never left unarmed
+        indefinitely.
+
+        The in-memory PerformanceTracker peak is deliberately NOT a seed
+        candidate: it can initialize from the CONFIGURED initial balance,
+        which mis-seeded the prod guard at the optimistic $100 book value vs
+        true session equity ~$84 (2026-07-04) and produced a phantom 15.6%
+        drawdown warning on boot.
+        """
         state = self._state
-        db_peak: float | None = None
+        if is_enabled(RESET_PEAK_FLAG, default=False):
+            # Operator override: re-baseline to current balance; history
+            # (including the DB peak) is intentionally ignored.
+            self._guard.seed_peak(balance)
+            return True
+
+        self._seed_attempts += 1
         session_id = state.trading_session_id
-        if state.db_manager is not None and session_id is not None:
+        db_read_ok = False
+        db_peak: float | None = None
+        if state.db_manager is None or session_id is None:
+            logger.info(
+                "Max-drawdown guard seeding deferred: trading session not resolved yet "
+                "(attempt %d/%d)",
+                self._seed_attempts,
+                MAX_SEED_ATTEMPTS,
+            )
+        else:
             try:
                 db_peak = state.db_manager.get_session_peak_balance(
                     session_id,
                     fallback_session_id=state._recovered_inactive_session_id,
                 )
+                # None here means the read SUCCEEDED but the session has no
+                # snapshots yet — a fresh session legitimately baselines at
+                # the current balance.
+                db_read_ok = True
             except Exception as e:
                 logger.warning(
-                    "Could not recompute session peak from account_history: %s — "
-                    "seeding max-drawdown guard from in-memory state only",
+                    "Could not recompute session peak from account_history "
+                    "(attempt %d/%d): %s — will retry next cycle",
+                    self._seed_attempts,
+                    MAX_SEED_ATTEMPTS,
                     e,
                 )
-        tracker_peak: float | None = None
-        try:
-            tracker_peak = state.performance_tracker.get_metrics().peak_balance
-        except Exception as e:
-            logger.warning("Could not read performance-tracker peak balance: %s", e)
-        self._guard.seed_peak(balance, db_peak, tracker_peak)
+
+        if not db_read_ok:
+            if self._seed_attempts < MAX_SEED_ATTEMPTS:
+                return False
+            logger.warning(
+                "Max-drawdown guard: no successful account_history read after %d "
+                "attempts — falling back to current balance $%.2f as the peak "
+                "baseline (drawdown measured from here on)",
+                self._seed_attempts,
+                balance,
+            )
+
+        self._guard.seed_peak(balance, db_peak)
         logger.info(
-            "Max-drawdown guard armed: peak=$%.2f, hard cap=%.1f%% (session %s)",
+            "Max-drawdown guard armed: peak=$%.2f, hard cap=%.1f%% (session %s, "
+            "account_history peak %s)",
             self._guard.peak_balance,
             self._guard.max_drawdown_pct * 100,
             session_id,
+            f"${db_peak:,.2f}" if db_peak is not None else "unavailable",
         )
+        return True

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -302,7 +302,13 @@ class LiveTradingEngine:
         # Performance tracker (unified with backtest engine)
         from src.performance.tracker import PerformanceTracker
 
-        self.performance_tracker = PerformanceTracker(initial_balance)
+        # Seed from self.initial_balance, which _resume_balance_from_snapshot
+        # may have just updated to the RECOVERED session balance. Seeding from
+        # the configured amount made peak_balance start at the optimistic book
+        # value ($100 vs true equity ~$84 in prod), poisoning
+        # account_history.drawdown and dynamic-risk drawdown with a phantom
+        # ~15% on every restart.
+        self.performance_tracker = PerformanceTracker(self.initial_balance)
 
         # Error handling
         self.max_consecutive_errors = max_consecutive_errors

--- a/tests/unit/engines/live/test_max_drawdown_guard.py
+++ b/tests/unit/engines/live/test_max_drawdown_guard.py
@@ -200,7 +200,7 @@ def _make_state(
     *,
     balance: float = 80.0,
     db_peak: float | None = 100.0,
-    tracker_peak: float = 80.0,
+    tracker_peak: float = 100.0,
     session_id: int | None = 7,
 ) -> MagicMock:
     from src.engines.live.monitoring.drawdown_guard import DrawdownEngineState
@@ -212,6 +212,9 @@ def _make_state(
     state._close_only_mode = False
     state.db_manager = MagicMock()
     state.db_manager.get_session_peak_balance.return_value = db_peak
+    # The engine carries a PerformanceTracker whose peak initializes from the
+    # CONFIGURED balance (the 2026-07-04 prod mis-seed poison, $100 vs true
+    # $84). It sits on the state to prove the enforcer never reads it.
     state.performance_tracker = MagicMock()
     metrics = MagicMock()
     metrics.peak_balance = tracker_peak
@@ -301,6 +304,8 @@ def test_restart_with_reset_peak_override_stays_trading(monkeypatch):
 
     state._enter_close_only_mode.assert_not_called()
     assert enforcer.guard.peak_balance == pytest.approx(78.0)
+    # The override ignores history entirely — no DB read is needed.
+    state.db_manager.get_session_peak_balance.assert_not_called()
 
 
 def test_breach_already_in_close_only_still_records_cause():
@@ -316,33 +321,101 @@ def test_breach_already_in_close_only_still_records_cause():
     state._record_event.assert_called_once()
 
 
-def test_db_seed_failure_fails_soft_to_in_memory_peak():
-    state = _make_state(balance=90.0, db_peak=None, tracker_peak=90.0)
-    state.db_manager.get_session_peak_balance.side_effect = RuntimeError("db down")
-
+def test_prod_regression_config_balance_cannot_poison_peak(caplog):
+    """2026-07-04 prod mis-seed: guard armed at the CONFIGURED $100 while true
+    session equity was $84 and immediately warned at a phantom 15.6% drawdown.
+    The DB session max is authoritative; the tracker's config-initialized peak
+    must never reach the seed."""
+    state = _make_state(balance=84.40, db_peak=84.4159, tracker_peak=100.0)
     enforcer = _make_enforcer(state)
-    enforcer.check()  # must not raise; seeds from tracker/balance → 0% drawdown
 
+    with caplog.at_level(logging.WARNING):
+        enforcer.check()
+
+    assert enforcer.guard.peak_balance == pytest.approx(84.4159)
+    state._enter_close_only_mode.assert_not_called()
+    # Real drawdown is ~0.02% — no phantom warning tier may fire.
+    assert not [r for r in caplog.records if "rawdown" in r.message]
+    state.performance_tracker.get_metrics.assert_not_called()
+
+
+def test_db_error_defers_seeding_then_seeds_on_retry():
+    """A failed DB read must not latch a half-seeded baseline — the enforcer
+    retries next cycle and arms from the authoritative session max."""
+    state = _make_state(balance=78.0, db_peak=100.0)
+    state.db_manager.get_session_peak_balance.side_effect = [
+        RuntimeError("db down"),
+        100.0,
+    ]
+    enforcer = _make_enforcer(state)
+
+    enforcer.check()  # DB read fails → seeding deferred, no observation
+    assert enforcer.guard.seeded is False
+    state._enter_close_only_mode.assert_not_called()
+
+    enforcer.check()  # DB back → seeds peak=100 → 22% drawdown trips
+    assert enforcer.guard.peak_balance == pytest.approx(100.0)
+    state._enter_close_only_mode.assert_called_once()
+
+
+def test_seed_retry_exhaustion_falls_back_to_current_balance(caplog):
+    """The cap must never stay unarmed indefinitely: after MAX_SEED_ATTEMPTS
+    failed DB reads the guard arms from the current balance with a WARNING."""
+    from src.engines.live.monitoring.drawdown_guard import MAX_SEED_ATTEMPTS
+
+    state = _make_state(balance=90.0)
+    state.db_manager.get_session_peak_balance.side_effect = RuntimeError("db down")
+    enforcer = _make_enforcer(state)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(MAX_SEED_ATTEMPTS):
+            enforcer.check()
+
+    assert enforcer.guard.seeded is True
+    assert enforcer.guard.peak_balance == pytest.approx(90.0)
+    assert [r for r in caplog.records if "falling back" in r.message]
+    # Still armed from the fallback baseline: a further 20% drawdown trips.
+    state.current_balance = 72.0
+    enforcer.check()
+    state._enter_close_only_mode.assert_called_once()
+
+
+def test_db_read_none_seeds_from_current_balance():
+    """A successful read with no snapshot rows (fresh session) is a legitimate
+    baseline: the session starts at the current balance — no retry loop."""
+    state = _make_state(balance=90.0, db_peak=None)
+    enforcer = _make_enforcer(state)
+
+    enforcer.check()
+
+    assert enforcer.guard.seeded is True
+    assert enforcer.guard.peak_balance == pytest.approx(90.0)
+    state.db_manager.get_session_peak_balance.assert_called_once()
     state._enter_close_only_mode.assert_not_called()
 
 
 def test_check_never_raises_into_the_trading_loop():
     state = _make_state()
-    state.performance_tracker.get_metrics.side_effect = RuntimeError("boom")
     state.current_balance = "not-a-number"  # type: ignore[assignment]
 
     enforcer = _make_enforcer(state)
     enforcer.check()  # swallowed + logged
 
 
-def test_no_db_session_seeds_from_in_memory_only():
-    state = _make_state(balance=100.0, session_id=None, tracker_peak=100.0)
+def test_missing_session_defers_seeding_until_available():
+    """No session id yet → no DB read is possible; seeding waits (bounded)
+    rather than latching a baseline that ignores persisted history."""
+    state = _make_state(balance=78.0, db_peak=100.0, session_id=None)
     enforcer = _make_enforcer(state)
 
     enforcer.check()
-
+    assert enforcer.guard.seeded is False
     state.db_manager.get_session_peak_balance.assert_not_called()
-    state._enter_close_only_mode.assert_not_called()
+
+    state.trading_session_id = 7  # session resolved on a later cycle
+    enforcer.check()
+    assert enforcer.guard.peak_balance == pytest.approx(100.0)
+    state._enter_close_only_mode.assert_called_once()  # 22% DD re-trips
 
 
 # ---------------------------------------------------------------------------
@@ -567,3 +640,42 @@ def test_exits_still_execute_while_tripped():
 
     assert result.success is True
     execution_engine.execute_exit.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# PerformanceTracker seeding: resumed balance, not configured balance
+# ---------------------------------------------------------------------------
+
+
+def test_performance_tracker_seeds_from_resumed_balance():
+    """The tracker peak must start from the RECOVERED session balance, not the
+    configured INITIAL_BALANCE. The config value ($100 vs true equity $84)
+    poisoned prod's account_history.drawdown with a phantom 15.6% and was the
+    poison candidate in the guard's 2026-07-04 mis-seed."""
+    from unittest.mock import patch
+
+    from src.engines.live.trading_engine import LiveTradingEngine
+
+    db = MagicMock()
+    db.get_active_session_id.return_value = 20
+    db.get_current_balance.return_value = 84.40
+
+    with (
+        patch("src.engines.live.trading_engine.DatabaseManager", return_value=db),
+        patch("src.engines.live.trading_engine.get_config", return_value={}),
+        patch(
+            "src.engines.live.trading_engine._create_exchange_provider",
+            return_value=(MagicMock(), "mock"),
+        ),
+    ):
+        engine = LiveTradingEngine(
+            strategy=MagicMock(),
+            data_provider=MagicMock(),
+            initial_balance=100.0,
+            enable_live_trading=True,
+            resume_from_last_balance=True,
+        )
+
+    assert engine.initial_balance == pytest.approx(84.40)
+    assert engine.performance_tracker.initial_balance == pytest.approx(84.40)
+    assert engine.performance_tracker.peak_balance == pytest.approx(84.40)


### PR DESCRIPTION
## Summary

Surgical promote of the #850 squash (develop `5017e931`) onto `main`. Fixes the live guard mis-seed (armed at phantom peak $100.00 → false 15.6% DD WARNING; false close-only trip line at $80.00). After deploy the guard re-arms at the true session peak (~$84.42, ~0% DD, halt floor ~$67.53 per policy).

**Cherry-pick divergence (intentional, per-file verified):** `drawdown_guard.py`, guard tests, and `docs/live_trading.md` are patch-id IDENTICAL to the reviewed develop squash. Two files adapted: `trading_engine.py` takes the `PerformanceTracker(self.initial_balance)` seed fix WITHOUT the adjacent #843 Kelly listener line (unpromoted, develop-only); `docs/changelog.md` carries only the promoted entry (not the #838/#843 entries). Full unit suite re-run green ON THIS BRANCH (47.6s); 34/34 guard tests green.

Reviews on #850: code-reviewer APPROVE with full consumer trace of the tracker one-liner (dynamic-risk/account_history/paper-mode all verified; the looser post-restart dynamic-risk baseline is the intended phantom-removal). Board weekend waiver in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)