### PR TITLE
fix(live): gate startup reconciler closes on close_position return value

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -172,6 +172,17 @@ class ReconciliationResult:
 # ---------- Startup Reconciliation ----------
 
 
+def _is_external_close_pending(position: Any) -> bool:
+    """True when a reconciler has confirmed this position is flat on the exchange (its asset
+    sold / stop-loss filled / borrow repaid) but the row's DB close is still pending after a
+    failed ``close_position``. Such a position is deliberately RETAINED in the tracker for close
+    retry, yet it no longer backs any exchange holding — so spot balance reconciliation must
+    exclude its notional (counting it would add the already-realized value back and overstate
+    capital, oversizing later positions). Set where a reconciler retains a position on close
+    failure; cleared once holdings are re-confirmed."""
+    return bool(getattr(position, "external_close_pending", False))
+
+
 class PositionReconciler:
     """Verifies recovered positions and resolves pending orders on startup.
 
@@ -1790,7 +1801,10 @@ class PositionReconciler:
         if not db_closed:
             # Leave the position in the in-memory tracker (consistent with its still-OPEN DB
             # row) so it is re-reconciled on a later pass — removing it while the DB row stays
-            # OPEN would diverge memory from the DB (CODE.md: no silent divergence).
+            # OPEN would diverge memory from the DB (CODE.md: no silent divergence). The SL has
+            # filled, so the asset is gone from the exchange: flag it so spot balance
+            # reconciliation excludes its notional instead of adding the realized value back.
+            position.external_close_pending = True
             logger.warning(
                 "Skipping close for %s — DB position %s was not closed; left in tracker for "
                 "re-reconciliation on a later pass.",
@@ -1979,6 +1993,11 @@ class PositionReconciler:
                         logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
 
                 if not db_closed:
+                    # Asset is gone from the exchange but the DB row is still OPEN: flag the
+                    # retained position so spot balance reconciliation excludes its notional
+                    # (counting it would add the already-realized value back and overstate
+                    # capital). Cleared below once holdings are re-confirmed.
+                    position.external_close_pending = True
                     logger.warning(
                         "External close for %s left tracked — DB position %s was not closed; "
                         "re-reconciled on a later pass.",
@@ -1995,6 +2014,15 @@ class PositionReconciler:
                 # External closes have no fill price; we cannot compute P&L
                 logger.info(
                     "External close for %s — P&L not realized (no exit price)",
+                    symbol,
+                )
+            elif _is_external_close_pending(position):
+                # Asset is held again (>= 50% of tracked) — clear a stale external-close-pending
+                # flag from a prior transient under-read so the position is counted/protected
+                # normally once more.
+                position.external_close_pending = False
+                logger.info(
+                    "Asset holdings for %s recovered — cleared external-close-pending flag",
                     symbol,
                 )
         except Exception as e:
@@ -2157,6 +2185,11 @@ class PositionReconciler:
         total = 0.0
         positions = self.position_tracker.positions
         for position in positions.values():
+            # Skip positions confirmed flat on the exchange but retained pending a failed DB
+            # close — their asset is already sold, so counting notional would add the realized
+            # value back and overstate capital (oversizing later positions).
+            if _is_external_close_pending(position):
+                continue
             # Use quantity (actual asset amount), not size (balance fraction).
             # Coerce to float — DB-loaded positions carry Decimal (Numeric)
             # fields, and mixing Decimal with the float `total`/price below
@@ -3416,6 +3449,11 @@ class PeriodicReconciler:
                         # Subtract position notional to get expected USDT
                         position_notional = 0.0
                         for position in positions_snapshot.values():
+                            # Skip positions confirmed flat on the exchange but retained pending
+                            # a failed DB close — their asset is already sold, so counting
+                            # notional would overstate capital.
+                            if _is_external_close_pending(position):
+                                continue
                             # Use quantity (actual asset amount), not size (balance fraction)
                             qty = getattr(position, "quantity", None) or 0.0
                             price = getattr(position, "entry_price", 0)

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1777,8 +1777,10 @@ class PositionReconciler:
         db_closed = False
         if db_pos_id:
             try:
-                self.db_manager.close_position(db_pos_id, exit_price=exit_price)
-                db_closed = True
+                # Gate on the RETURN value, not merely the absence of an exception:
+                # DatabaseManager.close_position swallows DB errors and returns False (it
+                # raises only on invalid input), so a False here means the row is still OPEN.
+                db_closed = bool(self.db_manager.close_position(db_pos_id, exit_price=exit_price))
             except Exception as e:
                 logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
 
@@ -1961,15 +1963,32 @@ class PositionReconciler:
                     held_qty,
                     position_qty,
                 )
-                # Remove from in-memory tracker
-                self.position_tracker.remove_position(position.order_id)
-                # Close the DB position
+                # Close the DB row FIRST; only drop the position from the in-memory tracker
+                # when the close actually succeeded. DatabaseManager.close_position swallows
+                # DB errors and returns False (it raises only on invalid input), so gating on
+                # the RETURN value — not merely the absence of an exception — keeps the tracker
+                # from diverging from a still-OPEN row. On failure the position is left tracked
+                # and re-reconciled on a later pass (CODE.md: no silent memory/DB divergence).
                 db_pos_id = getattr(position, "db_position_id", None)
+                db_closed = True
                 if db_pos_id:
+                    db_closed = False
                     try:
-                        self.db_manager.close_position(db_pos_id)
+                        db_closed = bool(self.db_manager.close_position(db_pos_id))
                     except Exception as e:
                         logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
+
+                if not db_closed:
+                    logger.warning(
+                        "External close for %s left tracked — DB position %s was not closed; "
+                        "re-reconciled on a later pass.",
+                        symbol,
+                        db_pos_id,
+                    )
+                    return
+
+                # DB row confirmed closed — now safe to drop from the in-memory tracker.
+                self.position_tracker.remove_position(position.order_id)
 
                 # Realize P&L — no exit price available for external closes,
                 # so skip balance update (P&L is unknown)
@@ -2074,7 +2093,15 @@ class PositionReconciler:
             logger.warning("Margin position check failed for %s: %s — position retained", symbol, e)
 
     def _remove_phantom_position(self, position: Any, result: ReconciliationResult) -> None:
-        """Remove a phantom position from tracker and DB, cancel its exchange SL."""
+        """Remove a phantom position from tracker and DB, cancel its exchange SL.
+
+        The DB row is closed FIRST; the position is dropped from the in-memory tracker (and the
+        result marked corrected) ONLY when the close actually succeeded. DatabaseManager.
+        close_position swallows DB errors and returns False (it raises only on invalid input),
+        so gating on the RETURN value — not merely the absence of an exception — keeps the
+        tracker from diverging from a still-OPEN row. On failure the phantom is left tracked and
+        re-reconciled on a later pass (CODE.md: no silent memory/DB divergence).
+        """
         # Cancel the server-side stop-loss before removing from tracker.
         # Leaving an orphaned SL on the exchange is a fund-loss path —
         # if it triggers with AUTO_REPAY, it opens a new naked position.
@@ -2095,13 +2122,26 @@ class PositionReconciler:
                     e,
                 )
 
-        self.position_tracker.remove_position(position.order_id)
         db_pos_id = getattr(position, "db_position_id", None)
+        db_closed = True
         if db_pos_id:
+            db_closed = False
             try:
-                self.db_manager.close_position(db_pos_id)
+                db_closed = bool(self.db_manager.close_position(db_pos_id))
             except Exception as e:
                 logger.warning("Failed to close DB position %s: %s", db_pos_id, e)
+
+        if not db_closed:
+            logger.warning(
+                "Phantom position %s left tracked — DB position %s was not closed; "
+                "re-reconciled on a later pass.",
+                getattr(position, "symbol", "?"),
+                db_pos_id,
+            )
+            return
+
+        # DB row confirmed closed (or there was none) — now safe to drop from the tracker.
+        self.position_tracker.remove_position(position.order_id)
         result.status = "corrected"
         result.severity = Severity.HIGH
 

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -1010,6 +1010,61 @@ class TestAssetHoldingsVerification:
         mock_position_tracker.remove_position.assert_called_once_with(pos.order_id)
         mock_db.close_position.assert_called_once_with(10)
 
+    def test_external_close_keeps_tracker_when_db_close_returns_false(
+        self, reconciler, mock_exchange, mock_db, mock_position_tracker
+    ):
+        """Spot external close where close_position RETURNS False (a swallowed DB error —
+        DatabaseManager.close_position returns False rather than raising on a commit failure)
+        must NOT remove the position from the tracker. The still-OPEN DB row would otherwise
+        diverge from memory; the position is left tracked and re-reconciled on a later pass."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(current_size=0.1, db_position_id=20)
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+        mock_exchange.get_order.return_value = entry_order
+        # Asset balance near zero — position looks externally closed.
+        mock_exchange.get_balance.return_value = MockBalance(
+            asset="BTC", total=0.0001, free=0.0001, locked=0.0
+        )
+        # Swallowed DB failure: close returns False instead of raising.
+        mock_db.close_position.return_value = False
+
+        reconciler.reconcile_position(pos)
+
+        mock_db.close_position.assert_called_once_with(20)
+        mock_position_tracker.remove_position.assert_not_called()
+
+    def test_remove_phantom_position_keeps_tracker_when_db_close_returns_false(
+        self, reconciler, mock_db, mock_position_tracker
+    ):
+        """_remove_phantom_position must NOT drop the position from the tracker when
+        close_position RETURNS False (a swallowed DB error). The still-OPEN DB row would
+        diverge from memory; the phantom is left tracked and re-reconciled on a later pass."""
+        pos = MockPosition(db_position_id=33, stop_loss_order_id=None)
+        mock_db.close_position.return_value = False
+        result = ReconciliationResult(entity_type="position", entity_id="test", status="resolved")
+
+        reconciler._remove_phantom_position(pos, result)
+
+        mock_db.close_position.assert_called_once_with(33)
+        mock_position_tracker.remove_position.assert_not_called()
+
+    def test_remove_phantom_position_removes_from_tracker_on_db_close_success(
+        self, reconciler, mock_db, mock_position_tracker
+    ):
+        """Success path: when close_position succeeds the phantom is removed from the tracker
+        and the result is marked corrected / HIGH (behavior preserved across the reorder)."""
+        pos = MockPosition(db_position_id=34, stop_loss_order_id=None)
+        mock_db.close_position.return_value = True
+        result = ReconciliationResult(entity_type="position", entity_id="test", status="resolved")
+
+        reconciler._remove_phantom_position(pos, result)
+
+        mock_db.close_position.assert_called_once_with(34)
+        mock_position_tracker.remove_position.assert_called_once_with(pos.order_id)
+        assert result.status == "corrected"
+        assert result.severity == Severity.HIGH
+
     def test_position_with_sufficient_balance_not_flagged(
         self, reconciler, mock_exchange, mock_db, mock_position_tracker
     ):

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -48,6 +48,7 @@ class MockPosition:
     last_partial_exit_price: float | None = None
     original_size: float | None = 0.1
     entry_balance: float | None = None
+    external_close_pending: bool = False
 
 
 @dataclass
@@ -1065,6 +1066,49 @@ class TestAssetHoldingsVerification:
         assert result.status == "corrected"
         assert result.severity == Severity.HIGH
 
+    def test_external_close_sets_pending_flag_when_db_close_fails(
+        self, reconciler, mock_exchange, mock_db, mock_position_tracker
+    ):
+        """When a spot external close is detected but close_position RETURNS False, the retained
+        position is flagged external_close_pending so balance reconciliation excludes its
+        (already-sold) notional rather than adding it back and overstating capital."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(current_size=0.1, db_position_id=25)
+        mock_exchange.get_order.return_value = MockExchangeOrder(
+            status=ExOS.FILLED, average_price=50000.0
+        )
+        mock_exchange.get_balance.return_value = MockBalance(
+            asset="BTC", total=0.0001, free=0.0001, locked=0.0
+        )
+        mock_db.close_position.return_value = False
+
+        reconciler.reconcile_position(pos)
+
+        assert getattr(pos, "external_close_pending", False) is True
+        mock_position_tracker.remove_position.assert_not_called()
+
+    def test_external_close_pending_flag_cleared_when_holdings_recover(
+        self, reconciler, mock_exchange, mock_db, mock_position_tracker
+    ):
+        """A stale external_close_pending flag (e.g. from a transient under-read) is cleared once
+        the asset is confirmed held again, so the position is counted/protected normally."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(current_size=0.1, db_position_id=26)
+        pos.external_close_pending = True
+        mock_exchange.get_order.return_value = MockExchangeOrder(
+            status=ExOS.FILLED, average_price=50000.0
+        )
+        # Asset comfortably held (> 50% of tracked) — not an external close.
+        mock_exchange.get_balance.return_value = MockBalance(
+            asset="BTC", total=0.08, free=0.08, locked=0.0
+        )
+
+        reconciler.reconcile_position(pos)
+
+        assert getattr(pos, "external_close_pending", False) is False
+
     def test_position_with_sufficient_balance_not_flagged(
         self, reconciler, mock_exchange, mock_db, mock_position_tracker
     ):
@@ -1265,6 +1309,46 @@ class TestBalanceAccountsForPositionNotional:
         result = reconciler._reconcile_balance()
         assert result.severity != Severity.CRITICAL
         assert result.status == "verified"
+
+    def test_external_close_pending_position_excluded_from_notional(
+        self, reconciler, mock_exchange, mock_db, mock_position_tracker
+    ):
+        """A position confirmed flat on the exchange but retained pending a FAILED DB close
+        must be excluded from the notional estimate. Its asset is already sold, so counting
+        its notional would add that value back into the corrected balance — overstating
+        capital and oversizing later positions.
+
+        Scenario: $10,000 DB capital, 0.1 BTC @ $50,000 ($5,000 notional) sold externally
+        ~break-even so the exchange now holds $10,000 USDT. With the position flagged
+        external-close-pending, expected USDT = $10,000 and there is NO discrepancy.
+        """
+        pos = MockPosition(entry_price=50000.0, current_size=0.1, original_size=0.1, quantity=0.1)
+        pos.external_close_pending = True
+        mock_position_tracker.positions = {"pos_1": pos}
+        mock_exchange.get_balance.return_value = MockBalance(total=10000.0)
+        mock_db.get_current_balance.return_value = 10000.0
+
+        result = reconciler._reconcile_balance()
+
+        # Notional excluded -> expected_usdt == exchange_total -> no spurious CRITICAL/correction.
+        assert result.severity != Severity.CRITICAL
+        mock_db.update_balance.assert_not_called()
+
+    def test_estimate_notional_excludes_only_external_close_pending(
+        self, reconciler, mock_position_tracker
+    ):
+        """_estimate_position_notional counts genuinely-held positions and skips flagged ones."""
+        held = MockPosition(
+            entry_price=50000.0, current_size=0.1, original_size=0.1, quantity=0.1, symbol="BTCUSDT"
+        )
+        flat = MockPosition(
+            entry_price=3000.0, current_size=1.0, original_size=1.0, quantity=1.0, symbol="ETHUSDT"
+        )
+        flat.external_close_pending = True
+        mock_position_tracker.positions = {"held": held, "flat": flat}
+
+        # Only the held position (0.1 * 50000 = 5000) contributes; the flat one is excluded.
+        assert reconciler._estimate_position_notional() == pytest.approx(5000.0)
 
     def test_genuine_discrepancy_still_triggers_critical(
         self, reconciler, mock_exchange, mock_db, mock_position_tracker

--- a/tests/unit/test_trade_commission_quantity_persistence.py
+++ b/tests/unit/test_trade_commission_quantity_persistence.py
@@ -401,6 +401,10 @@ def test_reconciler_filled_sl_converts_short_commission_to_usd_and_dedups(monkey
     db = MockDatabaseManager()
     reconciler = _make_reconciler(db, fee_rate=0.001)
     monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    # Success path: the DB close confirms (returns True) so the trade is logged. (The mock
+    # would otherwise return False for an unregistered position id, which now correctly
+    # suppresses the trade — exercised by test_..._skips_trade_when_db_close_returns_false.)
+    monkeypatch.setattr(db, "close_position", Mock(return_value=True))
     position = _make_position(
         quantity=2.5, entry_fee=None, side=PositionSide.SHORT, entry_price=100.0
     )
@@ -442,6 +446,33 @@ def test_reconciler_filled_sl_skips_trade_when_db_close_fails(monkeypatch):
     reconciler._close_position_from_filled_sl(position, sl_order)
 
     assert len(db._trades) == 0  # DB close failed -> trade not logged (no duplicate risk)
+
+
+def test_reconciler_filled_sl_skips_trade_when_db_close_returns_false(monkeypatch):
+    """If the DB close RETURNS False (a swallowed DB error — DatabaseManager.close_position
+    returns False rather than raising on a commit failure), NO trade is logged and the
+    position is NOT removed from the tracker. The row stays OPEN and is re-reconciled later;
+    logging/removing now would diverge the tracker from the DB and duplicate the trade when
+    the row is re-recovered."""
+    from types import SimpleNamespace as NS
+
+    db = MockDatabaseManager()
+    reconciler = _make_reconciler(db, fee_rate=0.001)
+    monkeypatch.setattr(reconciler, "_persist_audit", lambda *a, **k: None)
+    # close_position RETURNS False (swallowed DB failure); it does NOT raise.
+    monkeypatch.setattr(db, "close_position", Mock(return_value=False))
+    position = _make_position(
+        quantity=2.5, entry_fee=None, side=PositionSide.SHORT, entry_price=100.0
+    )
+    position.db_position_id = 88
+    position.order_id = "pos-88"
+    sl_order = NS(average_price=90.0, order_id="sl-88", commission=2.0, commission_asset="USDT")
+
+    reconciler._close_position_from_filled_sl(position, sl_order)
+
+    assert len(db._trades) == 0  # False return -> trade not logged (no duplicate risk)
+    # Row still OPEN -> position kept in the tracker for re-reconciliation, not removed.
+    reconciler.position_tracker.remove_position.assert_not_called()
 
 
 def test_reconciler_dedups_duplicate_trade_on_rerun():


### PR DESCRIPTION
## What & why

The startup `PositionReconciler` close paths treated a position as closed whenever `db_manager.close_position(...)` **did not raise**. But `DatabaseManager.close_position` ([manager.py:1227](../blob/develop/src/database/manager.py#L1227)) **swallows DB commit errors and returns `False`** (it raises only on invalid input). So on a swallowed DB failure these paths acted on a position whose row was still `OPEN`:

- **`_close_position_from_filled_sl`** set `db_closed = True` on no-exception, then removed the position from the tracker, **realized P&L, and logged a `trades` row** for a still-`OPEN` position → `account_balances`/`trades` divergence, and a duplicate trade when the row is re-recovered on the next pass.
- **`_verify_asset_holdings`** (spot external close) and **`_remove_phantom_position`** (margin phantom) removed the position from the in-memory tracker while **ignoring the close return value** → tracker diverges from a still-`OPEN` DB row.

This is real-capital state-consistency logic, so a swallowed failure quietly overstates balance and can double-book P&L.

## The fix

Gate on the **return value** — `db_closed = bool(self.db_manager.close_position(...))` inside `try/except` — and only remove-from-tracker / realize / log when the close actually succeeded, mirroring the early-return pattern already present in `_close_position_from_filled_sl`. On failure the position is **left tracked and re-reconciled on a later pass** (CODE.md: no silent memory/DB divergence). The success path is unchanged.

**Bonus correctness:** the periodic SL wrapper `PeriodicReconciler._close_position_from_filled_sl` infers DB-close failure from "position still tracked." Under the old bug a swallowed `False` removed the position anyway, so the wrapper wrongly returned `True` and logged a `CLOSED_BY_SL` audit for a still-`OPEN` row. Fixing the shared inner method fixes this too.

## Testing performed

TDD — each new test was watched to fail against the pre-fix code, then pass:

- `test_reconciler_filled_sl_skips_trade_when_db_close_returns_false` — no trade logged and position kept in the tracker when `close_position` returns `False` (mirrors the existing `_fails` test, but returning `False` instead of raising).
- `test_external_close_keeps_tracker_when_db_close_returns_false` and `test_remove_phantom_position_keeps_tracker_when_db_close_returns_false` — tracker untouched on a `False` return; plus `test_remove_phantom_position_removes_from_tracker_on_db_close_success` as a guard for the close-before-remove reorder.
- Updated `test_reconciler_filled_sl_converts_short_commission_to_usd_and_dedups` to stub the DB close to succeed — it drove the real `MockDatabaseManager` (whose `close_position` returns `False` for an unregistered id) and was silently relying on the old no-exception behavior.

Results:
- `pytest tests/unit/test_trade_commission_quantity_persistence.py tests/unit/live/test_reconciliation.py` → **153 passed**
- Adjacent: `test_order_execution.py` + `test_margin_side_effect.py` → **62 passed**
- `bin/run_mypy.py` on the changed source → clean; `black` + `ruff` → clean

## Reviewer notes

- Behavior is identical on the success path; the only observable change is on a swallowed DB failure (tracker/trade/P&L no longer act on a still-`OPEN` row) and a minor call-order change (DB close now precedes tracker removal, which the periodic SL test already expected).
- **Out of scope (flagged separately):** `_reconcile_filled_exit` has the same swallowed-`False` shape (removes + realizes P&L without checking the return). Left untouched here since it's a periodic path the task treated as already handled — worth a follow-up to verify and fix the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
