### PR TITLE
test(live): assert periodic reconciler persists SL-fill trade row

### DIFF
--- a/tests/integration/live/test_reconciliation_integration.py
+++ b/tests/integration/live/test_reconciliation_integration.py
@@ -726,6 +726,56 @@ class TestReconciliationIntegration:
         audits = self._query_audit_events(db_manager, session_id)
         assert any("stop-loss" in (a["reason"] or "").lower() for a in audits)
 
+    def test_periodic_sl_filled_persists_trade_row(
+        self,
+        periodic_reconciler,
+        mock_exchange,
+        db_manager,
+        session_id,
+        position_tracker,
+    ):
+        """FILLED SL detected in the periodic cycle persists a deduped ``trades``
+        row keyed by the real SL exit order id — not just a CLOSED_BY_SL audit.
+        Without it an offline SL loss the reconciler books leaves no trade record
+        (commission/quantity/pnl unrecorded)."""
+        from src.database.models import Trade
+
+        _db_id, _position = self._seed_position(
+            db_manager,
+            session_id,
+            position_tracker,
+            stop_loss_order_id="sl_active_777",
+        )
+        # Entry order FILLED, SL FILLED @ 48000 (a loss on the seeded long).
+        mock_exchange.get_order.side_effect = lambda oid, sym: MockExchangeOrder(
+            order_id=oid,
+            status=ExOrderStatus.FILLED,
+            average_price=48000.0,
+        )
+        mock_exchange.get_balance.side_effect = lambda asset: (
+            MockBalance(asset="USDT", total=10000.0)
+            if asset == "USDT"
+            else MockBalance(asset="BTC", total=0.0)
+        )
+
+        periodic_reconciler._reconcile_cycle()
+
+        assert len(position_tracker.positions) == 0
+        with db_manager.get_session() as s:
+            rows = (
+                s.query(Trade)
+                .filter(Trade.session_id == session_id, Trade.order_id == "sl_active_777")
+                .all()
+            )
+            assert len(rows) == 1
+            t = rows[0]
+            assert t.exit_reason == "stop_loss_filled_offline"
+            assert float(t.exit_price) == pytest.approx(48000.0)
+            assert t.commission is not None and float(t.commission) > 0.0
+            assert t.quantity is not None and float(t.quantity) == pytest.approx(0.001)
+            # GROSS long pnl: (48000 - 50000) * 0.001 = -2.0 (fees carried in commission).
+            assert float(t.pnl) == pytest.approx(-2.0)
+
     def test_periodic_orphaned_order_cancelled(
         self,
         periodic_reconciler,

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3235,6 +3235,44 @@ class TestPeriodicSLFillBooksPnl:
         assert len(pnl_calls) == 1
         assert pnl_calls[0].args[0] == pytest.approx(1000.0 + 200.0 - 0.05)
 
+    def test_sl_fill_persists_deduped_trade_row(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Driving the periodic cycle over a filled SL must persist a ``trades``
+        row (not just correct the balance) — keyed by the REAL SL exit order id,
+        GROSS pnl, positive USD commission, and the closed quantity. Guards the
+        periodic path against a refactor silently dropping the trade row, which
+        would leave the SL loss's commission/quantity/pnl unrecorded even though
+        the balance was corrected."""
+        pos = MockPosition(
+            order_id="entry_short",
+            side="short",
+            stop_loss_order_id="sl_short",
+            exchange_order_id="entry_short",
+            db_position_id=71,
+        )
+        mock_position_tracker.positions = {"entry_short": pos}
+        mock_position_tracker.get_position.side_effect = [pos, None, None]
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)
+        reconciler = self._make_filled_sl_cycle(mock_exchange, mock_position_tracker, mock_db, pos)
+        reconciler._use_margin = True
+        reconciler._position_reconciler._use_margin = False  # skip interest lookup
+        mock_db.close_position.return_value = True
+
+        reconciler._reconcile_cycle()
+
+        mock_db.log_trade.assert_called_once()
+        kwargs = mock_db.log_trade.call_args.kwargs
+        # Deduped by the real SL exit order id present on the fill (not the
+        # synthetic reconcile_sl_<id> fallback, which is only used when absent).
+        assert kwargs["exit_order_id"] == "sl_short"
+        assert kwargs["exit_reason"] == "stop_loss_filled_offline"
+        # GROSS short pnl: (50000 - 48000) * 0.1 = +200 (fees live in commission).
+        assert kwargs["pnl"] == pytest.approx(200.0)
+        assert kwargs["quantity"] == pytest.approx(0.1)
+        assert kwargs["commission"] is not None and kwargs["commission"] > 0.0
+        assert str(kwargs["side"]).lower() == "short"
+
     def test_margin_short_unconfirmed_sl_defers_classification(
         self, mock_exchange, mock_position_tracker, mock_db
     ):


### PR DESCRIPTION
## Summary

The periodic reconciler's SL-filled branch already realizes P&L and writes a deduped `trades` row via the shared `_close_position_from_filled_sl` (delivered by #753 → #796 → #797). But **no test asserted that the *periodic cycle* produces that row end-to-end** — existing coverage (`TestPeriodicSLFillBooksPnl`, integration `test_periodic_sl_filled_closes_position`) stopped at the balance update and the `CLOSED_BY_SL` audit event.

That's a latent capital-protection gap: a refactor like #796 could silently drop the trade row, leaving an offline SL loss's commission/quantity/pnl unrecorded → `account_balances`/`trades` divergence → overstated capital → oversized positions (the exact failure #753 fixed). This PR locks the behavior down with regression tests. **No production code changes.**

## Changes

- **unit** `TestPeriodicSLFillBooksPnl::test_sl_fill_persists_deduped_trade_row` — drives `_reconcile_cycle()` over a filled SL and asserts the `log_trade` call (real SL `exit_order_id`, GROSS pnl, positive USD commission, closed quantity, side).
- **integration** `test_periodic_sl_filled_persists_trade_row` — drives the real periodic cycle against Postgres and asserts the persisted `Trade` row by `order_id` (exit reason / price / commission / quantity / GROSS pnl).

## Testing

- `pytest tests/unit/live/test_reconciliation.py -q` → **119 passed** (118 → 119).
- Both integration tests green against a real Postgres testcontainer.
- **Teeth verified**: temporarily setting `log_trade=False` in the shared handler makes both new tests fail (`log_trade` called 0 times / `Trade` rows == 0); reverted → green.
- `black --check` + `ruff` clean on both files.

## Notes

- Not tied to a specific tracked issue — the periodic-SL trade-row behavior was already merged (#753/#796/#797); this only fills the missing regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
