### PR TITLE
feat(live): reconciler alert/event sink + page on naked-position emergency-sell (#853)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -61,6 +61,7 @@ def _emit_event(
     severity: str = "warning",
     component: str = "reconciler",
     error_code: str | None = None,
+    exc: BaseException | None = None,
     alert: bool = False,
 ) -> None:
     """Emit a ``system_events`` row (and optionally page an operator) via the
@@ -72,6 +73,9 @@ def _emit_event(
     construction the same way ``on_critical`` already is. When unset
     (standalone use / tests) this is a no-op. Never raises — observability must
     never break a reconciliation cycle.
+
+    ``exc`` (when passed from inside an ``except`` block) is forwarded so the
+    engine captures the traceback into the ``system_events`` stack-trace column.
     """
     if on_event is None:
         return
@@ -82,10 +86,11 @@ def _emit_event(
             severity=severity,
             component=component,
             error_code=error_code,
+            exc=exc,
             alert=alert,
         )
-    except Exception as exc:  # pragma: no cover - defensive; must never break reconcile
-        logger.warning("reconciler observability emit failed: %s", exc)
+    except Exception as emit_err:  # pragma: no cover - defensive; must never break reconcile
+        logger.warning("reconciler observability emit failed: %s", emit_err)
 
 
 class _OrderLookup(Protocol):
@@ -789,6 +794,13 @@ class PositionReconciler:
                                 symbol,
                                 fill_qty,
                             )
+                            # NOTE: alert=True POSTs to the webhook (10s-bounded)
+                            # while _positions_lock is held. Tolerated here: this
+                            # path runs only during startup / WS-resync recovery
+                            # (the live trading loop is not contending), and the
+                            # lock already spans the blocking emergency-sell
+                            # above. Steady-state reconciler emits (follow-up PRs)
+                            # MUST page outside the lock.
                             _emit_event(
                                 self.on_event,
                                 EventType.ALERT,
@@ -807,6 +819,9 @@ class PositionReconciler:
                             fill_qty,
                             sell_err,
                         )
+                        # Webhook POST under _positions_lock — tolerated on this
+                        # startup/WS-resync recovery path (see UNCONFIRMED branch).
+                        # exc=sell_err forwards the traceback into system_events.
                         _emit_event(
                             self.on_event,
                             EventType.ALERT,
@@ -814,6 +829,7 @@ class PositionReconciler:
                             f"exchange, manual intervention required",
                             severity="critical",
                             error_code="EMERGENCY_SELL_FAILED",
+                            exc=sell_err,
                             alert=True,
                         )
 
@@ -2864,6 +2880,9 @@ class PeriodicReconciler:
             session_id: Current trading session ID.
             interval: Seconds between reconciliation cycles.
             on_critical: Callback invoked on CRITICAL severity (e.g., enter close-only mode).
+            on_event: Callback (the engine's ``_record_event``) that writes a system_events
+                row and optionally pages an operator; propagated to the child reconciler.
+                None disables it (standalone use / tests).
             use_margin: Whether margin trading mode is active. When True,
                 skip spot-specific checks (asset holdings) that don't apply
                 to cross-margin accounts.

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -38,6 +38,7 @@ from src.config.constants import (
 )
 from src.config.feature_flags import get_flag
 from src.data_providers.exchange_interface import OrderLookupError, SideEffectType
+from src.database.models import EventType
 from src.engines.live.margin_interest_tracker import MarginInterestTracker
 from src.engines.shared.commission import order_commission_usd, split_base_quote
 from src.engines.shared.cost_calculator import CostCalculator
@@ -50,6 +51,41 @@ if TYPE_CHECKING:
     from src.engines.live.margin_interest_tracker import _ExchangeWithInterestHistory
 
 logger = logging.getLogger(__name__)
+
+
+def _emit_event(
+    on_event: Any,
+    event_type: EventType,
+    message: str,
+    *,
+    severity: str = "warning",
+    component: str = "reconciler",
+    error_code: str | None = None,
+    alert: bool = False,
+) -> None:
+    """Emit a ``system_events`` row (and optionally page an operator) via the
+    engine sink, when one is wired.
+
+    The reconciler holds ``db_manager`` (so it can already write
+    ``reconciliation_audit_events`` rows) but NOT the engine's webhook alerting.
+    ``on_event`` is the engine's fault-isolated ``_record_event``, passed in at
+    construction the same way ``on_critical`` already is. When unset
+    (standalone use / tests) this is a no-op. Never raises — observability must
+    never break a reconciliation cycle.
+    """
+    if on_event is None:
+        return
+    try:
+        on_event(
+            event_type,
+            message,
+            severity=severity,
+            component=component,
+            error_code=error_code,
+            alert=alert,
+        )
+    except Exception as exc:  # pragma: no cover - defensive; must never break reconcile
+        logger.warning("reconciler observability emit failed: %s", exc)
 
 
 class _OrderLookup(Protocol):
@@ -189,11 +225,13 @@ class PositionReconciler:
         use_margin: bool = False,
         fee_rate: float = DEFAULT_FEE_RATE,
         data_provider: Any | None = None,
+        on_event: Any = None,
     ) -> None:
         self.exchange = exchange_interface
         self.position_tracker = position_tracker
         self.db_manager = db_manager
         self.session_id = session_id
+        self.on_event = on_event
         self.max_position_size = max_position_size
         self._use_margin = use_margin
         # Optional market-data source (has get_current_price). Used only to mark-to-market the
@@ -751,6 +789,15 @@ class PositionReconciler:
                                 symbol,
                                 fill_qty,
                             )
+                            _emit_event(
+                                self.on_event,
+                                EventType.ALERT,
+                                f"Emergency sell unconfirmed for {symbol} — position may be "
+                                f"UNPROTECTED, manual verification required",
+                                severity="critical",
+                                error_code="EMERGENCY_SELL_UNCONFIRMED",
+                                alert=True,
+                            )
                     except Exception as sell_err:
                         logger.critical(
                             "CRITICAL: Emergency sell FAILED for %s "
@@ -759,6 +806,15 @@ class PositionReconciler:
                             symbol,
                             fill_qty,
                             sell_err,
+                        )
+                        _emit_event(
+                            self.on_event,
+                            EventType.ALERT,
+                            f"Emergency sell FAILED for {symbol} — position UNPROTECTED on "
+                            f"exchange, manual intervention required",
+                            severity="critical",
+                            error_code="EMERGENCY_SELL_FAILED",
+                            alert=True,
                         )
 
                     if sell_result is not None:
@@ -2792,6 +2848,7 @@ class PeriodicReconciler:
         session_id: int,
         interval: float = DEFAULT_RECONCILIATION_INTERVAL_SECONDS,
         on_critical: Any = None,
+        on_event: Any = None,
         use_margin: bool = False,
         symbols: list[str] | None = None,
         sweep_cooldown: dict[str, float] | None = None,
@@ -2820,6 +2877,7 @@ class PeriodicReconciler:
         self._use_margin = use_margin
         self.interval = interval
         self.on_critical = on_critical
+        self.on_event = on_event
         self._symbols = symbols or []
 
         self._running = False
@@ -2848,6 +2906,7 @@ class PeriodicReconciler:
             session_id=session_id,
             use_margin=use_margin,
             data_provider=data_provider,
+            on_event=on_event,
         )
 
     def start(self) -> None:

--- a/src/engines/live/recovery.py
+++ b/src/engines/live/recovery.py
@@ -473,6 +473,7 @@ class LiveSessionRecoverer:
                     use_margin=use_margin,
                     fee_rate=state.live_execution_engine.fee_rate,
                     data_provider=state.data_provider,
+                    on_event=state._record_event,
                 )
 
                 if not positions_snapshot:

--- a/src/engines/live/startup.py
+++ b/src/engines/live/startup.py
@@ -430,6 +430,7 @@ class LiveStartupSequencer:
                     db_manager=state.db_manager,
                     session_id=state.trading_session_id,
                     on_critical=state._enter_close_only_mode,
+                    on_event=state._record_event,
                     use_margin=use_margin,
                     symbols=[state._active_symbol] if state._active_symbol else [],
                     sweep_cooldown=state._orphan_sweep_cooldown,

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, call, create_autospec, patch
 import pytest
 
 from src.data_providers.exchange_interface import OrderLookupError
+from src.database.models import EventType
 from src.engines.live.reconciliation import (
     AuditEvent,
     PeriodicReconciler,
@@ -2770,6 +2771,88 @@ class TestEmergencySellVerification:
         # Result should be unresolved with CRITICAL severity
         assert any(r.status == "unresolved" and r.severity == Severity.CRITICAL for r in results)
 
+    def _drive_failed_emergency_sell(self, mock_exchange, mock_db, mock_position_tracker, on_event):
+        """Shared setup: recover a filled entry, SL placement returns None so the
+        engine emergency-closes, then the emergency sell fails/returns None."""
+        import threading
+
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        reconciler = PositionReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            on_event=on_event,
+        )
+        mock_position_tracker._positions_lock = threading.Lock()
+        mock_position_tracker._positions = {}
+        mock_db.log_position.return_value = 57
+        mock_db.get_unresolved_orders.return_value = [
+            {
+                "id": 22,
+                "client_order_id": "atb_BTCUSDT_long_5555_eeee",
+                "symbol": "BTCUSDT",
+                "side": "LONG",
+                "quantity": 0.001,
+                "status": "SUBMITTED",
+                "order_type": "ENTRY",
+                "created_at": datetime.now(UTC),
+            }
+        ]
+        exchange_order = MockExchangeOrder(
+            status=ExOS.FILLED, average_price=50000.0, filled_quantity=0.001
+        )
+        mock_exchange.get_order_by_client_id.return_value = exchange_order
+        # SL placement returns None -> emergency close path
+        mock_exchange.place_stop_loss_order.return_value = None
+        return reconciler
+
+    def test_emergency_sell_failure_pages_operator(
+        self, mock_exchange, mock_db, mock_position_tracker
+    ):
+        """A FAILED emergency sell leaves a naked position — it must page an
+        operator (critical ALERT via on_event), not just log (#853)."""
+        on_event = MagicMock()
+        reconciler = self._drive_failed_emergency_sell(
+            mock_exchange, mock_db, mock_position_tracker, on_event
+        )
+        mock_exchange.place_order.side_effect = ConnectionError("Network error")
+
+        reconciler.resolve_pending_orders()
+
+        alerts = [
+            c
+            for c in on_event.call_args_list
+            if c.kwargs.get("error_code") == "EMERGENCY_SELL_FAILED"
+        ]
+        assert alerts, f"expected EMERGENCY_SELL_FAILED alert, got {on_event.call_args_list}"
+        assert alerts[0].args[0] == EventType.ALERT
+        assert alerts[0].kwargs["severity"] == "critical"
+        assert alerts[0].kwargs["alert"] is True
+
+    def test_emergency_sell_unconfirmed_pages_operator(
+        self, mock_exchange, mock_db, mock_position_tracker
+    ):
+        """An unconfirmed emergency sell (returns None; position stays tracked)
+        may be unprotected — it must page an operator (critical ALERT) (#853)."""
+        on_event = MagicMock()
+        reconciler = self._drive_failed_emergency_sell(
+            mock_exchange, mock_db, mock_position_tracker, on_event
+        )
+        mock_exchange.place_order.return_value = None  # emergency sell unconfirmed
+
+        reconciler.resolve_pending_orders()
+
+        alerts = [
+            c
+            for c in on_event.call_args_list
+            if c.kwargs.get("error_code") == "EMERGENCY_SELL_UNCONFIRMED"
+        ]
+        assert alerts, f"expected EMERGENCY_SELL_UNCONFIRMED alert, got {on_event.call_args_list}"
+        assert alerts[0].kwargs["severity"] == "critical"
+        assert alerts[0].kwargs["alert"] is True
+
 
 # ---------- Fee Accounting Tests ----------
 
@@ -3661,3 +3744,58 @@ class TestPeriodicExternalCloseTradeRow:
         # _sync_margin_equity owns margin capital, and balance reconcile is margin-skipped.
         assert db.get_current_balance(1) == pytest.approx(10000.0)
         assert pos.order_id not in tracker.positions
+
+
+class TestReconcilerEventSink:
+    """The reconciler gains a system_events/alert sink via an injected on_event
+    callback (the engine's _record_event), mirroring on_critical (#853)."""
+
+    def test_emit_event_forwards_to_on_event(self):
+        from src.engines.live.reconciliation import _emit_event
+
+        cb = MagicMock()
+        _emit_event(
+            cb,
+            EventType.ALERT,
+            "naked position",
+            severity="critical",
+            error_code="EMERGENCY_SELL_FAILED",
+            alert=True,
+        )
+        cb.assert_called_once()
+        args, kwargs = cb.call_args
+        assert args == (EventType.ALERT, "naked position")
+        assert kwargs["severity"] == "critical"
+        assert kwargs["component"] == "reconciler"
+        assert kwargs["error_code"] == "EMERGENCY_SELL_FAILED"
+        assert kwargs["alert"] is True
+
+    def test_emit_event_noop_when_sink_unwired(self):
+        from src.engines.live.reconciliation import _emit_event
+
+        # Standalone use / tests pass on_event=None -> silent no-op, never raises.
+        _emit_event(None, EventType.WARNING, "msg")
+
+    def test_emit_event_never_raises(self):
+        from src.engines.live.reconciliation import _emit_event
+
+        cb = MagicMock(side_effect=RuntimeError("sink down"))
+        # Observability must never break a reconciliation cycle.
+        _emit_event(cb, EventType.ALERT, "msg", alert=True)
+        cb.assert_called_once()
+
+    def test_periodic_reconciler_propagates_sink_to_child(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        cb = MagicMock()
+        pr = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            on_event=cb,
+        )
+        assert pr.on_event is cb
+        # The child PositionReconciler must receive the same sink so its
+        # emergency-close paths can page too.
+        assert pr._position_reconciler.on_event is cb

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -2830,6 +2830,8 @@ class TestEmergencySellVerification:
         assert alerts[0].args[0] == EventType.ALERT
         assert alerts[0].kwargs["severity"] == "critical"
         assert alerts[0].kwargs["alert"] is True
+        # The exchange error is forwarded so the engine captures its traceback.
+        assert isinstance(alerts[0].kwargs.get("exc"), ConnectionError)
 
     def test_emergency_sell_unconfirmed_pages_operator(
         self, mock_exchange, mock_db, mock_position_tracker


### PR DESCRIPTION
## Summary
PR 2 of the observability-hardening series (#853). Gives the reconciler a **system_events + operator-alert sink** — it previously had none — and uses it to page on the most fund-critical reconciler path: a recovery emergency-close that fails or is unconfirmed, leaving a **naked/unprotected position**.

## Why
`reconciliation.py` had zero path to `system_events` or the alert webhook — only `logger.*` and `log_audit_event` (audit rows nobody watches, and which never page). So a naked position after a failed emergency close (the exact SL-fail→capital-erosion class) surfaced only as a log line. Meanwhile the engine already owns the fault-isolated `_record_event` (system_event row + webhook), reached elsewhere via the `on_critical` callback.

## Changes
- **`_emit_event()` module helper** — forwards to an injected `on_event` callback; no-op when unwired (standalone use / tests), never raises (observability must not break a reconcile cycle).
- **`on_event` callback** added to `PositionReconciler` and `PeriodicReconciler` (defaulted, mirroring the existing `on_critical`). `PeriodicReconciler` propagates it to its child `PositionReconciler`, so the child's emergency-close paths can page too.
- **Wired** at both construction sites: `startup.py` (`PeriodicReconciler`) and `recovery.py` (startup `PositionReconciler`), both passing the engine's `_record_event` (already declared on both `LiveStartupEngineState` and `RecoveryEngineState` protocols).
- **First consumers** — in the recovery emergency-sell block (`_reconcile_filled_entry`): the FAILED (exception) and unconfirmed (returns `None`, position stays tracked) branches now emit a critical `EventType.ALERT` with `alert=True` (`EMERGENCY_SELL_FAILED` / `EMERGENCY_SELL_UNCONFIRMED`).

## Deliberately deferred to follow-up PRs (#853)
This lands the sink with one clear consumer. The remaining silent reconciler sites are separate PRs so each stays reviewable: unprotected-SL / SL-re-placement sites; margin external-close/liquidation (audit row + severity bump to match the spot branch); orphan-borrow sweep (over-cap "manual review" + active repay); and a cycle-boundary emission for HIGH-severity drift (which today never reaches `system_events`).

## Testing
- 5 new unit tests: `_emit_event` forwards correctly / no-ops when unwired / never raises; `PeriodicReconciler` propagates the sink to its child; and the emergency-sell FAILED + unconfirmed branches page a critical ALERT (driven through `resolve_pending_orders()`).
- `tests/unit/live/test_reconciliation.py`: 130 passed. Broader `tests/unit/live/` + `tests/unit/engines/live/`: **761 passed** (no regression from the `__init__` signature additions).
- `atb dev quality --changed`: Black, Ruff, MyPy all pass.

## Scope
Merges to `develop`. No prod deploy — promotion stays human-gated. Behavior change is additive (new events/alerts on already-critical paths); the emergency-close/track logic is unchanged.

Part of #853.
