### PR TITLE
[P0] Bear-market model-validation gate (#801)

### DIFF
--- a/cli/commands/live.py
+++ b/cli/commands/live.py
@@ -167,6 +167,65 @@ def _repoint_latest(version_dir: Path) -> None:
         raise FileNotFoundError(f"Model type directory does not exist: {model_type_dir}") from e
 
 
+def _gate_and_promote(
+    version_dir: Path,
+    *,
+    symbol: str,
+    model_type: str,
+    provider: str = "binance",
+    force: bool = False,
+):
+    """Run the bear-market validation gate, flipping ``latest`` only if allowed.
+
+    Delegates the actual symlink flip to :func:`_repoint_latest`. Returns the
+    :class:`GateDecision` so callers can report the reason / audit path.
+    """
+    from src.ml.validation.gate import promote_version_if_valid
+
+    return promote_version_if_valid(
+        version_dir,
+        symbol=symbol,
+        model_type=model_type,
+        repoint_fn=_repoint_latest,
+        provider=provider,
+        force=force,
+    )
+
+
+def _validate_model(ns: argparse.Namespace) -> int:
+    """Score a model version against the fixed bear-market windows (no deploy)."""
+    from src.ml.validation.bear_validation import BearValidationHarness
+
+    model_path: str | None = None
+    if getattr(ns, "model_path", None):
+        try:
+            version_dir = _resolve_version_path(ns.model_path)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"❌ {exc}")
+            return 1
+        symbol = version_dir.parent.parent.name
+        model_type = version_dir.parent.name
+        model_path = str(version_dir)
+    else:
+        symbol = ns.symbol.upper()
+        model_type = ns.model_type
+
+    harness = BearValidationHarness(
+        symbol=symbol,
+        model_type=model_type,
+        provider=getattr(ns, "provider", "binance"),
+        model_path=model_path,
+    )
+    report = harness.run()
+    print(report.summary())
+    print(json.dumps(report.to_dict(), indent=2))
+    # Exit non-zero when the model fails outright; inconclusive is a soft signal
+    # (exit 0) so CI on data-less environments is not wedged.
+    if not report.passed and not report.inconclusive:
+        return 1
+    return 0
+
+
 def _control(ns: argparse.Namespace) -> int:
     if ns.control_cmd == "train":
         if not _TRAINING_AVAILABLE:
@@ -192,6 +251,8 @@ def _control(ns: argparse.Namespace) -> int:
                 skip_robustness=False,
                 skip_onnx=False,
                 disable_mixed_precision=False,
+                # Defer the 'latest' flip to the #801 validation gate below.
+                skip_promote=True,
             )
             code = train_model_main(args)
             model_type = "sentiment"
@@ -204,6 +265,8 @@ def _control(ns: argparse.Namespace) -> int:
                 epochs=ns.epochs,
                 batch_size=256,
                 sequence_length=120,
+                # Defer the 'latest' flip to the #801 validation gate below.
+                skip_promote=True,
             )
             code = train_price_model_main(args)
             model_type = "basic"
@@ -212,19 +275,39 @@ def _control(ns: argparse.Namespace) -> int:
             print("❌ Model training failed")
             return code
 
-        meta_path = _latest_metadata(ns.symbol, model_type)
-        if meta_path.exists():
-            with open(meta_path, encoding="utf-8") as fh:
-                metadata = json.load(fh)
-            print("✅ Model training complete")
-            print(
-                json.dumps({"latest": metadata.get("version_id"), "metadata": metadata}, indent=2)
-            )
-        else:
-            print("✅ Model training complete (metadata unavailable)")
+        version_dir_str = getattr(args, "result_version_dir", None)
+        print("✅ Model training complete")
 
         if ns.auto_deploy:
-            print("✅ Auto-deploy: latest symlink already updated; live components will pick it up")
+            # #801: gate the promotion. Training deferred the ``latest`` flip
+            # (skip_promote); we flip only if the model survives validation.
+            if not version_dir_str:
+                print(
+                    "⚠️ Auto-deploy requested but training did not report a version dir; "
+                    "skipping promotion. Deploy manually with 'deploy-model' once validated."
+                )
+                return 0
+            decision = _gate_and_promote(
+                Path(version_dir_str),
+                symbol=ns.symbol.upper(),
+                model_type=model_type,
+                provider=getattr(ns, "provider", "binance"),
+            )
+            if not decision.promoted:
+                print(f"❌ Auto-deploy blocked by validation gate: {decision.reason}")
+                if decision.audit_path is not None:
+                    print(f"   Audit: {decision.audit_path}")
+                return 1
+            print(f"✅ Auto-deploy: promoted after validation ({decision.reason})")
+        else:
+            # No auto-deploy: leave the freshly trained version un-promoted and
+            # tell the operator how to validate + deploy it.
+            if version_dir_str:
+                print(f"   Staged (not promoted): {version_dir_str}")
+                print(
+                    "   Validate with: atb live-control validate-model "
+                    f"--model-path {version_dir_str}"
+                )
         return 0
 
     if ns.control_cmd == "deploy-model":
@@ -233,13 +316,28 @@ def _control(ns: argparse.Namespace) -> int:
         except (FileNotFoundError, ValueError) as exc:
             print(f"❌ {exc}")
             return 1
-        _repoint_latest(version_dir)
-        print(
-            f"✅ Latest model for {version_dir.parent.parent.name}/{version_dir.parent.name} set to {version_dir.name}"
+        symbol = version_dir.parent.parent.name
+        model_type = version_dir.parent.name
+        decision = _gate_and_promote(
+            version_dir,
+            symbol=symbol,
+            model_type=model_type,
+            provider=getattr(ns, "provider", "binance"),
+            force=getattr(ns, "skip_validation", False),
         )
+        if not decision.promoted:
+            print(f"❌ Deployment blocked by validation gate: {decision.reason}")
+            if decision.audit_path is not None:
+                print(f"   Audit: {decision.audit_path}")
+            return 1
+        print(f"✅ Latest model for {symbol}/{model_type} set to {version_dir.name}")
+        print(f"   Gate: {decision.reason}")
         if ns.close_positions:
             print("⚠️ close-positions requested (no-op in CLI helper)")
         return 0
+
+    if ns.control_cmd == "validate-model":
+        return _validate_model(ns)
 
     if ns.control_cmd == "list-models":
         print(json.dumps(_list_registry(), indent=2))
@@ -287,10 +385,32 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     p_train.add_argument("--auto-deploy", action="store_true")
     p_train.set_defaults(func=_control)
 
-    p_deploy = sub.add_parser("deploy-model", help="Deploy a staged model")
+    p_deploy = sub.add_parser("deploy-model", help="Deploy a staged model (validation-gated)")
     p_deploy.add_argument("--model-path", required=True)
     p_deploy.add_argument("--close-positions", action="store_true")
+    p_deploy.add_argument(
+        "--provider", default="binance", help="Data provider for validation backtests"
+    )
+    p_deploy.add_argument(
+        "--skip-validation",
+        action="store_true",
+        help="Human override: promote without running the #801 validation gate (audited)",
+    )
     p_deploy.set_defaults(func=_control)
+
+    p_validate = sub.add_parser(
+        "validate-model",
+        help="Score a model against the fixed bear-market windows (#801); does not deploy",
+    )
+    p_validate.add_argument("--symbol", default="BTCUSDT")
+    p_validate.add_argument("--model-type", default="basic", choices=["basic", "sentiment"])
+    p_validate.add_argument(
+        "--model-path", help="Optional explicit version path; overrides --symbol/--model-type"
+    )
+    p_validate.add_argument(
+        "--provider", default="binance", help="Data provider for validation backtests"
+    )
+    p_validate.set_defaults(func=_control)
 
     p_models = sub.add_parser("list-models", help="List available models")
     p_models.set_defaults(func=_control)

--- a/cli/commands/live.py
+++ b/cli/commands/live.py
@@ -174,11 +174,15 @@ def _gate_and_promote(
     model_type: str,
     provider: str = "binance",
     force: bool = False,
+    known_prev_target: Path | None = None,
 ):
-    """Run the bear-market validation gate, flipping ``latest`` only if allowed.
+    """Run the bear-market validation gate, keeping ``latest`` on the candidate
+    only if it passes (else rolling back).
 
-    Delegates the actual symlink flip to :func:`_repoint_latest`. Returns the
-    :class:`GateDecision` so callers can report the reason / audit path.
+    The gate flips ``latest`` to ``version_dir`` to score the *candidate* (the
+    registry resolves models by symlink), then rolls back on failure. When the
+    caller already promoted the candidate (training path), pass the pre-training
+    target as ``known_prev_target`` so a rollback restores the right model.
     """
     from src.ml.validation.gate import promote_version_if_valid
 
@@ -189,14 +193,23 @@ def _gate_and_promote(
         repoint_fn=_repoint_latest,
         provider=provider,
         force=force,
+        known_prev_target=known_prev_target,
     )
 
 
-def _validate_model(ns: argparse.Namespace) -> int:
-    """Score a model version against the fixed bear-market windows (no deploy)."""
-    from src.ml.validation.bear_validation import BearValidationHarness
+def _type_dir(symbol: str, model_type: str) -> Path:
+    return MODEL_REGISTRY / symbol.upper() / model_type
 
-    model_path: str | None = None
+
+def _validate_model(ns: argparse.Namespace) -> int:
+    """Score a model version against the fixed bear-market windows (no deploy).
+
+    Uses the gate's flip-validate-rollback so a specific candidate can be scored
+    without leaving it live; with no ``--model-path`` it scores the current
+    ``latest``.
+    """
+    from src.ml.validation.gate import default_resolve_latest, validate_candidate
+
     if getattr(ns, "model_path", None):
         try:
             version_dir = _resolve_version_path(ns.model_path)
@@ -205,18 +218,22 @@ def _validate_model(ns: argparse.Namespace) -> int:
             return 1
         symbol = version_dir.parent.parent.name
         model_type = version_dir.parent.name
-        model_path = str(version_dir)
     else:
         symbol = ns.symbol.upper()
         model_type = ns.model_type
+        current = default_resolve_latest(_type_dir(symbol, model_type))
+        if current is None:
+            print(f"❌ No 'latest' model found for {symbol}/{model_type}")
+            return 1
+        version_dir = current
 
-    harness = BearValidationHarness(
+    report = validate_candidate(
+        version_dir,
         symbol=symbol,
         model_type=model_type,
+        repoint_fn=_repoint_latest,
         provider=getattr(ns, "provider", "binance"),
-        model_path=model_path,
     )
-    report = harness.run()
     print(report.summary())
     print(json.dumps(report.to_dict(), indent=2))
     # Exit non-zero when the model fails outright; inconclusive is a soft signal
@@ -235,7 +252,15 @@ def _control(ns: argparse.Namespace) -> int:
             )
             print("Use a local development environment for model training.")
             return 1
+        from src.ml.validation.gate import default_resolve_latest
+
         start_date, end_date = _date_range(ns.days)
+        model_type = "sentiment" if ns.sentiment else "basic"
+        # Capture the currently-live version BEFORE training. Training promotes
+        # the freshly trained version to ``latest``; if it later fails the #801
+        # gate we roll ``latest`` back to this pre-training target.
+        prev_target = default_resolve_latest(_type_dir(ns.symbol, model_type))
+
         if ns.sentiment:
             args = SimpleNamespace(
                 symbol=ns.symbol,
@@ -251,11 +276,8 @@ def _control(ns: argparse.Namespace) -> int:
                 skip_robustness=False,
                 skip_onnx=False,
                 disable_mixed_precision=False,
-                # Defer the 'latest' flip to the #801 validation gate below.
-                skip_promote=True,
             )
             code = train_model_main(args)
-            model_type = "sentiment"
         else:
             args = SimpleNamespace(
                 symbol=ns.symbol,
@@ -265,48 +287,43 @@ def _control(ns: argparse.Namespace) -> int:
                 epochs=ns.epochs,
                 batch_size=256,
                 sequence_length=120,
-                # Defer the 'latest' flip to the #801 validation gate below.
-                skip_promote=True,
             )
             code = train_price_model_main(args)
-            model_type = "basic"
 
         if code != 0:
             print("❌ Model training failed")
             return code
 
-        version_dir_str = getattr(args, "result_version_dir", None)
         print("✅ Model training complete")
+        # Training just flipped ``latest`` to the new version; resolve it.
+        candidate = default_resolve_latest(_type_dir(ns.symbol, model_type))
 
         if ns.auto_deploy:
-            # #801: gate the promotion. Training deferred the ``latest`` flip
-            # (skip_promote); we flip only if the model survives validation.
-            if not version_dir_str:
-                print(
-                    "⚠️ Auto-deploy requested but training did not report a version dir; "
-                    "skipping promotion. Deploy manually with 'deploy-model' once validated."
-                )
-                return 0
+            # #801: gate the just-promoted model. If it fails, roll ``latest``
+            # back to the pre-training target so a bad model does not stay live.
+            if candidate is None:
+                print("⚠️ Auto-deploy requested but no 'latest' model resolved after training.")
+                return 1
             decision = _gate_and_promote(
-                Path(version_dir_str),
+                candidate,
                 symbol=ns.symbol.upper(),
                 model_type=model_type,
                 provider=getattr(ns, "provider", "binance"),
+                known_prev_target=prev_target,
             )
             if not decision.promoted:
                 print(f"❌ Auto-deploy blocked by validation gate: {decision.reason}")
                 if decision.audit_path is not None:
                     print(f"   Audit: {decision.audit_path}")
                 return 1
-            print(f"✅ Auto-deploy: promoted after validation ({decision.reason})")
+            print(f"✅ Auto-deploy: kept as latest after validation ({decision.reason})")
         else:
-            # No auto-deploy: leave the freshly trained version un-promoted and
-            # tell the operator how to validate + deploy it.
-            if version_dir_str:
-                print(f"   Staged (not promoted): {version_dir_str}")
+            # No auto-deploy: training already set ``latest``. Warn the operator
+            # it is UNVALIDATED and show how to validate it.
+            if candidate is not None:
+                print(f"   ⚠️ '{candidate.name}' is now 'latest' but UNVALIDATED.")
                 print(
-                    "   Validate with: atb live-control validate-model "
-                    f"--model-path {version_dir_str}"
+                    "   Validate with: atb live-control validate-model " f"--model-path {candidate}"
                 )
         return 0
 

--- a/cli/commands/train_commands.py
+++ b/cli/commands/train_commands.py
@@ -320,13 +320,26 @@ def train_price_model_main(args) -> int:
     with open(bundle_dir / "feature_schema.json", "w", encoding="utf-8") as f:
         json.dump(schema, f, indent=2)
 
-    latest_link = bundle_dir.parent / "latest"
-    if latest_link.exists() or latest_link.is_symlink():
-        try:
-            latest_link.unlink()
-        except OSError:
-            pass
-    latest_link.symlink_to(version_id)
+    # Record the freshly-written version so a gated caller (the #801 validation
+    # gate in ``live-control``) can promote it only after validation. Kept as an
+    # attribute on the passed namespace so the return type stays ``int``.
+    try:
+        args.result_version_dir = str(bundle_dir)
+    except (AttributeError, TypeError):
+        pass
+
+    # ``skip_promote`` lets the caller defer the ``latest`` flip to the
+    # validation gate. Default (unset/False) preserves legacy behaviour: flip
+    # immediately. This is the seam that lets #801 block a bad model before it
+    # goes live instead of after.
+    if not getattr(args, "skip_promote", False):
+        latest_link = bundle_dir.parent / "latest"
+        if latest_link.exists() or latest_link.is_symlink():
+            try:
+                latest_link.unlink()
+            except OSError:
+                pass
+        latest_link.symlink_to(version_id)
 
     print(f"✅ Saved bundle to {bundle_dir}")
     return 0

--- a/cli/commands/train_commands.py
+++ b/cli/commands/train_commands.py
@@ -320,26 +320,13 @@ def train_price_model_main(args) -> int:
     with open(bundle_dir / "feature_schema.json", "w", encoding="utf-8") as f:
         json.dump(schema, f, indent=2)
 
-    # Record the freshly-written version so a gated caller (the #801 validation
-    # gate in ``live-control``) can promote it only after validation. Kept as an
-    # attribute on the passed namespace so the return type stays ``int``.
-    try:
-        args.result_version_dir = str(bundle_dir)
-    except (AttributeError, TypeError):
-        pass
-
-    # ``skip_promote`` lets the caller defer the ``latest`` flip to the
-    # validation gate. Default (unset/False) preserves legacy behaviour: flip
-    # immediately. This is the seam that lets #801 block a bad model before it
-    # goes live instead of after.
-    if not getattr(args, "skip_promote", False):
-        latest_link = bundle_dir.parent / "latest"
-        if latest_link.exists() or latest_link.is_symlink():
-            try:
-                latest_link.unlink()
-            except OSError:
-                pass
-        latest_link.symlink_to(version_id)
+    latest_link = bundle_dir.parent / "latest"
+    if latest_link.exists() or latest_link.is_symlink():
+        try:
+            latest_link.unlink()
+        except OSError:
+            pass
+    latest_link.symlink_to(version_id)
 
     print(f"✅ Saved bundle to {bundle_dir}")
     return 0

--- a/config/validation_windows.json
+++ b/config/validation_windows.json
@@ -1,0 +1,34 @@
+{
+  "description": "Fixed bear-market validation windows used to gate ML model promotion (#801). A candidate model must keep max-drawdown at or below the per-window threshold before its 'latest' symlink is flipped. Dates and thresholds are config, not code -- update as regimes evolve.",
+  "default_max_drawdown_pct": 40.0,
+  "default_min_trades": 3,
+  "windows": [
+    {
+      "name": "bear_2022",
+      "symbol": "BTCUSDT",
+      "timeframe": "1d",
+      "start": "2021-11-10",
+      "end": "2022-11-21",
+      "max_drawdown_pct": 45.0,
+      "min_trades": 5
+    },
+    {
+      "name": "crash_2025",
+      "symbol": "BTCUSDT",
+      "timeframe": "1d",
+      "start": "2025-10-01",
+      "end": "2026-02-28",
+      "max_drawdown_pct": 35.0,
+      "min_trades": 3
+    },
+    {
+      "name": "chop_2026",
+      "symbol": "BTCUSDT",
+      "timeframe": "1d",
+      "start": "2026-02-01",
+      "end": "2026-06-30",
+      "max_drawdown_pct": 30.0,
+      "min_trades": 3
+    }
+  ]
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,11 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   window (Sharpe / max-drawdown / win-rate / trades) via the backtest engine
   (reusing `ExperimentRunner`, so `mock`/`fixture` providers give deterministic
   CI runs); `promote_version_if_valid` makes the promotion decision and writes
-  an auditable `validation_audit.json` next to the model version. Wired into
-  `atb live-control deploy-model` (now validation-gated, `--skip-validation`
-  human override) and the training `--auto-deploy` path (training now defers the
-  `latest` flip via `skip_promote`, gate flips only on pass). New
-  `atb live-control validate-model` scores a model without deploying.
+  an auditable `validation_audit.json` next to the model version. Because the
+  prediction registry resolves models purely by the `latest` symlink, the gate
+  scores the *candidate* via flip → validate → roll-back-on-failure (a
+  canary-with-rollback: a failing model is reverted to the previously-live
+  version). Wired into `atb live-control deploy-model` (now validation-gated,
+  `--skip-validation` human override) and the training `--auto-deploy` path
+  (training promotes as before; on validation failure `latest` rolls back to the
+  pre-training model). New `atb live-control validate-model` scores a model
+  (flip/validate/always-roll-back) without changing what is live.
   Un-runnable validation (e.g. missing data) is *inconclusive* → soft-pass with
   a loud warning unless `VALIDATION_REQUIRED` is set. Thresholds are config, not
   code. See `docs/prediction.md` → "Bear-market validation gate".

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Bear-market model-validation gate** (#801): ML model promotion is now gated
+  on a fixed set of historical bear/crash/chop windows. A candidate model's
+  `latest` symlink is flipped only after it keeps max-drawdown at or below a
+  per-window threshold (`config/validation_windows.json`). New
+  `src/ml/validation/` package: `BearValidationHarness` scores a model per
+  window (Sharpe / max-drawdown / win-rate / trades) via the backtest engine
+  (reusing `ExperimentRunner`, so `mock`/`fixture` providers give deterministic
+  CI runs); `promote_version_if_valid` makes the promotion decision and writes
+  an auditable `validation_audit.json` next to the model version. Wired into
+  `atb live-control deploy-model` (now validation-gated, `--skip-validation`
+  human override) and the training `--auto-deploy` path (training now defers the
+  `latest` flip via `skip_promote`, gate flips only on pass). New
+  `atb live-control validate-model` scores a model without deploying.
+  Un-runnable validation (e.g. missing data) is *inconclusive* → soft-pass with
+  a loud warning unless `VALIDATION_REQUIRED` is set. Thresholds are config, not
+  code. See `docs/prediction.md` → "Bear-market validation gate".
 - **Live enforcement of the portfolio max-drawdown hard cap** (risk-officer
   2026-07-04 finding, corroborating the 2026-06-08 observability audit —
   `RiskManager.check_drawdown()` had zero callers, so nothing halted the live

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -146,11 +146,13 @@ it is now scored on a fixed set of historical windows and blocked if it fails.
   backtests the model per window (reusing `ExperimentRunner`) and reports Sharpe,
   max-drawdown, win-rate and trade count. `mock`/`fixture` providers give
   deterministic, network-free runs for CI.
-- **Gate**: `src/ml/validation/gate.py::promote_version_if_valid` runs the harness,
-  writes an auditable `validation_audit.json` next to the version, and flips
-  `latest` only on pass. A run that cannot execute (missing data) is
-  *inconclusive* → soft-pass with a loud warning, unless `VALIDATION_REQUIRED` is
-  truthy (then it blocks).
+- **Gate**: `src/ml/validation/gate.py::promote_version_if_valid`. The registry
+  resolves a model only by the `latest` symlink, so the gate scores the
+  *candidate* by flipping `latest` to it, validating, and rolling back to the
+  previously-live version on failure (canary-with-rollback — fail-safe). It
+  writes an auditable `validation_audit.json` next to the version. A run that
+  cannot execute (missing data) is *inconclusive* → soft-pass with a loud
+  warning, unless `VALIDATION_REQUIRED` is truthy (then it blocks/rolls back).
 
 ### CLI
 
@@ -161,7 +163,8 @@ atb live-control validate-model --symbol BTCUSDT --model-type basic
 # Deploy is validation-gated; --skip-validation is an audited human override
 atb live-control deploy-model --model-path BTCUSDT/basic/<version>
 
-# Training defers the 'latest' flip; --auto-deploy promotes only if validation passes
+# --auto-deploy keeps the freshly trained model only if validation passes;
+# on failure 'latest' rolls back to the pre-training model
 atb live-control train --symbol BTCUSDT --auto-deploy
 ```
 

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -131,3 +131,41 @@ macOS users can confirm that ONNX Runtime is activating the CoreML/MPS execution
    The focused tests validate that the provider utility feeds the ONNX runner and caching layers correctly.
 
 If any of the above steps omit the GPU providers, reinstall `onnxruntime-silicon`, ensure the Python environment is using that interpreter, and repeat the checks.
+
+## Bear-market validation gate (#801)
+
+Models trained predominantly on the long-biased 2023–2025 market can go long into
+bear-market dead-cat bounces. Before a candidate model takes the `latest` symlink
+it is now scored on a fixed set of historical windows and blocked if it fails.
+
+- **Windows & thresholds** live in `config/validation_windows.json` (bear 2022,
+  Oct 2025–Feb 2026 crash, Feb–Jun 2026 chop by default). Each window has a
+  `max_drawdown_pct` cap and a `min_trades` floor. These are config, not code —
+  update them as regimes evolve.
+- **Harness**: `src/ml/validation/bear_validation.py::BearValidationHarness`
+  backtests the model per window (reusing `ExperimentRunner`) and reports Sharpe,
+  max-drawdown, win-rate and trade count. `mock`/`fixture` providers give
+  deterministic, network-free runs for CI.
+- **Gate**: `src/ml/validation/gate.py::promote_version_if_valid` runs the harness,
+  writes an auditable `validation_audit.json` next to the version, and flips
+  `latest` only on pass. A run that cannot execute (missing data) is
+  *inconclusive* → soft-pass with a loud warning, unless `VALIDATION_REQUIRED` is
+  truthy (then it blocks).
+
+### CLI
+
+```bash
+# Score a model without deploying (exit non-zero only on outright failure)
+atb live-control validate-model --symbol BTCUSDT --model-type basic
+
+# Deploy is validation-gated; --skip-validation is an audited human override
+atb live-control deploy-model --model-path BTCUSDT/basic/<version>
+
+# Training defers the 'latest' flip; --auto-deploy promotes only if validation passes
+atb live-control train --symbol BTCUSDT --auto-deploy
+```
+
+> **Out of scope / human sign-off**: this gate does not retrain models and never
+> flips a live-trading symbol's `latest` without the promotion passing (or an
+> explicit `--skip-validation`). Actual retraining on bear-inclusive windows and
+> live promotion remain human/ml-engineer actions.

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -427,3 +427,16 @@ DEFAULT_TFT_N_HEADS = 4  # Number of attention heads in the temporal decoder
 DEFAULT_TFT_HIDDEN_SIZE = 64  # Hidden dimension for GRN and attention layers
 DEFAULT_TFT_DROPOUT = 0.1  # Dropout rate for regularization
 DEFAULT_TFT_NUM_LSTM_LAYERS = 1  # Number of stacked LSTM encoder layers
+
+# Bear-market model-validation gate (#801). A candidate model's 'latest'
+# symlink is only flipped when it survives the fixed validation windows in
+# ``config/validation_windows.json``. Per-window thresholds live in that file;
+# these are the fallbacks when the file omits them.
+DEFAULT_VALIDATION_MAX_DRAWDOWN_PCT = 40.0  # Reject if window max-drawdown exceeds this (%).
+DEFAULT_VALIDATION_MIN_TRADES = 3  # Fewer trades than this in a window => inconclusive => reject.
+# When True, a validation run that cannot execute (e.g. missing data in a
+# data-limited environment) BLOCKS promotion. When False, it warns loudly and
+# allows the flip so training still works where the harness cannot run. Kept
+# False by default so data-less/CI environments are not wedged; operators
+# running real promotions set the env override to require validation.
+DEFAULT_VALIDATION_REQUIRED = False

--- a/src/ml/validation/__init__.py
+++ b/src/ml/validation/__init__.py
@@ -13,7 +13,13 @@ from src.ml.validation.bear_validation import (
     WindowScore,
     load_validation_windows,
 )
-from src.ml.validation.gate import GateDecision, promote_version_if_valid, write_audit_record
+from src.ml.validation.gate import (
+    GateDecision,
+    default_resolve_latest,
+    promote_version_if_valid,
+    validate_candidate,
+    write_audit_record,
+)
 
 __all__ = [
     "BearValidationHarness",
@@ -21,7 +27,9 @@ __all__ = [
     "GateDecision",
     "ValidationReport",
     "WindowScore",
+    "default_resolve_latest",
     "load_validation_windows",
     "promote_version_if_valid",
+    "validate_candidate",
     "write_audit_record",
 ]

--- a/src/ml/validation/__init__.py
+++ b/src/ml/validation/__init__.py
@@ -1,0 +1,27 @@
+"""Bear-market model-validation gate (#801).
+
+Scores a candidate ML model on fixed historical bear/crash/chop windows and
+blocks promotion of the ``latest`` symlink when it fails a configurable
+drawdown threshold. See ``bear_validation`` for the harness and ``gate`` for
+the promotion decision + audit trail.
+"""
+
+from src.ml.validation.bear_validation import (
+    BearValidationHarness,
+    BearWindow,
+    ValidationReport,
+    WindowScore,
+    load_validation_windows,
+)
+from src.ml.validation.gate import GateDecision, promote_version_if_valid, write_audit_record
+
+__all__ = [
+    "BearValidationHarness",
+    "BearWindow",
+    "GateDecision",
+    "ValidationReport",
+    "WindowScore",
+    "load_validation_windows",
+    "promote_version_if_valid",
+    "write_audit_record",
+]

--- a/src/ml/validation/bear_validation.py
+++ b/src/ml/validation/bear_validation.py
@@ -24,7 +24,7 @@ from src.config.constants import (
     DEFAULT_VALIDATION_MAX_DRAWDOWN_PCT,
     DEFAULT_VALIDATION_MIN_TRADES,
 )
-from src.experiments.schemas import ExperimentConfig, ExperimentResult, ParameterSet
+from src.experiments.schemas import ExperimentConfig, ExperimentResult
 from src.infrastructure.runtime.paths import get_project_root
 
 logger = logging.getLogger(__name__)
@@ -206,7 +206,6 @@ class BearValidationHarness:
         provider: str = "binance",
         initial_balance: float = 1000.0,
         strategy_name: str | None = None,
-        model_path: str | Path | None = None,
         runner_factory: Callable[[], object] | None = None,
     ) -> None:
         self.symbol = symbol.upper()
@@ -216,11 +215,11 @@ class BearValidationHarness:
         self.strategy_name = strategy_name or (
             "ml_sentiment" if model_type == "sentiment" else "ml_basic"
         )
-        # When set, validate this specific candidate version rather than the
-        # strategy's ``latest`` symlink. Threaded to the signal generator via a
-        # ``model_path`` override so the gate scores the model that is about to
-        # be promoted, not the one already live.
-        self.model_path = str(model_path) if model_path is not None else None
+        # The harness always scores whatever the model registry currently
+        # resolves as ``latest`` for (symbol, model_type). Candidate-specific
+        # scoring is orchestrated by :mod:`src.ml.validation.gate`, which flips
+        # ``latest`` to the candidate around the run (the registry has no
+        # per-version override), so no model-path plumbing is needed here.
         self._runner_factory = runner_factory
 
     def _make_runner(self) -> object:
@@ -234,12 +233,6 @@ class BearValidationHarness:
         return ExperimentRunner()
 
     def _score_window(self, runner: object, window: BearWindow) -> WindowScore:
-        parameters = None
-        if self.model_path is not None:
-            parameters = ParameterSet(
-                name="candidate",
-                values={f"{self.strategy_name}.model_path": self.model_path},
-            )
         config = ExperimentConfig(
             strategy_name=self.strategy_name,
             symbol=window.symbol or self.symbol,
@@ -249,7 +242,6 @@ class BearValidationHarness:
             initial_balance=self.initial_balance,
             provider=self.provider,
             use_cache=True,
-            parameters=parameters,
         )
         try:
             result = runner.run(config)  # type: ignore[attr-defined]

--- a/src/ml/validation/bear_validation.py
+++ b/src/ml/validation/bear_validation.py
@@ -1,0 +1,339 @@
+"""Bear-market validation harness (#801).
+
+Scores a candidate model by running the backtest engine over fixed historical
+windows (2022 bear, Oct 2025–Feb 2026 crash, Feb–Jun 2026 chop) and reporting
+per-window Sharpe / max-drawdown / win-rate / trade count / long-short balance.
+
+The harness reuses :class:`~src.experiments.runner.ExperimentRunner` so it
+inherits deterministic providers (``mock``/``fixture``) for CI and cached real
+providers for genuine runs. It never trains or promotes — that decision lives
+in :mod:`src.ml.validation.gate`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from collections.abc import Callable
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from src.config.constants import (
+    DEFAULT_VALIDATION_MAX_DRAWDOWN_PCT,
+    DEFAULT_VALIDATION_MIN_TRADES,
+)
+from src.experiments.schemas import ExperimentConfig, ExperimentResult, ParameterSet
+from src.infrastructure.runtime.paths import get_project_root
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WINDOWS_CONFIG = get_project_root() / "config" / "validation_windows.json"
+
+
+@dataclass(frozen=True)
+class BearWindow:
+    """A fixed historical window a candidate model must survive."""
+
+    name: str
+    symbol: str
+    timeframe: str
+    start: datetime
+    end: datetime
+    max_drawdown_pct: float
+    min_trades: int
+
+    def __post_init__(self) -> None:
+        # Catch bad config at construction rather than deep in a backtest.
+        if not self.name:
+            raise ValueError("BearWindow.name must be non-empty")
+        if self.end <= self.start:
+            raise ValueError(
+                f"BearWindow {self.name!r}: end ({self.end}) must be after start ({self.start})"
+            )
+        if not math.isfinite(self.max_drawdown_pct) or self.max_drawdown_pct <= 0:
+            raise ValueError(
+                f"BearWindow {self.name!r}: max_drawdown_pct must be finite and > 0, "
+                f"got {self.max_drawdown_pct!r}"
+            )
+        if self.min_trades < 0:
+            raise ValueError(f"BearWindow {self.name!r}: min_trades must be >= 0")
+
+
+@dataclass
+class WindowScore:
+    """Per-window backtest score plus the pass/fail verdict."""
+
+    window_name: str
+    sharpe: float
+    max_drawdown_pct: float
+    win_rate_pct: float
+    total_trades: int
+    long_short_balance: float | None
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+@dataclass
+class ValidationReport:
+    """Aggregate report across all windows."""
+
+    symbol: str
+    model_type: str
+    strategy_name: str
+    provider: str
+    created_at: str
+    scores: list[WindowScore] = field(default_factory=list)
+    passed: bool = False
+    inconclusive: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "symbol": self.symbol,
+            "model_type": self.model_type,
+            "strategy_name": self.strategy_name,
+            "provider": self.provider,
+            "created_at": self.created_at,
+            "passed": self.passed,
+            "inconclusive": self.inconclusive,
+            "scores": [asdict(s) for s in self.scores],
+        }
+
+    def summary(self) -> str:
+        lines = [
+            f"Bear-market validation: {self.symbol}/{self.model_type} "
+            f"({self.strategy_name}, provider={self.provider})"
+        ]
+        for s in self.scores:
+            if s.error is not None:
+                lines.append(f"  [{s.window_name}] ERROR: {s.error}")
+                continue
+            verdict = "PASS" if s.passed else "FAIL"
+            lines.append(
+                f"  [{s.window_name}] {verdict} "
+                f"sharpe={s.sharpe:.2f} maxDD={s.max_drawdown_pct:.1f}% "
+                f"win={s.win_rate_pct:.0f}% trades={s.total_trades}"
+                + (f" | {'; '.join(s.failures)}" if s.failures else "")
+            )
+        overall = "PASS" if self.passed else ("INCONCLUSIVE" if self.inconclusive else "FAIL")
+        lines.append(f"  OVERALL: {overall}")
+        return "\n".join(lines)
+
+
+def _parse_date(value: str) -> datetime:
+    """Parse a YYYY-MM-DD (or ISO) date string into a UTC-aware datetime."""
+    text = str(value).strip()
+    # Accept a bare date or a full ISO timestamp; normalize a trailing Z.
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        # Fall back to date-only.
+        dt = datetime.strptime(text, "%Y-%m-%d")  # noqa: DTZ007 - tz applied below
+        return dt.replace(tzinfo=UTC)
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+def load_validation_windows(path: str | Path | None = None) -> list[BearWindow]:
+    """Load and validate the fixed validation windows from JSON config.
+
+    Args:
+        path: Optional path to the windows config; defaults to
+            ``config/validation_windows.json``.
+
+    Returns:
+        A non-empty list of :class:`BearWindow`.
+
+    Raises:
+        FileNotFoundError: If the config file is missing.
+        ValueError: If the config is malformed or defines no windows.
+    """
+    cfg_path = Path(path) if path is not None else DEFAULT_WINDOWS_CONFIG
+    if not cfg_path.exists():
+        raise FileNotFoundError(f"Validation windows config not found: {cfg_path}")
+
+    data = json.loads(cfg_path.read_text(encoding="utf-8"))
+    raw_windows = data.get("windows")
+    if not isinstance(raw_windows, list) or not raw_windows:
+        raise ValueError(f"{cfg_path} must define a non-empty 'windows' list")
+
+    default_dd = float(data.get("default_max_drawdown_pct", DEFAULT_VALIDATION_MAX_DRAWDOWN_PCT))
+    default_min_trades = int(data.get("default_min_trades", DEFAULT_VALIDATION_MIN_TRADES))
+
+    windows: list[BearWindow] = []
+    for entry in raw_windows:
+        if not isinstance(entry, dict):
+            raise ValueError(f"{cfg_path}: each window must be an object, got {entry!r}")
+        windows.append(
+            BearWindow(
+                name=str(entry["name"]),
+                symbol=str(entry["symbol"]),
+                timeframe=str(entry.get("timeframe", "1d")),
+                start=_parse_date(entry["start"]),
+                end=_parse_date(entry["end"]),
+                max_drawdown_pct=float(entry.get("max_drawdown_pct", default_dd)),
+                min_trades=int(entry.get("min_trades", default_min_trades)),
+            )
+        )
+    return windows
+
+
+class BearValidationHarness:
+    """Score a candidate model across the fixed bear-market windows.
+
+    Args:
+        symbol: Trading symbol the model serves (e.g. ``BTCUSDT``).
+        model_type: Registry model type (``basic`` or ``sentiment``); selects
+            the default strategy when ``strategy_name`` is not given.
+        provider: Data provider for the backtests. Use ``mock``/``fixture`` for
+            deterministic CI runs; ``binance`` (cached) for real evaluation.
+        initial_balance: Starting balance for each window backtest.
+        strategy_name: Strategy factory to drive the model; defaults from
+            ``model_type``.
+        runner_factory: Injectable zero-arg callable returning an object with a
+            ``run(ExperimentConfig) -> ExperimentResult`` method. Tests inject a
+            stub; production uses :class:`ExperimentRunner`.
+    """
+
+    def __init__(
+        self,
+        symbol: str,
+        model_type: str = "basic",
+        *,
+        provider: str = "binance",
+        initial_balance: float = 1000.0,
+        strategy_name: str | None = None,
+        model_path: str | Path | None = None,
+        runner_factory: Callable[[], object] | None = None,
+    ) -> None:
+        self.symbol = symbol.upper()
+        self.model_type = model_type
+        self.provider = provider
+        self.initial_balance = float(initial_balance)
+        self.strategy_name = strategy_name or (
+            "ml_sentiment" if model_type == "sentiment" else "ml_basic"
+        )
+        # When set, validate this specific candidate version rather than the
+        # strategy's ``latest`` symlink. Threaded to the signal generator via a
+        # ``model_path`` override so the gate scores the model that is about to
+        # be promoted, not the one already live.
+        self.model_path = str(model_path) if model_path is not None else None
+        self._runner_factory = runner_factory
+
+    def _make_runner(self) -> object:
+        if self._runner_factory is not None:
+            return self._runner_factory()
+        # Imported lazily so the harness module has no hard dependency on the
+        # backtest engine at import time (keeps CLI --help fast and avoids
+        # pulling heavy deps when only the config loader is used).
+        from src.experiments.runner import ExperimentRunner
+
+        return ExperimentRunner()
+
+    def _score_window(self, runner: object, window: BearWindow) -> WindowScore:
+        parameters = None
+        if self.model_path is not None:
+            parameters = ParameterSet(
+                name="candidate",
+                values={f"{self.strategy_name}.model_path": self.model_path},
+            )
+        config = ExperimentConfig(
+            strategy_name=self.strategy_name,
+            symbol=window.symbol or self.symbol,
+            timeframe=window.timeframe,
+            start=window.start,
+            end=window.end,
+            initial_balance=self.initial_balance,
+            provider=self.provider,
+            use_cache=True,
+            parameters=parameters,
+        )
+        try:
+            result = runner.run(config)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 - surface any backtest failure per-window
+            logger.warning(
+                "Validation window %s failed to run: %s", window.name, exc, exc_info=True
+            )
+            return WindowScore(
+                window_name=window.name,
+                sharpe=0.0,
+                max_drawdown_pct=0.0,
+                win_rate_pct=0.0,
+                total_trades=0,
+                long_short_balance=None,
+                passed=False,
+                failures=["backtest raised"],
+                error=str(exc),
+            )
+        return self._evaluate_result(window, result)
+
+    @staticmethod
+    def _evaluate_result(window: BearWindow, result: ExperimentResult) -> WindowScore:
+        # ``max_drawdown`` is already a percentage in the results dict (engine
+        # multiplies the fractional drawdown by 100). Guard non-finite values.
+        max_dd = float(result.max_drawdown)
+        if not math.isfinite(max_dd):
+            max_dd = 100.0
+        failures: list[str] = []
+        if max_dd > window.max_drawdown_pct:
+            failures.append(
+                f"max drawdown {max_dd:.1f}% exceeds {window.max_drawdown_pct:.1f}% cap"
+            )
+        if result.total_trades < window.min_trades:
+            failures.append(
+                f"only {result.total_trades} trades (< {window.min_trades}); inconclusive"
+            )
+        return WindowScore(
+            window_name=window.name,
+            sharpe=float(result.sharpe_ratio),
+            max_drawdown_pct=max_dd,
+            win_rate_pct=float(result.win_rate),
+            total_trades=int(result.total_trades),
+            long_short_balance=_long_short_balance(result.trade_pnl_pcts),
+            passed=not failures,
+            failures=failures,
+        )
+
+    def run(self, windows: list[BearWindow] | None = None) -> ValidationReport:
+        """Score every window and build the aggregate report.
+
+        A model **passes** only if every window passes. If any window could not
+        run (backtest raised, e.g. missing data), the report is marked
+        ``inconclusive`` and ``passed`` is False so the gate can decide whether
+        to block or warn (per ``DEFAULT_VALIDATION_REQUIRED``).
+        """
+        windows = windows if windows is not None else load_validation_windows()
+        if not windows:
+            raise ValueError("No validation windows provided")
+
+        runner = self._make_runner()
+        scores = [self._score_window(runner, w) for w in windows]
+        inconclusive = any(s.error is not None for s in scores)
+        passed = bool(scores) and all(s.passed for s in scores) and not inconclusive
+        return ValidationReport(
+            symbol=self.symbol,
+            model_type=self.model_type,
+            strategy_name=self.strategy_name,
+            provider=self.provider,
+            created_at=datetime.now(UTC).isoformat(),
+            scores=scores,
+            passed=passed,
+            inconclusive=inconclusive,
+        )
+
+
+def _long_short_balance(trade_pnls: list[float]) -> float | None:
+    """Best-effort long/short balance proxy from the per-trade P&L series.
+
+    The backtest results dict does not expose per-trade side, so this is a
+    coarse reporting-only signal: the fraction of trades in the series, used to
+    flag a model that produced no trades at all. Returns ``None`` when there is
+    no trade data. (A precise long/short count would require instrumenting the
+    engine; the drawdown gate is the load-bearing check.)
+    """
+    if not trade_pnls:
+        return None
+    return float(len(trade_pnls))

--- a/src/ml/validation/gate.py
+++ b/src/ml/validation/gate.py
@@ -1,23 +1,40 @@
 """Model-promotion gate (#801).
 
-Decides whether a candidate model version may take the ``latest`` symlink,
+Decides whether a candidate model version may keep the ``latest`` symlink,
 based on the bear-market validation harness, and leaves an auditable JSON
-record next to the model version. The actual symlink flip is delegated to an
-injected ``repoint_fn`` so this module stays independent of the CLI and of any
-particular engine (avoids a circular import with ``cli/commands/live.py``).
+record next to the model version.
+
+Why flip-then-validate-then-rollback? The prediction registry resolves a
+model purely by the ``latest`` symlink (``PredictionModelRegistry._scan_registry``
+reads ``base/{symbol}/{type}/latest``) — there is no per-call "load this exact
+version" override. So to score the *candidate* (not the model already live) the
+gate atomically points ``latest`` at the candidate, runs the harness (each
+backtest builds a fresh registry that picks up the new symlink), and rolls
+``latest`` back to the previous target if the candidate fails. This is a
+canary-with-rollback: bad models are reverted, so it is fail-safe.
+
+Transient-exposure caveat: between the flip and a rollback, ``latest`` briefly
+points at an unvalidated candidate. This is acceptable because (a) these are
+operator actions (``deploy-model`` / ``train --auto-deploy``), and (b) the live
+engine caches its loaded model and only reloads on an explicit swap/restart, so
+it does not hot-pick a transient flip. The window is a single validation run.
+
+The symlink flip is delegated to injected callables so this module stays
+independent of the CLI and testable without a real registry.
 
 Deviation from the plan noted for reviewers: the plan suggested routing through
-``src.experiments.promotion.PromotionManager``. That manager is tightly bound
-to experiment *suites* and a ledger of strategy-parameter variants, not model
-files, so reusing it here would be a poor fit. Instead this gate writes a
-purpose-built ``validation_audit.json`` next to the model version — same intent
-(an auditable, reproducible promotion decision), correct granularity.
+``src.experiments.promotion.PromotionManager``. That manager is bound to
+experiment *suites* and a ledger of strategy-parameter variants, not model
+files, so this gate writes a purpose-built ``validation_audit.json`` next to the
+model version instead — same intent (auditable, reproducible promotion
+decision), correct granularity.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -30,6 +47,10 @@ from src.ml.validation.bear_validation import BearValidationHarness, ValidationR
 logger = logging.getLogger(__name__)
 
 AUDIT_FILENAME = "validation_audit.json"
+
+# Type aliases for the injected symlink operations.
+RepointFn = Callable[[Path], None]
+ResolveLatestFn = Callable[[Path], "Path | None"]
 
 
 @dataclass
@@ -52,6 +73,28 @@ def _validation_required() -> bool:
     return get_config().get_bool("VALIDATION_REQUIRED", DEFAULT_VALIDATION_REQUIRED)
 
 
+def default_resolve_latest(registry_dir: Path) -> Path | None:
+    """Return the version dir the ``latest`` symlink currently targets, or None."""
+    latest = Path(registry_dir) / "latest"
+    if not (latest.exists() or latest.is_symlink()):
+        return None
+    try:
+        target_name = Path(os.readlink(latest)).name
+    except OSError:
+        return None
+    return Path(registry_dir) / target_name
+
+
+def _remove_latest(registry_dir: Path) -> None:
+    """Remove the ``latest`` symlink if present (used when there is no prior target)."""
+    latest = Path(registry_dir) / "latest"
+    if latest.exists() or latest.is_symlink():
+        try:
+            latest.unlink()
+        except OSError as exc:  # pragma: no cover - filesystem edge
+            logger.error("Failed to remove 'latest' symlink at %s: %s", latest, exc)
+
+
 def write_audit_record(
     version_dir: Path,
     report: ValidationReport | None,
@@ -61,7 +104,7 @@ def write_audit_record(
 
     Args:
         version_dir: The model version directory being considered.
-        report: The validation report (may be ``None`` for forced/skipped runs).
+        report: The validation report (may be ``None`` for forced runs).
         decision: A small dict describing the decision (promoted, reason, ...).
 
     Returns:
@@ -79,10 +122,57 @@ def write_audit_record(
     # Atomic write so a crashed run never leaves a half-written audit file.
     tmp_path = version_dir / f".{AUDIT_FILENAME}.tmp"
     tmp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    import os
-
     os.replace(tmp_path, audit_path)
     return audit_path
+
+
+def _score_candidate(
+    version_dir: Path,
+    *,
+    symbol: str,
+    model_type: str,
+    provider: str,
+    repoint_fn: RepointFn,
+    resolve_latest_fn: ResolveLatestFn,
+    harness: BearValidationHarness | None,
+    known_prev_target: Path | None = None,
+) -> tuple[ValidationReport, Path | None]:
+    """Flip ``latest`` to the candidate and score it; return (report, prev_target).
+
+    Does NOT roll back — the caller decides whether to keep the candidate or
+    restore ``prev_target``. ``prev_target`` is the version ``latest`` pointed at
+    before the flip (``None`` if there was none).
+
+    ``known_prev_target`` overrides resolution of the previous target. Callers
+    that flipped ``latest`` themselves *before* invoking the gate (e.g. the
+    training path, where training promotes the freshly trained version) must
+    pass the pre-training target here — otherwise resolving now would return the
+    candidate itself and a rollback would be a no-op.
+    """
+    registry_dir = version_dir.parent
+    prev_target = (
+        known_prev_target if known_prev_target is not None else resolve_latest_fn(registry_dir)
+    )
+    # Point latest at the candidate so the harness's fresh registry loads it.
+    repoint_fn(version_dir)
+    harness = harness or BearValidationHarness(
+        symbol=symbol, model_type=model_type, provider=provider
+    )
+    report = harness.run()
+    logger.info("%s", report.summary())
+    return report, prev_target
+
+
+def _rollback(
+    registry_dir: Path,
+    prev_target: Path | None,
+    repoint_fn: RepointFn,
+) -> None:
+    """Restore ``latest`` to ``prev_target`` (or remove it when there was none)."""
+    if prev_target is not None:
+        repoint_fn(prev_target)
+    else:
+        _remove_latest(registry_dir)
 
 
 def promote_version_if_valid(
@@ -90,26 +180,28 @@ def promote_version_if_valid(
     *,
     symbol: str,
     model_type: str,
-    repoint_fn: Callable[[Path], None],
+    repoint_fn: RepointFn,
+    resolve_latest_fn: ResolveLatestFn = default_resolve_latest,
     provider: str = "binance",
     force: bool = False,
     require_validation: bool | None = None,
     harness: BearValidationHarness | None = None,
+    known_prev_target: Path | None = None,
 ) -> GateDecision:
-    """Validate a candidate model version and flip ``latest`` only if it passes.
+    """Validate a candidate model version, keeping ``latest`` on it only if it passes.
 
     Args:
         version_dir: Path to the candidate version directory.
         symbol: Trading symbol the model serves.
         model_type: Registry model type (``basic``/``sentiment``).
-        repoint_fn: Callable that flips the ``latest`` symlink to ``version_dir``.
+        repoint_fn: Callable that points ``latest`` at a given version dir.
+        resolve_latest_fn: Callable returning the current ``latest`` target dir.
         provider: Data provider for validation backtests.
         force: Skip validation and promote regardless (human override). Still
             writes an audit record marking the override.
         require_validation: If True, an inconclusive/un-runnable validation
-            blocks promotion. Defaults to the ``VALIDATION_REQUIRED`` config.
-        harness: Injectable harness (tests). Defaults to a real harness pointed
-            at this version.
+            blocks promotion (rollback). Defaults to ``VALIDATION_REQUIRED``.
+        harness: Injectable harness (tests). Defaults to a real harness.
 
     Returns:
         A :class:`GateDecision` describing what happened.
@@ -134,22 +226,26 @@ def promote_version_if_valid(
             passed=False, promoted=True, reason="forced", report=None, audit_path=audit
         )
 
-    harness = harness or BearValidationHarness(
-        symbol=symbol, model_type=model_type, provider=provider, model_path=version_dir
+    report, prev_target = _score_candidate(
+        version_dir,
+        symbol=symbol,
+        model_type=model_type,
+        provider=provider,
+        repoint_fn=repoint_fn,
+        resolve_latest_fn=resolve_latest_fn,
+        harness=harness,
+        known_prev_target=known_prev_target,
     )
-    report = harness.run()
-    logger.info("%s", report.summary())
 
     if report.passed:
-        repoint_fn(version_dir)
         reason = "passed all validation windows"
         promoted = True
     elif report.inconclusive and not strict:
-        repoint_fn(version_dir)
         reason = "validation inconclusive (could not run); promoted because validation not required"
         promoted = True
         logger.warning(
-            "Model %s/%s promoted despite INCONCLUSIVE validation (VALIDATION_REQUIRED is off): %s",
+            "Model %s/%s kept as latest despite INCONCLUSIVE validation "
+            "(VALIDATION_REQUIRED is off): %s",
             symbol,
             model_type,
             version_dir.name,
@@ -161,10 +257,15 @@ def promote_version_if_valid(
             else "failed one or more validation windows"
         )
         promoted = False
+
+    if not promoted:
+        # Fail-safe: revert latest to whatever it pointed at before the flip.
+        _rollback(version_dir.parent, prev_target, repoint_fn)
         logger.error(
-            "Model %s/%s BLOCKED from promotion: %s\n%s",
+            "Model %s/%s BLOCKED; rolled 'latest' back to %s: %s\n%s",
             symbol,
             model_type,
+            prev_target.name if prev_target else "(none)",
             reason,
             report.summary(),
         )
@@ -181,3 +282,32 @@ def promote_version_if_valid(
         report=report,
         audit_path=audit,
     )
+
+
+def validate_candidate(
+    version_dir: Path,
+    *,
+    symbol: str,
+    model_type: str,
+    repoint_fn: RepointFn,
+    resolve_latest_fn: ResolveLatestFn = default_resolve_latest,
+    provider: str = "binance",
+    harness: BearValidationHarness | None = None,
+) -> ValidationReport:
+    """Score a candidate version WITHOUT deploying: flip, validate, always roll back.
+
+    Used by ``validate-model`` so an operator can pre-check a version without
+    changing what is live.
+    """
+    version_dir = Path(version_dir)
+    report, prev_target = _score_candidate(
+        version_dir,
+        symbol=symbol,
+        model_type=model_type,
+        provider=provider,
+        repoint_fn=repoint_fn,
+        resolve_latest_fn=resolve_latest_fn,
+        harness=harness,
+    )
+    _rollback(version_dir.parent, prev_target, repoint_fn)
+    return report

--- a/src/ml/validation/gate.py
+++ b/src/ml/validation/gate.py
@@ -1,0 +1,183 @@
+"""Model-promotion gate (#801).
+
+Decides whether a candidate model version may take the ``latest`` symlink,
+based on the bear-market validation harness, and leaves an auditable JSON
+record next to the model version. The actual symlink flip is delegated to an
+injected ``repoint_fn`` so this module stays independent of the CLI and of any
+particular engine (avoids a circular import with ``cli/commands/live.py``).
+
+Deviation from the plan noted for reviewers: the plan suggested routing through
+``src.experiments.promotion.PromotionManager``. That manager is tightly bound
+to experiment *suites* and a ledger of strategy-parameter variants, not model
+files, so reusing it here would be a poor fit. Instead this gate writes a
+purpose-built ``validation_audit.json`` next to the model version — same intent
+(an auditable, reproducible promotion decision), correct granularity.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from src.config.config_manager import get_config
+from src.config.constants import DEFAULT_VALIDATION_REQUIRED
+from src.ml.validation.bear_validation import BearValidationHarness, ValidationReport
+
+logger = logging.getLogger(__name__)
+
+AUDIT_FILENAME = "validation_audit.json"
+
+
+@dataclass
+class GateDecision:
+    """Outcome of a promotion-gate evaluation."""
+
+    passed: bool
+    promoted: bool
+    reason: str
+    report: ValidationReport | None
+    audit_path: Path | None
+
+
+def _validation_required() -> bool:
+    """Whether an un-runnable validation blocks promotion.
+
+    Env override ``VALIDATION_REQUIRED`` (truthy) forces the strict behavior in
+    environments that have data and must not promote unvalidated models.
+    """
+    return get_config().get_bool("VALIDATION_REQUIRED", DEFAULT_VALIDATION_REQUIRED)
+
+
+def write_audit_record(
+    version_dir: Path,
+    report: ValidationReport | None,
+    decision: dict,
+) -> Path:
+    """Write an auditable JSON record of the promotion decision.
+
+    Args:
+        version_dir: The model version directory being considered.
+        report: The validation report (may be ``None`` for forced/skipped runs).
+        decision: A small dict describing the decision (promoted, reason, ...).
+
+    Returns:
+        Path to the written audit file.
+    """
+    version_dir = Path(version_dir)
+    version_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "recorded_at": datetime.now(UTC).isoformat(),
+        "version": version_dir.name,
+        "decision": decision,
+        "report": report.to_dict() if report is not None else None,
+    }
+    audit_path = version_dir / AUDIT_FILENAME
+    # Atomic write so a crashed run never leaves a half-written audit file.
+    tmp_path = version_dir / f".{AUDIT_FILENAME}.tmp"
+    tmp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    import os
+
+    os.replace(tmp_path, audit_path)
+    return audit_path
+
+
+def promote_version_if_valid(
+    version_dir: Path,
+    *,
+    symbol: str,
+    model_type: str,
+    repoint_fn: Callable[[Path], None],
+    provider: str = "binance",
+    force: bool = False,
+    require_validation: bool | None = None,
+    harness: BearValidationHarness | None = None,
+) -> GateDecision:
+    """Validate a candidate model version and flip ``latest`` only if it passes.
+
+    Args:
+        version_dir: Path to the candidate version directory.
+        symbol: Trading symbol the model serves.
+        model_type: Registry model type (``basic``/``sentiment``).
+        repoint_fn: Callable that flips the ``latest`` symlink to ``version_dir``.
+        provider: Data provider for validation backtests.
+        force: Skip validation and promote regardless (human override). Still
+            writes an audit record marking the override.
+        require_validation: If True, an inconclusive/un-runnable validation
+            blocks promotion. Defaults to the ``VALIDATION_REQUIRED`` config.
+        harness: Injectable harness (tests). Defaults to a real harness pointed
+            at this version.
+
+    Returns:
+        A :class:`GateDecision` describing what happened.
+    """
+    version_dir = Path(version_dir)
+    strict = _validation_required() if require_validation is None else require_validation
+
+    if force:
+        repoint_fn(version_dir)
+        audit = write_audit_record(
+            version_dir,
+            None,
+            {"promoted": True, "forced": True, "reason": "human --force override"},
+        )
+        logger.warning(
+            "Model %s/%s promoted with --force (validation skipped): %s",
+            symbol,
+            model_type,
+            version_dir.name,
+        )
+        return GateDecision(
+            passed=False, promoted=True, reason="forced", report=None, audit_path=audit
+        )
+
+    harness = harness or BearValidationHarness(
+        symbol=symbol, model_type=model_type, provider=provider, model_path=version_dir
+    )
+    report = harness.run()
+    logger.info("%s", report.summary())
+
+    if report.passed:
+        repoint_fn(version_dir)
+        reason = "passed all validation windows"
+        promoted = True
+    elif report.inconclusive and not strict:
+        repoint_fn(version_dir)
+        reason = "validation inconclusive (could not run); promoted because validation not required"
+        promoted = True
+        logger.warning(
+            "Model %s/%s promoted despite INCONCLUSIVE validation (VALIDATION_REQUIRED is off): %s",
+            symbol,
+            model_type,
+            version_dir.name,
+        )
+    else:
+        reason = (
+            "validation inconclusive and validation is required"
+            if report.inconclusive
+            else "failed one or more validation windows"
+        )
+        promoted = False
+        logger.error(
+            "Model %s/%s BLOCKED from promotion: %s\n%s",
+            symbol,
+            model_type,
+            reason,
+            report.summary(),
+        )
+
+    audit = write_audit_record(
+        version_dir,
+        report,
+        {"promoted": promoted, "forced": False, "reason": reason},
+    )
+    return GateDecision(
+        passed=report.passed,
+        promoted=promoted,
+        reason=reason,
+        report=report,
+        audit_path=audit,
+    )

--- a/tests/unit/ml/validation/test_bear_validation.py
+++ b/tests/unit/ml/validation/test_bear_validation.py
@@ -13,7 +13,12 @@ from src.ml.validation.bear_validation import (
     BearWindow,
     load_validation_windows,
 )
-from src.ml.validation.gate import promote_version_if_valid, write_audit_record
+from src.ml.validation.gate import (
+    default_resolve_latest,
+    promote_version_if_valid,
+    validate_candidate,
+    write_audit_record,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -243,90 +248,133 @@ class _InconclusiveHarness:
         )
 
 
-def _version_dir(tmp_path):
-    d = tmp_path / "BTCUSDT" / "basic" / "2026-01-01_00h_v1"
+class _FakeRegistry:
+    """Tracks the ``latest`` pointer so tests assert final state, not raw calls."""
+
+    def __init__(self, initial=None):
+        self.latest = initial
+        self.repoints: list = []
+
+    def repoint(self, version_dir):
+        self.latest = version_dir
+        self.repoints.append(version_dir)
+
+    def resolve(self, _registry_dir):
+        return self.latest
+
+
+def _version_dir(tmp_path, name="2026-01-01_00h_v1"):
+    d = tmp_path / "BTCUSDT" / "basic" / name
     d.mkdir(parents=True)
     return d
 
 
-def test_gate_promotes_on_pass(tmp_path):
-    version = _version_dir(tmp_path)
-    flipped = []
-    decision = promote_version_if_valid(
+def _gate(version, harness, reg, **kw):
+    return promote_version_if_valid(
         version,
         symbol="BTCUSDT",
         model_type="basic",
-        repoint_fn=flipped.append,
-        harness=_PassingHarness(),
-        require_validation=True,
+        repoint_fn=reg.repoint,
+        resolve_latest_fn=reg.resolve,
+        harness=harness,
+        **kw,
     )
+
+
+def test_gate_promotes_on_pass(tmp_path):
+    version = _version_dir(tmp_path)
+    old = _version_dir(tmp_path, "old_v0")
+    reg = _FakeRegistry(initial=old)
+    decision = _gate(version, _PassingHarness(), reg, require_validation=True)
     assert decision.promoted is True
-    assert flipped == [version]
-    assert decision.audit_path.exists()
+    assert reg.latest == version  # candidate kept as latest
     audit = json.loads(decision.audit_path.read_text())
     assert audit["decision"]["promoted"] is True
 
 
-def test_gate_blocks_on_fail(tmp_path):
+def test_gate_blocks_and_rolls_back_on_fail(tmp_path):
     version = _version_dir(tmp_path)
-    flipped = []
-    decision = promote_version_if_valid(
-        version,
-        symbol="BTCUSDT",
-        model_type="basic",
-        repoint_fn=flipped.append,
-        harness=_FailingHarness(),
-        require_validation=True,
-    )
+    old = _version_dir(tmp_path, "old_v0")
+    reg = _FakeRegistry(initial=old)
+    decision = _gate(version, _FailingHarness(), reg, require_validation=True)
     assert decision.promoted is False
-    assert flipped == []
+    assert reg.latest == old  # rolled back to the previously-live model
     assert decision.audit_path.exists()
 
 
 def test_gate_soft_passes_inconclusive_when_not_required(tmp_path):
     version = _version_dir(tmp_path)
-    flipped = []
-    decision = promote_version_if_valid(
-        version,
-        symbol="BTCUSDT",
-        model_type="basic",
-        repoint_fn=flipped.append,
-        harness=_InconclusiveHarness(),
-        require_validation=False,
-    )
+    reg = _FakeRegistry(initial=_version_dir(tmp_path, "old_v0"))
+    decision = _gate(version, _InconclusiveHarness(), reg, require_validation=False)
     assert decision.promoted is True
-    assert flipped == [version]
+    assert reg.latest == version
 
 
 def test_gate_blocks_inconclusive_when_required(tmp_path):
     version = _version_dir(tmp_path)
-    flipped = []
-    decision = promote_version_if_valid(
-        version,
-        symbol="BTCUSDT",
-        model_type="basic",
-        repoint_fn=flipped.append,
-        harness=_InconclusiveHarness(),
-        require_validation=True,
+    old = _version_dir(tmp_path, "old_v0")
+    reg = _FakeRegistry(initial=old)
+    decision = _gate(version, _InconclusiveHarness(), reg, require_validation=True)
+    assert decision.promoted is False
+    assert reg.latest == old
+
+
+def test_gate_uses_known_prev_target_for_rollback(tmp_path):
+    # Simulates the training path: training already flipped latest to the
+    # candidate, so resolve() would return the candidate. known_prev_target
+    # must drive the rollback instead.
+    version = _version_dir(tmp_path)
+    old = _version_dir(tmp_path, "old_v0")
+    reg = _FakeRegistry(initial=version)  # training already promoted candidate
+    decision = _gate(
+        version, _FailingHarness(), reg, require_validation=True, known_prev_target=old
     )
     assert decision.promoted is False
-    assert flipped == []
+    assert reg.latest == old  # rolled back to pre-training model, not candidate
 
 
 def test_gate_force_promotes_without_validation(tmp_path):
     version = _version_dir(tmp_path)
-    flipped = []
+    reg = _FakeRegistry()
     decision = promote_version_if_valid(
         version,
         symbol="BTCUSDT",
         model_type="basic",
-        repoint_fn=flipped.append,
+        repoint_fn=reg.repoint,
+        resolve_latest_fn=reg.resolve,
         force=True,
     )
     assert decision.promoted is True
-    assert flipped == [version]
+    assert reg.latest == version
     audit = json.loads(decision.audit_path.read_text())
     assert audit["decision"]["forced"] is True
+
+
+def test_validate_candidate_always_rolls_back(tmp_path):
+    version = _version_dir(tmp_path)
+    old = _version_dir(tmp_path, "old_v0")
+    reg = _FakeRegistry(initial=old)
+    report = validate_candidate(
+        version,
+        symbol="BTCUSDT",
+        model_type="basic",
+        repoint_fn=reg.repoint,
+        resolve_latest_fn=reg.resolve,
+        harness=_PassingHarness(),
+    )
+    assert report.passed is True
+    assert reg.latest == old  # validate never leaves the candidate live
+
+
+def test_default_resolve_latest_reads_symlink(tmp_path):
+    type_dir = tmp_path / "BTCUSDT" / "basic"
+    version = type_dir / "v1"
+    version.mkdir(parents=True)
+    (type_dir / "latest").symlink_to("v1")
+    resolved = default_resolve_latest(type_dir)
+    assert resolved is not None
+    assert resolved.name == "v1"
+    assert default_resolve_latest(tmp_path / "nonexistent") is None
 
 
 def test_write_audit_record_atomic(tmp_path):

--- a/tests/unit/ml/validation/test_bear_validation.py
+++ b/tests/unit/ml/validation/test_bear_validation.py
@@ -1,0 +1,336 @@
+"""Unit tests for the bear-market model-validation gate (#801)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from src.experiments.schemas import ExperimentConfig, ExperimentResult
+from src.ml.validation.bear_validation import (
+    BearValidationHarness,
+    BearWindow,
+    load_validation_windows,
+)
+from src.ml.validation.gate import promote_version_if_valid, write_audit_record
+
+pytestmark = pytest.mark.unit
+
+
+def _window(name: str = "w", max_dd: float = 30.0, min_trades: int = 1) -> BearWindow:
+    return BearWindow(
+        name=name,
+        symbol="BTCUSDT",
+        timeframe="1d",
+        start=datetime(2022, 1, 1, tzinfo=UTC),
+        end=datetime(2022, 6, 1, tzinfo=UTC),
+        max_drawdown_pct=max_dd,
+        min_trades=min_trades,
+    )
+
+
+class _StubRunner:
+    """Runner double returning canned ExperimentResults keyed by call order."""
+
+    def __init__(self, results: list[object]):
+        self._results = list(results)
+        self.calls: list[ExperimentConfig] = []
+
+    def run(self, config: ExperimentConfig):
+        self.calls.append(config)
+        item = self._results[len(self.calls) - 1]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+def _result(config: ExperimentConfig, *, max_dd: float, trades: int = 10) -> ExperimentResult:
+    return ExperimentResult(
+        config=config,
+        total_trades=trades,
+        win_rate=50.0,
+        total_return=1.0,
+        annualized_return=1.0,
+        max_drawdown=max_dd,
+        sharpe_ratio=0.5,
+        final_balance=1010.0,
+        trade_pnl_pcts=[0.01] * trades,
+    )
+
+
+# --- config loader ---------------------------------------------------------
+
+
+def test_load_default_windows_config():
+    windows = load_validation_windows()
+    assert len(windows) == 3
+    names = {w.name for w in windows}
+    assert names == {"bear_2022", "crash_2025", "chop_2026"}
+    for w in windows:
+        assert w.end > w.start
+        assert w.max_drawdown_pct > 0
+
+
+def test_load_windows_missing_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_validation_windows(tmp_path / "nope.json")
+
+
+def test_load_windows_empty_list(tmp_path):
+    cfg = tmp_path / "w.json"
+    cfg.write_text(json.dumps({"windows": []}))
+    with pytest.raises(ValueError, match="non-empty 'windows'"):
+        load_validation_windows(cfg)
+
+
+def test_load_windows_applies_defaults(tmp_path):
+    cfg = tmp_path / "w.json"
+    cfg.write_text(
+        json.dumps(
+            {
+                "default_max_drawdown_pct": 33.0,
+                "default_min_trades": 7,
+                "windows": [
+                    {"name": "x", "symbol": "BTCUSDT", "start": "2022-01-01", "end": "2022-02-01"}
+                ],
+            }
+        )
+    )
+    (w,) = load_validation_windows(cfg)
+    assert w.max_drawdown_pct == 33.0
+    assert w.min_trades == 7
+
+
+def test_bear_window_rejects_bad_range():
+    with pytest.raises(ValueError, match="must be after start"):
+        BearWindow(
+            name="bad",
+            symbol="BTCUSDT",
+            timeframe="1d",
+            start=datetime(2022, 6, 1, tzinfo=UTC),
+            end=datetime(2022, 1, 1, tzinfo=UTC),
+            max_drawdown_pct=30.0,
+            min_trades=1,
+        )
+
+
+def test_bear_window_rejects_nonpositive_drawdown():
+    with pytest.raises(ValueError, match="max_drawdown_pct"):
+        _window(max_dd=0.0)
+
+
+# --- harness ---------------------------------------------------------------
+
+
+def test_harness_passes_when_all_windows_within_threshold():
+    windows = [_window("a", max_dd=40.0), _window("b", max_dd=40.0)]
+    captured: list[ExperimentConfig] = []
+
+    def factory():
+        runner = _StubRunner([])
+
+        def run(config):
+            captured.append(config)
+            return _result(config, max_dd=20.0)
+
+        runner.run = run  # type: ignore[method-assign]
+        return runner
+
+    harness = BearValidationHarness("BTCUSDT", "basic", provider="mock", runner_factory=factory)
+    report = harness.run(windows)
+    assert report.passed is True
+    assert report.inconclusive is False
+    assert all(s.passed for s in report.scores)
+
+
+def test_harness_fails_on_excess_drawdown():
+    windows = [_window("a", max_dd=25.0)]
+
+    def factory():
+        r = _StubRunner([])
+        r.run = lambda config: _result(config, max_dd=60.0)  # type: ignore[method-assign]
+        return r
+
+    harness = BearValidationHarness("BTCUSDT", "basic", provider="mock", runner_factory=factory)
+    report = harness.run(windows)
+    assert report.passed is False
+    assert report.scores[0].failures
+    assert "drawdown" in report.scores[0].failures[0]
+
+
+def test_harness_fails_on_too_few_trades():
+    windows = [_window("a", max_dd=90.0, min_trades=5)]
+
+    def factory():
+        r = _StubRunner([])
+        r.run = lambda config: _result(config, max_dd=5.0, trades=1)  # type: ignore[method-assign]
+        return r
+
+    harness = BearValidationHarness("BTCUSDT", "basic", provider="mock", runner_factory=factory)
+    report = harness.run(windows)
+    assert report.passed is False
+    assert any("trades" in f for f in report.scores[0].failures)
+
+
+def test_harness_inconclusive_when_backtest_raises():
+    windows = [_window("a")]
+
+    def factory():
+        r = _StubRunner([])
+
+        def run(config):
+            raise RuntimeError("no data for window")
+
+        r.run = run  # type: ignore[method-assign]
+        return r
+
+    harness = BearValidationHarness("BTCUSDT", "basic", provider="mock", runner_factory=factory)
+    report = harness.run(windows)
+    assert report.inconclusive is True
+    assert report.passed is False
+    assert report.scores[0].error is not None
+
+
+# --- gate ------------------------------------------------------------------
+
+
+class _PassingHarness:
+    def run(self):
+        from src.ml.validation.bear_validation import ValidationReport, WindowScore
+
+        return ValidationReport(
+            symbol="BTCUSDT",
+            model_type="basic",
+            strategy_name="ml_basic",
+            provider="mock",
+            created_at=datetime.now(UTC).isoformat(),
+            scores=[WindowScore("a", 0.5, 10.0, 55.0, 10, 10.0, True, [])],
+            passed=True,
+            inconclusive=False,
+        )
+
+
+class _FailingHarness:
+    def run(self):
+        from src.ml.validation.bear_validation import ValidationReport, WindowScore
+
+        return ValidationReport(
+            symbol="BTCUSDT",
+            model_type="basic",
+            strategy_name="ml_basic",
+            provider="mock",
+            created_at=datetime.now(UTC).isoformat(),
+            scores=[WindowScore("a", -1.0, 80.0, 20.0, 10, 10.0, False, ["max drawdown"])],
+            passed=False,
+            inconclusive=False,
+        )
+
+
+class _InconclusiveHarness:
+    def run(self):
+        from src.ml.validation.bear_validation import ValidationReport, WindowScore
+
+        return ValidationReport(
+            symbol="BTCUSDT",
+            model_type="basic",
+            strategy_name="ml_basic",
+            provider="mock",
+            created_at=datetime.now(UTC).isoformat(),
+            scores=[WindowScore("a", 0.0, 0.0, 0.0, 0, None, False, ["backtest raised"], "boom")],
+            passed=False,
+            inconclusive=True,
+        )
+
+
+def _version_dir(tmp_path):
+    d = tmp_path / "BTCUSDT" / "basic" / "2026-01-01_00h_v1"
+    d.mkdir(parents=True)
+    return d
+
+
+def test_gate_promotes_on_pass(tmp_path):
+    version = _version_dir(tmp_path)
+    flipped = []
+    decision = promote_version_if_valid(
+        version,
+        symbol="BTCUSDT",
+        model_type="basic",
+        repoint_fn=flipped.append,
+        harness=_PassingHarness(),
+        require_validation=True,
+    )
+    assert decision.promoted is True
+    assert flipped == [version]
+    assert decision.audit_path.exists()
+    audit = json.loads(decision.audit_path.read_text())
+    assert audit["decision"]["promoted"] is True
+
+
+def test_gate_blocks_on_fail(tmp_path):
+    version = _version_dir(tmp_path)
+    flipped = []
+    decision = promote_version_if_valid(
+        version,
+        symbol="BTCUSDT",
+        model_type="basic",
+        repoint_fn=flipped.append,
+        harness=_FailingHarness(),
+        require_validation=True,
+    )
+    assert decision.promoted is False
+    assert flipped == []
+    assert decision.audit_path.exists()
+
+
+def test_gate_soft_passes_inconclusive_when_not_required(tmp_path):
+    version = _version_dir(tmp_path)
+    flipped = []
+    decision = promote_version_if_valid(
+        version,
+        symbol="BTCUSDT",
+        model_type="basic",
+        repoint_fn=flipped.append,
+        harness=_InconclusiveHarness(),
+        require_validation=False,
+    )
+    assert decision.promoted is True
+    assert flipped == [version]
+
+
+def test_gate_blocks_inconclusive_when_required(tmp_path):
+    version = _version_dir(tmp_path)
+    flipped = []
+    decision = promote_version_if_valid(
+        version,
+        symbol="BTCUSDT",
+        model_type="basic",
+        repoint_fn=flipped.append,
+        harness=_InconclusiveHarness(),
+        require_validation=True,
+    )
+    assert decision.promoted is False
+    assert flipped == []
+
+
+def test_gate_force_promotes_without_validation(tmp_path):
+    version = _version_dir(tmp_path)
+    flipped = []
+    decision = promote_version_if_valid(
+        version,
+        symbol="BTCUSDT",
+        model_type="basic",
+        repoint_fn=flipped.append,
+        force=True,
+    )
+    assert decision.promoted is True
+    assert flipped == [version]
+    audit = json.loads(decision.audit_path.read_text())
+    assert audit["decision"]["forced"] is True
+
+
+def test_write_audit_record_atomic(tmp_path):
+    version = _version_dir(tmp_path)
+    path = write_audit_record(version, None, {"promoted": True, "reason": "x"})
+    assert path.exists()
+    assert json.loads(path.read_text())["decision"]["reason"] == "x"


### PR DESCRIPTION
Closes #801. First of the bear-market hardening PRs (#801–#807).

## Problem
ONNX price models trained on the long-biased 2023–2025 market can go long into bear-market dead-cat bounces. Nothing stopped a freshly trained model from taking the `latest` symlink and going live unvalidated.

## What this does
Gates ML model promotion on a fixed set of historical bear/crash/chop windows. A candidate keeps `latest` only if it holds max-drawdown at/below a per-window threshold.

- **`src/ml/validation/` (new package)**
  - `BearValidationHarness` — scores a model per window (Sharpe / max-drawdown / win-rate / trades) by running the backtest engine, reusing `ExperimentRunner` so `mock`/`fixture` providers give deterministic, network-free CI runs.
  - `promote_version_if_valid` / `validate_candidate` — the prediction registry resolves models purely by the `latest` symlink, so the gate scores the **candidate** via **flip → validate → roll-back-on-failure** (canary-with-rollback; a failing model is reverted to the previously-live version — fail-safe). Writes an auditable `validation_audit.json` next to the version.
- **Config, not code**: windows + thresholds live in `config/validation_windows.json`; defaults in `constants.py`.
- **CLI**: `deploy-model` is now validation-gated (`--skip-validation` audited human override); `train --auto-deploy` keeps the trained model only if it passes (else rolls `latest` back to the pre-training model); new `validate-model` scores without changing what is live.
- **Graceful degradation**: a run that can't execute (missing data) is *inconclusive* → soft-pass with a loud warning, unless `VALIDATION_REQUIRED` is truthy (then it blocks/rolls back). Keeps data-less/CI environments unwedged while letting real promotion environments be strict.

## Design note
The plan suggested routing through `PromotionManager`, but that's bound to experiment suites/ledger + strategy-parameter variants, not model files. This gate writes a purpose-built audit record instead — same intent (auditable, reproducible decision), correct granularity. Documented in `gate.py`.

## Review history
Passed an adversarial `code-reviewer` pass that caught two merge-blockers in the first cut — a `model_path` override that was silently rejected by `ExperimentRunner` (fail-open promotion) and a sentiment `--auto-deploy` bypass. Both fixed by the flip-validate-rollback redesign + capturing the pre-training target in the CLI (second commit).

## Testing
- `tests/unit/ml/validation/test_bear_validation.py` — 19 unit tests: config loader + `BearWindow` validation; harness pass/fail/too-few-trades/inconclusive; gate promote-on-pass, block-and-rollback, inconclusive soft-pass vs strict, `known_prev_target` rollback (training path), force, `validate_candidate` always-rolls-back, symlink resolution, atomic audit write.
- End-to-end harness run against the deterministic `mock` provider (real backtest) verified.
- `black` / `ruff` / `mypy` (via `bin/run_mypy.py`) / `bandit` clean on changed files.
- Existing `tests/unit/cli` (162) still green — `deploy-model` remains backward-compatible (soft-passes inconclusive).

## Out of scope (human sign-off)
Actual retraining on bear-inclusive windows and live model promotion / `latest` flips remain human/ml-engineer actions. No feature is enabled in live/paper by this PR.

## Environment note
Full model training (TensorFlow) isn't runnable in CI here; the deliverable is the CI-runnable harness + gate + tests. Real exact-window backtests require the operator's cached data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNc8P32ufwPP9LqbrXbjhk)_