### PR TITLE
fix(live): exclude offline-SL-fill-pending positions from balance notional

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -172,6 +172,16 @@ class ReconciliationResult:
 # ---------- Startup Reconciliation ----------
 
 
+def _is_exchange_close_pending(position: Any) -> bool:
+    """True when the exchange side of this position is already closed (its offline stop-loss
+    filled) but the DB row close is still pending after a failed ``close_position``. Such a
+    position is deliberately RETAINED in the tracker for close retry (removing it while the row
+    stays OPEN would diverge memory from the DB), yet it no longer backs any exchange holding —
+    so spot balance reconciliation must exclude its notional (counting it would add the
+    already-realized value back and overstate capital, oversizing later positions)."""
+    return bool(getattr(position, "exchange_close_pending", False))
+
+
 class PositionReconciler:
     """Verifies recovered positions and resolves pending orders on startup.
 
@@ -1835,7 +1845,10 @@ class PositionReconciler:
         if not db_closed:
             # Leave the position in the in-memory tracker (consistent with its still-OPEN DB
             # row) so it is re-reconciled on a later pass — removing it while the DB row stays
-            # OPEN would diverge memory from the DB (CODE.md: no silent divergence).
+            # OPEN would diverge memory from the DB (CODE.md: no silent divergence). The SL has
+            # filled, so the asset is gone from the exchange: flag it so spot balance
+            # reconciliation excludes its notional instead of adding the realized value back.
+            position.exchange_close_pending = True
             logger.warning(
                 "Skipping close for %s — DB position %s was not closed; left in tracker for "
                 "re-reconciliation on a later pass.",
@@ -2275,6 +2288,11 @@ class PositionReconciler:
         total = 0.0
         positions = self.position_tracker.positions
         for position in positions.values():
+            # Skip positions whose exchange side is already closed (offline SL fill) but whose
+            # DB close is still pending — the asset is gone, so counting notional would add the
+            # realized value back and overstate capital (oversizing later positions).
+            if _is_exchange_close_pending(position):
+                continue
             # Use quantity (actual asset amount), not size (balance fraction).
             # Coerce to float — DB-loaded positions carry Decimal (Numeric)
             # fields, and mixing Decimal with the float `total`/price below
@@ -2983,6 +3001,10 @@ class PeriodicReconciler:
             # to float — DB-loaded positions carry Decimal (Numeric) fields (#653 class).
             position_notional = 0.0
             for position in self.position_tracker.positions.values():
+                # Skip positions flat on the exchange (offline SL fill) but pending DB close —
+                # their asset is already sold, so counting notional would overstate capital.
+                if _is_exchange_close_pending(position):
+                    continue
                 qty = float(getattr(position, "quantity", None) or 0.0)
                 price = float(getattr(position, "entry_price", 0) or 0.0)
                 if qty > 0 and price > 0:

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -48,6 +48,7 @@ class MockPosition:
     last_partial_exit_price: float | None = None
     original_size: float | None = 0.1
     entry_balance: float | None = None
+    exchange_close_pending: bool = False
 
 
 @dataclass
@@ -1220,6 +1221,62 @@ class TestBalanceAccountsForPositionNotional:
         result = reconciler._reconcile_balance()
         assert result.severity != Severity.CRITICAL
         assert result.status == "verified"
+
+    def test_filled_sl_close_fail_flags_exchange_close_pending(
+        self, reconciler, mock_db, mock_position_tracker
+    ):
+        """_close_position_from_filled_sl retains the position when the DB close RETURNS False,
+        and flags it exchange_close_pending: the stop-loss already sold the asset, so balance
+        reconciliation must exclude its notional rather than add the realized value back."""
+        from types import SimpleNamespace as NS
+
+        pos = MockPosition(db_position_id=90, order_id="pos-90")
+        mock_db.close_position.return_value = False
+        sl_order = NS(
+            average_price=48000.0, order_id="sl-90", commission=0.0, commission_asset="USDT"
+        )
+
+        reconciler._close_position_from_filled_sl(pos, sl_order)
+
+        assert getattr(pos, "exchange_close_pending", False) is True
+        mock_position_tracker.remove_position.assert_not_called()
+
+    def test_estimate_notional_skips_exchange_close_pending(
+        self, reconciler, mock_position_tracker
+    ):
+        """_estimate_position_notional counts genuinely-held positions and skips flagged ones."""
+        held = MockPosition(
+            entry_price=50000.0, current_size=0.1, original_size=0.1, quantity=0.1, symbol="BTCUSDT"
+        )
+        flat = MockPosition(
+            entry_price=3000.0, current_size=1.0, original_size=1.0, quantity=1.0, symbol="ETHUSDT"
+        )
+        flat.exchange_close_pending = True
+        mock_position_tracker.positions = {"held": held, "flat": flat}
+
+        # Only the held position (0.1 * 50000 = 5000) contributes; the flat one is excluded.
+        assert reconciler._estimate_position_notional() == pytest.approx(5000.0)
+
+    def test_exchange_close_pending_position_not_overstated(
+        self, reconciler, mock_exchange, mock_db, mock_position_tracker
+    ):
+        """A retained offline-SL-fill whose DB close failed (exchange_close_pending) must not
+        trigger a spurious CRITICAL balance correction that adds its already-sold value back.
+
+        Scenario: $10,000 DB capital, 0.1 BTC @ $50,000 ($5,000 notional) sold by the offline
+        SL ~break-even, so the exchange now holds $10,000 USDT. Excluding the flat position,
+        expected USDT = $10,000 and there is no discrepancy.
+        """
+        pos = MockPosition(entry_price=50000.0, current_size=0.1)
+        pos.exchange_close_pending = True
+        mock_position_tracker.positions = {"pos_1": pos}
+        mock_exchange.get_balance.return_value = MockBalance(total=10000.0)
+        mock_db.get_current_balance.return_value = 10000.0
+
+        result = reconciler._reconcile_balance()
+
+        assert result.severity != Severity.CRITICAL
+        mock_db.update_balance.assert_not_called()
 
     def test_genuine_discrepancy_still_triggers_critical(
         self, reconciler, mock_exchange, mock_db, mock_position_tracker


### PR DESCRIPTION
## What & why

`PositionReconciler._close_position_from_filled_sl` deliberately **retains** a position in the tracker when `close_position` returns `False` (a swallowed DB error), so the still-`OPEN` row is re-reconciled on a later pass rather than diverging from memory. But the retained position's **stop-loss has already filled** — its asset is gone from the exchange — while both spot balance checks estimate open notional from the tracker:

- startup Step C: `_estimate_position_notional` → `_reconcile_balance`
- periodic: `_reconcile_spot_balance`

So they counted the flat position's notional and wrote `corrected_balance = exchange_total + position_notional`, **double-counting** the SL sale proceeds (already in `exchange_total`) and adding the notional back → capital overstated, later positions oversized.

This is the **only** remaining retain-on-fail path. The sibling external-close / phantom paths (`_verify_asset_holdings`, `_remove_phantom_position`, `_reconcile_filled_exit`, and the periodic removals) all pop-first + gate side-effects + escalate on divergence, so their flat positions never reach the balance check.

## The fix

Flag the retained position `exchange_close_pending` and skip flagged positions in **both** notional loops. No clear path is needed: an offline SL fill doesn't recover, and the flag is discarded when the DB close eventually succeeds and the position is removed.

## Testing performed

TDD — each new test watched to fail first:
- `test_filled_sl_close_fail_flags_exchange_close_pending` — flag set + position retained on a `False` close.
- `test_estimate_notional_skips_exchange_close_pending` — only genuinely-held positions contribute notional.
- `test_exchange_close_pending_position_not_overstated` — a flagged position no longer triggers a spurious CRITICAL balance correction.

Results:
- `pytest tests/unit/live/test_reconciliation.py tests/unit/test_trade_commission_quantity_persistence.py` → **172 passed**
- `bin/run_mypy.py` on the source → clean; `black` + `ruff` → clean

## Context

This is the sole residual from a broader look at reconciler close-return-value handling. The core close-return gating this branch originally set out to add already landed on `develop` via #799 (with a more complete pop-and-escalate design), so this PR carries only the one balance-overstatement gap #799's rework left in the retain-on-fail SL path. Supersedes #852 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
