### PR TITLE
feat(live): surface reconciliation-cycle severity in system_events (#853)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2915,6 +2915,10 @@ class PeriodicReconciler:
         self.interval = interval
         self.on_critical = on_critical
         self.on_event = on_event
+        # Peak severity of the previous cycle — used to edge-trigger the
+        # cycle-severity event so a persistent HIGH/CRITICAL condition pages/logs
+        # once on the rising edge, not every cycle.
+        self._last_cycle_severity = Severity.LOW
         self._symbols = symbols or []
 
         self._running = False
@@ -3741,6 +3745,47 @@ class PeriodicReconciler:
                 self.on_critical()
             except Exception as e:
                 logger.error("on_critical callback failed: %s", e)
+
+        # 6. Surface the cycle's peak severity in system_events (+ page on
+        # CRITICAL). Lock-free: positions were snapshotted at the top of the
+        # cycle and per-item locks are released, so the alert webhook cannot
+        # block a position mutation.
+        self._emit_cycle_severity(max_severity)
+
+    def _emit_cycle_severity(self, max_severity: Severity) -> None:
+        """Emit a system_events row for a HIGH/CRITICAL reconciliation cycle.
+
+        HIGH-severity drift (entry-price/qty mismatch, orphaned SL, external
+        close) otherwise writes only ``reconciliation_audit_events`` + logs and
+        never reaches ``system_events`` or an operator. Edge-triggered against
+        the previous cycle's peak severity so a persistent condition surfaces
+        once on the rising edge rather than every ~60s cycle (proper
+        rate-limiting/escalation is tracked separately).
+        """
+        prev = self._last_cycle_severity
+        self._last_cycle_severity = max_severity
+        if max_severity < Severity.HIGH or max_severity <= prev:
+            return
+        if max_severity == Severity.CRITICAL:
+            _emit_event(
+                self.on_event,
+                EventType.ALERT,
+                "Reconciliation cycle detected a CRITICAL discrepancy — see "
+                "reconciliation_audit_events for the specific correction",
+                severity="critical",
+                error_code="RECONCILE_CRITICAL",
+                alert=True,
+            )
+        else:  # HIGH
+            _emit_event(
+                self.on_event,
+                EventType.WARNING,
+                "Reconciliation cycle detected a HIGH-severity discrepancy — see "
+                "reconciliation_audit_events for details",
+                severity="warning",
+                error_code="RECONCILE_HIGH",
+                alert=False,
+            )
 
     def _place_missing_stop_loss(self, position: Any, order_key: str) -> None:
         """Place a stop-loss for a position that has none (e.g. phantom from timeout).

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3858,3 +3858,60 @@ class TestReconcilerEventSink:
         # The child PositionReconciler must receive the same sink so its
         # emergency-close paths can page too.
         assert pr._position_reconciler.on_event is cb
+
+
+class TestReconcileCycleSeverityEvent:
+    """The periodic cycle surfaces its peak severity in system_events — HIGH
+    drift was previously invisible (audit-row + log only). Edge-triggered so a
+    persistent condition doesn't page/log every ~60s cycle (#853)."""
+
+    @staticmethod
+    def _reconciler(mock_exchange, mock_position_tracker, mock_db, on_event):
+        return PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            on_event=on_event,
+        )
+
+    def test_critical_pages_operator(self, mock_exchange, mock_position_tracker, mock_db):
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.CRITICAL)
+        on_event.assert_called_once()
+        args, kwargs = on_event.call_args
+        assert args[0] == EventType.ALERT
+        assert kwargs["error_code"] == "RECONCILE_CRITICAL"
+        assert kwargs["alert"] is True
+
+    def test_high_emits_event_but_does_not_page(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.HIGH)
+        on_event.assert_called_once()
+        _, kwargs = on_event.call_args
+        assert kwargs["error_code"] == "RECONCILE_HIGH"
+        assert kwargs["alert"] is False
+
+    def test_low_and_medium_do_not_emit(self, mock_exchange, mock_position_tracker, mock_db):
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.LOW)
+        pr._emit_cycle_severity(Severity.MEDIUM)
+        on_event.assert_not_called()
+
+    def test_persistent_critical_only_pages_on_rising_edge(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.CRITICAL)  # rising edge -> emit
+        pr._emit_cycle_severity(Severity.CRITICAL)  # persistent -> no re-emit
+        assert on_event.call_count == 1
+        # Drops back then re-rises -> a new occurrence re-pages.
+        pr._emit_cycle_severity(Severity.LOW)
+        pr._emit_cycle_severity(Severity.CRITICAL)
+        assert on_event.call_count == 2

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3915,3 +3915,26 @@ class TestReconcileCycleSeverityEvent:
         pr._emit_cycle_severity(Severity.LOW)
         pr._emit_cycle_severity(Severity.CRITICAL)
         assert on_event.call_count == 2
+
+    def test_escalation_high_to_critical_pages(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """HIGH then CRITICAL must page on the escalation (prev=HIGH, not LOW)."""
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.HIGH)  # WARNING (rising edge)
+        pr._emit_cycle_severity(Severity.CRITICAL)  # escalation -> pages
+        assert on_event.call_count == 2
+        _, kwargs = on_event.call_args
+        assert kwargs["error_code"] == "RECONCILE_CRITICAL"
+        assert kwargs["alert"] is True
+
+    def test_de_escalation_critical_to_high_stays_silent(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """CRITICAL then HIGH must NOT re-emit (severity fell, not a rising edge)."""
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.CRITICAL)  # ALERT (rising edge)
+        pr._emit_cycle_severity(Severity.HIGH)  # de-escalation -> silent
+        assert on_event.call_count == 1


### PR DESCRIPTION
## Summary
PR 3 of #853. The periodic reconcile cycle tracked a peak severity but only *acted* on CRITICAL (flip to close-only). **HIGH-severity drift** (entry-price/qty mismatch, orphaned SL, external close) wrote only `reconciliation_audit_events` + logs — invisible to anyone watching `system_events` (gap #6). And CRITICAL had no distinct event beyond the mode flip.

## Changes
- `_emit_cycle_severity()` emits at the **cycle boundary**, which is **lock-free** — positions are snapshotted at the top of the cycle and per-item locks are released, so the alert webhook cannot block a position mutation (this is the lock-free pattern promised in PR 2's review). A paged `EventType.ALERT` on CRITICAL; a non-paging `EventType.WARNING` on HIGH.
- **Edge-triggered** against the previous cycle's peak severity: a persistent HIGH/CRITICAL surfaces once on the rising edge, not every ~60s cycle — avoids the alert/row spam the audit itself flagged (the 714 unalerted-but-would-now-be-spammy criticals). Proper rate-limiting/escalation is a separate follow-up.

## Testing
- 4 new unit tests: CRITICAL pages (ALERT, `alert=True`), HIGH emits a WARNING event but does **not** page, LOW/MEDIUM emit nothing, and a persistent CRITICAL only pages on the rising edge (drops + re-rises → re-pages). 137 passed in the file; quality gate (Black/Ruff/MyPy) clean.

## Scope
Merges to `develop`. Addresses gap #6; strengthens CRITICAL visibility. Follow-ups: margin-liquidation audit+severity (#3), orphan-sweep event (#7), phantom-removal audit (#8), realize-pnl skip audit (#9). Part of #853.