### PR TITLE
feat(live): audit + surface margin external-close/liquidation in reconcile cycle (#853)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -3296,6 +3296,27 @@ class PeriodicReconciler:
                             "cancelling SL and removing from tracker",
                             symbol,
                         )
+                        # Audit the external close / liquidation and raise the cycle
+                        # severity so it surfaces in system_events (the cycle-severity
+                        # event) — the spot branch already does this; the margin branch
+                        # previously left a liquidation with no audit row and no severity
+                        # bump (#853). Margin capital is reconciled by AccountSynchronizer,
+                        # so this is observability-only (no balance move here).
+                        if Severity.HIGH > max_severity:
+                            max_severity = Severity.HIGH
+                        self.db_manager.log_audit_event(
+                            session_id=self.session_id,
+                            entity_type="position",
+                            entity_id=getattr(position, "db_position_id", None),
+                            field="status",
+                            old_value="OPEN",
+                            new_value="CLOSED_EXTERNALLY",
+                            reason=(
+                                f"Margin position {symbol} externally closed / liquidated "
+                                f"(borrowed/netAsset for base asset ~ 0)"
+                            ),
+                            severity=Severity.HIGH.value,
+                        )
                         # Cancel exchange SL to prevent orphaned order
                         if sl_id:
                             try:

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3804,6 +3804,43 @@ class TestPeriodicExternalCloseTradeRow:
         assert db.get_current_balance(1) == pytest.approx(10000.0)
         assert pos.order_id not in tracker.positions
 
+    def test_margin_external_close_audits_and_surfaces_high_severity(self, mock_exchange):
+        """A margin external close / liquidation now writes a CLOSED_EXTERNALLY
+        audit row AND bumps cycle severity to HIGH, so it surfaces via the
+        cycle-severity event instead of being silent (#853)."""
+        from tests.mocks import MockDatabaseManager
+
+        db = MockDatabaseManager()
+        _db_id, tracker, pos = self._seed(db, side="short")
+
+        mock_exchange.get_order.side_effect = self._order_side_effect()
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)  # short closed
+        mock_exchange.get_balance.side_effect = lambda asset: MockBalance(asset=asset, total=0.0)
+        data_provider = MagicMock()
+        data_provider.get_current_price.return_value = 48000.0
+        on_event = MagicMock()
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=tracker,
+            db_manager=db,
+            session_id=1,
+            interval=60,
+            use_margin=True,
+            data_provider=data_provider,
+            on_event=on_event,
+        )
+        reconciler._reconcile_cycle()
+
+        # CLOSED_EXTERNALLY audit row written for the liquidation.
+        audits = db.get_audit_events(session_id=1)
+        assert any(a["new_value"] == "CLOSED_EXTERNALLY" for a in audits), audits
+        # Severity bumped to HIGH -> the cycle-severity event records it in system_events.
+        high_events = [
+            c for c in on_event.call_args_list if c.kwargs.get("error_code") == "RECONCILE_HIGH"
+        ]
+        assert high_events, f"expected RECONCILE_HIGH, got {on_event.call_args_list}"
+
 
 class TestReconcilerEventSink:
     """The reconciler gains a system_events/alert sink via an injected on_event
@@ -3916,9 +3953,7 @@ class TestReconcileCycleSeverityEvent:
         pr._emit_cycle_severity(Severity.CRITICAL)
         assert on_event.call_count == 2
 
-    def test_escalation_high_to_critical_pages(
-        self, mock_exchange, mock_position_tracker, mock_db
-    ):
+    def test_escalation_high_to_critical_pages(self, mock_exchange, mock_position_tracker, mock_db):
         """HIGH then CRITICAL must page on the escalation (prev=HIGH, not LOW)."""
         on_event = MagicMock()
         pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)


### PR DESCRIPTION
## Summary
PR 4 of #853. The periodic reconcile cycle's **margin** external-close branch closed the position and wrote a balance-neutral trade row but — unlike the **spot** branch — left **no `reconciliation_audit_events` row and did not raise the cycle severity**. So a margin liquidation (the live trading mode) was invisible to `system_events` (gap #3).

## Changes (mirrors the already-tested spot branch)
- Write a `CLOSED_EXTERNALLY` audit row for the margin external close / liquidation.
- Bump `max_severity` to HIGH, so the cycle-severity event from PR #861 automatically surfaces the liquidation in `system_events`.
- Observability-only: margin capital is reconciled by `AccountSynchronizer._sync_margin_equity`, so no balance move here (unchanged).

## Testing
- New test `test_margin_external_close_audits_and_surfaces_high_severity` drives the real margin external-close branch (short position, `get_margin_borrowed=0`, SL PENDING) and asserts both the `CLOSED_EXTERNALLY` audit row and a `RECONCILE_HIGH` event via `on_event`. 140 passed in the file; quality gate (Black/Ruff/MyPy) clean.

## Scope
Merges to `develop`. Addresses gap #3. Remaining reconciler follow-ups: orphan-sweep event (#7), phantom-removal audit (#8), realize-pnl skip audit (#9). Part of #853.