### PR TITLE
feat(live): page + record a distinct event on abnormal trading-loop death (#853)

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1325,6 +1325,18 @@ class LiveTradingEngine:
         except Exception as e:
             self._loop_crashed = True
             logger.critical("Trading loop terminated unexpectedly: %s", e, exc_info=True)
+            # Distinct paged event so an abnormal loop death is distinguishable
+            # from a clean ENGINE_STOP in system_events (the 2026-05-19 zombie-bot
+            # class, where the process stayed up but the loop was dead). #853
+            self._record_event(
+                EventType.ALERT,
+                f"Trading loop crashed unexpectedly: {e}",
+                severity="critical",
+                component="engine",
+                error_code="LOOP_CRASH",
+                exc=e,
+                alert=True,
+            )
 
     def _exit_if_loop_crashed(self, exit_on_crash: bool) -> None:
         """Exit the process non-zero if the trading loop died abnormally (#630).
@@ -1598,6 +1610,18 @@ class LiveTradingEngine:
                     logger.critical(
                         f"Too many consecutive errors ({self.consecutive_errors}). Stopping engine.",
                         exc_info=True,
+                    )
+                    # Paged event before the (generic) ENGINE_STOP so operators can
+                    # distinguish this abnormal shutdown from a clean stop. #853
+                    self._record_event(
+                        EventType.ALERT,
+                        f"Trading loop stopping — {self.consecutive_errors} consecutive errors "
+                        f"reached the limit (last: {e})",
+                        severity="critical",
+                        component="engine",
+                        error_code="LOOP_MAX_ERRORS",
+                        exc=e,
+                        alert=True,
                     )
                     # Abnormal stop: signal start() to exit non-zero for a restart (#630).
                     self._loop_crashed = True

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -257,3 +257,27 @@ class TestRunnerWebhookEnvFallback:
         monkeypatch.delenv("ALERT_WEBHOOK_URL", raising=False)
         monkeypatch.setattr(sys, "argv", ["prog", "ml_basic"])
         assert parse_args().webhook_url is None
+
+
+class TestLoopCrashEvent:
+    """An abnormal loop death must page + emit a distinct system_event so it is
+    distinguishable from a clean ENGINE_STOP — the 2026-05-19 zombie-bot class
+    where the process stayed up but the trading loop was dead (#853)."""
+
+    def test_unhandled_loop_crash_pages_and_flags(self):
+        engine = LiveTradingEngine.__new__(LiveTradingEngine)
+        engine._loop_crashed = False
+        engine._record_event = MagicMock()
+        engine._trading_loop = MagicMock(side_effect=RuntimeError("boom"))
+
+        # Must not propagate — the wrapper exists precisely to catch it.
+        engine._run_trading_loop("BTCUSDT", "1h")
+
+        assert engine._loop_crashed is True
+        engine._record_event.assert_called_once()
+        args, kwargs = engine._record_event.call_args
+        assert args[0] == EventType.ALERT
+        assert kwargs["error_code"] == "LOOP_CRASH"
+        assert kwargs["severity"] == "critical"
+        assert kwargs["alert"] is True
+        assert isinstance(kwargs["exc"], RuntimeError)


### PR DESCRIPTION
## Summary
PR 5 of #853. An unhandled trading-loop crash or a consecutive-error shutdown only did `logger.critical` and then emitted a **generic `ENGINE_STOP`** — byte-for-byte indistinguishable from a clean stop. That's the **2026-05-19 zombie-bot class** (process stayed up, loop dead, silent for 12 days). The engine already has the fault-isolated `_record_event`; it just wasn't called on these paths.

## Changes
- **`_run_trading_loop`** — on an unhandled exception, emit a critical `LOOP_CRASH` ALERT (carrying the exception for a traceback) before `start()` turns it into a non-zero exit. This fulfils the method's own docstring ("catch any unhandled exception, **record it**"), which the code wasn't doing.
- **`_trading_loop`** — on consecutive-error exhaustion (`>= max_consecutive_errors`), emit a critical `LOOP_MAX_ERRORS` ALERT before the generic `ENGINE_STOP`.

Now an operator can tell an abnormal death from a clean stop by the presence of a distinct paged event (no change to `ENGINE_STOP` itself — minimal, additive).

## Testing
- New `TestLoopCrashEvent::test_unhandled_loop_crash_pages_and_flags` drives `_run_trading_loop` with `_trading_loop` raising; asserts the crash is caught (no propagation), `_loop_crashed` set, and a critical `LOOP_CRASH` ALERT (`alert=True`, `exc` forwarded) is emitted. 18 in file; **773 passed** across `tests/unit/engines/live/` + `tests/unit/live/` (no regression). Quality gate (Black/Ruff/MyPy) clean.

## Scope
Merges to `develop`. Additive observability on already-abnormal paths (behavior of crash/restart unchanged). Part of #853.