### PR TITLE
fix(strategies): thread trading symbol to ML signal generator; guard cross-symbol model substitution

### DIFF
--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -20,6 +20,7 @@ if SRC_PATH.exists() and str(SRC_PATH) not in sys.path:
 
 from src.infrastructure.logging.config import configure_logging
 from src.strategies import (
+    call_strategy_factory,
     create_adaptive_trend_strategy,
     create_ensemble_weighted_strategy,
     create_hyper_growth_strategy,
@@ -36,7 +37,12 @@ from src.trading.symbols.factory import SymbolFactory
 logger = logging.getLogger("atb.backtest")
 
 
-def _load_strategy(strategy_name: str):
+def _load_strategy(strategy_name: str, symbol: str | None = None):
+    """Load a strategy by name, threading the trading symbol when supported.
+
+    Mirrors the live runner (backtest-live parity): the symbol must reach ML
+    signal generators so model registry selection matches the traded pair.
+    """
     # Define available strategies with their import paths and classes
     available_strategies: dict[str, Callable[..., Strategy]] = {
         "ml_basic": create_ml_basic_strategy,
@@ -53,7 +59,7 @@ def _load_strategy(strategy_name: str):
     try:
         builder = available_strategies.get(strategy_name)
         if builder is not None:
-            return builder()
+            return call_strategy_factory(builder, symbol=symbol)
 
         print(f"Unknown strategy: {strategy_name}")
         print(f"Available strategies: {', '.join(available_strategies.keys())}")
@@ -89,7 +95,7 @@ def _handle(ns: argparse.Namespace) -> int:
 
         start_date, end_date = _get_date_range(ns)
 
-        strategy = _load_strategy(ns.strategy)
+        strategy = _load_strategy(ns.strategy, symbol=ns.symbol)
         logger.info(f"Loaded strategy: {strategy.name}")
 
         # Provider - use factory for automatic failover support

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+<<<<<<< HEAD
 - **Exposure-governor pre-enablement fixes** (#802 follow-ups, from the PR merge
   note): (P2) `src/engines/shared/exposure.py::position_notional` now uses a
   position's `current_size` (the live fraction after partial exits / scale-ins)
@@ -21,6 +22,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scale-in's added exposure to `scale_in_gross_cap_headroom` (conservative cap −
   current gross). Both remain inert unless `enable_exposure_governor` is on. This
   clears the two conditions the PM flagged before the governor can be enabled live.
+=======
+- **P0: trading symbol now reaches the ML signal generator; cross-symbol model
+  substitution is guarded** (2026-07-04 ml-engineer audit finding): the live
+  runner and the backtest CLI constructed strategies with zero arguments, so
+  `--symbol ETHUSDT` never reached `MLBasicSignalGenerator`, which defaulted to
+  `BTCUSDT` for model registry selection — HyperGrowth live on ETHUSDT silently
+  scored every bar with the BTCUSDT basic model. Both runners now thread the
+  symbol through `call_strategy_factory()` (`src/strategies/__init__.py`) into
+  every factory that composes `MLBasicSignalGenerator` (`hyper_growth`,
+  `ml_basic`, `leveraged_regime`, `ensemble_weighted`, `StrategyFactory`
+  presets); the generator normalizes it to the registry's Binance-style form.
+  Guards at the generator/registry seam (identical in backtest and live):
+  - **Fail fast at startup** when no model bundle exists for
+    `(symbol, model_type, timeframe)` — the error lists available bundles
+    instead of silently substituting the default model.
+  - **`FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true`** explicitly opts into the
+    substitution: startup logs CRITICAL and pins a deterministic fallback
+    bundle (same type/timeframe, `BTCUSDT` preferred), and every resolution
+    logs a rate-limited WARNING. **Prod transition path**: production ETHUSDT
+    has no `basic` model yet, so promoting this fix requires setting the flag
+    temporarily — behavior is then *unchanged but loud* — until an ETHUSDT
+    basic model ships, at which point the flag must be unset.
+  - **Rate-limited ERROR on mismatch** whenever the resolved bundle's symbol
+    differs from the trading symbol, and `Signal.metadata` is stamped with
+    `trading_symbol` + `model_symbol` for auditability.
+  - If the bundle vanishes after startup (registry reload), predictions fail
+    safe (HOLD) instead of falling back to another symbol's model.
+  Direct constructions without a symbol keep the `BTCUSDT` default.
+>>>>>>> fa307655 (fix(strategies): thread trading symbol to ML signal generator; guard cross-symbol model substitution)
 
 ### Added
 - **Account circuit-breaker loop enforcement** (#807 follow-up): a new

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-<<<<<<< HEAD
 - **Exposure-governor pre-enablement fixes** (#802 follow-ups, from the PR merge
   note): (P2) `src/engines/shared/exposure.py::position_notional` now uses a
   position's `current_size` (the live fraction after partial exits / scale-ins)
@@ -22,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scale-in's added exposure to `scale_in_gross_cap_headroom` (conservative cap −
   current gross). Both remain inert unless `enable_exposure_governor` is on. This
   clears the two conditions the PM flagged before the governor can be enabled live.
-=======
 - **P0: trading symbol now reaches the ML signal generator; cross-symbol model
   substitution is guarded** (2026-07-04 ml-engineer audit finding): the live
   runner and the backtest CLI constructed strategies with zero arguments, so
@@ -59,7 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - If the bundle vanishes after startup (registry reload), predictions fail
     safe (HOLD) instead of falling back to another symbol's model.
   Direct constructions without a symbol keep the `BTCUSDT` default.
->>>>>>> fa307655 (fix(strategies): thread trading symbol to ML signal generator; guard cross-symbol model substitution)
 
 ### Added
 - **Account circuit-breaker loop enforcement** (#807 follow-up): a new

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,7 +32,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symbol through `call_strategy_factory()` (`src/strategies/__init__.py`) into
   every factory that composes `MLBasicSignalGenerator` (`hyper_growth`,
   `ml_basic`, `leveraged_regime`, `ensemble_weighted`, `StrategyFactory`
-  presets); the generator normalizes it to the registry's Binance-style form.
+  presets); the generator normalizes it to the registry's Binance-style form
+  (invalid symbols raise a clear `Invalid trading symbol` error at init). The
+  hot-swap path is covered too: `StrategyManager` accepts the trading symbol
+  (assigned by the startup sequencer at session start) and threads it through
+  `_instantiate_strategy`, so regime-switcher hot-swaps select models for the
+  traded pair — and a swap-time missing-model failure rejects the swap and
+  keeps the current strategy instead of killing the trading loop.
   Guards at the generator/registry seam (identical in backtest and live):
   - **Fail fast at startup** when no model bundle exists for
     `(symbol, model_type, timeframe)` — the error lists available bundles
@@ -44,9 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     has no `basic` model yet, so promoting this fix requires setting the flag
     temporarily — behavior is then *unchanged but loud* — until an ETHUSDT
     basic model ships, at which point the flag must be unset.
-  - **Rate-limited ERROR on mismatch** whenever the resolved bundle's symbol
-    differs from the trading symbol, and `Signal.metadata` is stamped with
-    `trading_symbol` + `model_symbol` for auditability.
+  - **Rate-limited ERROR on mismatch** (separate rate-limit clock per guard
+    condition) whenever the resolved bundle's symbol differs from the trading
+    symbol, and `Signal.metadata` is stamped with `trading_symbol` +
+    `model_symbol` on every branch — including HOLD paths
+    (`insufficient_history`, `prediction_failed`,
+    `invalid_prediction_or_price`) — for auditability.
   - If the bundle vanishes after startup (registry reload), predictions fail
     safe (HOLD) instead of falling back to another symbol's model.
   Direct constructions without a symbol keep the `BTCUSDT` default.

--- a/feature_flags.json
+++ b/feature_flags.json
@@ -4,6 +4,7 @@
   "optimizer_canary_fraction": "0.1",
   "optimizer_auto_apply": false,
   "entry_pause": false,
+  "allow_cross_symbol_model": false,
   "max_drawdown_reset_peak": false,
   "enable_exposure_governor": false,
   "enable_etf_flow_gate": false,

--- a/src/engines/live/runner.py
+++ b/src/engines/live/runner.py
@@ -26,6 +26,7 @@ from src.infrastructure.logging.config import configure_logging
 from src.risk.risk_manager import RiskParameters
 
 # Import strategies
+from src.strategies import call_strategy_factory
 from src.strategies.chaos_test import create_chaos_test_strategy
 from src.strategies.hyper_growth import create_hyper_growth_strategy
 from src.strategies.ml_basic import create_ml_basic_strategy
@@ -35,8 +36,13 @@ configure_logging()
 logger = logging.getLogger("live_trading")
 
 
-def load_strategy(strategy_name: str):
-    """Load a strategy by name"""
+def load_strategy(strategy_name: str, symbol: str | None = None):
+    """Load a strategy by name, threading the trading symbol when supported.
+
+    The symbol must reach ML signal generators so model registry selection
+    matches the traded pair — otherwise the strategy silently scores with
+    the default (BTCUSDT) model.
+    """
     strategies = {
         "chaos_test": create_chaos_test_strategy,
         "hyper_growth": create_hyper_growth_strategy,
@@ -58,7 +64,7 @@ def load_strategy(strategy_name: str):
             msg = f"Strategy factory for {strategy_name} must be callable"
             logger.error(msg)
             raise TypeError(msg)
-        strategy = strategy_factory()
+        strategy = call_strategy_factory(strategy_factory, symbol=symbol)
         logger.info(f"Loaded strategy: {strategy.name}")
         return strategy
     except Exception as e:
@@ -189,9 +195,9 @@ def validate_configuration(args):
     else:
         logger.info("📄 PAPER TRADING MODE - No real money will be used")
 
-    # Validate strategy exists
+    # Validate strategy exists (and that a model exists for the symbol)
     try:
-        load_strategy(args.strategy)
+        load_strategy(args.strategy, symbol=args.symbol)
     except Exception:
         return False
 
@@ -219,8 +225,8 @@ def main():
         if not validate_configuration(args):
             sys.exit(1)
 
-        # Load strategy
-        strategy = load_strategy(args.strategy)
+        # Load strategy with the traded symbol so ML model selection matches
+        strategy = load_strategy(args.strategy, symbol=args.symbol)
 
         # Show startup information
         print_startup_info(args, strategy)

--- a/src/engines/live/startup.py
+++ b/src/engines/live/startup.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from src.engines.live.logging.event_logger import LiveEventLogger
     from src.engines.live.order_tracker import OrderTracker
     from src.engines.live.reconciliation import BaseAssetLockRegistry, PeriodicReconciler
+    from src.engines.live.strategy_manager import StrategyManager
     from src.position_management.time_exits import TimeExitPolicy
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class LiveStartupEngineState(Protocol):
     live_position_tracker: LivePositionTracker
     order_tracker: OrderTracker | None
     time_exit_policy: TimeExitPolicy | None
+    strategy_manager: StrategyManager | None
     _base_asset_locks: BaseAssetLockRegistry
     _periodic_reconciler: PeriodicReconciler | None
 
@@ -154,6 +156,10 @@ class LiveStartupSequencer:
         state.is_running = True
         state._active_symbol = symbol
         state.timeframe = timeframe  # Store the trading timeframe
+        # Thread the traded symbol into the hot-swap manager so swapped-in
+        # strategies select models for this pair, not the default (#867).
+        if state.strategy_manager is not None:
+            state.strategy_manager.symbol = symbol
         # Set base logging context for this engine run
         set_context(
             component="live_engine",

--- a/src/engines/live/strategy_manager.py
+++ b/src/engines/live/strategy_manager.py
@@ -6,10 +6,12 @@ import threading
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
+from functools import partial
 from pathlib import Path
 from typing import Any
 
 from src.prediction.models.execution_providers import get_preferred_providers
+from src.strategies import call_strategy_factory
 from src.strategies.components import Strategy
 from src.strategies.versioning import StrategyVersionRecord
 
@@ -37,9 +39,14 @@ class StrategyManager:
         strategies_dir: str = "strategies",
         models_dir: str = "src/ml/models",
         staging_dir: str | None = None,
+        symbol: str | None = None,
     ):
         self.strategies_dir = Path(strategies_dir)
         self.models_dir = Path(models_dir)
+        # Trading symbol of the (single-symbol) engine. Threaded into strategy
+        # factories on load/hot-swap so ML model registry selection matches
+        # the traded pair; the engine assigns it at session start.
+        self.symbol = symbol
         default_staging = Path(
             os.environ.get(
                 "ATB_STAGING_DIR", os.path.join(tempfile.gettempdir(), "ai-trading-bot-staging")
@@ -135,11 +142,17 @@ class StrategyManager:
 
         factory_function = self.strategy_registry[strategy_name]
 
-        # Call factory function with config
-        if config:
-            strategy = factory_function(**config)
+        # Call factory function with config, threading the engine's trading
+        # symbol so ML model selection matches the traded pair (#867). An
+        # explicit symbol in config wins over the engine-level symbol.
+        config_kwargs = dict(config) if config else {}
+        if "symbol" in config_kwargs:
+            strategy = factory_function(**config_kwargs)
         else:
-            strategy = factory_function()
+            factory: Callable[..., Strategy] = factory_function
+            if config_kwargs:
+                factory = partial(factory_function, **config_kwargs)
+            strategy = call_strategy_factory(factory, symbol=self.symbol)
 
         version_id = f"{strategy_name}_{version}"
         strategy_version = StrategyVersionRecord(

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,3 +1,7 @@
+import inspect
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
 from .adaptive_trend import create_adaptive_trend_strategy
 from .ensemble_weighted import create_ensemble_weighted_strategy
 from .hyper_growth import create_hyper_growth_strategy
@@ -7,6 +11,9 @@ from .ml_adaptive import create_ml_adaptive_strategy
 from .ml_basic import create_ml_basic_strategy
 from .ml_sentiment import create_ml_sentiment_strategy
 from .momentum_leverage import create_momentum_leverage_strategy
+
+if TYPE_CHECKING:
+    from .components import Strategy
 
 __all__ = [
     "create_ml_basic_strategy",
@@ -18,4 +25,28 @@ __all__ = [
     "create_kelly_momentum_strategy",
     "create_leveraged_regime_strategy",
     "create_hyper_growth_strategy",
+    "call_strategy_factory",
 ]
+
+
+def call_strategy_factory(factory: Callable[..., Any], *, symbol: str | None = None) -> "Strategy":
+    """Invoke a strategy factory, threading the trading symbol when supported.
+
+    Runners (live and backtest) must construct strategies through this helper
+    so the symbol they trade reaches ML signal generators for model registry
+    selection — otherwise a strategy silently scores with the default
+    (BTCUSDT) model. Factories without a ``symbol`` parameter (e.g.
+    chaos_test) are called unchanged.
+    """
+    if symbol is None:
+        return factory()
+    try:
+        parameters = inspect.signature(factory).parameters
+    except (TypeError, ValueError):
+        return factory()
+    accepts_symbol = "symbol" in parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+    if accepts_symbol:
+        return factory(symbol=symbol)
+    return factory()

--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -8,20 +8,24 @@ regime-aware threshold adjustments and confidence calculations.
 
 import logging
 import math
+import time
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
 if TYPE_CHECKING:
-    from src.prediction.models.registry import PredictionModelRegistry
+    from src.prediction.models.registry import PredictionModelRegistry, StrategyModel
 
 from src.config.config_manager import get_config
+from src.config.feature_flags import is_enabled
 from src.prediction import PredictionConfig, PredictionEngine
 from src.prediction.features.pipeline import FeaturePipeline
 from src.prediction.features.price_only import PriceOnlyFeatureExtractor
+from src.prediction.models.exceptions import ModelNotAvailableError
 from src.regime.detector import TrendLabel, VolLabel
 from src.strategies.components.regime_context import RegimeContext
 from src.strategies.components.signal_generator import Signal, SignalDirection, SignalGenerator
+from src.trading.symbols.factory import SymbolFactory
 
 logger = logging.getLogger(__name__)
 
@@ -541,6 +545,14 @@ class MLBasicSignalGenerator(SignalGenerator):
     # Default symbol used for registry selection when none specified
     DEFAULT_SYMBOL = "BTCUSDT"
 
+    # Feature flag that explicitly opts into scoring one symbol with another
+    # symbol's model when no model exists for the trading symbol.
+    CROSS_SYMBOL_FLAG = "allow_cross_symbol_model"
+
+    # Guard logs (mismatch/substitution) are emitted at most once per interval
+    # per generator instance so a 1m loop cannot flood the logs.
+    SYMBOL_GUARD_LOG_INTERVAL_SECONDS = 300.0
+
     def __init__(
         self,
         name: str = "ml_basic_signal_generator",
@@ -588,10 +600,12 @@ class MLBasicSignalGenerator(SignalGenerator):
             self.CONFIDENCE_MULTIPLIER if confidence_multiplier is None else confidence_multiplier,
         )
 
-        # Registry model selection preferences
+        # Registry model selection preferences. Normalize to the registry's
+        # Binance-style directory convention so provider-specific formats
+        # (e.g. Coinbase "ETH-USD") select the same model bundle.
         self.model_type = model_type or "basic"
         self.model_timeframe = timeframe or "1h"
-        self.symbol = symbol or self.DEFAULT_SYMBOL
+        self.symbol = SymbolFactory.to_exchange_symbol(symbol or self.DEFAULT_SYMBOL, "binance")
 
         # Model name configuration
         cfg = get_config()
@@ -604,11 +618,21 @@ class MLBasicSignalGenerator(SignalGenerator):
         self._engine_warning_emitted = False
         self.use_engine_batch = get_config().get_bool("ENGINE_BATCH_INFERENCE", default=False)
 
+        # Cross-symbol guard state: which model symbol actually scored the
+        # last prediction, the pinned substitute bundle (flag opt-in only),
+        # and the rate-limit clock for guard logs.
+        self._model_symbol: str | None = None
+        self._cross_symbol_bundle_key: str | None = None
+        self._last_symbol_guard_log_ts: float | None = None
+
         # Initialize feature pipeline
         self._setup_feature_pipeline()
 
         # Initialize prediction engine (always enabled)
         self._initialize_prediction_engine()
+
+        # Fail fast if the registry has no model for the trading symbol
+        self._validate_model_availability()
 
     def _setup_feature_pipeline(self):
         """Setup feature pipeline for data preprocessing"""
@@ -669,6 +693,113 @@ class MLBasicSignalGenerator(SignalGenerator):
                 logger.exception("MLBasicSignalGenerator: Prediction engine initialization failed")
                 self._engine_warning_emitted = True
             self.prediction_engine = None
+
+    def _validate_model_availability(self) -> None:
+        """Fail fast when the registry has no model for the trading symbol.
+
+        Without this check the prediction engine silently falls back to the
+        default bundle — typically another symbol's model — and every signal
+        is scored by a model trained on a different market.
+        FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true explicitly opts into that
+        substitution as a transition path while the symbol's own model has
+        not shipped yet.
+        """
+        if self._registry is None:
+            # Engine degraded/unavailable — prediction path already fails
+            # safe (returns None → HOLD), so nothing to validate against.
+            return
+        try:
+            self._registry.select_bundle(
+                symbol=self.symbol,
+                model_type=self.model_type,
+                timeframe=self.model_timeframe,
+            )
+            return
+        except ModelNotAvailableError:
+            pass
+        except Exception:
+            # Registry probing failure (not a missing model) — leave it to
+            # the prediction path, which degrades to HOLD.
+            return
+
+        available = self._available_bundle_keys()
+        if not is_enabled(self.CROSS_SYMBOL_FLAG, default=False):
+            raise ModelNotAvailableError(
+                f"No {self.model_type}/{self.model_timeframe} model exists for trading "
+                f"symbol {self.symbol}. Available models: {', '.join(available) or 'none'}. "
+                f"Train and deploy a {self.symbol} model, or set "
+                f"FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true to explicitly accept scoring "
+                f"{self.symbol} with another symbol's model."
+            )
+
+        fallback = self._select_cross_symbol_fallback()
+        if fallback is None:
+            raise ModelNotAvailableError(
+                f"FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true but no "
+                f"{self.model_type}/{self.model_timeframe} model exists for any symbol "
+                f"to substitute for {self.symbol}. "
+                f"Available models: {', '.join(available) or 'none'}."
+            )
+        self._cross_symbol_bundle_key = fallback.key
+        self._model_symbol = fallback.symbol
+        logger.critical(
+            "CROSS-SYMBOL MODEL SUBSTITUTION ACTIVE: trading %s but scoring with %s "
+            "model %s (FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true). Predictions are not "
+            "trained on %s — deploy a %s model and unset the flag as soon as possible.",
+            self.symbol,
+            fallback.symbol,
+            fallback.key,
+            self.symbol,
+            self.symbol,
+        )
+
+    def _available_bundle_keys(self) -> list[str]:
+        """List loaded bundle keys for error messages; empty on failure."""
+        if self._registry is None:
+            return []
+        try:
+            return sorted(str(bundle.key) for bundle in self._registry.list_bundles())
+        except Exception:
+            return []
+
+    def _select_cross_symbol_fallback(self) -> "StrategyModel | None":
+        """Pick a deterministic same-type/timeframe bundle from another symbol.
+
+        Prefers DEFAULT_SYMBOL, then lexicographic order, so restarts always
+        substitute the same model.
+        """
+        if self._registry is None:
+            return None
+        try:
+            candidates = [
+                bundle
+                for bundle in self._registry.list_bundles()
+                if bundle.model_type == self.model_type and bundle.timeframe == self.model_timeframe
+            ]
+        except Exception:
+            return None
+        if not candidates:
+            return None
+        candidates.sort(key=lambda bundle: (bundle.symbol != self.DEFAULT_SYMBOL, bundle.symbol))
+        return candidates[0]
+
+    def _log_symbol_guard(self, level: int, msg: str, *args: Any) -> None:
+        """Emit a guard log, rate-limited per instance."""
+        now = time.monotonic()
+        if (
+            self._last_symbol_guard_log_ts is not None
+            and now - self._last_symbol_guard_log_ts < self.SYMBOL_GUARD_LOG_INTERVAL_SECONDS
+        ):
+            return
+        self._last_symbol_guard_log_ts = now
+        logger.log(level, msg, *args)
+
+    @staticmethod
+    def _parse_model_symbol(model_name: Any) -> str | None:
+        """Extract the symbol from a bundle key like ``BTCUSDT:1h:basic:v1``."""
+        if isinstance(model_name, str) and ":" in model_name:
+            return model_name.split(":", 1)[0]
+        return None
 
     def generate_signal(
         self, df: pd.DataFrame, index: int, regime: RegimeContext | None = None
@@ -758,6 +889,10 @@ class MLBasicSignalGenerator(SignalGenerator):
             "engine_batch": self.use_engine_batch,
             "model_type": self.model_type,
             "model_timeframe": self.model_timeframe,
+            # Cross-symbol guard stamps: which symbol is being traded vs which
+            # symbol's model scored this prediction (None when undetermined).
+            "trading_symbol": self.symbol,
+            "model_symbol": self._model_symbol,
         }
 
         # Enable short entries for SELL signals
@@ -823,7 +958,22 @@ class MLBasicSignalGenerator(SignalGenerator):
 
             # Try to select bundle using registry
             selected_bundle_key = None
-            if self._registry is not None:
+            resolved_model_symbol: str | None = None
+            if self._cross_symbol_bundle_key is not None:
+                # Startup explicitly opted into substitution via
+                # FEATURE_ALLOW_CROSS_SYMBOL_MODEL — score with the pinned
+                # bundle and keep reminding the operator.
+                selected_bundle_key = self._cross_symbol_bundle_key
+                resolved_model_symbol = self._model_symbol
+                self._log_symbol_guard(
+                    logging.WARNING,
+                    "Cross-symbol model substitution: scoring %s with %s model %s "
+                    "(FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true)",
+                    self.symbol,
+                    resolved_model_symbol,
+                    selected_bundle_key,
+                )
+            elif self._registry is not None:
                 try:
                     bundle = self._registry.select_bundle(
                         symbol=self.symbol,
@@ -831,6 +981,23 @@ class MLBasicSignalGenerator(SignalGenerator):
                         timeframe=self.model_timeframe,
                     )
                     selected_bundle_key = bundle.key
+                    bundle_symbol = getattr(bundle, "symbol", None)
+                    if isinstance(bundle_symbol, str):
+                        resolved_model_symbol = bundle_symbol
+                except ModelNotAvailableError:
+                    # Bundle vanished after startup validation (e.g. registry
+                    # reload). Refuse to silently score another symbol's
+                    # model — fail the prediction (caller emits HOLD).
+                    self._log_symbol_guard(
+                        logging.ERROR,
+                        "No %s/%s model available for %s at prediction time — holding "
+                        "(refusing cross-symbol fallback)",
+                        self.model_type,
+                        self.model_timeframe,
+                        self.symbol,
+                    )
+                    self._model_symbol = None
+                    return None
                 except (KeyError, ValueError, AttributeError):
                     # Bundle not found or invalid - fall back to default
                     selected_bundle_key = None
@@ -845,6 +1012,28 @@ class MLBasicSignalGenerator(SignalGenerator):
             except (KeyError, ValueError):
                 # Fall back to default registry resolution if explicit lookup fails
                 result = self.prediction_engine.predict(window_df)
+
+            # Detect which symbol's model actually scored this prediction so
+            # signals can be stamped and mismatches surfaced loudly.
+            if resolved_model_symbol is None:
+                resolved_model_symbol = self._parse_model_symbol(
+                    getattr(result, "model_name", None)
+                )
+            self._model_symbol = resolved_model_symbol
+            if (
+                self._cross_symbol_bundle_key is None
+                and resolved_model_symbol is not None
+                and resolved_model_symbol != self.symbol
+            ):
+                self._log_symbol_guard(
+                    logging.ERROR,
+                    "MODEL/SYMBOL MISMATCH: trading %s but the resolved model bundle is "
+                    "for %s (model=%s). Signals are scored by a model trained on a "
+                    "different symbol.",
+                    self.symbol,
+                    resolved_model_symbol,
+                    engine_model_name,
+                )
 
             pred = float(result.price)
 

--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -605,7 +605,11 @@ class MLBasicSignalGenerator(SignalGenerator):
         # (e.g. Coinbase "ETH-USD") select the same model bundle.
         self.model_type = model_type or "basic"
         self.model_timeframe = timeframe or "1h"
-        self.symbol = SymbolFactory.to_exchange_symbol(symbol or self.DEFAULT_SYMBOL, "binance")
+        raw_symbol = symbol or self.DEFAULT_SYMBOL
+        try:
+            self.symbol = SymbolFactory.to_exchange_symbol(raw_symbol, "binance")
+        except ValueError as exc:
+            raise ValueError(f"Invalid trading symbol {raw_symbol!r}: {exc}") from exc
 
         # Model name configuration
         cfg = get_config()
@@ -620,10 +624,11 @@ class MLBasicSignalGenerator(SignalGenerator):
 
         # Cross-symbol guard state: which model symbol actually scored the
         # last prediction, the pinned substitute bundle (flag opt-in only),
-        # and the rate-limit clock for guard logs.
+        # and per-condition rate-limit clocks for guard logs (keyed by kind
+        # so one condition's log cannot swallow another's).
         self._model_symbol: str | None = None
         self._cross_symbol_bundle_key: str | None = None
-        self._last_symbol_guard_log_ts: float | None = None
+        self._symbol_guard_log_ts: dict[str, float] = {}
 
         # Initialize feature pipeline
         self._setup_feature_pipeline()
@@ -783,15 +788,18 @@ class MLBasicSignalGenerator(SignalGenerator):
         candidates.sort(key=lambda bundle: (bundle.symbol != self.DEFAULT_SYMBOL, bundle.symbol))
         return candidates[0]
 
-    def _log_symbol_guard(self, level: int, msg: str, *args: Any) -> None:
-        """Emit a guard log, rate-limited per instance."""
+    def _log_symbol_guard(self, kind: str, level: int, msg: str, *args: Any) -> None:
+        """Emit a guard log, rate-limited per instance and per condition kind.
+
+        Separate clocks per ``kind`` so distinct conditions (substitution
+        warning, mismatch, bundle vanished) each announce at least once per
+        window instead of suppressing one another.
+        """
         now = time.monotonic()
-        if (
-            self._last_symbol_guard_log_ts is not None
-            and now - self._last_symbol_guard_log_ts < self.SYMBOL_GUARD_LOG_INTERVAL_SECONDS
-        ):
+        last = self._symbol_guard_log_ts.get(kind)
+        if last is not None and now - last < self.SYMBOL_GUARD_LOG_INTERVAL_SECONDS:
             return
-        self._last_symbol_guard_log_ts = now
+        self._symbol_guard_log_ts[kind] = now
         logger.log(level, msg, *args)
 
     @staticmethod
@@ -800,6 +808,14 @@ class MLBasicSignalGenerator(SignalGenerator):
         if isinstance(model_name, str) and ":" in model_name:
             return model_name.split(":", 1)[0]
         return None
+
+    def _symbol_guard_stamps(self) -> dict[str, str | None]:
+        """Cross-symbol guard stamps included in every Signal's metadata.
+
+        ``model_symbol`` is the symbol whose model scored the most recent
+        prediction (None when no prediction has resolved, e.g. HOLD paths).
+        """
+        return {"trading_symbol": self.symbol, "model_symbol": self._model_symbol}
 
     def generate_signal(
         self, df: pd.DataFrame, index: int, regime: RegimeContext | None = None
@@ -828,6 +844,7 @@ class MLBasicSignalGenerator(SignalGenerator):
                     "reason": "insufficient_history",
                     "index": index,
                     "required_length": self.sequence_length,
+                    **self._symbol_guard_stamps(),
                 },
             )
 
@@ -838,7 +855,12 @@ class MLBasicSignalGenerator(SignalGenerator):
                 direction=SignalDirection.HOLD,
                 strength=0.0,
                 confidence=0.0,
-                metadata={"generator": self.name, "reason": "prediction_failed", "index": index},
+                metadata={
+                    "generator": self.name,
+                    "reason": "prediction_failed",
+                    "index": index,
+                    **self._symbol_guard_stamps(),
+                },
             )
 
         current_price = df["close"].iloc[index]
@@ -856,6 +878,7 @@ class MLBasicSignalGenerator(SignalGenerator):
                     "current_price": current_price,
                     "predicted_return": 0,  # Set to 0 when price is invalid
                     "index": index,
+                    **self._symbol_guard_stamps(),
                 },
             )
 
@@ -889,10 +912,7 @@ class MLBasicSignalGenerator(SignalGenerator):
             "engine_batch": self.use_engine_batch,
             "model_type": self.model_type,
             "model_timeframe": self.model_timeframe,
-            # Cross-symbol guard stamps: which symbol is being traded vs which
-            # symbol's model scored this prediction (None when undetermined).
-            "trading_symbol": self.symbol,
-            "model_symbol": self._model_symbol,
+            **self._symbol_guard_stamps(),
         }
 
         # Enable short entries for SELL signals
@@ -966,6 +986,7 @@ class MLBasicSignalGenerator(SignalGenerator):
                 selected_bundle_key = self._cross_symbol_bundle_key
                 resolved_model_symbol = self._model_symbol
                 self._log_symbol_guard(
+                    "cross_symbol_substitution",
                     logging.WARNING,
                     "Cross-symbol model substitution: scoring %s with %s model %s "
                     "(FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true)",
@@ -989,6 +1010,7 @@ class MLBasicSignalGenerator(SignalGenerator):
                     # reload). Refuse to silently score another symbol's
                     # model — fail the prediction (caller emits HOLD).
                     self._log_symbol_guard(
+                        "model_unavailable",
                         logging.ERROR,
                         "No %s/%s model available for %s at prediction time — holding "
                         "(refusing cross-symbol fallback)",
@@ -1026,6 +1048,7 @@ class MLBasicSignalGenerator(SignalGenerator):
                 and resolved_model_symbol != self.symbol
             ):
                 self._log_symbol_guard(
+                    "symbol_mismatch",
                     logging.ERROR,
                     "MODEL/SYMBOL MISMATCH: trading %s but the resolved model bundle is "
                     "for %s (model=%s). Signals are scored by a model trained on a "
@@ -1041,6 +1064,9 @@ class MLBasicSignalGenerator(SignalGenerator):
             return pred
 
         except Exception:
+            # No model scored this bar — clear the stamp so the HOLD signal
+            # doesn't carry the previous bar's model_symbol.
+            self._model_symbol = None
             logger.exception("MLBasicSignalGenerator: Prediction error at index %d", index)
             return None
 

--- a/src/strategies/components/strategy_factory.py
+++ b/src/strategies/components/strategy_factory.py
@@ -249,6 +249,7 @@ class StrategyFactory:
         model_name: str | None = None,
         model_type: str = "basic",
         timeframe: str = "1h",
+        symbol: str | None = None,
     ) -> Strategy:
         """
         Create ML Basic strategy with component-based architecture
@@ -259,6 +260,8 @@ class StrategyFactory:
             model_name: Model name for registry
             model_type: Model type
             timeframe: Model timeframe
+            symbol: Trading symbol for model registry selection (None keeps
+                the generator default BTCUSDT)
 
         Returns:
             Configured ML Basic strategy
@@ -269,6 +272,7 @@ class StrategyFactory:
             model_name=model_name,
             model_type=model_type,
             timeframe=timeframe,
+            symbol=symbol,
         )
 
         risk_manager = FixedRiskManager(
@@ -422,6 +426,7 @@ class StrategyFactory:
         use_ml_basic: bool = True,
         use_ml_adaptive: bool = True,
         use_ml_sentiment: bool = False,
+        symbol: str | None = None,
     ) -> Strategy:
         """
         Create Ensemble Weighted strategy with component-based architecture
@@ -431,6 +436,8 @@ class StrategyFactory:
             use_ml_basic: Whether to include ML Basic
             use_ml_adaptive: Whether to include ML Adaptive
             use_ml_sentiment: Whether to include ML Sentiment
+            symbol: Trading symbol for model registry selection (None keeps
+                the generator default BTCUSDT)
 
         Returns:
             Configured Ensemble Weighted strategy
@@ -438,7 +445,7 @@ class StrategyFactory:
         # Create individual signal generators
         generators: dict[SignalGenerator, float] = {}
         if use_ml_basic:
-            generators[MLBasicSignalGenerator(name="ml_basic_signals")] = 0.30
+            generators[MLBasicSignalGenerator(name="ml_basic_signals", symbol=symbol)] = 0.30
         if use_ml_adaptive:
             generators[MLSignalGenerator(name="ml_adaptive_signals")] = 0.30
         if use_ml_sentiment:

--- a/src/strategies/ensemble_weighted.py
+++ b/src/strategies/ensemble_weighted.py
@@ -47,6 +47,7 @@ def create_ensemble_weighted_strategy(
     use_ml_basic: bool = True,
     use_ml_adaptive: bool = True,
     use_ml_sentiment: bool = False,
+    symbol: str | None = None,
 ) -> Strategy:
     """
     Create Ensemble Weighted strategy using component composition.
@@ -56,6 +57,8 @@ def create_ensemble_weighted_strategy(
         use_ml_basic: Whether to include ML Basic signal generator
         use_ml_adaptive: Whether to include ML Adaptive signal generator
         use_ml_sentiment: Whether to include ML Sentiment signal generator
+        symbol: Trading symbol threaded to the ML Basic signal generator for
+            model registry selection (None keeps the generator default BTCUSDT).
 
     Returns:
         Configured Strategy instance
@@ -71,7 +74,7 @@ def create_ensemble_weighted_strategy(
     generators: dict[SignalGenerator, float] = {}
 
     if use_ml_basic:
-        generators[MLBasicSignalGenerator()] = 0.30
+        generators[MLBasicSignalGenerator(symbol=symbol)] = 0.30
     if use_ml_adaptive:
         generators[MLSignalGenerator()] = 0.30
     if use_ml_sentiment:

--- a/src/strategies/hyper_growth.py
+++ b/src/strategies/hyper_growth.py
@@ -182,6 +182,7 @@ def create_hyper_growth_strategy(
     min_regime_bars: int = 3,
     take_profit_pct: float = 0.30,
     stop_loss_pct: float = 0.10,
+    symbol: str | None = None,
 ) -> Strategy:
     """Create hyper-growth strategy targeting high annual returns.
 
@@ -209,6 +210,9 @@ def create_hyper_growth_strategy(
             outperform 0.20 on BTCUSDT 2024 by ~50 pp of annualized return
             because the trailing stop and partial exits capture upside while
             tight SL caps short-side losses in the 2024 uptrend).
+        symbol: Trading symbol threaded to the ML signal generator for model
+            registry selection. Runners must pass the symbol they trade;
+            None keeps the generator default (BTCUSDT).
 
     Returns:
         Configured Strategy instance.
@@ -239,7 +243,9 @@ def create_hyper_growth_strategy(
         # sentiment_momentum_scaled), so feeding it the price-only tensor
         # silently returns 0.0 on every bar — which the generator converts to
         # predicted_return = -1.0 (a constant SELL sentinel, not a prediction).
-        signal_generator = MLBasicSignalGenerator(name=f"{name}_signals", model_type="basic")
+        signal_generator = MLBasicSignalGenerator(
+            name=f"{name}_signals", model_type="basic", symbol=symbol
+        )
 
     risk_manager = FlatRiskManager(
         risk_fraction=risk_fraction,

--- a/src/strategies/leveraged_regime.py
+++ b/src/strategies/leveraged_regime.py
@@ -45,6 +45,7 @@ def create_leveraged_regime_strategy(
     min_regime_bars: int = DEFAULT_MIN_REGIME_BARS,
     take_profit_pct: float = 0.10,
     stop_loss_pct: float = 0.05,
+    symbol: str | None = None,
 ) -> Strategy:
     """Create a leveraged regime strategy using component composition.
 
@@ -62,6 +63,8 @@ def create_leveraged_regime_strategy(
         min_regime_bars: Minimum bars before conviction scaling begins.
         take_profit_pct: Target profit percentage.
         stop_loss_pct: Stop loss percentage.
+        symbol: Trading symbol threaded to the ML signal generator for model
+            registry selection (None keeps the generator default BTCUSDT).
 
     Returns:
         Configured Strategy instance with leverage manager attached.
@@ -75,7 +78,7 @@ def create_leveraged_regime_strategy(
     # (declared up-front: branches assign different subtypes)
     signal_generator: SignalGenerator
     if signal_source == "ml":
-        signal_generator = MLBasicSignalGenerator(name=f"{name}_signals")
+        signal_generator = MLBasicSignalGenerator(name=f"{name}_signals", symbol=symbol)
     else:
         signal_generator = MomentumSignalGenerator(name=f"{name}_signals")
 

--- a/src/strategies/ml_basic.py
+++ b/src/strategies/ml_basic.py
@@ -58,6 +58,7 @@ def create_ml_basic_strategy(
     timeframe: str | None = None,
     fast_mode: bool = False,
     *,
+    symbol: str | None = None,
     long_entry_threshold: float | None = None,
     short_entry_threshold: float | None = None,
     confidence_multiplier: float | None = None,
@@ -77,6 +78,8 @@ def create_ml_basic_strategy(
         model_type: Model type (e.g., "basic")
         timeframe: Model timeframe (e.g., "1h")
         fast_mode: Enable fast mode for testing (disables ML)
+        symbol: Trading symbol threaded to the ML signal generator for model
+            registry selection (None keeps the generator default BTCUSDT).
         long_entry_threshold: Minimum predicted return for long entry.
         short_entry_threshold: Maximum predicted return for short entry.
         confidence_multiplier: Scales |predicted_return| → confidence.
@@ -149,6 +152,7 @@ def create_ml_basic_strategy(
             model_name=model_name,
             model_type=model_type,
             timeframe=timeframe,
+            symbol=symbol,
             long_entry_threshold=long_entry_threshold,
             short_entry_threshold=short_entry_threshold,
             confidence_multiplier=confidence_multiplier,

--- a/tests/unit/cli/test_backtest.py
+++ b/tests/unit/cli/test_backtest.py
@@ -207,7 +207,7 @@ class TestHandleBacktest:
 
             # Assert
             assert result == 0
-            mock_load_strategy.assert_called_once_with("ml_basic")
+            mock_load_strategy.assert_called_once_with("ml_basic", symbol="BTCUSDT")
             mock_backtester.run.assert_called_once()
 
     def test_backtest_with_sentiment_enabled(self, default_args, mock_backtester):

--- a/tests/unit/cli/test_backtest_symbol_wiring.py
+++ b/tests/unit/cli/test_backtest_symbol_wiring.py
@@ -1,0 +1,76 @@
+"""Tests that the backtest CLI threads --symbol into strategy factories.
+
+Backtest-live parity counterpart of the live runner symbol wiring tests:
+both runners must hand the trading symbol to ML strategies so model
+registry selection matches the traded pair.
+"""
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from cli.commands.backtest import _handle, _load_strategy
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+
+class TestLoadStrategySymbolThreading:
+    def test_threads_symbol_to_hyper_growth(self):
+        with patch(
+            "cli.commands.backtest.create_hyper_growth_strategy", autospec=True
+        ) as mock_create:
+            _load_strategy("hyper_growth", symbol="ETHUSDT")
+
+            mock_create.assert_called_once_with(symbol="ETHUSDT")
+
+    def test_threads_symbol_to_ml_basic(self):
+        with patch("cli.commands.backtest.create_ml_basic_strategy", autospec=True) as mock_create:
+            _load_strategy("ml_basic", symbol="ETHUSDT")
+
+            mock_create.assert_called_once_with(symbol="ETHUSDT")
+
+    def test_factory_without_symbol_param_called_plain(self):
+        """Factories that do not accept symbol are invoked without it."""
+        with patch(
+            "cli.commands.backtest.create_momentum_leverage_strategy", autospec=True
+        ) as mock_create:
+            _load_strategy("momentum_leverage", symbol="ETHUSDT")
+
+            _, kwargs = mock_create.call_args
+            assert "symbol" not in kwargs
+
+
+class TestHandleSymbolWiring:
+    def test_handle_passes_cli_symbol_to_load_strategy(self, monkeypatch):
+        recorded = {}
+
+        def fake_load(name, symbol=None):
+            recorded["call"] = (name, symbol)
+            raise RuntimeError("stop after strategy load")
+
+        monkeypatch.setattr("cli.commands.backtest._load_strategy", fake_load)
+        ns = argparse.Namespace(
+            strategy="hyper_growth",
+            symbol="ETHUSDT",
+            timeframe="1h",
+            days=30,
+            start=None,
+            end=None,
+            initial_balance=1000.0,
+            risk_per_trade=0.01,
+            max_risk_per_trade=0.02,
+            max_drawdown=0.5,
+            max_position_size=None,
+            use_sentiment=False,
+            no_cache=True,
+            cache_ttl=24,
+            log_to_db=False,
+            provider="binance",
+            disable_engine_sl=False,
+        )
+
+        rc = _handle(ns)
+
+        assert rc == 1
+        assert recorded["call"] == ("hyper_growth", "ETHUSDT")

--- a/tests/unit/engines/live/test_runner_symbol_wiring.py
+++ b/tests/unit/engines/live/test_runner_symbol_wiring.py
@@ -1,0 +1,82 @@
+"""Tests that the live runner threads --symbol into strategy factories.
+
+Regression tests for the P0 wiring bug where load_strategy() called
+create_hyper_growth_strategy() with zero args, so live ETHUSDT scored
+with the BTCUSDT model.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+ENGINE_PATH = "src.strategies.components.ml_signal_generator.PredictionEngine"
+CONFIG_PATH = "src.strategies.components.ml_signal_generator.PredictionConfig"
+
+
+def _mock_prediction_engine():
+    engine = MagicMock()
+    engine.health_check.return_value = {"status": "healthy"}
+    return engine
+
+
+class TestLoadStrategySymbolThreading:
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_load_strategy_threads_symbol_to_hyper_growth(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+        from src.engines.live.runner import load_strategy
+
+        strategy = load_strategy("hyper_growth", symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_load_strategy_threads_symbol_to_ml_basic(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+        from src.engines.live.runner import load_strategy
+
+        strategy = load_strategy("ml_basic", symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    def test_load_strategy_without_symbol_keeps_working(self):
+        """Factories without a symbol parameter must not receive one."""
+        from src.engines.live.runner import load_strategy
+
+        strategy = load_strategy("chaos_test", symbol="ETHUSDT")
+
+        assert strategy is not None
+
+
+class TestMainSymbolWiring:
+    def test_main_passes_cli_symbol_to_load_strategy(self, monkeypatch):
+        from src.engines.live import runner
+
+        strategy = MagicMock()
+        strategy.name = "HyperGrowth"
+        recorded = {}
+
+        def fake_load(name, symbol=None):
+            recorded["call"] = (name, symbol)
+            return strategy
+
+        engine = MagicMock()
+        monkeypatch.setattr(runner, "load_strategy", fake_load)
+        monkeypatch.setattr(runner, "validate_configuration", lambda args: True)
+        monkeypatch.setattr(runner, "LiveTradingEngine", MagicMock(return_value=engine))
+        monkeypatch.setattr(runner, "MockDataProvider", MagicMock())
+        monkeypatch.setattr(runner, "LiveEngineSettings", MagicMock())
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["runner", "hyper_growth", "--symbol", "ETHUSDT", "--paper-trading", "--mock-data"],
+        )
+
+        runner.main()
+
+        assert recorded["call"] == ("hyper_growth", "ETHUSDT")
+        engine.start.assert_called_once_with("ETHUSDT", "1h", exit_on_crash=True)

--- a/tests/unit/engines/live/test_startup_sequencer.py
+++ b/tests/unit/engines/live/test_startup_sequencer.py
@@ -31,6 +31,7 @@ def _make_state() -> object:
     state.strategy = MagicMock()
     # Annotation-only Protocol attributes aren't auto-created by autospec.
     state.db_manager = MagicMock()
+    state.strategy_manager = None
     return state
 
 
@@ -40,6 +41,22 @@ def test_begin_session_runtime_sets_flags():
     assert state.is_running is True
     assert state._active_symbol == "BTCUSDT"
     assert state.timeframe == "1h"
+
+
+def test_begin_session_runtime_threads_symbol_to_strategy_manager():
+    """Hot-swapped strategies must select models for the traded pair (#867)."""
+    state = _make_state()
+    state.strategy_manager = MagicMock()
+    LiveStartupSequencer(engine_state=state).begin_session_runtime("ETHUSDT", "1h")
+    assert state.strategy_manager.symbol == "ETHUSDT"
+
+
+def test_begin_session_runtime_tolerates_missing_strategy_manager():
+    """Engines constructed without hot-swapping keep working."""
+    state = _make_state()
+    state.strategy_manager = None
+    LiveStartupSequencer(engine_state=state).begin_session_runtime("ETHUSDT", "1h")
+    assert state._active_symbol == "ETHUSDT"
 
 
 def test_run_returns_early_when_already_running():

--- a/tests/unit/live/test_strategy_manager_unit.py
+++ b/tests/unit/live/test_strategy_manager_unit.py
@@ -196,3 +196,98 @@ class TestStrategyVersioning:
 
         assert result is False
         assert "doesn't match other_strategy" in caplog.text
+
+
+class TestStrategyManagerSymbolThreading:
+    """Hot-swap/load must thread the engine's trading symbol (#867)."""
+
+    ENGINE_PATH = "src.strategies.components.ml_signal_generator.PredictionEngine"
+    CONFIG_PATH = "src.strategies.components.ml_signal_generator.PredictionConfig"
+
+    def _mock_engine(self):
+        from unittest.mock import MagicMock
+
+        engine = MagicMock()
+        engine.health_check.return_value = {"status": "healthy"}
+        return engine
+
+    def test_load_strategy_threads_symbol(self, temp_directory):
+        from unittest.mock import patch
+
+        with patch(self.ENGINE_PATH) as engine_cls, patch(self.CONFIG_PATH):
+            engine_cls.return_value = self._mock_engine()
+            manager = StrategyManager(staging_dir=str(temp_directory), symbol="ETHUSDT")
+
+            strategy = manager.load_strategy("ml_basic")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    def test_hot_swap_threads_symbol(self, temp_directory):
+        from unittest.mock import MagicMock, patch
+
+        with patch(self.ENGINE_PATH) as engine_cls, patch(self.CONFIG_PATH):
+            engine_cls.return_value = self._mock_engine()
+            manager = StrategyManager(staging_dir=str(temp_directory), symbol="ETHUSDT")
+            manager.current_strategy = MagicMock()
+
+            assert manager.hot_swap_strategy("ml_basic", new_config={"name": "SwapTest"}) is True
+
+        swapped = manager.pending_update["data"]["new_strategy"]
+        assert swapped.signal_generator.symbol == "ETHUSDT"
+
+    def test_explicit_config_symbol_wins_over_manager_symbol(self, temp_directory):
+        from unittest.mock import patch
+
+        with patch(self.ENGINE_PATH) as engine_cls, patch(self.CONFIG_PATH):
+            engine_cls.return_value = self._mock_engine()
+            manager = StrategyManager(staging_dir=str(temp_directory), symbol="ETHUSDT")
+
+            strategy = manager.load_strategy("ml_basic", config={"symbol": "BTCUSDT"})
+
+        assert strategy.signal_generator.symbol == "BTCUSDT"
+
+    def test_no_symbol_keeps_legacy_default(self, temp_directory):
+        from unittest.mock import patch
+
+        with patch(self.ENGINE_PATH) as engine_cls, patch(self.CONFIG_PATH):
+            engine_cls.return_value = self._mock_engine()
+            manager = StrategyManager(staging_dir=str(temp_directory))
+
+            strategy = manager.load_strategy("ml_basic")
+
+        assert strategy.signal_generator.symbol == "BTCUSDT"
+
+    def test_swap_time_model_unavailable_rejects_swap_and_keeps_current(
+        self, temp_directory, caplog, monkeypatch
+    ):
+        """A missing-model failure during hot-swap must not kill the loop.
+
+        The swap is rejected, the current strategy stays active, and the
+        failure is logged at ERROR.
+        """
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        from src.prediction.models.exceptions import ModelNotAvailableError
+
+        monkeypatch.delenv("FEATURE_ALLOW_CROSS_SYMBOL_MODEL", raising=False)
+
+        registry = MagicMock()
+        registry.select_bundle.side_effect = ModelNotAvailableError("no ETHUSDT basic model")
+        registry.list_bundles.return_value = []
+        engine = self._mock_engine()
+        engine.model_registry = registry
+
+        with patch(self.ENGINE_PATH) as engine_cls, patch(self.CONFIG_PATH):
+            engine_cls.return_value = engine
+            manager = StrategyManager(staging_dir=str(temp_directory), symbol="ETHUSDT")
+            current = MagicMock()
+            manager.current_strategy = current
+
+            with caplog.at_level(logging.ERROR):
+                result = manager.hot_swap_strategy("ml_basic")
+
+        assert result is False
+        assert manager.current_strategy is current
+        assert manager.pending_update is None
+        assert "Hot-swap failed" in caplog.text

--- a/tests/unit/strategies/components/test_ml_signal_generator.py
+++ b/tests/unit/strategies/components/test_ml_signal_generator.py
@@ -714,12 +714,15 @@ class TestMLBasicSignalGenerator:
         df = self.create_test_dataframe(150)
         generator._get_ml_prediction(df, 130)
 
-        # Verify registry select_bundle was called with correct symbol
-        mock_registry.select_bundle.assert_called_once_with(
-            symbol="ETHUSDT",
-            model_type="basic",
-            timeframe="1h",
-        )
+        # Verify registry select_bundle was called with correct symbol.
+        # Called twice: startup model-availability validation + prediction.
+        assert mock_registry.select_bundle.call_count == 2
+        for call in mock_registry.select_bundle.call_args_list:
+            assert call.kwargs == {
+                "symbol": "ETHUSDT",
+                "model_type": "basic",
+                "timeframe": "1h",
+            }
 
 
 class TestMLSignalGeneratorEdgeCases:

--- a/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
+++ b/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
@@ -1,0 +1,318 @@
+"""Tests for trading-symbol threading and cross-symbol model guards.
+
+Covers the P0 wiring bug where the live runner's --symbol never reached
+MLBasicSignalGenerator, so e.g. HyperGrowth on ETHUSDT silently scored with
+the BTCUSDT model. Guards live at the generator/registry seam so backtest
+and live get identical behavior.
+"""
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.prediction.models.exceptions import ModelNotAvailableError
+from src.strategies.components.ml_signal_generator import MLBasicSignalGenerator
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+ENGINE_PATH = "src.strategies.components.ml_signal_generator.PredictionEngine"
+CONFIG_PATH = "src.strategies.components.ml_signal_generator.PredictionConfig"
+
+
+def _make_bundle(symbol="BTCUSDT", timeframe="1h", model_type="basic", version="v1"):
+    return SimpleNamespace(
+        symbol=symbol,
+        timeframe=timeframe,
+        model_type=model_type,
+        version_id=version,
+        key=f"{symbol}:{timeframe}:{model_type}:{version}",
+    )
+
+
+def _make_engine(registry=None, predicted_price=51000.0):
+    engine = MagicMock()
+    engine.health_check.return_value = {"status": "healthy"}
+    result = Mock()
+    result.price = predicted_price
+    result.model_name = "BTCUSDT:1h:basic:v1"
+    engine.predict.return_value = result
+    if registry is not None:
+        engine.model_registry = registry
+    return engine
+
+
+def _make_df(length=150, base_price=50000.0):
+    rng = np.random.default_rng(42)
+    prices = base_price * np.cumprod(1 + rng.normal(0, 0.005, length))
+    return pd.DataFrame(
+        {
+            "open": prices,
+            "high": prices * 1.01,
+            "low": prices * 0.99,
+            "close": prices,
+            "volume": rng.uniform(1000, 10000, length),
+        },
+        index=pd.date_range("2023-01-01", periods=length, freq="1h"),
+    )
+
+
+class TestSymbolThreadingThroughFactories:
+    """The trading symbol must reach MLBasicSignalGenerator via each factory."""
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_hyper_growth_threads_symbol(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+        from src.strategies.hyper_growth import create_hyper_growth_strategy
+
+        strategy = create_hyper_growth_strategy(symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_ml_basic_threads_symbol(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+        from src.strategies.ml_basic import create_ml_basic_strategy
+
+        strategy = create_ml_basic_strategy(symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_leveraged_regime_threads_symbol(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+        from src.strategies.leveraged_regime import create_leveraged_regime_strategy
+
+        strategy = create_leveraged_regime_strategy(signal_source="ml", symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_ensemble_weighted_threads_symbol(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+        from src.strategies.ensemble_weighted import create_ensemble_weighted_strategy
+
+        strategy = create_ensemble_weighted_strategy(
+            symbol="ETHUSDT", use_ml_adaptive=False, use_ml_sentiment=False
+        )
+
+        ml_basic_gens = [
+            gen
+            for gen in strategy.signal_generator.generators
+            if isinstance(gen, MLBasicSignalGenerator)
+        ]
+        assert len(ml_basic_gens) == 1
+        assert ml_basic_gens[0].symbol == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_hyper_growth_default_symbol_unchanged(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+        from src.strategies.hyper_growth import create_hyper_growth_strategy
+
+        strategy = create_hyper_growth_strategy()
+
+        assert strategy.signal_generator.symbol == "BTCUSDT"
+
+
+class TestDirectConstructionBackwardCompat:
+    """Direct constructions without a symbol keep the BTCUSDT default."""
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_default_symbol_is_btcusdt(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+
+        generator = MLBasicSignalGenerator()
+
+        assert generator.symbol == "BTCUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_symbol_normalized_to_binance_style(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+
+        generator = MLBasicSignalGenerator(symbol="ETH-USD")
+
+        assert generator.symbol == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_degraded_engine_does_not_fail_fast(self, _cfg, engine_cls):
+        """Engine init failure keeps the legacy fail-safe (HOLD) path."""
+        engine_cls.side_effect = RuntimeError("no onnxruntime")
+
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+
+        assert generator.prediction_engine is None
+
+
+class TestMissingModelFailFast:
+    """No model for (symbol, type, timeframe) must fail fast at startup."""
+
+    def _registry_without_eth(self):
+        registry = MagicMock()
+        registry.select_bundle.side_effect = ModelNotAvailableError(
+            "No model bundle for ETHUSDT 1h basic."
+        )
+        registry.list_bundles.return_value = [_make_bundle(symbol="BTCUSDT")]
+        return registry
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_missing_model_raises_with_available_models(self, _cfg, engine_cls, monkeypatch):
+        monkeypatch.delenv("FEATURE_ALLOW_CROSS_SYMBOL_MODEL", raising=False)
+        engine_cls.return_value = _make_engine(registry=self._registry_without_eth())
+
+        with pytest.raises(ModelNotAvailableError) as exc_info:
+            MLBasicSignalGenerator(symbol="ETHUSDT")
+
+        message = str(exc_info.value)
+        assert "ETHUSDT" in message
+        assert "BTCUSDT:1h:basic:v1" in message
+        assert "FEATURE_ALLOW_CROSS_SYMBOL_MODEL" in message
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_flag_allows_substitution_and_logs_critical(
+        self, _cfg, engine_cls, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("FEATURE_ALLOW_CROSS_SYMBOL_MODEL", "true")
+        engine_cls.return_value = _make_engine(registry=self._registry_without_eth())
+
+        with caplog.at_level(logging.CRITICAL):
+            generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+
+        assert generator._cross_symbol_bundle_key == "BTCUSDT:1h:basic:v1"
+        critical_records = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+        assert len(critical_records) == 1
+        assert "ETHUSDT" in critical_records[0].getMessage()
+        assert "BTCUSDT" in critical_records[0].getMessage()
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_flag_without_any_fallback_still_raises(self, _cfg, engine_cls, monkeypatch):
+        monkeypatch.setenv("FEATURE_ALLOW_CROSS_SYMBOL_MODEL", "true")
+        registry = MagicMock()
+        registry.select_bundle.side_effect = ModelNotAvailableError("nothing")
+        registry.list_bundles.return_value = []
+        engine_cls.return_value = _make_engine(registry=registry)
+
+        with pytest.raises(ModelNotAvailableError):
+            MLBasicSignalGenerator(symbol="ETHUSDT")
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_flag_substitution_warns_per_resolution_and_stamps_metadata(
+        self, _cfg, engine_cls, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("FEATURE_ALLOW_CROSS_SYMBOL_MODEL", "true")
+        engine = _make_engine(registry=self._registry_without_eth())
+        engine_cls.return_value = engine
+
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(150)
+
+        with caplog.at_level(logging.WARNING):
+            signal = generator.generate_signal(df, 130)
+
+        assert signal.metadata["trading_symbol"] == "ETHUSDT"
+        assert signal.metadata["model_symbol"] == "BTCUSDT"
+        warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "cross-symbol" in r.getMessage().lower()
+        ]
+        assert len(warnings) == 1
+        # Substituted bundle key must be what the engine scores with
+        _, kwargs = engine.predict.call_args
+        assert kwargs.get("model_name") == "BTCUSDT:1h:basic:v1"
+
+
+class TestMismatchGuardAtResolution:
+    """Resolved bundle symbol != trading symbol logs ERROR and stamps metadata."""
+
+    def _mismatched_registry(self):
+        registry = MagicMock()
+        registry.select_bundle.return_value = _make_bundle(symbol="BTCUSDT")
+        registry.list_bundles.return_value = [_make_bundle(symbol="BTCUSDT")]
+        return registry
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_mismatch_logs_error_and_stamps_metadata(self, _cfg, engine_cls, caplog):
+        engine_cls.return_value = _make_engine(registry=self._mismatched_registry())
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(150)
+
+        with caplog.at_level(logging.ERROR):
+            signal = generator.generate_signal(df, 130)
+
+        assert signal.metadata["trading_symbol"] == "ETHUSDT"
+        assert signal.metadata["model_symbol"] == "BTCUSDT"
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "ETHUSDT" in errors[0].getMessage()
+        assert "BTCUSDT" in errors[0].getMessage()
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_mismatch_error_is_rate_limited(self, _cfg, engine_cls, caplog):
+        engine_cls.return_value = _make_engine(registry=self._mismatched_registry())
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(150)
+
+        with caplog.at_level(logging.ERROR):
+            generator.generate_signal(df, 130)
+            generator.generate_signal(df, 131)
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_matching_symbol_produces_no_guard_logs(self, _cfg, engine_cls, caplog):
+        registry = MagicMock()
+        registry.select_bundle.return_value = _make_bundle(symbol="BTCUSDT")
+        registry.list_bundles.return_value = [_make_bundle(symbol="BTCUSDT")]
+        engine_cls.return_value = _make_engine(registry=registry)
+        generator = MLBasicSignalGenerator(symbol="BTCUSDT")
+        df = _make_df(150)
+
+        with caplog.at_level(logging.WARNING):
+            signal = generator.generate_signal(df, 130)
+
+        assert signal.metadata["trading_symbol"] == "BTCUSDT"
+        assert signal.metadata["model_symbol"] == "BTCUSDT"
+        guard_records = [
+            r for r in caplog.records if r.levelno >= logging.WARNING and "symbol" in r.getMessage().lower()
+        ]
+        assert guard_records == []
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_bundle_vanishing_after_startup_fails_safe(self, _cfg, engine_cls, caplog):
+        """Registry reload removing the bundle must not silently substitute."""
+        registry = MagicMock()
+        registry.select_bundle.return_value = _make_bundle(symbol="ETHUSDT")
+        registry.list_bundles.return_value = [_make_bundle(symbol="ETHUSDT")]
+        engine = _make_engine(registry=registry)
+        engine_cls.return_value = engine
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(150)
+
+        registry.select_bundle.side_effect = ModelNotAvailableError("bundle gone")
+        with caplog.at_level(logging.ERROR):
+            signal = generator.generate_signal(df, 130)
+
+        # Prediction must fail (HOLD) rather than scoring another symbol's model
+        assert signal.metadata["reason"] == "prediction_failed"
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("ETHUSDT" in r.getMessage() for r in errors)

--- a/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
+++ b/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
@@ -153,6 +153,14 @@ class TestDirectConstructionBackwardCompat:
 
         assert generator.prediction_engine is None
 
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_invalid_symbol_raises_clear_error(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+
+        with pytest.raises(ValueError, match="[Ii]nvalid trading symbol.*ETH-USD-X"):
+            MLBasicSignalGenerator(symbol="ETH-USD-X")
+
 
 class TestMissingModelFailFast:
     """No model for (symbol, type, timeframe) must fail fast at startup."""
@@ -292,7 +300,9 @@ class TestMismatchGuardAtResolution:
         assert signal.metadata["trading_symbol"] == "BTCUSDT"
         assert signal.metadata["model_symbol"] == "BTCUSDT"
         guard_records = [
-            r for r in caplog.records if r.levelno >= logging.WARNING and "symbol" in r.getMessage().lower()
+            r
+            for r in caplog.records
+            if r.levelno >= logging.WARNING and "symbol" in r.getMessage().lower()
         ]
         assert guard_records == []
 
@@ -314,5 +324,74 @@ class TestMismatchGuardAtResolution:
 
         # Prediction must fail (HOLD) rather than scoring another symbol's model
         assert signal.metadata["reason"] == "prediction_failed"
+        # HOLD path still carries the guard stamps for auditability
+        assert signal.metadata["trading_symbol"] == "ETHUSDT"
+        assert signal.metadata["model_symbol"] is None
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert any("ETHUSDT" in r.getMessage() for r in errors)
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_distinct_guard_conditions_use_separate_rate_limit_clocks(
+        self, _cfg, engine_cls, caplog
+    ):
+        """A mismatch log must not swallow the first bundle-vanished log."""
+        registry = MagicMock()
+        registry.select_bundle.return_value = _make_bundle(symbol="BTCUSDT")
+        registry.list_bundles.return_value = [_make_bundle(symbol="BTCUSDT")]
+        engine_cls.return_value = _make_engine(registry=registry)
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(150)
+
+        with caplog.at_level(logging.ERROR):
+            generator.generate_signal(df, 130)  # mismatch ERROR
+            registry.select_bundle.side_effect = ModelNotAvailableError("bundle gone")
+            generator.generate_signal(df, 131)  # vanished ERROR — separate clock
+
+        errors = [r.getMessage() for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("MISMATCH" in message for message in errors)
+        assert any("refusing cross-symbol fallback" in message for message in errors)
+
+
+class TestHoldPathMetadataStamps:
+    """All HOLD branches stamp trading_symbol/model_symbol for auditability."""
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_insufficient_history_stamps_symbols(self, _cfg, engine_cls):
+        engine_cls.return_value = _make_engine()
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(50)
+
+        signal = generator.generate_signal(df, 30)
+
+        assert signal.metadata["reason"] == "insufficient_history"
+        assert signal.metadata["trading_symbol"] == "ETHUSDT"
+        assert signal.metadata["model_symbol"] is None
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_prediction_failed_stamps_symbols(self, _cfg, engine_cls):
+        engine = _make_engine()
+        engine.predict.side_effect = RuntimeError("inference exploded")
+        engine_cls.return_value = engine
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.metadata["reason"] == "prediction_failed"
+        assert signal.metadata["trading_symbol"] == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_invalid_prediction_stamps_symbols(self, _cfg, engine_cls):
+        engine = _make_engine(predicted_price=float("nan"))
+        engine_cls.return_value = engine
+        generator = MLBasicSignalGenerator(symbol="ETHUSDT")
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.metadata["reason"] == "invalid_prediction_or_price"
+        assert signal.metadata["trading_symbol"] == "ETHUSDT"


### PR DESCRIPTION
## Summary

**P0 wiring bug** (2026-07-04 ml-engineer audit): the live runner's `--symbol` never reached the strategy's ML signal generator. `load_strategy()` called `create_hyper_growth_strategy()` with zero args → `MLBasicSignalGenerator` defaulted `symbol` to `BTCUSDT` → the registry resolved `BTCUSDT/basic/latest` with no warning. **HyperGrowth live on ETHUSDT silently scored every bar with the BTCUSDT model**, and `Signal.metadata` didn't even record which model's symbol scored the signal. The backtest CLI had the identical gap.

## User-facing impact

- `atb live <strategy> --symbol X` and `atb backtest <strategy> --symbol X` now select the model for **X** — or refuse to start if none exists.
- Running an ML strategy on a symbol with **no model** for `(symbol, model_type, timeframe)` now **fails fast at startup** with an error listing available bundles, instead of silently trading on another symbol's predictions.
- `FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true` explicitly opts into the substitution: CRITICAL log at startup, deterministic pinned fallback bundle (same type/timeframe, BTCUSDT preferred), rate-limited WARNING on every resolution.
- Every ML signal is stamped with `trading_symbol` + `model_symbol` in `Signal.metadata` for auditability; any resolved-bundle/trading-symbol mismatch logs a rate-limited ERROR.

## Changes

1. **Symbol threading (end-to-end)**
   - New `call_strategy_factory()` helper (`src/strategies/__init__.py`) used by **both** the live runner (`src/engines/live/runner.py`) and the backtest CLI (`cli/commands/backtest.py`) — passes `symbol=` to factories that support it, calls others (e.g. `chaos_test`) unchanged.
   - `symbol: str | None = None` added to every factory that composes `MLBasicSignalGenerator`: `create_hyper_growth_strategy`, `create_ml_basic_strategy`, `create_leveraged_regime_strategy`, `create_ensemble_weighted_strategy`, plus both `StrategyFactory` presets. Direct constructions keep the `BTCUSDT` default (backward compatible).
   - The generator normalizes the symbol to the registry's Binance-style convention (`ETH-USD` → `ETHUSDT`), so Coinbase-format symbols select the same bundle.

2. **Guards at the generator/registry seam** (`MLBasicSignalGenerator`) — shared by both engines, so **backtest-live parity holds by construction**:
   - Startup `_validate_model_availability()`: `ModelNotAvailableError` with available-bundle list when no model exists (unless the flag opts in).
   - Per-resolution: mismatch → ERROR (rate-limited, 300s/instance); flag substitution → WARNING (rate-limited); metadata stamped with `trading_symbol`/`model_symbol`.
   - Bundle vanishing after startup (registry reload) → prediction fails safe to HOLD; **no silent fallback to the default bundle**.
   - Engine-init failure keeps the legacy degraded path (HOLD) — no new startup crash for environments without ONNX.

## Prod transition path

Production ETHUSDT has **no `basic` model yet** (only `sentiment`). Promoting this fix therefore requires setting `FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true` on the ETHUSDT service — behavior is then **unchanged but loud** (CRITICAL at startup + periodic WARNING) — until an ETHUSDT basic model ships, at which point the flag must be unset so the fail-fast guard arms. Documented in `docs/changelog.md`.

## Testing performed

- **TDD**: 24 new failing-first tests across three files:
  - `tests/unit/strategies/components/test_ml_signal_symbol_guard.py` — factory threading (all 4 factories), default-symbol backward compat, normalization, degraded-engine tolerance, missing-model fail-fast (message lists bundles + flag), flag opt-in (CRITICAL + pinned bundle + per-resolution WARNING + metadata + engine called with substituted key), mismatch ERROR + metadata stamp, rate limiting, no-guard-logs on match, vanished-bundle fail-safe.
  - `tests/unit/engines/live/test_runner_symbol_wiring.py` — `load_strategy` threads symbol (hyper_growth, ml_basic), chaos_test unaffected, `main()` passes `--symbol` through to `load_strategy` and `engine.start`.
  - `tests/unit/cli/test_backtest_symbol_wiring.py` — `_load_strategy` threads symbol (autospec), non-symbol factories called plain, `_handle` passes `ns.symbol`.
- **Full `atb test unit`**: ✅ all pass (63s). Two existing tests updated to reflect the fixed wiring (`_load_strategy` now receives `symbol`; `select_bundle` called at startup validation + prediction).
- **`atb dev quality --changed`**: ✅ black + ruff + mypy all pass.
- **Real-registry verification** (no mocks): `create_hyper_growth_strategy(symbol="BTCUSDT")` ✅; `symbol="ETHUSDT"` without flag → `ModelNotAvailableError` listing all 6 available bundles ✅; with flag → constructs, logs CRITICAL, pins `BTCUSDT:1h:basic:2025-10-30_12h_v1` ✅.

## References

- 2026-07-04 ml-engineer audit finding (runner.py:61 → hyper_growth.py:227 → ml_signal_generator.py:594 evidence chain)
- CODE.md: Backtest-Live Parity, Input Validation ("fail at init")

🤖 Generated with [Claude Code](https://claude.com/claude-code)