### PR TITLE
feat(live): page on WS user-stream circuit-open + record recovery (#853)

### DIFF
--- a/src/engines/live/ws_health.py
+++ b/src/engines/live/ws_health.py
@@ -40,6 +40,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from src.data_providers.binance_provider import WebSocketState
+from src.database.models import EventType
 
 if TYPE_CHECKING:
     from src.engines.live.execution.position_tracker import LivePosition, LivePositionTracker
@@ -99,6 +100,18 @@ class WebSocketHealthEngineState(Protocol):
     def _handle_kline_disconnect(self) -> None: ...
 
     def _handle_user_stream_disconnect(self, *, hard: bool = ...) -> None: ...
+
+    def _record_event(
+        self,
+        event_type: EventType,
+        message: str,
+        *,
+        severity: str = ...,
+        component: str | None = ...,
+        error_code: str | None = ...,
+        exc: BaseException | None = ...,
+        alert: bool = ...,
+    ) -> None: ...
 
 
 class WebSocketHealthMonitor:
@@ -474,6 +487,21 @@ class WebSocketHealthMonitor:
             if hasattr(exchange, "mark_user_degraded"):
                 exchange.mark_user_degraded()
             state.order_tracker.enable_polling()
+            # The real-time order/balance push feed is now dead; the bot runs on
+            # slower REST polling until a real event returns it to primary. Page an
+            # operator — degraded fill/balance visibility on a live account was
+            # previously only a logger.warning (#717/#853). Fires once per
+            # circuit-open: while REST_DEGRADED the method returns early above, so
+            # this is edge-triggered by construction (no per-cycle spam).
+            state._record_event(
+                EventType.ALERT,
+                f"User data stream circuit-open after {state._user_reconnect_failures} "
+                "reconnects — REST-degraded; real-time fills/balance updates unavailable",
+                severity="critical",
+                component="connectivity",
+                error_code="USER_WS_DEGRADED",
+                alert=True,
+            )
             return
 
         state._user_reconnect_failures += 1
@@ -645,6 +673,15 @@ class WebSocketHealthMonitor:
         logger.info(
             "User data WebSocket recovered — real event confirmed, REST polling "
             "disabled, WS primary again (#717)"
+        )
+        # Paired recovery signal so an operator sees the degraded→recovered
+        # transition in system_events (no page — recovery is good news). #853
+        state._record_event(
+            EventType.WARNING,
+            "User data WebSocket recovered — WS primary again, REST polling disabled",
+            severity="info",
+            component="connectivity",
+            error_code="USER_WS_RECOVERED",
         )
 
     def handle_kline_disconnect(self) -> None:

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -186,6 +186,45 @@ class TestCheckUserStreamHealth:
             assert ordered == ["stop_user_stream", "mark_user_degraded"]
 
     @pytest.mark.fast
+    def test_circuit_open_pages_operator(self, mock_engine):
+        """Circuit-open (REST-degraded) pages a critical USER_WS_DEGRADED alert —
+        it was previously only a logger.warning while the bot ran blind on REST,
+        possibly forever (#717/#853)."""
+        from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
+
+        self._dead_socket_engine(mock_engine)
+        with (
+            patch.object(mock_engine, "_handle_user_stream_disconnect"),
+            patch.object(mock_engine, "_record_event") as rec,
+        ):
+            for _ in range(LIMIT):
+                mock_engine._check_user_stream_health()
+            rec.assert_not_called()  # silent during the fast-reconnect phase
+            # Circuit-open cycle:
+            mock_engine._check_user_stream_health()
+
+        alerts = [c for c in rec.call_args_list if c.kwargs.get("error_code") == "USER_WS_DEGRADED"]
+        assert alerts, f"expected USER_WS_DEGRADED, got {rec.call_args_list}"
+        assert alerts[0].kwargs["severity"] == "critical"
+        assert alerts[0].kwargs["alert"] is True
+
+    @pytest.mark.fast
+    def test_recovery_records_event(self, mock_engine):
+        """Returning to WS-primary records a USER_WS_RECOVERED event (no page)."""
+        tracker = MagicMock()
+        tracker.is_polling_enabled.return_value = True
+        mock_engine.order_tracker = tracker
+
+        with patch.object(mock_engine, "_record_event") as rec:
+            mock_engine.ws_health_monitor.restore_user_ws_primary()
+
+        events = [
+            c for c in rec.call_args_list if c.kwargs.get("error_code") == "USER_WS_RECOVERED"
+        ]
+        assert events, f"expected USER_WS_RECOVERED, got {rec.call_args_list}"
+        assert events[0].kwargs.get("alert", False) is False
+
+    @pytest.mark.fast
     def test_breaker_resets_on_real_event(self, mock_engine):
         """A genuinely healthy stream (real event) clears the failure counter."""
         mock_engine.enable_live_trading = True

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -186,13 +186,20 @@ class TestCheckUserStreamHealth:
             assert ordered == ["stop_user_stream", "mark_user_degraded"]
 
     @pytest.mark.fast
-    def test_circuit_open_pages_operator(self, mock_engine):
-        """Circuit-open (REST-degraded) pages a critical USER_WS_DEGRADED alert —
-        it was previously only a logger.warning while the bot ran blind on REST,
-        possibly forever (#717/#853)."""
+    def test_circuit_open_pages_operator_exactly_once(self, mock_engine):
+        """Circuit-open pages a critical USER_WS_DEGRADED alert — but exactly ONCE,
+        not every subsequent REST_DEGRADED cycle. Drives the REAL transition
+        (mark_user_degraded flips state to REST_DEGRADED so later cycles take the
+        early-returning degraded branch) so the anti-spam edge-trigger the audit
+        warned about is actually pinned, not just asserted in a comment (#717/#853)."""
         from src.config.constants import DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT as LIMIT
 
-        self._dead_socket_engine(mock_engine)
+        ex, _tracker = self._dead_socket_engine(mock_engine)
+        # Real breaker semantics: degrading flips the state so the PRIMARY path
+        # (and thus the circuit-open block) is not re-entered on later cycles.
+        ex.mark_user_degraded.side_effect = lambda: setattr(
+            ex, "_user_ws_state", WebSocketState.REST_DEGRADED
+        )
         with (
             patch.object(mock_engine, "_handle_user_stream_disconnect"),
             patch.object(mock_engine, "_record_event") as rec,
@@ -200,11 +207,12 @@ class TestCheckUserStreamHealth:
             for _ in range(LIMIT):
                 mock_engine._check_user_stream_health()
             rec.assert_not_called()  # silent during the fast-reconnect phase
-            # Circuit-open cycle:
-            mock_engine._check_user_stream_health()
+            mock_engine._check_user_stream_health()  # circuit opens -> alert #1
+            for _ in range(5):
+                mock_engine._check_user_stream_health()  # REST_DEGRADED -> no re-page
 
         alerts = [c for c in rec.call_args_list if c.kwargs.get("error_code") == "USER_WS_DEGRADED"]
-        assert alerts, f"expected USER_WS_DEGRADED, got {rec.call_args_list}"
+        assert len(alerts) == 1, f"expected exactly one USER_WS_DEGRADED, got {rec.call_args_list}"
         assert alerts[0].kwargs["severity"] == "critical"
         assert alerts[0].kwargs["alert"] is True
 


### PR DESCRIPTION
## Summary
PR 6 of #853. The user/margin data-stream **circuit-opening** (dead multiplexed socket → `REST_DEGRADED`) means the bot loses its real-time order-fill / balance push feed and runs on slower REST polling — possibly indefinitely — on a **live margin account**. It was only a `logger.warning`, so **#717 (live in prod right now) pages no one**.

## Changes
- **Circuit-open** (`ws_health.py`): emit a critical `USER_WS_DEGRADED` ALERT at the transition. **Edge-triggered by construction** — while `REST_DEGRADED` the method returns early before this block, so it fires once per circuit-open, not every cycle (no spam).
- **Recovery** (`restore_user_ws_primary`): emit a `USER_WS_RECOVERED` event (no page — recovery is good news) so operators see the degraded→recovered pair.
- Declare `_record_event` on the `WebSocketHealthEngineState` protocol (the monitor already holds the engine via `engine_state`).

## Testing
- `test_circuit_open_pages_operator`: drives the real fast-reconnect phase (silent) then the circuit-open cycle; asserts a critical `USER_WS_DEGRADED` alert (`alert=True`).
- `test_recovery_records_event`: `restore_user_ws_primary` records `USER_WS_RECOVERED` with no page.
- 78 passed across the two WS-health test files; quality gate (Black/Ruff/MyPy) clean.

## Scope
Merges to `develop`. Additive observability on the existing WS state machine (no connectivity behavior change). Follow-up (noted in the audit): duration-based re-escalation if still degraded after N minutes. Part of #853.