### PR TITLE
feat(live): OrderTracker alert sink + page on orphaned-order force-remove (#853)

### DIFF
--- a/src/engines/live/order_tracker.py
+++ b/src/engines/live/order_tracker.py
@@ -448,8 +448,9 @@ class OrderTracker:
                             e,
                             exc_info=True,
                         )
-                        # Runs outside any lock (see the callback comment above), so
-                        # the alert webhook cannot block order handling. #853
+                        # This runs UNDER the per-order lock; the engine adapter
+                        # delivers the alert off-thread so the (up to 10s) webhook
+                        # never blocks the poll / fill-processing path. #853
                         self._emit_critical(
                             f"Fill callback failed {tracked.callback_failure_count}x for order "
                             f"{order_id} on {tracked.symbol} — order force-removed; position is "

--- a/src/engines/live/order_tracker.py
+++ b/src/engines/live/order_tracker.py
@@ -83,6 +83,7 @@ class OrderTracker:
         on_partial_fill: Callable[[str, str, float, float], None] | None = None,
         on_cancel: Callable[[str, str, float], None] | None = None,
         on_tracking_lost: Callable[[str, str, int], None] | None = None,
+        on_critical: Callable[[str, str], None] | None = None,
         event_deduplicator: EventDeduplicator | None = None,
     ):
         """
@@ -112,6 +113,11 @@ class OrderTracker:
         self.on_partial_fill = on_partial_fill
         self.on_cancel = on_cancel
         self.on_tracking_lost = on_tracking_lost
+        # Optional sink for operator-critical conditions (orphaned/unrecoverable
+        # orders). Signature: (message, error_code). The engine adapts it to
+        # _record_event so these reach system_events + an alert instead of only
+        # application logs. None in standalone use / tests.
+        self.on_critical = on_critical
         self._dedup = event_deduplicator or EventDeduplicator()
         self._polling_enabled = True  # Controls whether _poll_loop runs checks
 
@@ -124,6 +130,20 @@ class OrderTracker:
         # Circuit breaker to handle exchange API failures gracefully
         # Prevents resource exhaustion from repeated failing API calls
         self._circuit_breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=60.0)
+
+    def _emit_critical(self, message: str, error_code: str) -> None:
+        """Route an operator-critical order condition (an orphaned/unrecoverable
+        order that the docstrings say "MANUAL RECONCILIATION REQUIRED") to the
+        engine's alert sink, if wired, so it reaches system_events + an operator
+        instead of only application logs. Fault-isolated: observability must never
+        break the poll loop or the fill/cancel handling around it.
+        """
+        if self.on_critical is None:
+            return
+        try:
+            self.on_critical(message, error_code)
+        except Exception as e:
+            logger.warning("order-tracker critical emit failed: %s", e)
 
     def _get_order_lock(self, order_id: str) -> threading.Lock:
         """Return the per-order lock, creating one if needed.
@@ -427,6 +447,14 @@ class OrderTracker:
                             tracked.symbol,
                             e,
                             exc_info=True,
+                        )
+                        # Runs outside any lock (see the callback comment above), so
+                        # the alert webhook cannot block order handling. #853
+                        self._emit_critical(
+                            f"Fill callback failed {tracked.callback_failure_count}x for order "
+                            f"{order_id} on {tracked.symbol} — order force-removed; position is "
+                            "ORPHANED on exchange, manual reconciliation required",
+                            "ORDER_ORPHANED",
                         )
                         self.stop_tracking(order_id)
                         return

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2188,15 +2188,28 @@ class LiveTradingEngine:
         """Adapter so OrderTracker (kept free of EventType/DB coupling) can page an
         operator for orphaned/unrecoverable orders via the engine's fault-isolated
         ``_record_event`` — routing its "MANUAL RECONCILIATION REQUIRED" criticals
-        to system_events + an alert instead of only application logs."""
-        self._record_event(
-            EventType.ALERT,
-            message,
-            severity="critical",
-            component="order_tracker",
-            error_code=error_code,
-            alert=True,
-        )
+        to system_events + an alert instead of only application logs.
+
+        OrderTracker invokes this while holding its per-order lock (which serializes
+        the poll thread and the UserDataProcessor worker to prevent double-fills),
+        so the up-to-10s alert webhook must NOT run inline. Deliver on a short-lived
+        daemon thread so this returns immediately and the lock is released promptly.
+        """
+
+        def _deliver() -> None:
+            self._record_event(
+                EventType.ALERT,
+                message,
+                severity="critical",
+                component="order_tracker",
+                error_code=error_code,
+                alert=True,
+            )
+
+        try:
+            threading.Thread(target=_deliver, name="order-tracker-alert", daemon=True).start()
+        except Exception as e:  # pragma: no cover - defensive; never break order handling
+            logger.warning("order-tracker alert dispatch failed: %s", e)
 
     def _sleep_with_interrupt(self, seconds: float) -> None:
         """Sleep in small increments to allow for interrupt (delegated to LiveLoopTimingCoordinator)."""

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -650,6 +650,7 @@ class LiveTradingEngine:
                         on_partial_fill=self._handle_partial_fill,
                         on_cancel=self._handle_order_cancel,
                         on_tracking_lost=self._handle_order_tracking_lost,
+                        on_critical=self._order_tracker_alert,
                     )
                     logger.info(
                         f"{provider_name} exchange interface and account synchronizer initialized"
@@ -2182,6 +2183,20 @@ class LiveTradingEngine:
             )
         except Exception as e:  # pragma: no cover - defensive; must never break startup
             logger.warning("no-alert-channel guard failed: %s", e)
+
+    def _order_tracker_alert(self, message: str, error_code: str) -> None:
+        """Adapter so OrderTracker (kept free of EventType/DB coupling) can page an
+        operator for orphaned/unrecoverable orders via the engine's fault-isolated
+        ``_record_event`` — routing its "MANUAL RECONCILIATION REQUIRED" criticals
+        to system_events + an alert instead of only application logs."""
+        self._record_event(
+            EventType.ALERT,
+            message,
+            severity="critical",
+            component="order_tracker",
+            error_code=error_code,
+            alert=True,
+        )
 
     def _sleep_with_interrupt(self, seconds: float) -> None:
         """Sleep in small increments to allow for interrupt (delegated to LiveLoopTimingCoordinator)."""

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -281,3 +281,27 @@ class TestLoopCrashEvent:
         assert kwargs["severity"] == "critical"
         assert kwargs["alert"] is True
         assert isinstance(kwargs["exc"], RuntimeError)
+
+
+class TestOrderTrackerAlertAdapter:
+    """OrderTracker calls this adapter while holding its per-order lock, so the
+    (blocking, up-to-10s) alert webhook must be delivered OFF-thread — not inline
+    under the lock (#853; the webhook-under-lock class PR #857's review flagged)."""
+
+    def test_dispatches_record_event_off_thread(self):
+        import threading
+
+        engine = LiveTradingEngine.__new__(LiveTradingEngine)
+        delivered = threading.Event()
+        engine._record_event = MagicMock(side_effect=lambda *a, **k: delivered.set())
+
+        # Returns immediately (does not block on _record_event / the webhook).
+        engine._order_tracker_alert("position orphaned!", "ORDER_ORPHANED")
+
+        assert delivered.wait(timeout=2.0), "adapter did not deliver the event off-thread"
+        args, kwargs = engine._record_event.call_args
+        assert args[0] == EventType.ALERT
+        assert kwargs["error_code"] == "ORDER_ORPHANED"
+        assert kwargs["component"] == "order_tracker"
+        assert kwargs["severity"] == "critical"
+        assert kwargs["alert"] is True

--- a/tests/unit/live/test_order_tracker.py
+++ b/tests/unit/live/test_order_tracker.py
@@ -525,3 +525,42 @@ class TestApiErrorHandling:
 
         # Assert - order still force-removed despite callback failure
         assert order_tracker.get_tracked_count() == 0
+
+
+def test_fill_callback_failure_orphan_pages_operator(mock_exchange):
+    """When the fill callback fails MAX times, the order is force-removed with a
+    position ORPHANED on the exchange — previously logger.critical-only. It must
+    now page an operator via on_critical (#853)."""
+    from src.engines.live.order_tracker import MAX_CALLBACK_RETRIES
+
+    on_critical = Mock()
+    tracker = OrderTracker(
+        exchange=mock_exchange,
+        poll_interval=0.1,
+        on_fill=Mock(side_effect=RuntimeError("boom")),
+        on_critical=on_critical,
+    )
+    mock_order = MagicMock()
+    mock_order.status = OrderStatus.FILLED
+    mock_order.filled_quantity = 1.5
+    mock_order.average_price = 50000.0
+    mock_exchange.get_order.return_value = mock_order
+
+    tracker.track_order("order123", "BTCUSDT")
+    for _ in range(MAX_CALLBACK_RETRIES):
+        tracker._check_orders()
+
+    orphan = [c for c in on_critical.call_args_list if c.args[1] == "ORDER_ORPHANED"]
+    assert len(orphan) == 1, on_critical.call_args_list
+    assert "ORPHANED" in orphan[0].args[0]
+    assert tracker.get_tracked_count() == 0  # force-removed after the final failure
+
+
+def test_emit_critical_noop_and_fault_isolated(mock_exchange):
+    """_emit_critical is a no-op with no sink and never raises if the sink does."""
+    OrderTracker(exchange=mock_exchange)._emit_critical("msg", "CODE")  # no sink -> no-op
+
+    boom = Mock(side_effect=RuntimeError("sink down"))
+    tracker = OrderTracker(exchange=mock_exchange, on_critical=boom)
+    tracker._emit_critical("msg", "CODE")  # must not raise
+    boom.assert_called_once_with("msg", "CODE")


### PR DESCRIPTION
## Summary
PR 7 of #853. `OrderTracker` had **no path** to `system_events`/alerts — its ~12 `logger.critical("MANUAL RECONCILIATION REQUIRED")` sites reached only application logs. The sharpest: when a **fill callback fails `MAX_CALLBACK_RETRIES` times**, the order is force-removed with *"POSITION IS ORPHANED ON EXCHANGE"* — silent.

## Changes
- **`OrderTracker`** gains an `on_critical(message, error_code)` callback (kept **free of `EventType`/DB coupling** — it's low-level infrastructure) + a fault-isolated `_emit_critical` helper (no-op when unwired, never raises).
- **Engine adapter** `_order_tracker_alert` routes it to `_record_event` as a critical `ALERT` (`component="order_tracker"`, `alert=True`); wired at the `OrderTracker` construction site.
- **First consumer:** the fill-callback-failure orphan force-remove now pages `ORDER_ORPHANED`. That site runs **outside any lock** (per the "call callback outside any lock" contract), so the webhook cannot block order handling — the lock-free pattern from PR 2's review.

## Testing
- `test_fill_callback_failure_orphan_pages_operator`: drives `_check_orders()` with a failing `on_fill` `MAX_CALLBACK_RETRIES` times; asserts exactly one `ORDER_ORPHANED` page and the order is force-removed.
- `test_emit_critical_noop_and_fault_isolated`: no-op without a sink, never raises when the sink does.
- 30 in the file; **775 passed** across `tests/unit/live/` + `tests/unit/engines/live/` (no regression). Quality gate (Black/Ruff/MyPy) clean.

## Scope
Merges to `develop`. This lands the OrderTracker sink; the other ~11 critical sites can now call `_emit_critical` trivially in a fast follow-up. Part of #853.