### PR TITLE
feat(live): page on the remaining OrderTracker force-remove sites (#853)

### DIFF
--- a/src/engines/live/order_tracker.py
+++ b/src/engines/live/order_tracker.py
@@ -281,6 +281,12 @@ class OrderTracker:
                                 tracked.symbol,
                                 tracked.callback_failure_count,
                             )
+                            self._emit_critical(
+                                f"Order {order_id} on {tracked.symbol} vanished from the exchange "
+                                f"after {tracked.callback_failure_count} failed callbacks — "
+                                "force-removed; position may be untracked, reconcile manually",
+                                "ORDER_UNTRACKED",
+                            )
                             self.stop_tracking(order_id)
                         else:
                             logger.warning(
@@ -377,6 +383,12 @@ class OrderTracker:
                         avg_price,
                         tracked.invalid_data_count,
                     )
+                    self._emit_critical(
+                        f"Filled order {order_id} on {tracked.symbol} returned invalid avg_price "
+                        f"({avg_price}) for {tracked.invalid_data_count} polls — force-removed; "
+                        "the fill is unbooked, reconcile manually",
+                        "ORDER_INVALID_DATA",
+                    )
                     self.stop_tracking(order_id)
                     return
                 logger.error(
@@ -406,6 +418,12 @@ class OrderTracker:
                         tracked.symbol,
                         filled_qty,
                         tracked.invalid_data_count,
+                    )
+                    self._emit_critical(
+                        f"Filled order {order_id} on {tracked.symbol} returned invalid filled_qty "
+                        f"({filled_qty}) for {tracked.invalid_data_count} polls — force-removed; "
+                        "the fill is unbooked, reconcile manually",
+                        "ORDER_INVALID_DATA",
                     )
                     self.stop_tracking(order_id)
                     return
@@ -495,6 +513,12 @@ class OrderTracker:
                         avg_price,
                         tracked.invalid_data_count,
                     )
+                    self._emit_critical(
+                        f"Partial fill {order_id} on {tracked.symbol} returned invalid avg_price "
+                        f"({avg_price}) for {tracked.invalid_data_count} polls — force-removed; "
+                        "the partial fill is unbooked, reconcile manually",
+                        "ORDER_INVALID_DATA",
+                    )
                     self.stop_tracking(order_id)
                     return
                 logger.error(
@@ -524,6 +548,12 @@ class OrderTracker:
                         tracked.symbol,
                         filled_qty,
                         tracked.invalid_data_count,
+                    )
+                    self._emit_critical(
+                        f"Partial fill {order_id} on {tracked.symbol} returned invalid filled_qty "
+                        f"({filled_qty}) for {tracked.invalid_data_count} polls — force-removed; "
+                        "the partial fill is unbooked, reconcile manually",
+                        "ORDER_INVALID_DATA",
                     )
                     self.stop_tracking(order_id)
                     return
@@ -633,6 +663,11 @@ class OrderTracker:
                         order_id,
                         tracked.symbol,
                         e,
+                    )
+                    self._emit_critical(
+                        f"Cancel callback failed for order {order_id} on {tracked.symbol} — "
+                        "order untracked; a phantom position may remain, reconcile manually",
+                        "ORDER_ORPHANED",
                     )
             # Stop tracking even if callback fails - cancelled orders won't
             # re-appear on exchange so keeping them tracked is a memory leak.

--- a/tests/unit/live/test_order_tracker.py
+++ b/tests/unit/live/test_order_tracker.py
@@ -368,6 +368,33 @@ def test_zero_average_price_skips_fill_callback(order_tracker, mock_exchange):
     assert order_tracker.get_tracked_count() == 1
 
 
+def test_invalid_data_force_remove_pages_operator(mock_exchange):
+    """After MAX_INVALID_DATA_RETRIES of un-processable fill data, the order is
+    force-removed with the fill unbooked — it must page an operator (#853)."""
+    from src.engines.live.order_tracker import MAX_INVALID_DATA_RETRIES
+
+    on_critical = Mock()
+    tracker = OrderTracker(
+        exchange=mock_exchange,
+        poll_interval=0.1,
+        on_fill=Mock(),
+        on_critical=on_critical,
+    )
+    mock_order = MagicMock()
+    mock_order.status = OrderStatus.FILLED
+    mock_order.filled_quantity = 1.0
+    mock_order.average_price = None  # invalid every poll -> never processable
+    mock_exchange.get_order.return_value = mock_order
+
+    tracker.track_order("order123", "BTCUSDT")
+    for _ in range(MAX_INVALID_DATA_RETRIES):
+        tracker._check_orders()
+
+    pages = [c for c in on_critical.call_args_list if c.args[1] == "ORDER_INVALID_DATA"]
+    assert len(pages) == 1, on_critical.call_args_list
+    assert tracker.get_tracked_count() == 0  # force-removed after the retry limit
+
+
 class TestApiErrorHandling:
     """Tests for persistent API error handling in order tracking."""
 

--- a/tests/unit/live/test_order_tracker.py
+++ b/tests/unit/live/test_order_tracker.py
@@ -395,6 +395,29 @@ def test_invalid_data_force_remove_pages_operator(mock_exchange):
     assert tracker.get_tracked_count() == 0  # force-removed after the retry limit
 
 
+def test_cancel_callback_failure_pages_operator(mock_exchange):
+    """A failing cancel callback may leave a phantom position — it must page an
+    operator (ORDER_ORPHANED); stop_tracking still runs regardless (#853)."""
+    on_critical = Mock()
+    tracker = OrderTracker(
+        exchange=mock_exchange,
+        poll_interval=0.1,
+        on_cancel=Mock(side_effect=RuntimeError("boom")),
+        on_critical=on_critical,
+    )
+    mock_order = MagicMock()
+    mock_order.status = OrderStatus.CANCELLED
+    mock_order.filled_quantity = 0.0
+    mock_exchange.get_order.return_value = mock_order
+
+    tracker.track_order("order123", "BTCUSDT")
+    tracker._check_orders()
+
+    pages = [c for c in on_critical.call_args_list if c.args[1] == "ORDER_ORPHANED"]
+    assert len(pages) == 1, on_critical.call_args_list
+    assert tracker.get_tracked_count() == 0  # untracked even though the callback failed
+
+
 class TestApiErrorHandling:
     """Tests for persistent API error handling in order tracking."""
 


### PR DESCRIPTION
Completes the OrderTracker observability started in #875. The remaining force-remove `MANUAL RECONCILIATION REQUIRED` sites now page via `_emit_critical`: order vanished after failed callbacks (`ORDER_UNTRACKED`), invalid avg_price/filled_qty on a fill and on a partial fill (`ORDER_INVALID_DATA` — the fill is unbooked), and cancel-callback failure leaving a phantom position (`ORDER_ORPHANED`). All route through the existing off-thread engine adapter (`_order_tracker_alert`), so the webhook is lock-safe at every site. New test drives the real invalid-data force-remove and asserts one `ORDER_INVALID_DATA` page + force-remove. 31 in file; quality gate clean. Part of #853.