### PR TITLE
feat(live): record entry-order rejection + phantom-order reason in system_events (#853)

### DIFF
--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -26,6 +26,7 @@ from src.data_providers.exchange_interface import (
     OrderType,
     SideEffectType,
 )
+from src.database.models import EventType
 from src.engines.shared.commission import order_commission_usd
 from src.engines.shared.cost_calculator import CostCalculator
 from src.engines.shared.models import PositionSide
@@ -123,6 +124,33 @@ class LiveExecutionEngine:
             fee_rate=fee_rate,
             slippage_rate=slippage_rate,
         )
+
+    def _log_execution_event(
+        self,
+        event_type: EventType,
+        message: str,
+        error_code: str,
+        *,
+        severity: str = "error",
+    ) -> None:
+        """Record an execution-layer condition (order rejection / phantom-order
+        UNKNOWN) in ``system_events`` so the exchange reason isn't lost to
+        application logs + a reason-less FAILED order row. Guarded on an active
+        session and fault-isolated: observability must never break execution.
+        """
+        if not (self.db_manager and self.session_id):
+            return
+        try:
+            self.db_manager.log_event(
+                event_type=event_type,
+                message=message,
+                severity=severity,
+                component="execution",
+                session_id=self.session_id,
+                error_code=error_code,
+            )
+        except Exception as e:  # pragma: no cover - defensive; never break execution
+            logger.warning("Failed to log execution event %s: %s", error_code, e)
 
     @staticmethod
     def _position_side_to_str(side: PositionSide) -> str:
@@ -762,6 +790,14 @@ class LiveExecutionEngine:
                         self.db_manager.update_order_journal(client_order_id, "FAILED")
                     except Exception as journal_err:
                         logger.warning("Failed to mark order as FAILED: %s", journal_err)
+                # Capture the exchange rejection reason (e.g. -2010 insufficient
+                # balance, -1111/51077 precision) in system_events — it was
+                # previously only in application logs + a reason-less FAILED row.
+                self._log_execution_event(
+                    EventType.ERROR,
+                    f"Entry order rejected for {symbol}: {e}",
+                    "ORDER_REJECTED",
+                )
                 return None, None
 
             if order_result is None:
@@ -775,6 +811,15 @@ class LiveExecutionEngine:
                         self.db_manager.update_order_journal(client_order_id, "UNKNOWN")
                     except Exception as e:
                         logger.warning("Failed to mark order as UNKNOWN: %s", e)
+                # Phantom-order window: the order may be live on the exchange.
+                # Surface it in system_events (the reconciler resolves on restart).
+                self._log_execution_event(
+                    EventType.WARNING,
+                    f"Entry order state UNKNOWN for {symbol} (may be live on exchange) — "
+                    "reconciler will resolve; phantom position possible until then",
+                    "ORDER_UNKNOWN",
+                    severity="warning",
+                )
                 return client_order_id, client_order_id
 
             # Extract order_id and update journal with exchange data

--- a/tests/unit/live/test_order_execution.py
+++ b/tests/unit/live/test_order_execution.py
@@ -24,6 +24,7 @@ from src.data_providers.exchange_interface import (
 from src.data_providers.exchange_interface import (
     OrderStatus as ExchangeOrderStatus,
 )
+from src.database.models import EventType
 from src.engines.live.execution.execution_engine import LiveExecutionEngine
 from src.engines.live.execution.exit_handler import LiveExitHandler
 from src.engines.live.execution.position_tracker import LivePosition, LivePositionTracker
@@ -248,6 +249,50 @@ class TestExecuteEntry:
         assert result.client_order_id is not None
         # order_id equals client_order_id for phantom positions
         assert result.order_id == result.client_order_id
+
+    def test_entry_rejection_records_reason_in_system_events(
+        self, execution_engine_with_exchange, mock_exchange
+    ):
+        """A definitive exchange rejection captures the reason (e.g. -2010) in
+        system_events — previously only in logs + a reason-less FAILED row (#853)."""
+        engine = execution_engine_with_exchange
+        engine.db_manager = MagicMock()
+        engine.session_id = 1
+        mock_exchange.place_order.side_effect = ValueError(
+            "APIError(code=-2010): Account has insufficient balance"
+        )
+
+        result = engine.execute_entry("BTCUSDT", PositionSide.LONG, 0.1, 50000.0, 10000.0)
+
+        assert result.success is False
+        rejects = [
+            c
+            for c in engine.db_manager.log_event.call_args_list
+            if c.kwargs.get("error_code") == "ORDER_REJECTED"
+        ]
+        assert rejects, engine.db_manager.log_event.call_args_list
+        assert rejects[0].kwargs["event_type"] == EventType.ERROR
+        assert "-2010" in rejects[0].kwargs["message"]
+
+    def test_entry_unknown_records_system_event(
+        self, execution_engine_with_exchange, mock_exchange
+    ):
+        """A None place_order result (phantom-order window) is surfaced in
+        system_events so the possibly-live order is queryable (#853)."""
+        engine = execution_engine_with_exchange
+        engine.db_manager = MagicMock()
+        engine.session_id = 1
+        mock_exchange.place_order.return_value = None
+
+        engine.execute_entry("BTCUSDT", PositionSide.LONG, 0.1, 50000.0, 10000.0)
+
+        unknowns = [
+            c
+            for c in engine.db_manager.log_event.call_args_list
+            if c.kwargs.get("error_code") == "ORDER_UNKNOWN"
+        ]
+        assert unknowns, engine.db_manager.log_event.call_args_list
+        assert unknowns[0].kwargs["event_type"] == EventType.WARNING
 
     def test_execute_entry_no_symbol_info(self, execution_engine_with_exchange, mock_exchange):
         """Order succeeds without symbol info (uses defaults)."""


### PR DESCRIPTION
PR 9 of #853. A definitive exchange rejection (invalid params / insufficient balance — **−2010/−1111/51077**) and the phantom-order **UNKNOWN** window were only in application logs + a reason-less `FAILED`/`UNKNOWN` order row — the exchange reason was lost. This adds a fault-isolated `_log_execution_event` helper (LiveExecutionEngine already holds `db_manager`) and emits an `ORDER_REJECTED` ERROR event (capturing the reason) at the rejection site and an `ORDER_UNKNOWN` WARNING at the phantom-order site. Not paged — rejections can be semi-routine and failed *protective* orders already page via the emergency-close path; these make patterns queryable in `system_events`. 2 new tests (drive the real rejection/None paths, assert the events); 46 in file, 488 across `tests/unit/live/` (no regression); quality gate clean. Part of #853.