### PR TITLE
feat(live): audit phantom-position removal (#853)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2345,6 +2345,22 @@ class PositionReconciler:
                 getattr(position, "symbol", "?"),
                 db_pos_id,
             )
+        # Audit the phantom removal (it sets HIGH severity but previously wrote no
+        # reconciliation_audit_events row, unlike the spot external-close path). #853
+        audit = AuditEvent(
+            entity_type="position",
+            entity_id=db_pos_id,
+            field="status",
+            old_value="OPEN",
+            new_value="CLOSED_EXTERNALLY",
+            reason=(
+                f"Phantom {getattr(position, 'symbol', '?')} position removed — not present on the "
+                "exchange (external close / liquidation)"
+            ),
+            severity=Severity.HIGH,
+        )
+        self._persist_audit(audit)
+        result.corrections.append(audit)
         result.status = "corrected"
         result.severity = Severity.HIGH
 

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3880,6 +3880,26 @@ class TestPeriodicExternalCloseTradeRow:
         assert high_events, f"expected RECONCILE_HIGH, got {on_event.call_args_list}"
 
 
+def test_remove_phantom_position_writes_audit(reconciler, mock_db):
+    """Removing a phantom (externally-closed) position writes a CLOSED_EXTERNALLY
+    audit row + records it on the result — it previously set HIGH severity with no
+    audit row, unlike the spot external-close path (#853)."""
+    reconciler._log_external_close_trade = MagicMock()  # isolate from trade-row math
+    pos = MockPosition(symbol="BTCUSDT", order_id="k1", db_position_id=42, stop_loss_order_id="sl1")
+    result = ReconciliationResult(entity_type="position", entity_id=42, status="unresolved")
+
+    reconciler._remove_phantom_position(pos, result)
+
+    audits = [
+        c
+        for c in mock_db.log_audit_event.call_args_list
+        if c.kwargs.get("new_value") == "CLOSED_EXTERNALLY"
+    ]
+    assert audits, mock_db.log_audit_event.call_args_list
+    assert result.severity == Severity.HIGH
+    assert any(a.new_value == "CLOSED_EXTERNALLY" for a in result.corrections)
+
+
 class TestReconcilerEventSink:
     """The reconciler gains a system_events/alert sink via an injected on_event
     callback (the engine's _record_event), mirroring on_critical (#853)."""


### PR DESCRIPTION
PR 10 of #853 (gap #8). `_remove_phantom_position` set HIGH severity but wrote no `reconciliation_audit_events` row — unlike the spot external-close path. Adds a `CLOSED_EXTERNALLY` audit (via `_persist_audit`) + records it on the result, so a phantom removal / liquidation is traceable in the audit table. New test asserts the audit row + result.corrections. 142 in file; quality gate clean. Part of #853.

Note: gap #9 (`_realize_pnl_on_close` skip-guard audits) is deliberately deferred — its skip guards (no exit price / missing data) are largely benign (external closes legitimately lack a fill price), so auditing them risks noise for little value.