### PR TITLE
Enforce account circuit breakers on the live loop — #807 follow-ups (baseline persistence, halt-on-trip, surfacing)

### DIFF
--- a/.claude/LESSONS.md
+++ b/.claude/LESSONS.md
@@ -199,6 +199,11 @@ keep the skill generic and let the specifics live here.
 - `emergency.close` / "Stop-loss placement failed" — opened a position it couldn't protect; repeated
   = capital-bleed churn.
 - `CLOSE-ONLY MODE ACTIVATED` — entries halted (reconcile/DB problem).
+- `ACCOUNT CIRCUIT BREAKER TRIPPED` / `error_code=ACCOUNT_CIRCUIT_BREAKER_TRIP` /
+  `risk_event=account_circuit_breaker_trip` (#807) — the daily-loss (2.5% of the UTC-day baseline)
+  or drawdown (15% peak-to-trough) hard halt fired; account is close-only for the day. Operator
+  reviews & clears. `🟡 ... WOULD HALT (dry_run)` is the pre-enablement dry-run signal (report, not
+  escalate).
 - `code=-1111` (price precision) / `code=51077` (qty precision) — order precision rejection (should
   be fixed; recurrence = regression, see §1.1).
 - `-2010` / "insufficient balance" on a stop-loss → unprotected position.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Account circuit-breaker loop enforcement** (#807 follow-up): a new
+  `CircuitBreakerEnforcer` (`src/engines/live/monitoring/circuit_breaker_enforcer.py`)
+  runs the #807 `AccountCircuitBreaker` on every trading-loop iteration (mirroring
+  `MaxDrawdownEnforcer`), completing the follow-ups flagged as human-sign-off:
+  (1) **restart-safe daily baseline** — seeds the daily-loss baseline from the
+  day's first `account_history` snapshot (`get_first_snapshot_of_day`) on boot, so
+  an intraday restart no longer disarms the halt; (2) **halt on trip** — in
+  `active` mode a trip flips the engine's existing **close-only mode** (new entries
+  and scale-ins stop; exits/stop-losses keep running — nothing is liquidated,
+  matching the `MaxDrawdownGuard` precedent), and in `dry_run` it logs "would
+  halt"; (3) **surfacing** — emits a `risk_event` + a CRITICAL `system_events`
+  ALERT (`ACCOUNT_CIRCUIT_BREAKER_TRIP`) for the dashboard/alerting, with the log
+  signatures added to `.claude/LESSONS.md §5`. Fault-isolated (never crashes the
+  loop). Still gated by `account_circuit_breakers` (default `off`). Deliberate
+  non-goal: literal force-liquidation of open positions (the codebase does not
+  liquidate into a dip; close-only is the safe halt).
 - **Account-level circuit breakers** (#807): new `AccountCircuitBreaker`
   (`src/risk/circuit_breaker.py`) enforces hard, account-level safety limits
   independent of strategy logic — a **daily-loss halt** (default 2.5% below a

--- a/src/engines/live/monitoring/circuit_breaker_enforcer.py
+++ b/src/engines/live/monitoring/circuit_breaker_enforcer.py
@@ -1,0 +1,179 @@
+"""Account circuit-breaker enforcement on the live trading loop (#807 follow-up).
+
+The #807 ``AccountCircuitBreaker`` is evaluated in the pre-order gate (it blocks
+new entries when tripped). This enforcer adds the loop-driven half:
+
+- **Restart-safe daily baseline**: on boot it seeds the breaker's daily-loss
+  baseline from the day's first ``account_history`` snapshot
+  (``get_first_snapshot_of_day``), so an intraday restart does not re-anchor the
+  baseline to current equity and silently disarm the daily-loss halt.
+- **Close-only on trip**: in ``active`` mode a trip flips the engine's existing
+  **close-only mode** (new entries AND scale-ins stop; exits and stop-losses keep
+  running — nothing is liquidated), matching the ``MaxDrawdownGuard`` precedent
+  (the codebase deliberately does not force-liquidate into a dip). In ``dry_run``
+  it logs "would halt" and takes no action. ``off`` is fully inert.
+- **Surfacing**: a trip emits a ``risk_event`` + a CRITICAL ``system_events`` row
+  so the monitoring dashboard and alerting pick it up.
+
+Fault-isolated: a failing check never crashes the trading loop, and the
+protective action is taken before observability so an event failure cannot leave
+the account unprotected.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Protocol
+
+from src.database.models import EventType
+from src.infrastructure.logging.events import log_risk_event
+from src.risk.circuit_breaker import MODE_ACTIVE, MODE_DRY_RUN, AccountCircuitBreaker
+
+if TYPE_CHECKING:
+    from src.database.manager import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+# Bounded seeding deferrals (mirrors MaxDrawdownEnforcer): a failed/unavailable
+# day-snapshot read defers seeding to the next cycle; after this many attempts we
+# arm from the current balance so the breaker is never left unseeded indefinitely.
+MAX_SEED_ATTEMPTS = 10
+
+
+class CircuitBreakerEngineState(Protocol):
+    """Live engine state the circuit-breaker enforcer reads and acts through."""
+
+    current_balance: float
+    trading_session_id: int | None
+    _recovered_inactive_session_id: int | None
+    db_manager: DatabaseManager
+    _close_only_mode: bool
+
+    def _enter_close_only_mode(self) -> None: ...
+
+    def _record_event(
+        self,
+        event_type: EventType,
+        message: str,
+        *,
+        severity: str = ...,
+        component: str | None = ...,
+        error_code: str | None = ...,
+        exc: BaseException | None = ...,
+        alert: bool = ...,
+    ) -> None: ...
+
+
+class CircuitBreakerEnforcer:
+    """Runs the account circuit breaker on the trading loop."""
+
+    def __init__(
+        self, engine_state: CircuitBreakerEngineState, breaker: AccountCircuitBreaker
+    ) -> None:
+        self._state = engine_state
+        self._breaker = breaker
+        self._seeded = False
+        self._seed_attempts = 0
+        self._halt_notified = False
+
+    @property
+    def breaker(self) -> AccountCircuitBreaker:
+        return self._breaker
+
+    def check(self) -> None:
+        """Evaluate the breaker against current equity; enforce halts."""
+        state = self._state
+        mode = self._breaker.mode
+        if mode not in (MODE_DRY_RUN, MODE_ACTIVE):
+            return  # off -> fully inert
+
+        try:
+            balance = float(state.current_balance)
+            now = datetime.now(UTC)
+            if not self._seeded:
+                self._try_seed(balance, now)  # best-effort; evaluate proceeds regardless
+            decision = self._breaker.evaluate(balance, now)
+        except Exception as e:  # noqa: BLE001 - monitoring must never crash the loop
+            logger.error("Circuit-breaker check failed: %s", e, exc_info=True)
+            return
+
+        if not decision.tripped:
+            self._halt_notified = False  # cleared (e.g. next UTC day) -> allow re-notify
+            return
+
+        if mode == MODE_DRY_RUN:
+            if not self._halt_notified:
+                logger.warning(
+                    "🟡 Account circuit breaker WOULD HALT (dry_run): %s (balance $%.2f). "
+                    "Set account_circuit_breakers=active to enforce.",
+                    decision.reason,
+                    balance,
+                )
+                self._halt_notified = True
+            return
+
+        # active mode: trip close-only (protective action first, then observe).
+        if self._halt_notified and state._close_only_mode:
+            return
+        try:
+            state._enter_close_only_mode()
+            self._halt_notified = True
+            message = (
+                f"ACCOUNT CIRCUIT BREAKER TRIPPED: {decision.reason} (balance ${balance:,.2f}). "
+                "Close-only mode in force — no new entries or scale-ins; exits and stop-losses "
+                "remain active. Operator action required to review and clear."
+            )
+            logger.critical("🛑 %s", message)
+            log_risk_event(
+                "account_circuit_breaker_trip",
+                reason=decision.reason,
+                balance=balance,
+                mode=mode,
+            )
+            state._record_event(
+                EventType.ALERT,
+                message,
+                severity="critical",
+                component="risk",
+                error_code="ACCOUNT_CIRCUIT_BREAKER_TRIP",
+                alert=True,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.critical(
+                "Circuit-breaker trip handling failed after close-only: %s", e, exc_info=True
+            )
+
+    def _try_seed(self, balance: float, now: datetime) -> None:
+        """Seed the daily baseline from the day's first snapshot (restart-safety).
+
+        Best-effort: on any failure or missing snapshot, leaves the breaker to
+        self-anchor from current equity. After ``MAX_SEED_ATTEMPTS`` deferrals we
+        stop trying (the breaker is already self-anchored to a live baseline)."""
+        state = self._state
+        self._seed_attempts += 1
+        if state.db_manager is None or state.trading_session_id is None:
+            if self._seed_attempts >= MAX_SEED_ATTEMPTS:
+                self._seeded = True  # give up; breaker self-anchors from current equity
+            return
+        try:
+            snapshot = state.db_manager.get_first_snapshot_of_day(
+                session_id=state.trading_session_id,
+                target_date=now.date(),
+                fallback_session_id=getattr(state, "_recovered_inactive_session_id", None),
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("Circuit-breaker daily-baseline seed deferred: %s", e)
+            if self._seed_attempts >= MAX_SEED_ATTEMPTS:
+                self._seeded = True
+            return
+
+        if snapshot is not None and getattr(snapshot, "balance", None):
+            baseline = float(snapshot.balance)
+            self._breaker.seed_daily_baseline(baseline, now.date())
+            logger.info(
+                "Circuit-breaker daily baseline seeded from day-start snapshot: $%.2f",
+                baseline,
+            )
+        # No snapshot for today yet (fresh day / first run) -> self-anchor is fine.
+        self._seeded = True

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -70,6 +70,7 @@ from src.engines.live.monitoring import (
     extract_ml_predictions,
     extract_sentiment_data,
 )
+from src.engines.live.monitoring.circuit_breaker_enforcer import CircuitBreakerEnforcer
 from src.engines.live.monitoring.drawdown_guard import MaxDrawdownEnforcer, MaxDrawdownGuard
 from src.engines.live.recovery import LiveSessionRecoverer
 from src.engines.live.startup import LiveStartupSequencer
@@ -936,10 +937,13 @@ class LiveTradingEngine:
             MacroEventGuard(enabled=is_enabled("enable_macro_event_guard", default=False))
         )
         # #807: account-level circuit breaker. Mode (off/dry_run/active) resolved
-        # once here to keep feature_flags.json I/O off the entry hot path.
-        self.live_entry_handler.configure_circuit_breaker(
-            AccountCircuitBreaker(mode=get_flag("account_circuit_breakers", default="off"))
+        # once here to keep feature_flags.json I/O off the entry hot path. Held on
+        # the engine so both the entry gate and the loop enforcer share one
+        # breaker (one daily-loss baseline, one latch).
+        self._circuit_breaker = AccountCircuitBreaker(
+            mode=get_flag("account_circuit_breakers", default="off")
         )
+        self.live_entry_handler.configure_circuit_breaker(self._circuit_breaker)
 
         # Wrap PartialExitPolicy in unified PartialOperationsManager
         partial_ops_manager = (
@@ -983,6 +987,12 @@ class LiveTradingEngine:
         self._drawdown_enforcer = MaxDrawdownEnforcer(
             engine_state=self,
             guard=MaxDrawdownGuard(self.risk_manager.params.max_drawdown),
+        )
+        # #807 follow-up: run the account circuit breaker on the loop too —
+        # restart-safe daily baseline + close-only-on-trip (dry_run/active).
+        self._circuit_breaker_enforcer = CircuitBreakerEnforcer(
+            engine_state=self,
+            breaker=self._circuit_breaker,
         )
 
         # Startup recovery — session balance, persisted positions, exchange
@@ -2027,8 +2037,12 @@ class LiveTradingEngine:
         self.account_monitor.update_performance_metrics()
 
     def _check_max_drawdown(self) -> None:
-        """Enforce the max-drawdown hard cap (delegated to MaxDrawdownEnforcer)."""
+        """Enforce the max-drawdown hard cap + account circuit breakers.
+
+        Both run every trading-loop iteration and trip the same close-only mode.
+        """
         self._drawdown_enforcer.check()
+        self._circuit_breaker_enforcer.check()
 
     def _extract_indicators(self, df: pd.DataFrame, index: int) -> dict:
         """Extract indicator values from dataframe for logging"""

--- a/tests/unit/engines/live/test_circuit_breaker_enforcer.py
+++ b/tests/unit/engines/live/test_circuit_breaker_enforcer.py
@@ -1,0 +1,107 @@
+"""Unit tests for the account circuit-breaker loop enforcer (#807 follow-up)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.engines.live.monitoring.circuit_breaker_enforcer import (
+    MAX_SEED_ATTEMPTS,
+    CircuitBreakerEnforcer,
+)
+from src.risk.circuit_breaker import AccountCircuitBreaker
+
+pytestmark = pytest.mark.unit
+
+
+class _State:
+    def __init__(self, balance=1000.0, day_snapshot=None, session_id=1):
+        self.current_balance = balance
+        self.trading_session_id = session_id
+        self._recovered_inactive_session_id = None
+        self._close_only_mode = False
+        self.events: list[str | None] = []
+        self._day_snapshot = day_snapshot
+        self.db_manager = SimpleNamespace(get_first_snapshot_of_day=lambda **kw: self._day_snapshot)
+
+    def _enter_close_only_mode(self):
+        self._close_only_mode = True
+
+    def _record_event(self, *args, **kwargs):
+        self.events.append(kwargs.get("error_code"))
+
+
+def _breaker(mode, **kw):
+    kw.setdefault("daily_loss_limit", 0.025)
+    return AccountCircuitBreaker(mode=mode, **kw)
+
+
+def test_active_trip_enters_close_only_and_records_event():
+    s = _State()
+    enf = CircuitBreakerEnforcer(s, _breaker("active"))
+    enf.check()  # anchor baseline 1000
+    s.current_balance = 970.0  # -3%
+    enf.check()
+    assert s._close_only_mode is True
+    assert "ACCOUNT_CIRCUIT_BREAKER_TRIP" in s.events
+
+
+def test_dry_run_trips_but_takes_no_action():
+    s = _State()
+    enf = CircuitBreakerEnforcer(s, _breaker("dry_run"))
+    enf.check()
+    s.current_balance = 950.0
+    enf.check()
+    assert s._close_only_mode is False
+    assert s.events == []
+
+
+def test_off_mode_is_inert():
+    s = _State()
+    enf = CircuitBreakerEnforcer(s, _breaker("off"))
+    enf.check()
+    s.current_balance = 100.0  # catastrophic but off
+    enf.check()
+    assert s._close_only_mode is False
+
+
+def test_seeds_daily_baseline_from_day_snapshot_restart_safety():
+    # Restart mid-day at 985 while the day opened at 1000: a -3% intraday move
+    # (to 970) must still trip against the persisted 1000, not the 985 restart.
+    s = _State(balance=985.0, day_snapshot=SimpleNamespace(balance=1000.0))
+    enf = CircuitBreakerEnforcer(s, _breaker("active"))
+    enf.check()  # seeds baseline 1000 (not 985)
+    assert s._close_only_mode is False  # -1.5% not yet a trip
+    s.current_balance = 970.0
+    enf.check()  # -3% vs seeded 1000
+    assert s._close_only_mode is True
+
+
+def test_no_day_snapshot_self_anchors():
+    s = _State(balance=1000.0, day_snapshot=None)
+    enf = CircuitBreakerEnforcer(s, _breaker("active"))
+    enf.check()  # no snapshot -> baseline = current 1000
+    s.current_balance = 980.0  # -2% < 2.5%
+    enf.check()
+    assert s._close_only_mode is False
+
+
+def test_seed_deferred_until_session_ready_then_gives_up():
+    s = _State(session_id=None)  # session not resolved yet
+    enf = CircuitBreakerEnforcer(s, _breaker("active"))
+    for _ in range(MAX_SEED_ATTEMPTS):
+        enf.check()
+    assert enf._seeded is True  # armed from current balance after bounded deferrals
+
+
+def test_check_never_raises_on_bad_state():
+    s = _State()
+    s.db_manager = SimpleNamespace(
+        get_first_snapshot_of_day=lambda **kw: (_ for _ in ()).throw(RuntimeError("db down"))
+    )
+    enf = CircuitBreakerEnforcer(s, _breaker("active"))
+    enf.check()  # must not raise despite DB failure
+    s.current_balance = 970.0
+    enf.check()
+    assert s._close_only_mode is True  # still enforces against self-anchored baseline


### PR DESCRIPTION
Follow-up to #807 (merged as #874). Completes the three items that PR flagged as **human-sign-off** — done the safe way, consistent with the codebase's existing `MaxDrawdownGuard` precedent.

## Context
#807 shipped the safe core: the `AccountCircuitBreaker` is evaluated in the pre-order gate and **blocks new entries** when tripped. This PR adds the loop-driven half via a new `CircuitBreakerEnforcer` (mirrors `MaxDrawdownEnforcer`), run every trading-loop iteration.

## The three follow-ups
1. **Restart-safe daily baseline** (the review's key concern) — on boot the enforcer seeds the breaker's daily-loss baseline from the day's first `account_history` snapshot (`get_first_snapshot_of_day`, which already exists). So a mid-day restart no longer re-anchors the baseline to current equity and silently disarms the daily-loss halt. Bounded seed deferral until the session/DB is ready; self-anchors if there's no snapshot yet.
2. **Halt on trip** — in `active` mode a trip flips the engine's **existing close-only mode** (new entries *and* scale-ins stop; exits and stop-losses keep running). In `dry_run` it logs "🟡 WOULD HALT"; `off` is fully inert.
   - **Deliberate non-goal**: literal force-liquidation of open positions. The codebase's `MaxDrawdownGuard` already establishes the policy — *do not liquidate into a possibly-temporary dip*; close-only is the safe halt. I followed that precedent rather than force-selling.
3. **Surfacing** — a trip emits a `risk_event` (`account_circuit_breaker_trip`) + a CRITICAL `system_events` ALERT (`ACCOUNT_CIRCUIT_BREAKER_TRIP`) so the monitoring dashboard and alerting pick it up, with the grep signatures added to `.claude/LESSONS.md §5` for `bot-monitor-live`.

The engine now holds **one** breaker instance shared by the entry gate and the enforcer (one daily baseline, one latch). Fault-isolated: a failing check never crashes the trading loop, and the protective action is taken before observability.

## Still gated off
`account_circuit_breakers` defaults to `off` — no behavior change until an operator sets `dry_run` (validate) then `active`.

## Testing (7 unit tests)
- active trip → close-only + `ACCOUNT_CIRCUIT_BREAKER_TRIP` event; dry_run trips-but-no-action; off inert.
- **restart-safety**: seeds baseline from the day snapshot so a −3% intraday move trips against the persisted day-open, not the restart balance; self-anchors when no snapshot; bounded seed deferral gives up after N attempts; `check()` never raises on a DB failure.
- Existing max-drawdown-guard + engine tests green; `black`/`ruff`/`mypy`/`bandit` clean.

Closes the #807 money-mover/live-integration follow-ups tracked from the #874 review.

## Note on merge
This branch and #879 (#802 P2/P3) both touch `trading_engine.py`; expect a small additive conflict if #879 merges first — I'll resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNc8P32ufwPP9LqbrXbjhk)_