### PR TITLE
fix(live): guard stop-loss re-placement against externally-closed positions (#852)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -144,6 +144,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FEATURE_ENTRY_PAUSE` env var remains the override path.
 
 ### Fixed
+- **Stop-loss re-placement could arm a naked margin position for an
+  externally-closed position** (Codex review of #852, finding 2 — pre-existing):
+  when a position is closed or liquidated externally while the bot is offline,
+  its DB row stays OPEN and is re-loaded on the next startup. Stop-loss
+  verification deliberately runs *before* the asset-holdings check (so an offline
+  SL *fill* can book its realized P&L first), so for an externally-closed
+  position the tracked stop looks missing/cancelled and was **re-placed with
+  `AUTO_REPAY`** before the holdings check could remove the phantom — on margin,
+  the naked-position (fund-loss) path. The periodic cycle had the same risk (it
+  iterates a stale snapshot copy while step 1b removes phantoms from the live
+  tracker). A new `_position_holding_is_gone(exchange, use_margin, position)`
+  guard now gates all five stop re-placement sites (startup `_verify_stop_loss`
+  not-found + cancelled/expired/rejected branches, startup `reconcile_position`
+  step-3 placement, periodic step-2 re-placement, and periodic
+  `_place_missing_stop_loss`): it positively confirms the asset is gone using the
+  same 50%-of-tracked thresholds as `_verify_asset_holdings` /
+  `_verify_margin_position_exists` (margin short → borrowed, long → netAsset;
+  short-circuits on `exchange_close_pending`), and **fails safe** (returns
+  `False`, keep protecting) on a transient API error. Ordering was **not**
+  changed, so offline SL-fill P&L booking is preserved. Adds 15 unit tests.
 - **Max-drawdown guard mis-seeded its peak from the configured balance**
   (prod 2026-07-04: guard armed at $100.00 vs true session equity $84.42 and
   immediately warned at a phantom 15.60% drawdown): the seed took

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -163,7 +163,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `_verify_margin_position_exists` (margin short → borrowed, long → netAsset;
   short-circuits on `exchange_close_pending`), and **fails safe** (returns
   `False`, keep protecting) on a transient API error. Ordering was **not**
-  changed, so offline SL-fill P&L booking is preserved. Adds 15 unit tests.
+  changed, so offline SL-fill P&L booking is preserved. A follow-up (Codex review
+  of #881) extended the guard to two more paths — the crash-recovery stop in
+  `_reconcile_filled_entry` (a pending entry that filled then closed externally
+  while offline is now handled as an external close: no stop, no emergency-sell)
+  and the startup partial-exit `_resize_stop_loss_after_partial_exit` — and made
+  margin-**long** liveness robust: `get_balance` returns `None` for **both** an
+  absent asset and a transient error, so a fully-closed margin long could not be
+  distinguished from an API blip; a new `_margin_net_asset`
+  (`get_margin_account_asset`: zeros for an absent asset, `None` only on error)
+  now backs the guard and both margin-long phantom-removers. Spot is unaffected
+  (AUTO_REPAY is a no-op on spot and an oversell is exchange-rejected). Adds 22
+  unit tests.
 - **Max-drawdown guard mis-seeded its peak from the configured balance**
   (prod 2026-07-04: guard armed at $100.00 vs true session equity $84.42 and
   immediately warned at a phantom 15.60% drawdown): the seed took

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -821,26 +821,41 @@ class PositionReconciler:
             # If the entry filled earlier but the position was closed/liquidated externally
             # before this recovery ran, its asset is gone. Placing an AUTO_REPAY stop — or the
             # emergency-sell below that fires when a stop is not placed — would open a naked
-            # position. Treat it as an external close: drop it from the tracker and close the DB
-            # row, and do NOT place a stop or sell. The recovered position is not in the startup
-            # Step-B snapshot, so nothing else holdings-checks it this run (#852 finding 1).
+            # position. Treat it as an external close: close the DB row and drop it from the
+            # tracker, and do NOT place a stop or sell. The recovered position is not in the
+            # startup Step-B snapshot, so nothing else holdings-checks it this run (#852 f1).
             if _position_holding_is_gone(self.exchange, self._use_margin, position):
                 logger.warning(
                     "Recovered entry %s filled earlier but the position no longer backs an "
                     "exchange holding — treating as external close (no stop-loss, no "
-                    "emergency-sell); removing from tracker and closing DB.",
+                    "emergency-sell).",
                     order_id,
                 )
-                self.position_tracker.remove_position(order_id)
+                # Gate tracker removal on the DB close actually succeeding — close_position
+                # returns False without raising on a failed commit. Removing while the row stays
+                # OPEN would diverge memory from the DB (CODE.md: no silent divergence); mirror
+                # the external-close paths and escalate instead. No db_id means log_position never
+                # persisted a row, so there is nothing to diverge from — safe to drop.
+                db_closed = False
                 if db_id is not None:
                     try:
-                        self.db_manager.close_position(db_id)
+                        db_closed = bool(self.db_manager.close_position(db_id))
                     except Exception as e:
                         logger.warning(
                             "Failed to close DB for externally-closed recovered entry %s: %s",
                             order_id,
                             e,
                         )
+                if db_closed or db_id is None:
+                    self.position_tracker.remove_position(order_id)
+                else:
+                    logger.critical(
+                        "Externally-closed recovered entry %s: DB position %s close FAILED "
+                        "(still OPEN) — left tracked to avoid memory/DB divergence; it is "
+                        "re-reconciled on the next pass.",
+                        order_id,
+                        db_id,
+                    )
                 return
 
             # Place server-side stop-loss on exchange for protection.

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -223,6 +223,80 @@ def _is_exchange_close_pending(position: Any) -> bool:
     return bool(getattr(position, "exchange_close_pending", False))
 
 
+def _position_holding_is_gone(exchange: Any, use_margin: bool, position: Any) -> bool:
+    """True only when the position no longer backs an exchange holding — i.e. it was closed or
+    liquidated externally while the bot was offline.
+
+    Gates stop-loss RE-PLACEMENT. When a position is externally closed its DB row stays OPEN and
+    is re-loaded on the next startup; stop-loss verification (which deliberately runs before the
+    asset-holdings check, so an offline SL *fill* can book its realized P&L first) then sees the
+    tracked stop as missing/cancelled. Re-arming it re-places a margin ``AUTO_REPAY`` stop for a
+    position whose asset is gone — the naked-position path. Callers skip re-placement when this
+    returns True and let the holdings check remove the phantom.
+
+    Mirrors the thresholds of ``_verify_asset_holdings`` / ``_verify_margin_position_exists`` so
+    that for a position with tracked quantity > 0 — the only case that carries naked-position
+    risk — the guard and the phantom-remover never disagree. (A flat, zero-quantity position has
+    no stop to place either way, so the spot holdings check's ``qty <= 0`` early-return is
+    immaterial.) Fails SAFE: on a transient API error (balance/borrowed unknown, or an exception)
+    it returns False so the caller keeps its existing protective behavior and the periodic
+    reconciler re-checks next cycle.
+    """
+    # Exchange side already known closed (offline SL fill, DB close still pending).
+    if _is_exchange_close_pending(position):
+        return True
+
+    side = getattr(position, "side", None)
+    is_short = side == PositionSide.SHORT or str(side).lower() == "short"
+
+    # A spot short holds no base asset, so a spot balance check cannot confirm a close —
+    # do not skip re-placement on that basis (mirrors _verify_asset_holdings skipping shorts).
+    if is_short and not use_margin:
+        return False
+
+    base_asset = PositionReconciler._extract_base_asset(position.symbol)
+
+    # Tracked held quantity after partial exits. Coerce to float — DB-loaded positions carry
+    # Decimal (Numeric) fields, and "Decimal * float" below raises otherwise (#653 class).
+    qty = float(getattr(position, "quantity", 0) or 0.0)
+    current_size = getattr(position, "current_size", None)
+    original_size = getattr(position, "original_size", None)
+    if current_size is not None and original_size is not None and float(original_size) > 0:
+        position_qty = qty * (float(current_size) / float(original_size))
+    else:
+        position_qty = qty
+
+    try:
+        if use_margin and is_short:
+            # Shorts create debt — the base asset's borrowed amount is the source of truth.
+            borrowed = (
+                exchange.get_margin_borrowed(base_asset)
+                if hasattr(exchange, "get_margin_borrowed")
+                else None
+            )
+            if borrowed is None:
+                return False  # transient / unsupported — cannot prove gone
+            held = float(borrowed)
+        else:
+            # Spot long and margin long: the held base-asset balance (netAsset in margin).
+            balance = exchange.get_balance(base_asset)
+            if balance is None:
+                return False  # transient — cannot prove gone
+            held = float(balance.total)
+    except Exception as e:  # noqa: BLE001 — never let a lookup error skip protection
+        logger.warning(
+            "SL re-placement holding check failed for %s: %s — treating asset as present",
+            getattr(position, "symbol", "?"),
+            e,
+        )
+        return False
+
+    # Same 50%-of-tracked threshold the holdings checks use to declare an external close.
+    if position_qty > 0:
+        return held < position_qty * 0.5
+    return held <= 0
+
+
 class PositionReconciler:
     """Verifies recovered positions and resolves pending orders on startup.
 
@@ -1354,7 +1428,16 @@ class PositionReconciler:
                         side,
                     )
 
-            if sl_price and hasattr(self.exchange, "place_stop_loss_order"):
+            # Do not place a stop for a position that was closed/liquidated externally (asset
+            # gone): a margin AUTO_REPAY stop would open a naked position. Fall through to the
+            # asset-holdings check (step 4), which removes the phantom.
+            if _position_holding_is_gone(self.exchange, self._use_margin, position):
+                logger.warning(
+                    "Position %s has no exchange stop-loss but no longer backs an exchange "
+                    "holding — skipping placement (asset-holdings check will remove the phantom).",
+                    position.symbol,
+                )
+            elif sl_price and hasattr(self.exchange, "place_stop_loss_order"):
                 try:
                     from src.data_providers.exchange_interface import OrderSide
 
@@ -1633,7 +1716,18 @@ class PositionReconciler:
                     result.severity = Severity.MEDIUM
                 position.stop_loss_order_id = None
 
-                # Attempt to re-place the stop-loss so the position is protected
+                # Attempt to re-place the stop-loss so the position is protected — unless the
+                # position was closed/liquidated externally (its asset is gone). Re-arming an
+                # AUTO_REPAY stop for a phantom opens a naked position; skip and let the
+                # asset-holdings check (step 4) remove it.
+                if _position_holding_is_gone(self.exchange, self._use_margin, position):
+                    logger.warning(
+                        "Stop-loss for %s not found but the position no longer backs an exchange "
+                        "holding — skipping re-placement (asset-holdings check will remove the "
+                        "phantom).",
+                        position.symbol,
+                    )
+                    return
                 if position.stop_loss and hasattr(self.exchange, "place_stop_loss_order"):
                     try:
                         from src.data_providers.exchange_interface import OrderSide
@@ -1783,7 +1877,18 @@ class PositionReconciler:
                     sl_order.status.value,
                 )
 
-                # Attempt to re-place the stop-loss so the position is protected
+                # Attempt to re-place the stop-loss so the position is protected — unless the
+                # position was closed/liquidated externally (its asset is gone). Re-arming an
+                # AUTO_REPAY stop for a phantom opens a naked position; skip and let the
+                # asset-holdings check (step 4) remove it.
+                if _position_holding_is_gone(self.exchange, self._use_margin, position):
+                    logger.warning(
+                        "Stop-loss for %s was cancelled/expired but the position no longer backs "
+                        "an exchange holding — skipping re-placement (asset-holdings check will "
+                        "remove the phantom).",
+                        position.symbol,
+                    )
+                    return
                 if position.stop_loss and hasattr(self.exchange, "place_stop_loss_order"):
                     try:
                         from src.data_providers.exchange_interface import OrderSide
@@ -3632,6 +3737,20 @@ class PeriodicReconciler:
                                 position.symbol,
                             )
 
+                    # Do not re-place a stop for a position closed/liquidated externally (asset
+                    # gone): a margin AUTO_REPAY stop would open a naked position. Step 1b above
+                    # removes such phantoms, but it works off the live tracker while this loop
+                    # iterates a stale snapshot — so guard here too.
+                    if _position_holding_is_gone(self.exchange, self._use_margin, position):
+                        logger.warning(
+                            "Stop-loss for %s is %s but the position no longer backs an exchange "
+                            "holding — skipping re-placement (external close/liquidation; the "
+                            "asset-holdings check removes the phantom).",
+                            position.symbol,
+                            status_desc,
+                        )
+                        continue
+
                     stop_price = getattr(position, "stop_loss", None)
                     if stop_price and hasattr(self.exchange, "place_stop_loss_order"):
                         try:
@@ -3830,6 +3949,17 @@ class PeriodicReconciler:
         Computes a default stop price from the position's stop_loss attribute
         or falls back to DEFAULT_STOP_LOSS_PCT from entry_price.
         """
+        # A position closed/liquidated externally no longer backs an exchange holding; placing an
+        # AUTO_REPAY stop for it opens a naked position. Skip — the asset-holdings check removes
+        # the phantom (this loop iterates a stale snapshot, so the phantom may still appear here).
+        if _position_holding_is_gone(self.exchange, self._use_margin, position):
+            logger.warning(
+                "Skipping missing-stop-loss placement for %s — position no longer backs an "
+                "exchange holding (external close/liquidation).",
+                order_key,
+            )
+            return
+
         stop_price = getattr(position, "stop_loss", None)
         entry_price = getattr(position, "entry_price", None)
         side = getattr(position, "side", "long")

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -223,6 +223,26 @@ def _is_exchange_close_pending(position: Any) -> bool:
     return bool(getattr(position, "exchange_close_pending", False))
 
 
+def _margin_net_asset(exchange: Any, asset: str) -> float | None:
+    """Cross-margin ``netAsset`` for ``asset`` as a float, or None if the lookup is unconfirmed.
+
+    Uses the raw margin-asset accessor (``get_margin_account_asset``), which returns zeros for an
+    asset absent from the wallet and None only on a transient API error — so an externally-closed
+    long (netAsset 0) is distinguishable from an API blip. ``get_balance`` conflates the two (it
+    returns None for both an absent asset and an error), which would leave the naked-position
+    stop armed for a fully-closed margin long (#852 finding 3)."""
+    getter = getattr(exchange, "get_margin_account_asset", None)
+    if not callable(getter):
+        return None
+    raw = getter(asset)
+    if not raw:
+        return None
+    try:
+        return float(raw.get("netAsset", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return None
+
+
 def _position_holding_is_gone(exchange: Any, use_margin: bool, position: Any) -> bool:
     """True only when the position no longer backs an exchange holding — i.e. it was closed or
     liquidated externally while the bot was offline.
@@ -277,8 +297,18 @@ def _position_holding_is_gone(exchange: Any, use_margin: bool, position: Any) ->
             if borrowed is None:
                 return False  # transient / unsupported — cannot prove gone
             held = float(borrowed)
+        elif use_margin:
+            # Margin long — read netAsset via the raw margin-asset accessor (absent asset -> 0,
+            # transient error -> None). get_balance() returns None for BOTH, so it cannot tell a
+            # fully-closed long from an API blip and would leave the naked stop armed (#852 f3).
+            net_asset = _margin_net_asset(exchange, base_asset)
+            if net_asset is None:
+                return False  # transient / unsupported — cannot prove gone
+            held = net_asset
         else:
-            # Spot long and margin long: the held base-asset balance (netAsset in margin).
+            # Spot long. get_balance()'s None is ambiguous (absent vs transient), but on spot
+            # AUTO_REPAY is a no-op and an oversell is exchange-rejected, so a misclassified "not
+            # gone" cannot arm a naked position — the fail-safe is acceptable here.
             balance = exchange.get_balance(base_asset)
             if balance is None:
                 return False  # transient — cannot prove gone
@@ -788,6 +818,31 @@ class PositionReconciler:
                         e,
                     )
 
+            # If the entry filled earlier but the position was closed/liquidated externally
+            # before this recovery ran, its asset is gone. Placing an AUTO_REPAY stop — or the
+            # emergency-sell below that fires when a stop is not placed — would open a naked
+            # position. Treat it as an external close: drop it from the tracker and close the DB
+            # row, and do NOT place a stop or sell. The recovered position is not in the startup
+            # Step-B snapshot, so nothing else holdings-checks it this run (#852 finding 1).
+            if _position_holding_is_gone(self.exchange, self._use_margin, position):
+                logger.warning(
+                    "Recovered entry %s filled earlier but the position no longer backs an "
+                    "exchange holding — treating as external close (no stop-loss, no "
+                    "emergency-sell); removing from tracker and closing DB.",
+                    order_id,
+                )
+                self.position_tracker.remove_position(order_id)
+                if db_id is not None:
+                    try:
+                        self.db_manager.close_position(db_id)
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to close DB for externally-closed recovered entry %s: %s",
+                            order_id,
+                            e,
+                        )
+                return
+
             # Place server-side stop-loss on exchange for protection.
             # If SL placement fails, emergency-close the position to match
             # the normal entry path behavior (never leave unprotected).
@@ -1133,6 +1188,19 @@ class PositionReconciler:
 
         symbol = getattr(position, "symbol", "")
         db_pos_id = getattr(position, "db_position_id", None)
+
+        # This runs during startup reconciliation of a filled partial-exit order. If the residual
+        # was closed/liquidated externally while offline (asset gone), do NOT cancel-and-re-place:
+        # re-arming an AUTO_REPAY stop for a position that no longer exists is the naked-position
+        # path. Leave the stale stop for the phantom-removal path, which cancels it when it removes
+        # the position (#852 finding 2).
+        if _position_holding_is_gone(self.exchange, self._use_margin, position):
+            logger.warning(
+                "Skipping stop-loss resize for %s — position no longer backs an exchange holding "
+                "(residual closed/liquidated externally); leaving cleanup to the holdings check.",
+                symbol,
+            )
+            return
 
         # Cancel the old stop-loss order
         try:
@@ -2324,9 +2392,6 @@ class PositionReconciler:
         is_short = side == PositionSide.SHORT or str(side).lower() == "short"
 
         try:
-            # get_balance returns AccountBalance with total=netAsset in margin mode
-            balance = self.exchange.get_balance(base_asset)
-
             # Scale tracked quantity by partial exit ratio. Coerce to float —
             # DB-loaded positions carry Decimal (Numeric) fields, and the
             # "position_qty * 0.5" comparisons below raise "Decimal * float"
@@ -2371,16 +2436,19 @@ class PositionReconciler:
                     )
                     self._remove_phantom_position(position, result)
             else:
-                # Long positions hold the asset — check netAsset.
-                # None = API error — skip to avoid deleting real positions.
-                if balance is None:
+                # Long positions hold the asset — check netAsset via the raw margin-asset
+                # accessor (absent asset -> 0, transient error -> None). get_balance() returns
+                # None for both, so it cannot tell an externally-closed long from an API blip
+                # and would leave the phantom tracked (#852 finding 3).
+                net_asset = _margin_net_asset(self.exchange, base_asset)
+                if net_asset is None:
                     logger.warning(
                         "Could not verify holdings for %s — skipping "
                         "margin long check (transient API error)",
                         symbol,
                     )
                 else:
-                    held = balance.total
+                    held = net_asset
 
                     if held <= 0:
                         logger.warning(
@@ -3342,7 +3410,6 @@ class PeriodicReconciler:
                     side = getattr(position, "side", None)
                     is_short = side == PositionSide.SHORT or str(side).lower() == "short"
 
-                    balance = self.exchange.get_balance(base_asset)
                     position_gone = False
 
                     # Scale tracked quantity by partial exit ratio. Coerce to
@@ -3370,13 +3437,15 @@ class PeriodicReconciler:
                         elif pos_qty > 0 and borrowed < pos_qty * 0.5:
                             position_gone = True
                     else:
-                        # Long detection: check held quantity.
-                        # None = API error — skip to avoid deleting real positions.
-                        if balance is None:
+                        # Long detection: check netAsset via the raw margin-asset accessor
+                        # (absent asset -> 0, transient error -> None). get_balance() returns
+                        # None for both, so it cannot tell a closed long from an API blip (#852 f3).
+                        net_asset = _margin_net_asset(self.exchange, base_asset)
+                        if net_asset is None:
                             pass  # Unknown — retain position
-                        elif balance.total <= 0:
+                        elif net_asset <= 0:
                             position_gone = True
-                        elif pos_qty > 0 and balance.total < pos_qty * 0.5:
+                        elif pos_qty > 0 and net_asset < pos_qty * 0.5:
                             position_gone = True
 
                     if position_gone:

--- a/tests/unit/engines/live/test_margin_side_effect.py
+++ b/tests/unit/engines/live/test_margin_side_effect.py
@@ -263,10 +263,9 @@ def test_reconciler_uses_margin_check_in_margin_mode():
     mock_exchange = MagicMock()
     mock_exchange.get_order.return_value = None
     mock_exchange.get_open_orders.return_value = []
-    # Long position still exists (positive netAsset)
-    mock_balance = MagicMock()
-    mock_balance.total = 0.001
-    mock_exchange.get_balance.return_value = mock_balance
+    # Long position still exists (positive netAsset) — margin long reads the raw
+    # margin-asset accessor (get_margin_account_asset), not spot get_balance.
+    mock_exchange.get_margin_account_asset.return_value = {"netAsset": "0.001", "borrowed": "0"}
     mock_tracker = MagicMock()
     mock_db = MagicMock()
 
@@ -294,8 +293,8 @@ def test_reconciler_uses_margin_check_in_margin_mode():
 
     reconciler._reconcile_cycle()
 
-    # get_balance IS called now (margin position check uses it)
-    mock_exchange.get_balance.assert_called()
+    # The raw margin-asset accessor IS used for the margin long check (not spot get_balance)
+    mock_exchange.get_margin_account_asset.assert_called()
     # Position still exists — should NOT be removed
     mock_tracker.remove_position.assert_not_called()
 
@@ -325,6 +324,11 @@ def test_reconciler_stop_loss_has_auto_repay():
     mock_position.current_size = 1.0
     mock_position.original_size = 1.0
     mock_position.db_position_id = 42
+    # The re-placement guard skips positions with no exchange holding. Model a live
+    # position: not flagged close-pending (a bare MagicMock attribute would read truthy)
+    # and the base asset still held on the exchange.
+    mock_position.exchange_close_pending = False
+    mock_exchange.get_balance.return_value = MagicMock(total=1.0)
 
     reconciler._place_missing_stop_loss(mock_position, "test_order_key")
 
@@ -377,11 +381,10 @@ def test_startup_reconciler_uses_margin_check_in_margin_mode():
     )
 
     exchange = MagicMock()
-    # Long position with asset holdings present — should not be removed
-    balance_obj = MagicMock()
-    balance_obj.asset = "BTC"
-    balance_obj.total = 1.0
-    exchange.get_balance.return_value = balance_obj
+    # Long position with asset holdings present — margin long reads netAsset via the raw
+    # margin-asset accessor (get_margin_account_asset), not spot get_balance (which returns
+    # None for both an absent asset and a transient error).
+    exchange.get_margin_account_asset.return_value = {"netAsset": "1.0", "borrowed": "0"}
 
     reconciler = PositionReconciler(
         exchange_interface=exchange,
@@ -406,8 +409,8 @@ def test_startup_reconciler_uses_margin_check_in_margin_mode():
     )
 
     reconciler._verify_asset_holdings(position, result)
-    # In margin mode, it calls get_balance for margin position check (not skipped)
-    exchange.get_balance.assert_called_once_with("BTC")
+    # In margin mode the long check reads netAsset via the raw margin-asset accessor
+    exchange.get_margin_account_asset.assert_called_once_with("BTC")
     # Position still exists — result should not be "corrected"
     assert result.status == "ok"
 

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -4095,6 +4095,34 @@ class TestStopLossReplacementHoldingGuard:
         mock_exchange.get_margin_borrowed = MagicMock(return_value=None)
         assert _position_holding_is_gone(mock_exchange, True, pos) is False
 
+    def test_helper_margin_long_absent_asset_is_gone(self, mock_exchange):
+        """Finding 3: a margin long whose base asset is ABSENT from the wallet (netAsset 0) is
+        detected as gone via the raw margin-asset accessor. get_balance returns None for an
+        absent asset — indistinguishable from a transient error — and would miss it, leaving the
+        naked AUTO_REPAY stop armed."""
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="ETHUSDT", side="long", quantity=1.0)
+        mock_exchange.get_margin_account_asset.return_value = {"netAsset": "0", "borrowed": "0"}
+        mock_exchange.get_balance.return_value = None  # get_balance can't tell absent from error
+        assert _position_holding_is_gone(mock_exchange, True, pos) is True
+
+    def test_helper_margin_long_present_not_gone(self, mock_exchange):
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="ETHUSDT", side="long", quantity=1.0)
+        mock_exchange.get_margin_account_asset.return_value = {"netAsset": "1.0", "borrowed": "0"}
+        assert _position_holding_is_gone(mock_exchange, True, pos) is False
+
+    def test_helper_margin_long_transient_none_not_gone(self, mock_exchange):
+        """Finding 3: a transient margin-asset lookup failure (None) must NOT read as gone —
+        the guard fails safe and keeps protecting the position."""
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="ETHUSDT", side="long", quantity=1.0)
+        mock_exchange.get_margin_account_asset.return_value = None
+        assert _position_holding_is_gone(mock_exchange, True, pos) is False
+
     def test_helper_exchange_close_pending_short_circuits(self, mock_exchange):
         """The exchange_close_pending flag (offline SL fill, DB close pending) already means
         the asset is gone — return True without an exchange round-trip."""
@@ -4301,7 +4329,9 @@ class TestStopLossReplacementHoldingGuard:
         self, mock_exchange, mock_position_tracker, mock_db
     ):
         """Margin long closed externally while offline (netAsset=0): the guard must dispatch to
-        the balance (netAsset) check — not the borrowed check — and skip re-placement."""
+        the netAsset check via the raw margin-asset accessor — not the borrowed check, and not
+        spot get_balance (which can't tell an absent asset from a transient error) — and skip
+        re-placement."""
         from src.data_providers.exchange_interface import OrderStatus as ExOS
 
         pos = MockPosition(
@@ -4326,10 +4356,12 @@ class TestStopLossReplacementHoldingGuard:
         mock_exchange.get_order.side_effect = lambda oid, sym: (
             sl_order if oid == "sl_gone_ml" else entry_order
         )
-        # Margin long → the base asset's netAsset (get_balance total) is the source of truth.
-        # borrowed>0 would be misleading here; assert the guard does NOT rely on it.
+        # Margin long → netAsset (via the raw margin-asset accessor) is the source of truth;
+        # netAsset 0 = externally closed. borrowed>0 and a spot balance would be misleading —
+        # assert the guard/remover rely on neither.
         mock_exchange.get_margin_borrowed = MagicMock(return_value=5.0)
-        mock_exchange.get_balance.side_effect = self._balance_by_asset("ETH", 0.0)
+        mock_exchange.get_margin_account_asset.return_value = {"netAsset": "0", "borrowed": "5.0"}
+        mock_exchange.get_balance.side_effect = self._balance_by_asset("ETH", 999.0)
         mock_db.close_position.return_value = True
 
         self._periodic(
@@ -4337,3 +4369,119 @@ class TestStopLossReplacementHoldingGuard:
         )._reconcile_cycle()
 
         mock_exchange.place_stop_loss_order.assert_not_called()
+
+    # --- startup pending-partial-exit reconciliation: _resize_stop_loss_after_partial_exit ---
+
+    def test_startup_partial_exit_resize_skips_when_residual_gone(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Startup reconciliation of a filled partial-exit must not cancel-and-re-arm an
+        AUTO_REPAY stop for a residual that was closed/liquidated externally (Codex #852
+        finding 2). The stale stop is left for the phantom-removal path."""
+        reconciler = PositionReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            use_margin=True,
+        )
+        pos = MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            stop_loss_order_id="sl_old",
+            stop_loss=2200.0,
+            quantity=1.0,
+            current_size=0.5,
+            original_size=1.0,
+            db_position_id=80,
+        )
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)  # residual gone
+
+        reconciler._resize_stop_loss_after_partial_exit(pos)
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        mock_exchange.cancel_order.assert_not_called()  # left for the phantom-removal path
+
+    def test_startup_partial_exit_resize_still_runs_when_residual_present(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Control: a live residual (borrowed > 0) still gets its stop-loss resized."""
+        reconciler = PositionReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            use_margin=True,
+        )
+        pos = MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            stop_loss_order_id="sl_old",
+            stop_loss=2200.0,
+            quantity=1.0,
+            current_size=0.5,
+            original_size=1.0,
+            db_position_id=81,
+        )
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=1.0)  # residual present
+        mock_exchange.place_stop_loss_order.return_value = "new_sl"
+
+        reconciler._resize_stop_loss_after_partial_exit(pos)
+
+        mock_exchange.cancel_order.assert_called_once()
+        mock_exchange.place_stop_loss_order.assert_called_once()
+
+    # --- startup pending-entry recovery: _reconcile_filled_entry ---
+
+    def test_recovered_entry_skips_stop_and_sell_when_holding_gone(
+        self, reconciler, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """A pending entry that filled while offline, then was closed/liquidated externally
+        before startup, must NOT get an AUTO_REPAY recovery stop OR an emergency-sell (both open
+        a naked position). It is handled as an external close: dropped from the tracker and DB
+        (Codex #852 finding 1). reconcile_startup Step B never holdings-checks it — it is not in
+        the pre-recovery snapshot."""
+        order_data = {
+            "client_order_id": "atb_BTCUSDT_long_1",
+            "exchange_order_id": "ex_recover_1",
+            "entry_balance": 1000.0,
+        }
+        exchange_order = MockExchangeOrder(
+            order_id="ex_recover_1", average_price=50000.0, filled_quantity=0.001
+        )
+        # Asset gone on the exchange (spot: base-asset balance 0).
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.0)
+        mock_db.log_position.return_value = 99
+        mock_db.close_position.return_value = True
+
+        reconciler._reconcile_filled_entry(
+            order_data, exchange_order, "BTCUSDT", "long", 50000.0, 0.001
+        )
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        mock_exchange.place_order.assert_not_called()  # no emergency-sell for a gone asset
+        mock_position_tracker.remove_position.assert_called_once()
+        mock_db.close_position.assert_called_once_with(99)
+
+    def test_recovered_entry_places_stop_when_holding_present(
+        self, reconciler, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Control: a genuinely-open recovered entry (asset held) still gets its recovery stop."""
+        order_data = {
+            "client_order_id": "atb_BTCUSDT_long_2",
+            "exchange_order_id": "ex_recover_2",
+            "entry_balance": 1000.0,
+        }
+        exchange_order = MockExchangeOrder(
+            order_id="ex_recover_2", average_price=50000.0, filled_quantity=0.001
+        )
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.001)
+        mock_db.log_position.return_value = 100
+        mock_exchange.place_stop_loss_order.return_value = "recovery_sl"
+
+        reconciler._reconcile_filled_entry(
+            order_data, exchange_order, "BTCUSDT", "long", 50000.0, 0.001
+        )
+
+        mock_exchange.place_stop_loss_order.assert_called_once()
+        mock_position_tracker.remove_position.assert_not_called()

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -4031,3 +4031,309 @@ class TestReconcileCycleSeverityEvent:
         pr._emit_cycle_severity(Severity.CRITICAL)  # ALERT (rising edge)
         pr._emit_cycle_severity(Severity.HIGH)  # de-escalation -> silent
         assert on_event.call_count == 1
+
+
+# ---------- SL Re-placement Naked-Position Guard (externally-closed positions) ----------
+
+
+class TestStopLossReplacementHoldingGuard:
+    """A stop-loss that is missing/cancelled on the exchange must NOT be re-placed when the
+    position no longer backs an exchange holding.
+
+    When a position is closed or liquidated externally while the bot is offline, its DB row
+    stays OPEN and is re-loaded on the next startup. The stop-loss verification (which runs
+    BEFORE the asset-holdings check, so an offline SL *fill* can book its P&L first) then sees
+    the tracked stop as missing/cancelled and would re-arm it. On margin the replacement stop
+    carries ``AUTO_REPAY``, so re-placing it for a position whose asset is gone opens a naked
+    position — the exact fund-loss path the holdings check exists to prevent. The guard skips
+    re-placement and lets the holdings check remove the phantom. (Codex PR #852 finding 2.)
+    """
+
+    # --- helper: _position_holding_is_gone ---
+
+    def test_helper_spot_long_zero_balance_is_gone(self, mock_exchange):
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="BTCUSDT", side="long", quantity=0.1)
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.0)
+        assert _position_holding_is_gone(mock_exchange, False, pos) is True
+
+    def test_helper_spot_long_held_present_not_gone(self, mock_exchange):
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="BTCUSDT", side="long", quantity=0.1)
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.1)
+        assert _position_holding_is_gone(mock_exchange, False, pos) is False
+
+    def test_helper_spot_transient_balance_none_not_gone(self, mock_exchange):
+        """A transient get_balance=None must NOT be read as 'asset gone' — fail safe toward
+        keeping the position protected; the periodic reconciler re-checks next cycle."""
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="BTCUSDT", side="long", quantity=0.1)
+        mock_exchange.get_balance.return_value = None
+        assert _position_holding_is_gone(mock_exchange, False, pos) is False
+
+    def test_helper_margin_short_zero_borrowed_is_gone(self, mock_exchange):
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="ETHUSDT", side="short", quantity=1.0)
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)
+        assert _position_holding_is_gone(mock_exchange, True, pos) is True
+
+    def test_helper_margin_short_borrowed_present_not_gone(self, mock_exchange):
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="ETHUSDT", side="short", quantity=1.0)
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=1.0)
+        assert _position_holding_is_gone(mock_exchange, True, pos) is False
+
+    def test_helper_margin_short_borrowed_none_not_gone(self, mock_exchange):
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="ETHUSDT", side="short", quantity=1.0)
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=None)
+        assert _position_holding_is_gone(mock_exchange, True, pos) is False
+
+    def test_helper_exchange_close_pending_short_circuits(self, mock_exchange):
+        """The exchange_close_pending flag (offline SL fill, DB close pending) already means
+        the asset is gone — return True without an exchange round-trip."""
+        from src.engines.live.reconciliation import _position_holding_is_gone
+
+        pos = MockPosition(symbol="BTCUSDT", side="long", quantity=0.1)
+        pos.exchange_close_pending = True
+        assert _position_holding_is_gone(mock_exchange, False, pos) is True
+        mock_exchange.get_balance.assert_not_called()
+
+    # --- startup: PositionReconciler._verify_stop_loss ---
+
+    def test_startup_cancelled_sl_skips_replacement_when_holding_gone(
+        self, reconciler, mock_exchange
+    ):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(stop_loss_order_id="sl_gone", db_position_id=60, quantity=0.1)
+        pos.stop_loss = 45000.0
+        mock_exchange.get_order.return_value = MockExchangeOrder(
+            order_id="sl_gone", status=ExOS.CANCELLED, filled_quantity=0.0
+        )
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.0)
+
+        result = ReconciliationResult(entity_type="position", entity_id=60, status="verified")
+        reconciler._verify_stop_loss(pos, "sl_gone", result)
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        assert pos.stop_loss_order_id is None  # stale reference still cleared
+
+    def test_startup_missing_sl_skips_replacement_when_holding_gone(
+        self, reconciler, mock_exchange
+    ):
+        pos = MockPosition(stop_loss_order_id="sl_missing", db_position_id=61, quantity=0.1)
+        pos.stop_loss = 45000.0
+        mock_exchange.get_order.return_value = None  # not found on exchange
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.0)
+
+        result = ReconciliationResult(entity_type="position", entity_id=61, status="verified")
+        reconciler._verify_stop_loss(pos, "sl_missing", result)
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        assert pos.stop_loss_order_id is None
+
+    def test_startup_missing_sl_still_replaces_when_holding_present(
+        self, reconciler, mock_exchange
+    ):
+        """Control: a real position (asset still held) still gets its stop-loss re-placed."""
+        pos = MockPosition(stop_loss_order_id="sl_real", db_position_id=62, quantity=0.1)
+        pos.stop_loss = 45000.0
+        mock_exchange.get_order.return_value = None
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.1)
+        mock_exchange.place_stop_loss_order.return_value = "new_sl_real"
+
+        result = ReconciliationResult(entity_type="position", entity_id=62, status="verified")
+        reconciler._verify_stop_loss(pos, "sl_real", result)
+
+        mock_exchange.place_stop_loss_order.assert_called_once()
+        assert pos.stop_loss_order_id == "new_sl_real"
+
+    # --- startup: reconcile_position Step 3 (has stop price, no live SL order) ---
+
+    def test_startup_reconcile_position_no_sl_order_skips_placement_when_holding_gone(
+        self, reconciler, mock_exchange, mock_position_tracker
+    ):
+        """An externally-closed position with a stop price but no live SL order must not get a
+        naked AUTO_REPAY stop placed in Step 3; the holdings check removes it as a phantom."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            stop_loss_order_id=None,
+            stop_loss=45000.0,
+            db_position_id=63,
+            quantity=0.1,
+            exchange_order_id="entry_63",
+        )
+        # Entry confirmed FILLED with matching price/qty → no correction, so Steps 3 & 4 run.
+        mock_exchange.get_order.return_value = MockExchangeOrder(
+            status=ExOS.FILLED, average_price=50000.0, filled_quantity=0.1
+        )
+        mock_exchange.get_balance.return_value = MockBalance(total=0.0)  # asset gone
+
+        result = reconciler.reconcile_position(pos)
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        # Step 4 detected the external close and removed the phantom.
+        mock_position_tracker.pop_position.assert_called_once_with(pos.order_id)
+        assert result.status == "corrected"
+
+    # --- periodic: PeriodicReconciler._reconcile_cycle ---
+
+    @staticmethod
+    def _periodic(mock_exchange, mock_position_tracker, mock_db, *, use_margin=False):
+        return PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            use_margin=use_margin,
+        )
+
+    @staticmethod
+    def _balance_by_asset(base_asset, base_total):
+        """get_balance side effect: normal USDT, a chosen total for the base asset."""
+
+        def _fn(asset):
+            if asset == "USDT":
+                return MockBalance(asset="USDT", total=1000.0)
+            return MockBalance(asset=asset, total=base_total if asset == base_asset else 0.0)
+
+        return _fn
+
+    def test_periodic_cancelled_sl_skips_replacement_when_holding_gone(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            stop_loss_order_id="sl_gone",
+            exchange_order_id="entry_p1",
+            db_position_id=70,
+            quantity=0.1,
+        )
+        pos.stop_loss = 45000.0
+        mock_position_tracker.positions = {"entry_p1": pos}
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=50000.0)
+        sl_order = MockExchangeOrder(order_id="sl_gone", status=ExOS.CANCELLED, filled_quantity=0.0)
+        mock_exchange.get_order.side_effect = lambda oid, sym: (
+            sl_order if oid == "sl_gone" else entry_order
+        )
+        mock_exchange.get_balance.side_effect = self._balance_by_asset("BTC", 0.0)
+        mock_db.close_position.return_value = True
+
+        self._periodic(mock_exchange, mock_position_tracker, mock_db)._reconcile_cycle()
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+
+    def test_periodic_missing_sl_placement_skips_when_holding_gone(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """A phantom with no SL order id must not get a naked stop via _place_missing_stop_loss."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            stop_loss_order_id=None,
+            stop_loss=45000.0,
+            exchange_order_id="entry_p2",
+            db_position_id=71,
+            quantity=0.1,
+        )
+        mock_position_tracker.positions = {"entry_p2": pos}
+
+        mock_exchange.get_order.return_value = MockExchangeOrder(
+            status=ExOS.FILLED, average_price=50000.0
+        )
+        mock_exchange.get_balance.side_effect = self._balance_by_asset("BTC", 0.0)
+        mock_db.close_position.return_value = True
+
+        self._periodic(mock_exchange, mock_position_tracker, mock_db)._reconcile_cycle()
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+
+    def test_periodic_margin_short_cancelled_sl_skips_replacement_when_borrow_gone(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Margin short liquidated while offline (borrowed=0): the cancelled stop must not be
+        re-armed with AUTO_REPAY — that is the naked-position path."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            symbol="ETHUSDT",
+            side="short",
+            entry_price=2000.0,
+            stop_loss_order_id="sl_gone_m",
+            exchange_order_id="entry_p3",
+            db_position_id=72,
+            quantity=1.0,
+            current_size=1.0,
+            original_size=1.0,
+            size=1.0,
+        )
+        pos.stop_loss = 2200.0
+        mock_position_tracker.positions = {"entry_p3": pos}
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=2000.0)
+        sl_order = MockExchangeOrder(
+            order_id="sl_gone_m", status=ExOS.CANCELLED, filled_quantity=0.0
+        )
+        mock_exchange.get_order.side_effect = lambda oid, sym: (
+            sl_order if oid == "sl_gone_m" else entry_order
+        )
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)  # liquidated
+        mock_exchange.get_balance.side_effect = self._balance_by_asset("ETH", 0.0)
+        mock_db.close_position.return_value = True
+
+        self._periodic(
+            mock_exchange, mock_position_tracker, mock_db, use_margin=True
+        )._reconcile_cycle()
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+
+    def test_periodic_margin_long_cancelled_sl_skips_replacement_when_net_asset_gone(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Margin long closed externally while offline (netAsset=0): the guard must dispatch to
+        the balance (netAsset) check — not the borrowed check — and skip re-placement."""
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        pos = MockPosition(
+            symbol="ETHUSDT",
+            side="long",
+            entry_price=2000.0,
+            stop_loss_order_id="sl_gone_ml",
+            exchange_order_id="entry_p4",
+            db_position_id=73,
+            quantity=1.0,
+            current_size=1.0,
+            original_size=1.0,
+            size=1.0,
+        )
+        pos.stop_loss = 1800.0
+        mock_position_tracker.positions = {"entry_p4": pos}
+
+        entry_order = MockExchangeOrder(status=ExOS.FILLED, average_price=2000.0)
+        sl_order = MockExchangeOrder(
+            order_id="sl_gone_ml", status=ExOS.CANCELLED, filled_quantity=0.0
+        )
+        mock_exchange.get_order.side_effect = lambda oid, sym: (
+            sl_order if oid == "sl_gone_ml" else entry_order
+        )
+        # Margin long → the base asset's netAsset (get_balance total) is the source of truth.
+        # borrowed>0 would be misleading here; assert the guard does NOT rely on it.
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=5.0)
+        mock_exchange.get_balance.side_effect = self._balance_by_asset("ETH", 0.0)
+        mock_db.close_position.return_value = True
+
+        self._periodic(
+            mock_exchange, mock_position_tracker, mock_db, use_margin=True
+        )._reconcile_cycle()
+
+        mock_exchange.place_stop_loss_order.assert_not_called()

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -4485,3 +4485,29 @@ class TestStopLossReplacementHoldingGuard:
 
         mock_exchange.place_stop_loss_order.assert_called_once()
         mock_position_tracker.remove_position.assert_not_called()
+
+    def test_recovered_entry_gone_but_db_close_fails_retains_position(
+        self, reconciler, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """If the DB close fails (returns False) for a gone recovered entry, the position must
+        NOT be removed from the tracker — removing while the row stays OPEN diverges memory from
+        the DB (CODE.md). Still no stop and no emergency-sell."""
+        order_data = {
+            "client_order_id": "atb_BTCUSDT_long_3",
+            "exchange_order_id": "ex_recover_3",
+            "entry_balance": 1000.0,
+        }
+        exchange_order = MockExchangeOrder(
+            order_id="ex_recover_3", average_price=50000.0, filled_quantity=0.001
+        )
+        mock_exchange.get_balance.return_value = MockBalance(asset="BTC", total=0.0)
+        mock_db.log_position.return_value = 101
+        mock_db.close_position.return_value = False  # close failed / rolled back
+
+        reconciler._reconcile_filled_entry(
+            order_data, exchange_order, "BTCUSDT", "long", 50000.0, 0.001
+        )
+
+        mock_exchange.place_stop_loss_order.assert_not_called()
+        mock_exchange.place_order.assert_not_called()
+        mock_position_tracker.remove_position.assert_not_called()  # retained — no divergence


### PR DESCRIPTION
## Summary

Fixes a **pre-existing naked-margin-position risk** surfaced by the Codex review of #852 (finding 2 — *not* caused by that PR).

When a position is closed or liquidated externally while the bot is offline, its DB row stays `OPEN` and is re-loaded on the next startup. `PositionReconciler.reconcile_position` runs stop-loss verification (`_verify_stop_loss`) **before** the asset-holdings check (`_verify_asset_holdings`) — deliberately, so an offline SL **fill** can book its realized P&L first. But for an externally-*closed* position the tracked stop looks missing/cancelled, so the code **re-placed it with `SideEffectType.AUTO_REPAY`** *before* the holdings check could remove the phantom. On a margin account that re-arms a **naked position** — the fund-loss path the code comments warn about.

The periodic cycle (`PeriodicReconciler._reconcile_cycle`) had the analogous risk: it iterates a **stale snapshot copy** (`dict(self._positions)`) while step 1b removes phantoms from the *live* tracker, so a just-removed phantom still reaches the step-2 SL loop.

## What changed

- **New guard helper** `_position_holding_is_gone(exchange, use_margin, position)` (module-level, alongside `_is_exchange_close_pending`). It positively confirms the asset is gone using the **same 50%-of-tracked thresholds** as the phantom-removers `_verify_asset_holdings` / `_verify_margin_position_exists` (margin short → `borrowed`, long/spot → `netAsset`/balance; short-circuits on the `exchange_close_pending` flag), so guard and remover never disagree for any position that carries risk. **Fails safe** — returns `False` (keep protecting) on a transient API error (`balance`/`borrowed` `None` or exception).
- **Guard applied at all 5 re-placement sites** (skip placement when the holding is gone, let the holdings check remove the phantom):
  1. startup `_verify_stop_loss` — SL-not-found branch (`return`)
  2. startup `_verify_stop_loss` — cancelled/expired/rejected branch (`return`)
  3. startup `reconcile_position` step-3 missing-SL placement (`elif`, so step-4 still removes the phantom)
  4. periodic step-2 re-placement (`continue`)
  5. periodic `_place_missing_stop_loss` (early `return`)

### Explicitly not changed
- **Ordering is untouched** — reordering holdings-before-SL would lose offline SL-*fill* P&L (`_close_position_from_filled_sl`). The `FILLED` branch is a sibling and is not guarded, so offline SL-fill P&L booking is preserved.
- Two other `place_stop_loss_order` sites are **correctly left unguarded** — recovery SL after a just-confirmed-`FILLED` entry, and `_resize_stop_loss_after_partial_exit` (reached only from the bot's own partial-exit fill) — both act on genuinely-open positions.

## Why fail-safe (not fail-closed)
A false "present" → a redundant stop on a phantom that the holdings check cancels moments later (or an exchange `-3027/-3028` reject). A false "gone" → stripping the stop off a **real** position during an API blip. Failing safe matches the existing convention in `_verify_asset_holdings` / `_verify_margin_position_exists`.

## Testing
- **TDD** — 15 new tests in `TestStopLossReplacementHoldingGuard` (watched all fail first): helper units (spot/margin, present/gone/transient-`None`/`exchange_close_pending` short-circuit), startup (`_verify_stop_loss` cancelled + missing, `reconcile_position` step-3 with phantom removal asserted), periodic (cancelled, missing-via-`_place_missing_stop_loss`, **margin short + margin long** branch dispatch), plus a **control** proving a real position still gets its SL re-placed.
- `PYTHONPATH=. .venv/bin/python -m pytest tests/unit/live/test_reconciliation.py -q` → **157 passed**.
- `black` / `ruff` / `mypy` clean on changed files.
- **Reviewed by `code-reviewer` (verdict: CORRECT) and `architecture-reviewer` (approved for production)** — both independently confirmed the 5-site selection, the preserved SL-fill P&L path, and the fail-safe polarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)