### PR TITLE
feat(live): rate-limit repeated operator alerts (dedup the alert channel) (#853)

### DIFF
--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -131,6 +131,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Cooldown (seconds) for deduplicating operator ALERTS: a recurring/flapping
+# critical with the same (component, error_code) pages once per window; the
+# system_events row is still written but the repeat webhook is suppressed, so one
+# looping condition can't flood the single alert channel (the audit's
+# 714-critical-storm class, now that alerts are wired across every subsystem). #853
+ALERT_DEDUP_COOLDOWN_SECONDS = 300.0
+
 # Type aliases for backward compatibility - use shared models
 # Position uses LivePosition which has stop_loss_order_id for server-side stop tracking
 Position = LivePosition
@@ -339,6 +346,11 @@ class LiveTradingEngine:
         # exhaustion) so start() can exit non-zero for an orchestrator restart (#630).
         self._loop_crashed = False
         self.stop_event = threading.Event()
+        # Per-(component, error_code) last-alert timestamps for alert dedup; guarded
+        # by its lock because _record_event fires from the loop, the reconciler
+        # daemon, the WS-health thread and the order-tracker-alert thread.
+        self._alert_dedup: dict[str, float] = {}
+        self._alert_dedup_lock = threading.Lock()
 
         # Optional regime detector (feature-gated)
         self.regime_detector = None
@@ -2104,6 +2116,29 @@ class LiveTradingEngine:
         except Exception as e:
             logger.error("Failed to log trade: %s", e, exc_info=True)
 
+    def _alert_rate_limited(self, error_code: str | None, component: str | None) -> bool:
+        """True if an alert with this ``(component, error_code)`` key was already
+        paged within ``ALERT_DEDUP_COOLDOWN_SECONDS`` — so a recurring/flapping
+        critical pages once per window instead of flooding the single webhook.
+
+        Alerts with no ``error_code`` (no stable dedup key) are never rate-limited.
+        Thread-safe; tolerates a bare engine (``__new__`` in tests) with no dedup
+        state by never rate-limiting.
+        """
+        if not error_code:
+            return False
+        dedup = getattr(self, "_alert_dedup", None)
+        if dedup is None:
+            return False
+        key = f"{component or '?'}:{error_code}"
+        now = time.time()
+        with self._alert_dedup_lock:
+            last = dedup.get(key)
+            if last is not None and (now - last) < ALERT_DEDUP_COOLDOWN_SECONDS:
+                return True
+            dedup[key] = now
+            return False
+
     def _record_event(
         self,
         event_type: EventType,
@@ -2137,11 +2172,17 @@ class LiveTradingEngine:
             alert_sent = False
             alert_method: str | None = None
             if alert:
-                # Record the real OUTCOME, not just intent: _send_alert returns
-                # False when no webhook is configured or the POST fails, so
-                # alert_sent reflects whether an operator was actually paged.
-                alert_sent = bool(self._send_alert(message))
-                alert_method = "webhook" if alert_sent else None
+                if self._alert_rate_limited(error_code, component):
+                    # Repeated identical condition within the cooldown: still write
+                    # the row (queryable) but suppress the repeat page, so one
+                    # flapping/looping critical can't flood the operator.
+                    alert_method = "suppressed"
+                else:
+                    # Record the real OUTCOME, not just intent: _send_alert returns
+                    # False when no webhook is configured or the POST fails, so
+                    # alert_sent reflects whether an operator was actually paged.
+                    alert_sent = bool(self._send_alert(message))
+                    alert_method = "webhook" if alert_sent else None
 
             self.db_manager.log_event(
                 event_type=event_type,

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2117,13 +2117,16 @@ class LiveTradingEngine:
             logger.error("Failed to log trade: %s", e, exc_info=True)
 
     def _alert_rate_limited(self, error_code: str | None, component: str | None) -> bool:
-        """True if an alert with this ``(component, error_code)`` key was already
-        paged within ``ALERT_DEDUP_COOLDOWN_SECONDS`` — so a recurring/flapping
-        critical pages once per window instead of flooding the single webhook.
+        """True if a successfully-delivered alert with this ``(component,
+        error_code)`` key is still within ``ALERT_DEDUP_COOLDOWN_SECONDS`` — so a
+        recurring/flapping critical pages once per window instead of flooding the
+        single webhook.
 
-        Alerts with no ``error_code`` (no stable dedup key) are never rate-limited.
-        Thread-safe; tolerates a bare engine (``__new__`` in tests) with no dedup
-        state by never rate-limiting.
+        Read-only: the cooldown window opens only on SUCCESSFUL delivery (via
+        :meth:`_mark_alert_sent`), so a failed first page never suppresses the
+        retry that finally reaches an operator. Alerts with no ``error_code`` (no
+        stable dedup key) are never rate-limited. Thread-safe; tolerates a bare
+        engine (``__new__`` in tests) with no dedup state by never rate-limiting.
         """
         if not error_code:
             return False
@@ -2131,13 +2134,21 @@ class LiveTradingEngine:
         if dedup is None:
             return False
         key = f"{component or '?'}:{error_code}"
-        now = time.time()
         with self._alert_dedup_lock:
             last = dedup.get(key)
-            if last is not None and (now - last) < ALERT_DEDUP_COOLDOWN_SECONDS:
-                return True
-            dedup[key] = now
-            return False
+            return last is not None and (time.time() - last) < ALERT_DEDUP_COOLDOWN_SECONDS
+
+    def _mark_alert_sent(self, error_code: str | None, component: str | None) -> None:
+        """Open the dedup cooldown window for this key. Called only after a webhook
+        was actually delivered, so a failed page never suppresses later retries."""
+        if not error_code:
+            return
+        dedup = getattr(self, "_alert_dedup", None)
+        if dedup is None:
+            return
+        key = f"{component or '?'}:{error_code}"
+        with self._alert_dedup_lock:
+            dedup[key] = time.time()
 
     def _record_event(
         self,
@@ -2183,6 +2194,10 @@ class LiveTradingEngine:
                     # alert_sent reflects whether an operator was actually paged.
                     alert_sent = bool(self._send_alert(message))
                     alert_method = "webhook" if alert_sent else None
+                    if alert_sent:
+                        # Open the cooldown only on a real page, so a failed first
+                        # delivery doesn't blind the operator to later retries.
+                        self._mark_alert_sent(error_code, component)
 
             self.db_manager.log_event(
                 event_type=event_type,

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -366,3 +366,23 @@ class TestAlertRateLimiting:
         for _ in range(3):
             engine._record_event(EventType.ALERT, "x", error_code="X", component="c", alert=True)
         assert engine._send_alert.call_count == 3
+
+    def test_failed_delivery_does_not_open_cooldown(self):
+        """The cooldown opens only on a SUCCESSFUL page: if the first delivery
+        fails, later occurrences must retry, not be silently suppressed — else a
+        transient webhook failure would blind the operator for the whole window."""
+        engine = self._engine()
+        engine._send_alert = MagicMock(return_value=False)  # delivery keeps failing
+        for _ in range(3):
+            engine._record_event(
+                EventType.ALERT,
+                "orphan!",
+                severity="critical",
+                component="order_tracker",
+                error_code="ORDER_ORPHANED",
+                alert=True,
+            )
+        # Every occurrence retried the webhook; none was suppressed.
+        assert engine._send_alert.call_count == 3
+        calls = engine.db_manager.log_event.call_args_list
+        assert all(c.kwargs["alert_method"] != "suppressed" for c in calls)

--- a/tests/unit/engines/live/test_record_event.py
+++ b/tests/unit/engines/live/test_record_event.py
@@ -305,3 +305,64 @@ class TestOrderTrackerAlertAdapter:
         assert kwargs["component"] == "order_tracker"
         assert kwargs["severity"] == "critical"
         assert kwargs["alert"] is True
+
+
+class TestAlertRateLimiting:
+    """A recurring critical (same component+error_code) pages once per cooldown
+    window; the system_events row is still written but the repeat webhook is
+    suppressed, so one looping condition can't flood the operator (#853)."""
+
+    @staticmethod
+    def _engine() -> LiveTradingEngine:
+        import threading
+
+        engine = LiveTradingEngine.__new__(LiveTradingEngine)
+        engine.db_manager = MagicMock()
+        engine.trading_session_id = 1
+        engine._send_alert = MagicMock(return_value=True)
+        engine._alert_dedup = {}
+        engine._alert_dedup_lock = threading.Lock()
+        return engine
+
+    def test_repeat_alert_suppressed_within_cooldown(self):
+        engine = self._engine()
+        for _ in range(3):
+            engine._record_event(
+                EventType.ALERT,
+                "orphan!",
+                severity="critical",
+                component="order_tracker",
+                error_code="ORDER_ORPHANED",
+                alert=True,
+            )
+        # Paged exactly once; the two repeats within the window are suppressed.
+        assert engine._send_alert.call_count == 1
+        calls = engine.db_manager.log_event.call_args_list
+        assert len(calls) == 3  # every row is still written (queryable)
+        assert calls[0].kwargs["alert_sent"] is True
+        assert calls[0].kwargs["alert_method"] == "webhook"
+        assert calls[1].kwargs["alert_sent"] is False
+        assert calls[1].kwargs["alert_method"] == "suppressed"
+
+    def test_distinct_error_codes_not_cross_deduped(self):
+        engine = self._engine()
+        engine._record_event(EventType.ALERT, "a", error_code="A", component="x", alert=True)
+        engine._record_event(EventType.ALERT, "b", error_code="B", component="x", alert=True)
+        assert engine._send_alert.call_count == 2
+
+    def test_no_error_code_never_rate_limited(self):
+        engine = self._engine()
+        for _ in range(3):
+            engine._record_event(EventType.ALERT, "no-code", component="x", alert=True)
+        assert engine._send_alert.call_count == 3
+
+    def test_bare_engine_without_dedup_state_not_rate_limited(self):
+        """Backward-compat: a bare engine (__new__, no dedup state) never rate-limits
+        and never raises AttributeError — the many existing bare-engine tests rely on it."""
+        engine = LiveTradingEngine.__new__(LiveTradingEngine)
+        engine.db_manager = MagicMock()
+        engine.trading_session_id = 1
+        engine._send_alert = MagicMock(return_value=True)
+        for _ in range(3):
+            engine._record_event(EventType.ALERT, "x", error_code="X", component="c", alert=True)
+        assert engine._send_alert.call_count == 3


### PR DESCRIPTION
## Summary
PR 11 of #853. Now that alerts are wired across every subsystem (PRs 1–10), a **recurring/flapping critical** with the same `(component, error_code)` could page the single webhook every cycle — the audit's **714-critical-storm** class. This dedups the alert channel.

## Changes
- `_record_event` (the one alert dispatch point) now checks `_alert_rate_limited(error_code, component)` before paging. An alert with a stable `(component, error_code)` key pages **once per `ALERT_DEDUP_COOLDOWN_SECONDS` (300s)**; within the window the `system_events` row is **still written** (queryable) but the repeat webhook is **suppressed** (`alert_method="suppressed"`, `alert_sent=False`).
- Alerts with **no `error_code`** (no stable key) are never rate-limited. Distinct error codes never cross-dedup.
- **Thread-safe** — a lock-guarded map, because `_record_event` fires from the loop, the reconciler daemon, the WS-health thread, and the order-tracker-alert thread.
- **Backward-compatible** — a bare engine (`__new__`, no dedup state) never rate-limits and never raises, so the many existing bare-engine tests are unaffected (verified).

## Testing
- 4 new tests: repeat suppressed within cooldown (paged once, all 3 rows written, 2nd row `alert_method="suppressed"`); distinct codes not cross-deduped; no-error_code never limited; bare-engine backward-compat.
- 23 in file; **785 passed** across `tests/unit/engines/live/` + `tests/unit/live/` (no regression). Quality gate (Black/Ruff/MyPy) clean.

## Scope
Merges to `develop`. This makes the alert channel robust and is the safety prerequisite for later surfacing the reconciler's HIGH/CRITICAL audit rows to operators (the audit→system_event bridge). Part of #853.