### PR TITLE
feat(live): surface startup reconciliation severity + fix silent close-only (#853)

### DIFF
--- a/src/engines/live/recovery.py
+++ b/src/engines/live/recovery.py
@@ -439,6 +439,31 @@ class LiveSessionRecoverer:
         except Exception as e:
             logger.error("❌ Error recovering positions: %s", e, exc_info=True)
 
+    def _emit_reconcile_summary(
+        self, results: list, critical_count: int, high_count: int, phase: str
+    ) -> None:
+        """Surface a HIGH/CRITICAL startup reconciliation as ONE summary
+        ``system_events`` row — the startup analog of the periodic cycle-severity
+        event (#861). So the per-row audit storm (e.g. the 714 UNKNOWN-order
+        corrections from ``resolve_pending_orders``) reaches operators as a single
+        bounded event instead of silence. Paged on critical + deduped by
+        ``_record_event``; the detail stays in ``reconciliation_audit_events``.
+        """
+        if critical_count == 0 and high_count == 0:
+            return
+        corrections = sum(len(r.corrections) for r in results)
+        self._state._record_event(
+            EventType.ALERT if critical_count else EventType.WARNING,
+            f"Startup {phase}: {critical_count} critical + {high_count} high-severity "
+            f"corrections ({corrections} total) — see reconciliation_audit_events",
+            severity="critical" if critical_count else "warning",
+            component="reconciler",
+            error_code=(
+                "STARTUP_RECONCILE_CRITICAL" if critical_count else "STARTUP_RECONCILE_HIGH"
+            ),
+            alert=critical_count > 0,
+        )
+
     def reconcile_positions_with_exchange(self) -> None:
         """
         Reconcile local positions with exchange state on startup.
@@ -499,12 +524,21 @@ class LiveSessionRecoverer:
                     # order may create a position, and critical issues must
                     # still trigger close-only mode.
                     critical_count = sum(1 for r in results if r.severity == Severity.CRITICAL)
+                    high_count = sum(1 for r in results if r.severity == Severity.HIGH)
                     if critical_count > 0:
                         logger.critical(
                             "🚨 %d CRITICAL reconciliation issues — entering close-only mode",
                             critical_count,
                         )
-                        state._close_only_mode = True
+                        # Route through the guarded helper so the CLOSE_ONLY event
+                        # fires — this path previously entered close-only SILENTLY,
+                        # unlike the reconcile_startup path below. #853
+                        state._enter_close_only_mode()
+                    # One bounded, deduped, paged-on-critical summary — this
+                    # resolve_pending path is where the 714 UNKNOWN-order storm arose.
+                    self._emit_reconcile_summary(
+                        results, critical_count, high_count, "pending-order resolution"
+                    )
 
                     for r in results:
                         if r.status == "corrected" and r.severity >= Severity.HIGH:
@@ -531,6 +565,7 @@ class LiveSessionRecoverer:
 
                 # Check for critical issues
                 critical_count = sum(1 for r in results if r.severity == Severity.CRITICAL)
+                high_count = sum(1 for r in results if r.severity == Severity.HIGH)
                 if critical_count > 0:
                     logger.critical(
                         "🚨 %d CRITICAL reconciliation issues — entering close-only mode",
@@ -539,6 +574,7 @@ class LiveSessionRecoverer:
                     # Route through the guarded helper so the CLOSE_ONLY event is
                     # emitted on this startup-critical path too, not just runtime.
                     state._enter_close_only_mode()
+                self._emit_reconcile_summary(results, critical_count, high_count, "reconciliation")
 
                 # Log HIGH severity auto-corrections (cancelled entries, SL fills)
                 for r in results:

--- a/tests/unit/engines/live/test_session_recoverer_wiring.py
+++ b/tests/unit/engines/live/test_session_recoverer_wiring.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.database.models import EventType
 from src.engines.live import trade_close_accounting
 from src.engines.live.recovery import LiveSessionRecoverer
 from src.engines.live.trading_engine import (
@@ -84,3 +85,36 @@ class TestRecovererWiring:
 
         with pytest.raises(ValueError, match="not finite"):
             engine._recover_existing_session()
+
+
+class TestStartupReconcileSummary:
+    """Startup reconciliation surfaces its HIGH/CRITICAL severity as ONE summary
+    system_events row — the startup analog of the periodic cycle-severity event —
+    so the per-row audit storm (the 714 UNKNOWN-order class) reaches operators
+    without flooding them (#853)."""
+
+    def test_critical_pages_alert(self):
+        state = MagicMock()
+        rec = LiveSessionRecoverer(state)
+        rec._emit_reconcile_summary(
+            [MagicMock(corrections=[1, 2]), MagicMock(corrections=[3])], 1, 1, "reconciliation"
+        )
+        args, kwargs = state._record_event.call_args
+        assert args[0] == EventType.ALERT
+        assert kwargs["error_code"] == "STARTUP_RECONCILE_CRITICAL"
+        assert kwargs["severity"] == "critical"
+        assert kwargs["alert"] is True
+
+    def test_high_only_emits_warning_no_page(self):
+        state = MagicMock()
+        rec = LiveSessionRecoverer(state)
+        rec._emit_reconcile_summary([MagicMock(corrections=[3])], 0, 1, "reconciliation")
+        _, kwargs = state._record_event.call_args
+        assert kwargs["error_code"] == "STARTUP_RECONCILE_HIGH"
+        assert kwargs["alert"] is False
+
+    def test_no_findings_no_emit(self):
+        state = MagicMock()
+        rec = LiveSessionRecoverer(state)
+        rec._emit_reconcile_summary([], 0, 0, "reconciliation")
+        state._record_event.assert_not_called()


### PR DESCRIPTION
## Summary
PR 12 of #853 — the "audit→system_event bridge, done right" for **startup** reconciliation, now safe because PR #882 landed alert dedup.

Startup reconciliation (`resolve_pending_orders` / `reconcile_startup`) logged its critical/high findings but emitted **no `system_event`** — so the per-row audit storm (e.g. the **714 UNKNOWN-order** corrections from `resolve_pending_orders`) reached no operator. And the `resolve_pending_orders` critical path entered close-only via a direct `_close_only_mode = True`, **bypassing the `CLOSE_ONLY` event** (unlike the `reconcile_startup` path — a known inconsistency).

## Changes
- **`_emit_reconcile_summary()`** — one **bounded** summary `system_event` per startup reconciliation (`ALERT` + page on critical, `WARNING` on high), **deduped** by `_record_event` (PR #882). The startup analog of the periodic cycle-severity event (#861); per-row detail stays in `reconciliation_audit_events`. So 714 audit rows → **one** paged event, not silence and not 714 pages.
- **Fix the silent close-only**: route the `resolve_pending_orders` critical path through `_enter_close_only_mode()` so the `CLOSE_ONLY` event fires there too.

## Testing
- 3 new tests (`_emit_reconcile_summary`: critical→ALERT+page, high→WARNING no-page, nothing→no emit).
- 159 passed across session-recoverer / clean-restart / reconciliation suites (the close-only fix + emit don't regress the startup path). Quality gate clean.

## Scope
Merges to `develop`. Part of #853. This is the last clearly-valuable observability item; remaining (#2 balance-correction audit row, #7 orphan-sweep event which is DRY-RUN in prod, #9 skip-guard audits) are marginal.