### PR TITLE
feat(live): audit the periodic balance correction (#853)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -3129,6 +3129,23 @@ class PeriodicReconciler:
                 # DB balance represents total capital (USDT + position notional), not just
                 # free USDT on exchange.
                 corrected_balance = usdt_balance.total + position_notional
+                # Audit the correction — the startup twin (_reconcile_balance) audits
+                # its identical correction, but this periodic path previously wrote
+                # only a log line (no reconciliation_audit_events row). #853
+                self.db_manager.log_audit_event(
+                    session_id=self.session_id,
+                    entity_type="balance",
+                    entity_id=None,
+                    field="total_balance",
+                    old_value=f"{db_balance:.2f}",
+                    new_value=f"{corrected_balance:.2f}",
+                    reason=(
+                        f"Periodic balance correction: discrepancy {diff_pct:.2%} exceeds threshold "
+                        f"(exchange_usdt={usdt_balance.total:.2f}, "
+                        f"position_notional={position_notional:.2f})"
+                    ),
+                    severity=Severity.CRITICAL.value,
+                )
                 self.db_manager.update_balance(
                     corrected_balance,
                     "reconciliation_balance_correction",

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3660,6 +3660,13 @@ class TestPeriodicSpotBalanceReconcile:
         # Corrected to exchange USDT + 0 notional (fresh tracker is empty) — NOT 900 + the
         # closed position's notional (the stale-snapshot over-correction).
         assert mock_db.update_balance.call_args.args[0] == pytest.approx(900.0)
+        # The correction is now audited (this periodic path previously wrote no
+        # reconciliation_audit_events row, unlike its startup twin). #853
+        mock_db.log_audit_event.assert_called_once()
+        audit = mock_db.log_audit_event.call_args.kwargs
+        assert audit["entity_type"] == "balance"
+        assert audit["field"] == "total_balance"
+        assert audit["severity"] == Severity.CRITICAL.value
 
     def test_no_correction_within_threshold(self, mock_exchange, mock_position_tracker, mock_db):
         mock_position_tracker.positions = {}


### PR DESCRIPTION
PR 13 of #853 (gap #2). The periodic `_reconcile_spot_balance` corrected the DB balance to exchange truth but wrote only a log line — no `reconciliation_audit_events` row, unlike its startup twin `_reconcile_balance` which audits the identical correction. Adds the audit row (entity_type=balance, field=total_balance, CRITICAL), mirroring the twin. It's **already surfaced** to operators via close-only + the #861 cycle-severity event; this just completes the audit trail. Existing correction test now asserts the audit row; 142 in file, quality gate clean. Part of #853.