### PR TITLE
fix(ml): harden SageMaker cloud training for production use (#890)

### DIFF
--- a/.github/workflows/weekly-training.yml
+++ b/.github/workflows/weekly-training.yml
@@ -1,9 +1,10 @@
+# Scheduled retraining is handled by a Claude Code routine with an
+# evaluate-vs-incumbent gate (see #890); this workflow remains for
+# manual/emergency cloud training only. Its models sync to the runner's
+# filesystem — download from S3 or use the routine for repo integration.
 name: Weekly Model Training
 
 on:
-  schedule:
-    # Run every Sunday at 2 AM UTC
-    - cron: '0 2 * * 0'
   workflow_dispatch:
     # Allow manual trigger with custom parameters
     inputs:

--- a/cli/commands/train_cloud.py
+++ b/cli/commands/train_cloud.py
@@ -8,6 +8,71 @@ from __future__ import annotations
 
 import argparse
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.ml.cloud.providers.base import CloudTrainingProvider
+
+# Training window length used when neither --days nor --start-date is given
+DEFAULT_TRAINING_DAYS = 365
+
+
+def _parse_utc_date(value: str) -> datetime:
+    """Parse an ISO date/datetime string into a UTC-aware datetime."""
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"Invalid date {value!r}: expected ISO format (YYYY-MM-DD)") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _resolve_date_range(
+    days: int | None,
+    start_date_str: str | None,
+    end_date_str: str | None,
+) -> tuple[datetime, datetime]:
+    """Resolve the training data window from CLI arguments.
+
+    Supported combinations:
+    - nothing: last DEFAULT_TRAINING_DAYS days ending now
+    - --days N: last N days ending now
+    - --start-date [--end-date]: explicit window (end defaults to now)
+    - --end-date --days N: fixed-cutoff window of N days ending at --end-date
+
+    Raises:
+        ValueError: If --days is combined with --start-date, a date string is
+            invalid, or the resolved start is not before the end.
+    """
+    if days is not None and start_date_str:
+        raise ValueError("--days and --start-date are mutually exclusive")
+
+    end_date = _parse_utc_date(end_date_str) if end_date_str else datetime.now(UTC)
+    if start_date_str:
+        start_date = _parse_utc_date(start_date_str)
+    else:
+        start_date = end_date - timedelta(days=days if days is not None else DEFAULT_TRAINING_DAYS)
+
+    if start_date >= end_date:
+        raise ValueError(f"start date must be before end date ({start_date} >= {end_date})")
+
+    return start_date, end_date
+
+
+def _parse_job_name(job_id: str) -> tuple[str, str] | None:
+    """Recover (SYMBOL, timeframe) from a job name or ARN.
+
+    Job names are generated as ``atb-{symbol}-{timeframe}-{YYYYmmdd-HHMMSS}``.
+
+    Returns:
+        (symbol, timeframe) tuple, or None if the name doesn't match.
+    """
+    job_name = job_id.split("/")[-1]
+    parts = job_name.split("-")
+    if len(parts) >= 4 and parts[0] == "atb" and parts[1] and parts[2]:
+        return parts[1].upper(), parts[2]
+    return None
 
 
 def _handle_cloud(ns: argparse.Namespace) -> int:
@@ -23,8 +88,24 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
     parser.add_argument(
         "--days",
         type=int,
-        default=365,
-        help="Days of training data (default: 365)",
+        default=None,
+        help=f"Days of training data ending at --end-date or now "
+        f"(default: {DEFAULT_TRAINING_DAYS}; mutually exclusive with --start-date)",
+    )
+    parser.add_argument(
+        "--start-date",
+        type=str,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Training data start date (UTC). Mutually exclusive with --days.",
+    )
+    parser.add_argument(
+        "--end-date",
+        type=str,
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Training data end date (UTC, default: now). "
+        "Enables fixed-cutoff experimental protocols.",
     )
     parser.add_argument(
         "--timeframe",
@@ -104,6 +185,13 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
 
     args = parser.parse_args(ns.args or [])
 
+    # Resolve dates first: cheap validation should fail before any AWS call
+    try:
+        start_date, end_date = _resolve_date_range(args.days, args.start_date, args.end_date)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
     # Import cloud training modules (may fail if boto3 not installed)
     try:
         from src.ml.cloud.config import CloudInstanceConfig, CloudTrainingConfig
@@ -127,10 +215,6 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         print()
         print("For local testing, use: --provider local")
         return 1
-
-    # Build training configuration
-    end_date = datetime.now(UTC)
-    start_date = end_date - timedelta(days=args.days)
 
     training_config = TrainingConfig(
         symbol=args.symbol.upper(),
@@ -167,7 +251,10 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
     print("=" * 60)
     print(f"  Symbol:          {args.symbol.upper()}")
     print(f"  Timeframe:       {args.timeframe}")
-    print(f"  Data Range:      {start_date.date()} to {end_date.date()} ({args.days} days)")
+    print(
+        f"  Data Range:      {start_date.date()} to {end_date.date()} "
+        f"({(end_date - start_date).days} days)"
+    )
     print(f"  Epochs:          {args.epochs}")
     print(f"  Batch Size:      {args.batch_size}")
     print(f"  Sequence Length: {args.sequence_length}")
@@ -184,13 +271,15 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
     orchestrator = CloudTrainingOrchestrator(cloud_config, provider)
 
     if args.no_wait:
-        print("Submitting training job (not waiting for completion)...")
+        print("Uploading training data and submitting job (not waiting for completion)...")
         try:
             job_id = orchestrator.submit_job()
             print(f"Job submitted: {job_id}")
             print()
             print("To check status:")
             print(f"  atb train cloud-status {job_id}")
+            print("To download and sync artifacts once completed:")
+            print(f"  atb train cloud-status {job_id} --sync")
             return 0
         except Exception as exc:
             print(f"Error: Failed to submit job: {exc}")
@@ -240,7 +329,13 @@ def _handle_cloud_status(ns: argparse.Namespace) -> int:
     parser.add_argument(
         "--sync",
         action="store_true",
-        help="Sync artifacts if job is complete",
+        help="Download artifacts and sync to the local registry if job is complete",
+    )
+    parser.add_argument(
+        "--symbol",
+        type=str,
+        default=None,
+        help="Trading symbol for --sync when it cannot be derived from the job name",
     )
 
     args = parser.parse_args(ns.args or [])
@@ -280,11 +375,12 @@ def _handle_cloud_status(ns: argparse.Namespace) -> int:
                 print(f"    {key}: {value:.4f}")
         print("=" * 60)
 
-        if args.sync and status.is_successful:
-            print()
-            print("Syncing artifacts to local registry...")
-            # Would need full config to sync, simplified for status check
-            print("Use 'atb train cloud' with --wait to auto-sync on completion.")
+        if args.sync:
+            if not status.is_successful:
+                print()
+                print(f"Cannot sync: job is in state {status.status}.")
+                return 1
+            return _sync_job_artifacts(args.job_id, status.job_name, args.symbol, provider)
 
         return 0 if status.is_successful or not status.is_terminal else 1
 
@@ -293,15 +389,65 @@ def _handle_cloud_status(ns: argparse.Namespace) -> int:
         return 1
 
 
+def _sync_job_artifacts(
+    job_id: str,
+    job_name: str,
+    symbol_override: str | None,
+    provider: CloudTrainingProvider,
+) -> int:
+    """Download a completed job's artifacts and sync them into the registry.
+
+    The symbol/timeframe recovered from the job name only seed a placeholder
+    config; the synced bundle's own metadata.json determines the final
+    registry location.
+    """
+    from src.ml.cloud.config import CloudTrainingConfig
+    from src.ml.cloud.orchestrator import CloudTrainingOrchestrator
+    from src.ml.training_pipeline.config import TrainingConfig
+
+    parsed = _parse_job_name(job_name)
+    if parsed:
+        symbol, timeframe = parsed
+    elif symbol_override:
+        symbol, timeframe = symbol_override.upper(), "1h"
+    else:
+        print("Error: Cannot derive symbol from job name; pass --symbol explicitly.")
+        return 1
+
+    # Placeholder window: sync only reads symbol/timeframe, never the dates
+    placeholder_config = TrainingConfig(
+        symbol=symbol,
+        timeframe=timeframe,
+        start_date=datetime(2020, 1, 1, tzinfo=UTC),
+        end_date=datetime.now(UTC),
+    )
+
+    try:
+        cloud_config = CloudTrainingConfig.from_env(placeholder_config)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print()
+    print("Syncing artifacts to local registry...")
+    try:
+        orchestrator = CloudTrainingOrchestrator(cloud_config, provider)
+        artifact_path = orchestrator.sync_artifacts(job_id)
+        print(f"Artifacts synced to: {artifact_path}")
+        return 0
+    except Exception as exc:
+        print(f"Error: Failed to sync artifacts: {exc}")
+        return 1
+
+
 def _handle_cloud_list(ns: argparse.Namespace) -> int:
-    """List S3 model versions."""
-    parser = argparse.ArgumentParser(description="List model versions in S3")
-    parser.add_argument("symbol", help="Trading symbol (e.g., BTCUSDT)")
+    """List cloud training job outputs stored in S3."""
+    parser = argparse.ArgumentParser(description="List cloud-trained model outputs in S3")
     parser.add_argument(
-        "--model-type",
-        type=str,
-        default="basic",
-        help="Model type (default: basic)",
+        "symbol",
+        nargs="?",
+        default=None,
+        help="Optional trading symbol filter (e.g., BTCUSDT)",
     )
 
     args = parser.parse_args(ns.args or [])
@@ -322,22 +468,83 @@ def _handle_cloud_list(ns: argparse.Namespace) -> int:
 
     try:
         s3_manager = S3ArtifactManager(bucket)
-        versions = s3_manager.list_model_versions(args.symbol.upper(), args.model_type)
+        jobs = s3_manager.list_training_jobs(symbol=args.symbol)
 
-        if not versions:
-            print(f"No model versions found for {args.symbol.upper()}/{args.model_type}")
+        scope = args.symbol.upper() if args.symbol else "all symbols"
+        if not jobs:
+            print(f"No cloud training outputs found for {scope}")
             return 0
 
-        print(f"Model versions for {args.symbol.upper()}/{args.model_type}:")
+        print(f"Cloud training outputs for {scope} (newest first):")
         print()
-        for version in versions:
-            print(f"  - {version}")
+        for job in jobs:
+            print(f"  - {job}")
+        print()
+        print("Sync one into the local registry with:")
+        print("  atb train cloud-status <JOB_NAME> --sync")
 
         return 0
 
     except Exception as exc:
         print(f"Error: {exc}")
         return 1
+
+
+def _handle_cloud_promote(ns: argparse.Namespace) -> int:
+    """Promote a synced cloud model from price/ into another namespace."""
+    parser = argparse.ArgumentParser(
+        description="Promote a cloud-trained model bundle between registry namespaces "
+        "(never touches the target's 'latest' symlink unless --set-latest is passed)",
+    )
+    parser.add_argument("symbol", help="Trading symbol (e.g., BTCUSDT)")
+    parser.add_argument("version", help="Version directory name (e.g., 2026-07-05_10h30m00s_v1)")
+    parser.add_argument(
+        "--from",
+        dest="source_type",
+        type=str,
+        default="price",
+        help="Source namespace (default: price, where cloud syncs land)",
+    )
+    parser.add_argument(
+        "--to",
+        dest="target_type",
+        type=str,
+        default="basic",
+        help="Target namespace (default: basic, loaded by live strategies)",
+    )
+    parser.add_argument(
+        "--set-latest",
+        action="store_true",
+        help="Also point the target namespace's 'latest' symlink at this version. "
+        "For basic/ this changes which model live strategies load.",
+    )
+
+    args = parser.parse_args(ns.args or [])
+
+    from src.ml.cloud.exceptions import ModelPromotionError
+    from src.ml.cloud.promotion import promote_model_version
+
+    try:
+        target = promote_model_version(
+            symbol=args.symbol,
+            version_id=args.version,
+            source_type=args.source_type,
+            target_type=args.target_type,
+            set_latest=args.set_latest,
+        )
+    except ModelPromotionError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(f"Promoted {args.symbol.upper()}/{args.source_type}/{args.version}")
+    print(f"  -> {target}")
+    if args.set_latest:
+        print(f"  {args.target_type}/latest now points to {args.version}")
+        if args.target_type == "basic":
+            print("  WARNING: live strategies load basic/latest — verify before deploying.")
+    else:
+        print(f"  {args.target_type}/latest was NOT changed (pass --set-latest to update it)")
+    return 0
 
 
 def register(subparsers: argparse._SubParsersAction) -> None:
@@ -361,7 +568,15 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     # List versions command
     p_list = subparsers.add_parser(
         "cloud-list",
-        help="List model versions in S3",
+        help="List cloud-trained model outputs in S3",
     )
     p_list.add_argument("args", nargs=argparse.REMAINDER)
     p_list.set_defaults(func=_handle_cloud_list)
+
+    # Promotion command (price/ -> basic/ is always explicit, never automatic)
+    p_promote = subparsers.add_parser(
+        "cloud-promote",
+        help="Promote a synced cloud model bundle (default: price/ -> basic/)",
+    )
+    p_promote.add_argument("args", nargs=argparse.REMAINDER)
+    p_promote.set_defaults(func=_handle_cloud_promote)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Cloud training hardening (#890)**: `atb train cloud` accepts `--start-date`/`--end-date`
+  (UTC, mutually exclusive with `--days`) for fixed-cutoff experiments; `--no-wait` now uploads
+  the S3 data channel before submitting (previously the async path always failed in-container);
+  `atb train cloud-status --sync` actually downloads and syncs artifacts; `atb train cloud-list`
+  lists real S3 job outputs; new `atb train cloud-promote SYMBOL VERSION --to basic [--set-latest]`
+  copies a synced bundle from `price/` into `basic/` without touching `basic/latest` unless
+  explicitly requested. Version IDs now include minutes/seconds (`YYYY-MM-DD_HHhMMmSSs_vN`) so
+  same-hour cloud jobs cannot collide, and the local sync never overwrites an existing bundle
+  (falls back to a `-N` suffixed sibling). Cloud workflow documented in `docs/prediction.md`.
+
 ### Changed
 - **#486 live-engine modularization complete**: `LiveTradingEngine._init_modular_handlers`
   (the last open item from `docs/refactor/live_engine_modularization.md`) is now a

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -102,6 +102,53 @@ Use the following knobs when running `atb train model` locally:
 
 The defaults remain equivalent to the legacy behavior (300 epochs, batch size 32, sequence length 120, diagnostics on, ONNX on), so unattended jobs continue to produce identical artifacts unless you override the flags explicitly.
 
+## Cloud training (AWS SageMaker)
+
+`atb train cloud` runs the same training pipeline on SageMaker spot GPU instances (`src/ml/cloud/`). Because Binance blocks
+AWS IPs, the CLI always downloads candles locally, uploads them to S3 as the job's data channel, and the container trains
+from that channel — both in blocking mode and with `--no-wait`.
+
+```bash
+# Fixed-cutoff experiment window (dates are UTC; --days and --start-date are mutually exclusive)
+atb train cloud BTCUSDT --start-date 2026-05-01 --end-date 2026-06-01 --epochs 50 --force-price-only
+
+# Production-style retrain: last 365 days ending now
+atb train cloud BTCUSDT --days 365 --epochs 300
+
+# Async round trip
+atb train cloud BTCUSDT --no-wait            # uploads data, submits, prints job id
+atb train cloud-status <JOB_NAME>            # poll status
+atb train cloud-status <JOB_NAME> --sync     # download + sync bundle into the registry
+atb train cloud-list [BTCUSDT]               # list job outputs in S3 (newest first)
+```
+
+### Namespace and promotion flow
+
+Cloud bundles record `model_type: price`, so syncs land in `src/ml/models/{SYMBOL}/price/{VERSION}` and only move
+`price/latest`. Live strategies load `{SYMBOL}/basic/latest`, which cloud training **never** touches — promotion to live is
+always an explicit, separate step:
+
+```bash
+# Copy the bundle into basic/ WITHOUT touching basic/latest (safe default)
+atb train cloud-promote BTCUSDT 2026-07-05_10h30m00s_v1 --to basic
+
+# Only when you intend to change what live strategies load:
+atb train cloud-promote BTCUSDT 2026-07-05_10h30m00s_v1 --to basic --set-latest
+```
+
+Version IDs include seconds (`YYYY-MM-DD_HHhMMmSSs_vN`), so parallel cloud jobs cannot collide; if a name somehow already
+exists locally, the sync writes to a `-2`/`-3` suffixed sibling instead of overwriting the existing bundle.
+
+### Cost expectations and operational notes
+
+- Spot `ml.g4dn.xlarge` (default) bills ~$0.21–0.25/hr; measured runs: a 2-epoch smoke job was 36 billable seconds
+  (~$0.0074), a full-history 1h retrain ≈ $0.37 (~1.3h). Instance startup (~3–4 min) is not billed.
+- Requires `SAGEMAKER_ROLE_ARN`, `SAGEMAKER_S3_BUCKET`, `AWS_REGION`, and `SAGEMAKER_DOCKER_IMAGE` in the environment
+  (one-time infra setup: `src/ml/cloud/README.md`).
+- **Rebuild the ECR image whenever feature engineering changes** (`./src/ml/cloud/build-and-push.sh`) — the container bakes
+  in `src/ml/training_pipeline/`, so a stale image trains with features that diverge from current inference code
+  (train/serve skew).
+
 ## macOS GPU inference verification
 
 macOS users can confirm that ONNX Runtime is activating the CoreML/MPS execution providers introduced in [issue #156](https://github.com/bumpy-croc/ai-trading-bot/issues/156) with the following steps:

--- a/src/ml/cloud/README.md
+++ b/src/ml/cloud/README.md
@@ -50,10 +50,13 @@ atb train cloud BTCUSDT --provider local --days 30 --epochs 10
 
 ## Workflow
 
-1. Build a training job spec from local TrainingConfig.
-2. Upload training data and submit the job to the provider.
-3. Poll for completion and collect metrics.
-4. Download artifacts from S3 and sync into `src/ml/models`.
+1. Download candles locally and upload them to S3 as the job's data channel
+   (Binance blocks AWS IPs, so the container never fetches market data itself).
+2. Build a training job spec from local TrainingConfig and submit it.
+3. Poll for completion and collect metrics (skipped with `--no-wait`).
+4. Download artifacts from S3 and sync into `src/ml/models/{SYMBOL}/price/`.
+5. Optionally promote the bundle into `basic/` with `atb train cloud-promote`
+   (live strategies load `basic/latest`; cloud sync never touches it).
 
 ## Modules
 
@@ -61,6 +64,7 @@ atb train cloud BTCUSDT --provider local --days 30 --epochs 10
 - `orchestrator.py`: End-to-end workflow coordinator and artifact sync.
 - `entrypoint.py`: SageMaker container entrypoint that runs the training pipeline.
 - `artifacts/s3_manager.py`: S3 upload/download helpers and registry sync.
+- `promotion.py`: Explicit promotion of synced bundles between registry namespaces.
 - `providers/`: Provider interface and implementations (`sagemaker`, `local`).
 - `exceptions.py`: Typed errors for cloud training failures.
 
@@ -70,12 +74,29 @@ atb train cloud BTCUSDT --provider local --days 30 --epochs 10
 # Run a cloud training job and wait for completion
 atb train cloud BTCUSDT --timeframe 1h --days 365
 
-# Submit without waiting, then check status later
-atb train cloud BTCUSDT --no-wait
-atb train cloud-status <JOB_ID>
+# Fixed-cutoff window for experiments (UTC dates; --days and --start-date are mutually exclusive)
+atb train cloud BTCUSDT --start-date 2026-05-01 --end-date 2026-06-01 --epochs 50
 
-# List model versions stored in S3
-atb train cloud-list BTCUSDT --model-type basic
+# Submit without waiting (data channel is still uploaded first), then finish later
+atb train cloud BTCUSDT --no-wait
+atb train cloud-status <JOB_NAME>
+atb train cloud-status <JOB_NAME> --sync   # download + sync into the registry
+
+# List cloud training outputs in S3 (job names embed symbol/timeframe/timestamp)
+atb train cloud-list [BTCUSDT]
+
+# Promote a synced bundle into the live namespace (basic/latest only moves with --set-latest)
+atb train cloud-promote BTCUSDT <VERSION> --to basic [--set-latest]
+```
+
+## Keeping the training image fresh
+
+The ECR image bakes in `src/ml/training_pipeline/`. Rebuild and push it whenever
+feature engineering or pipeline code changes, or cloud-trained models will skew
+from current inference code:
+
+```bash
+./src/ml/cloud/build-and-push.sh
 ```
 
 ## Configuration

--- a/src/ml/cloud/artifacts/latest_link.py
+++ b/src/ml/cloud/artifacts/latest_link.py
@@ -1,0 +1,36 @@
+"""Atomic 'latest' symlink updates for the local model registry."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def update_latest_symlink(type_dir: Path, version_id: str) -> None:
+    """Atomically point ``{type_dir}/latest`` at ``version_id``.
+
+    Creates the symlink under a temporary name and swaps it in with
+    ``os.replace`` (atomic on POSIX), so readers never observe a missing
+    ``latest`` during the update.
+
+    Raises:
+        OSError: If the symlink cannot be created or swapped in.
+    """
+    latest_link = type_dir / "latest"
+    temp_link = type_dir / f".latest.{version_id}.tmp"
+
+    # Clean up any stale temp link from an interrupted earlier update
+    if temp_link.exists() or temp_link.is_symlink():
+        temp_link.unlink()
+
+    try:
+        temp_link.symlink_to(version_id)
+        os.replace(str(temp_link), str(latest_link))
+    except OSError:
+        if temp_link.exists() or temp_link.is_symlink():
+            try:
+                temp_link.unlink()
+            except OSError:
+                # Best-effort cleanup — the original error takes precedence
+                pass
+        raise

--- a/src/ml/cloud/artifacts/s3_manager.py
+++ b/src/ml/cloud/artifacts/s3_manager.py
@@ -308,6 +308,47 @@ class S3ArtifactManager:
             logger.warning(f"Failed to list model versions: {exc}")
             return []
 
+    def list_training_jobs(self, symbol: str | None = None) -> list[str]:
+        """List SageMaker training-job outputs stored in this bucket.
+
+        SageMaker writes each job's artifacts to ``models/{job_name}/output/``,
+        so the job-name prefixes under ``models/`` are the actual catalogue of
+        cloud-trained model bundles (job names embed symbol and timeframe,
+        e.g. ``atb-btcusdt-1h-20260704-215649``).
+
+        Args:
+            symbol: Optional trading symbol to filter by (e.g., BTCUSDT)
+
+        Returns:
+            Job names sorted newest first (empty list on error)
+        """
+        self._ensure_client()
+        if self._s3_client is None:
+            raise ArtifactSyncError("S3 client not initialized")
+
+        try:
+            paginator = self._s3_client.get_paginator("list_objects_v2")
+            pages = paginator.paginate(Bucket=self.bucket_name, Prefix="models/", Delimiter="/")
+
+            jobs = []
+            for page in pages:
+                for common_prefix in page.get("CommonPrefixes", []):
+                    job_name = common_prefix["Prefix"].rstrip("/").split("/")[-1]
+                    jobs.append(job_name)
+
+            if symbol:
+                token = f"-{symbol.lower()}-"
+                jobs = [job for job in jobs if token in job]
+
+            # Job names end in YYYYmmdd-HHMMSS, so reverse lexicographic order
+            # is newest-first within a symbol/timeframe
+            jobs.sort(reverse=True)
+            return jobs
+
+        except Exception as exc:
+            logger.warning(f"Failed to list training jobs: {exc}")
+            return []
+
     def _parse_s3_uri(self, s3_uri: str) -> tuple[str, str]:
         """Parse S3 URI into bucket and prefix.
 

--- a/src/ml/cloud/artifacts/s3_manager.py
+++ b/src/ml/cloud/artifacts/s3_manager.py
@@ -346,7 +346,7 @@ class S3ArtifactManager:
             return jobs
 
         except Exception as exc:
-            logger.warning(f"Failed to list training jobs: {exc}")
+            logger.warning("Failed to list training jobs: %s", exc)
             return []
 
     def _parse_s3_uri(self, s3_uri: str) -> tuple[str, str]:

--- a/src/ml/cloud/build-and-push.sh
+++ b/src/ml/cloud/build-and-push.sh
@@ -59,9 +59,16 @@ echo "This may take 5-10 minutes..."
 # Navigate to project root (where Dockerfile expects files)
 cd "$(dirname "$0")/../../.."
 
-# Build with BuildKit for better caching
+# Build with BuildKit for better caching.
+# --platform linux/amd64: SageMaker instances are x86_64; a host-native arm64
+#   image (Apple Silicon) fails at pull time with "no matching manifest".
+# --provenance/--sbom false: attestation manifests turn the push into an OCI
+#   index whose extra entries SageMaker's puller cannot resolve.
 DOCKER_BUILDKIT=1 docker build \
     -f src/ml/cloud/Dockerfile \
+    --platform linux/amd64 \
+    --provenance=false \
+    --sbom=false \
     -t "$REPO_NAME:$IMAGE_TAG" \
     -t "$IMAGE_URI" \
     --progress=plain \

--- a/src/ml/cloud/exceptions.py
+++ b/src/ml/cloud/exceptions.py
@@ -49,6 +49,18 @@ class ArtifactSyncError(CloudTrainingError):
     pass
 
 
+class ModelPromotionError(CloudTrainingError):
+    """Raised when promoting a model version between registry namespaces fails.
+
+    Common causes:
+    - Source version missing or incomplete (no model file)
+    - Target version already exists (never overwritten)
+    - Unsafe path components in symbol/version/type
+    """
+
+    pass
+
+
 class JobTimeoutError(CloudTrainingError):
     """Raised when training job exceeds maximum runtime.
 

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -50,6 +50,9 @@ MAX_JOB_SUFFIX_LENGTH = 100
 # Prevents slow searches on deeply nested directories or large artifact trees
 MAX_METADATA_SEARCH_DEPTH = 100
 
+# Maximum suffix counter when a synced version collides with an existing bundle
+MAX_VERSION_SUFFIX_ATTEMPTS = 1000
+
 
 def _validate_registry_component(value: str, field: str) -> str:
     """Validate a path component used to build local model-registry paths.
@@ -200,21 +203,8 @@ class CloudTrainingOrchestrator:
         start_time = perf_counter()
 
         try:
-            # Step 0: Download training data and upload to S3
-            # This is required because Binance API blocks AWS IP addresses
-            logger.info("Step 0/5: Preparing training data...")
-            s3_uri = self._prepare_training_data()
-            if s3_uri:
-                self.config.input_data_s3_uri = s3_uri
-
-            # Step 1: Build job specification
-            logger.info("Step 1/5: Building training job specification...")
-            job_spec = self._build_job_spec()
-
-            # Step 2: Submit training job
-            logger.info(f"Step 2/5: Submitting job to {self.provider.provider_name}...")
-            job_id = self.provider.submit_training_job(job_spec)
-            logger.info(f"Job submitted: {job_id}")
+            # Steps 0-2: Prepare data, upload to S3, submit job (shared with --no-wait)
+            job_id = self.submit_job()
 
             if not wait:
                 return CloudTrainingResult(
@@ -260,16 +250,52 @@ class CloudTrainingOrchestrator:
             return self._create_failure_result(f"Unexpected error: {exc}", start_time)
 
     def submit_job(self) -> str:
-        """Submit training job without waiting.
+        """Prepare the data channel and submit a training job without waiting.
+
+        Runs the same data-upload step as the blocking workflow: Binance blocks
+        AWS IPs, so a job submitted without an uploaded data channel fails at
+        the in-container fetch.
 
         Returns:
             Job identifier for status checking
 
         Raises:
             JobSubmissionError: If submission fails
+            RuntimeError: If data download or upload fails
         """
+        logger.info("Step 0/5: Preparing training data...")
+        s3_uri = self._prepare_training_data()
+        if s3_uri:
+            self.config.input_data_s3_uri = s3_uri
+
+        logger.info("Step 1/5: Building training job specification...")
         job_spec = self._build_job_spec()
-        return self.provider.submit_training_job(job_spec)
+
+        logger.info(f"Step 2/5: Submitting job to {self.provider.provider_name}...")
+        job_id = self.provider.submit_training_job(job_spec)
+        logger.info(f"Job submitted: {job_id}")
+        return job_id
+
+    def sync_artifacts(self, job_id: str) -> Path:
+        """Download and sync artifacts for a completed job.
+
+        Completes the round trip for jobs submitted with --no-wait
+        (used by ``atb train cloud-status --sync``).
+
+        Args:
+            job_id: Job identifier from submit_job()
+
+        Returns:
+            Path to the synced model directory
+
+        Raises:
+            ArtifactSyncError: If the job is not in a successful terminal state
+                or the download/sync fails
+        """
+        status = self.provider.get_job_status(job_id)
+        if not status.is_successful:
+            raise ArtifactSyncError(f"Cannot sync artifacts for job in state: {status.status}")
+        return self._sync_artifacts(job_id, status.output_s3_path)
 
     def check_status(self, job_id: str) -> CloudTrainingResult:
         """Check status of a submitted training job.
@@ -413,26 +439,38 @@ class CloudTrainingOrchestrator:
             actual_artifact_path = self._find_artifacts_root(artifact_path)
             logger.info(f"Found artifacts at: {actual_artifact_path}")
 
-            # Determine version ID and model type from metadata
+            # Determine version ID, model type, and symbol from metadata
             metadata_path = actual_artifact_path / "metadata.json"
+            metadata: dict = {}
             if metadata_path.exists():
                 with open(metadata_path) as f:
                     metadata = json.load(f)
-                version_id = metadata.get(
-                    "version_id", datetime.now(UTC).strftime("%Y-%m-%d_%Hh_v1")
-                )
-                model_type = metadata.get("model_type", "basic")
-            else:
-                version_id = datetime.now(UTC).strftime("%Y-%m-%d_%Hh_v1")
-                model_type = "basic"
+            fallback_version = datetime.now(UTC).strftime("%Y-%m-%d_%Hh%Mm%Ss_v1")
+            version_id = metadata.get("version_id", fallback_version)
+            model_type = metadata.get("model_type", "basic")
 
             # Validate metadata-supplied path components (see helper docstring).
             version_id = _validate_registry_component(version_id, "version_id")
             model_type = _validate_registry_component(model_type, "model_type")
 
+            # Prefer the bundle's own symbol: for cloud-status --sync the config
+            # symbol is only a placeholder parsed from the job name.
+            config_symbol = self.config.training_config.symbol.upper()
+            metadata_symbol = metadata.get("symbol")
+            if metadata_symbol:
+                symbol = _validate_registry_component(str(metadata_symbol).upper(), "symbol")
+                if symbol != config_symbol:
+                    logger.warning(
+                        "Metadata symbol %s differs from configured symbol %s; "
+                        "syncing under metadata symbol",
+                        symbol,
+                        config_symbol,
+                    )
+            else:
+                symbol = config_symbol
+
             # Sync to local registry
             local_registry = get_project_root() / "src" / "ml" / "models"
-            symbol = self.config.training_config.symbol.upper()
 
             # Artifacts are already extracted locally by provider.download_artifacts()
             # Use _sync_local_artifacts for both local and cloud providers
@@ -510,7 +548,7 @@ class CloudTrainingOrchestrator:
         version_dir = local_registry / symbol / model_type / version_id
 
         # Defense in depth: ensure the resolved target never escapes the registry
-        # before any destructive rmtree/copytree/symlink operation runs.
+        # before any destructive copytree/symlink operation runs.
         registry_root = local_registry.resolve()
         if not version_dir.resolve().is_relative_to(registry_root):
             raise ArtifactSyncError(f"Computed model path escapes registry root: {version_dir}")
@@ -519,10 +557,18 @@ class CloudTrainingOrchestrator:
         if artifact_path.resolve() == version_dir.resolve():
             logger.info(f"Artifacts already at correct registry location: {version_dir}")
         else:
-            # Copy artifacts to registry
-            version_dir.parent.mkdir(parents=True, exist_ok=True)
+            # Never overwrite an existing bundle: a same-name collision (e.g. two
+            # cloud jobs producing identical version IDs) syncs to a suffixed
+            # sibling instead of destroying the earlier model.
             if version_dir.exists():
-                shutil.rmtree(version_dir)
+                version_dir = self._next_free_version_dir(version_dir)
+                logger.warning(
+                    "Version %s already exists in registry; syncing to %s instead",
+                    version_id,
+                    version_dir.name,
+                )
+                version_id = version_dir.name
+            version_dir.parent.mkdir(parents=True, exist_ok=True)
             shutil.copytree(artifact_path, version_dir)
             logger.info(f"Copied artifacts to {version_dir}")
 
@@ -534,6 +580,18 @@ class CloudTrainingOrchestrator:
         logger.info(f"Updated latest symlink: {latest_link} -> {version_id}")
 
         return version_dir
+
+    @staticmethod
+    def _next_free_version_dir(version_dir: Path) -> Path:
+        """Return the first non-existing ``{version_dir}-{n}`` sibling (n >= 2)."""
+        for counter in range(2, MAX_VERSION_SUFFIX_ATTEMPTS + 1):
+            candidate = version_dir.with_name(f"{version_dir.name}-{counter}")
+            if not candidate.exists():
+                return candidate
+        raise ArtifactSyncError(
+            f"Could not find a free version directory after "
+            f"{MAX_VERSION_SUFFIX_ATTEMPTS} attempts for {version_dir}"
+        )
 
 
 class CloudTrainingResult:

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from time import perf_counter
 
 from src.infrastructure.runtime.paths import get_project_root
+from src.ml.cloud.artifacts.latest_link import update_latest_symlink
 from src.ml.cloud.artifacts.s3_manager import S3ArtifactManager
 from src.ml.cloud.config import CloudTrainingConfig
 from src.ml.cloud.exceptions import (
@@ -572,12 +573,10 @@ class CloudTrainingOrchestrator:
             shutil.copytree(artifact_path, version_dir)
             logger.info(f"Copied artifacts to {version_dir}")
 
-        # Update 'latest' symlink
-        latest_link = local_registry / symbol / model_type / "latest"
-        if latest_link.exists() or latest_link.is_symlink():
-            latest_link.unlink()
-        latest_link.symlink_to(version_id)
-        logger.info(f"Updated latest symlink: {latest_link} -> {version_id}")
+        # Update 'latest' symlink atomically so readers never see it missing
+        type_dir = local_registry / symbol / model_type
+        update_latest_symlink(type_dir, version_id)
+        logger.info(f"Updated latest symlink: {type_dir / 'latest'} -> {version_id}")
 
         return version_dir
 

--- a/src/ml/cloud/promotion.py
+++ b/src/ml/cloud/promotion.py
@@ -10,18 +10,15 @@ The ``basic/latest`` symlink is only touched when ``set_latest`` is passed.
 from __future__ import annotations
 
 import logging
-import os
 import re
 import shutil
 from pathlib import Path
 
 from src.infrastructure.runtime.paths import get_project_root
+from src.ml.cloud.artifacts.latest_link import update_latest_symlink
 from src.ml.cloud.exceptions import ModelPromotionError
 
 logger = logging.getLogger(__name__)
-
-# Model bundle is only usable with at least one of these files present.
-_MODEL_FILES = ("model.onnx", "model.keras")
 
 
 def _validate_component(value: str, field: str) -> str:
@@ -34,18 +31,6 @@ def _validate_component(value: str, field: str) -> str:
     if text in (".", "..") or not re.match(r"^[\w\-.]+$", text):
         raise ModelPromotionError(f"Unsafe {field}: {value!r}")
     return text
-
-
-def _update_latest_symlink(type_dir: Path, version_id: str) -> None:
-    """Atomically point ``{type_dir}/latest`` at ``version_id``."""
-    latest_link = type_dir / "latest"
-    temp_link = type_dir / f".latest.{version_id}.tmp"
-
-    if temp_link.exists() or temp_link.is_symlink():
-        temp_link.unlink()
-    temp_link.symlink_to(version_id)
-    # os.replace is atomic on POSIX, so readers never see a missing symlink
-    os.replace(str(temp_link), str(latest_link))
 
 
 def promote_model_version(
@@ -92,9 +77,11 @@ def promote_model_version(
 
     if not source_dir.is_dir():
         raise ModelPromotionError(f"Source version not found: {source_dir}")
-    if not any((source_dir / name).exists() for name in _MODEL_FILES):
+    # Live loading requires ONNX; a keras-only bundle promoted into basic/
+    # would make the strategy fail safe to HOLD and silently stop trading.
+    if not (source_dir / "model.onnx").exists():
         raise ModelPromotionError(
-            f"Source bundle has no model file ({' or '.join(_MODEL_FILES)}): {source_dir}"
+            f"Source bundle has no model.onnx (live loading requires ONNX): {source_dir}"
         )
     if target_dir.exists():
         raise ModelPromotionError(
@@ -106,7 +93,7 @@ def promote_model_version(
     logger.info("Promoted %s/%s/%s -> %s", symbol, source_type, version_id, target_dir)
 
     if set_latest:
-        _update_latest_symlink(target_dir.parent, version_id)
+        update_latest_symlink(target_dir.parent, version_id)
         logger.info("Updated %s/%s/latest -> %s", symbol, target_type, version_id)
 
     return target_dir

--- a/src/ml/cloud/promotion.py
+++ b/src/ml/cloud/promotion.py
@@ -1,0 +1,112 @@
+"""Explicit promotion of model bundles between registry namespaces.
+
+Cloud training syncs bundles into ``{SYMBOL}/price/`` (the ``model_type``
+recorded by the training pipeline), while live strategies load
+``{SYMBOL}/basic/latest``. Promoting a cloud-trained model into the live
+namespace is therefore a deliberate, human-triggered copy — never automatic.
+The ``basic/latest`` symlink is only touched when ``set_latest`` is passed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+
+from src.infrastructure.runtime.paths import get_project_root
+from src.ml.cloud.exceptions import ModelPromotionError
+
+logger = logging.getLogger(__name__)
+
+# Model bundle is only usable with at least one of these files present.
+_MODEL_FILES = ("model.onnx", "model.keras")
+
+
+def _validate_component(value: str, field: str) -> str:
+    """Validate a user-supplied path component used inside the registry.
+
+    Symbol, model type, and version id become directory names under the
+    registry root; anything containing separators or ``..`` could escape it.
+    """
+    text = str(value)
+    if text in (".", "..") or not re.match(r"^[\w\-.]+$", text):
+        raise ModelPromotionError(f"Unsafe {field}: {value!r}")
+    return text
+
+
+def _update_latest_symlink(type_dir: Path, version_id: str) -> None:
+    """Atomically point ``{type_dir}/latest`` at ``version_id``."""
+    latest_link = type_dir / "latest"
+    temp_link = type_dir / f".latest.{version_id}.tmp"
+
+    if temp_link.exists() or temp_link.is_symlink():
+        temp_link.unlink()
+    temp_link.symlink_to(version_id)
+    # os.replace is atomic on POSIX, so readers never see a missing symlink
+    os.replace(str(temp_link), str(latest_link))
+
+
+def promote_model_version(
+    symbol: str,
+    version_id: str,
+    source_type: str = "price",
+    target_type: str = "basic",
+    set_latest: bool = False,
+    registry_root: Path | None = None,
+) -> Path:
+    """Copy a model bundle from one registry namespace to another.
+
+    Args:
+        symbol: Trading symbol (e.g., BTCUSDT)
+        version_id: Version directory name to promote
+        source_type: Namespace the bundle currently lives in (default: price)
+        target_type: Namespace to copy the bundle into (default: basic)
+        set_latest: Also point ``{target_type}/latest`` at the promoted version.
+            Without this flag the live-loading symlink is never touched.
+        registry_root: Model registry root (default: ``src/ml/models``)
+
+    Returns:
+        Path to the promoted bundle directory
+
+    Raises:
+        ModelPromotionError: If the source is missing/incomplete, the target
+            already exists, or any path component is unsafe.
+    """
+    symbol = _validate_component(symbol, "symbol").upper()
+    version_id = _validate_component(version_id, "version_id")
+    source_type = _validate_component(source_type, "source_type")
+    target_type = _validate_component(target_type, "target_type")
+
+    root = registry_root or (get_project_root() / "src" / "ml" / "models")
+    source_dir = root / symbol / source_type / version_id
+    target_dir = root / symbol / target_type / version_id
+
+    # Defense in depth: validated components cannot escape, but check anyway
+    # before any filesystem mutation.
+    root_resolved = root.resolve()
+    for candidate in (source_dir, target_dir):
+        if not candidate.resolve().is_relative_to(root_resolved):
+            raise ModelPromotionError(f"Path escapes registry root: {candidate}")
+
+    if not source_dir.is_dir():
+        raise ModelPromotionError(f"Source version not found: {source_dir}")
+    if not any((source_dir / name).exists() for name in _MODEL_FILES):
+        raise ModelPromotionError(
+            f"Source bundle has no model file ({' or '.join(_MODEL_FILES)}): {source_dir}"
+        )
+    if target_dir.exists():
+        raise ModelPromotionError(
+            f"Target version already exists, refusing to overwrite: {target_dir}"
+        )
+
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source_dir, target_dir)
+    logger.info("Promoted %s/%s/%s -> %s", symbol, source_type, version_id, target_dir)
+
+    if set_latest:
+        _update_latest_symlink(target_dir.parent, version_id)
+        logger.info("Updated %s/%s/latest -> %s", symbol, target_type, version_id)
+
+    return target_dir

--- a/src/ml/cloud/requirements-cloud.txt
+++ b/src/ml/cloud/requirements-cloud.txt
@@ -8,8 +8,11 @@ scikit-learn>=1.3.2
 pandas>=2.1.4
 numpy<2.0.0,>=1.23.5
 
-# Model export - TensorFlow 2.15 requires protobuf<5
-onnx>=1.15.0
+# Model export - TensorFlow 2.15 requires protobuf<5.
+# onnx must stay <1.18: newer onnx imports float4 types from ml_dtypes that
+# TF 2.15's pinned ml-dtypes lacks, breaking tf2onnx at import time and
+# silently producing bundles without model.onnx.
+onnx>=1.15.0,<1.18
 onnxruntime>=1.17.0
 tf2onnx>=1.16.0
 protobuf<5.0.0,>=3.20.3

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -57,7 +57,11 @@ def _generate_version_id(models_dir: Path, symbol: str, model_type: str) -> str:
     """Generate auto-incrementing version ID to prevent collisions.
 
     Checks if version directory exists and increments counter until finding
-    a unique version ID. Format: YYYY-MM-DD_HHh_vN where N starts at 1.
+    a unique version ID. Format: YYYY-MM-DD_HHhMMmSSs_vN where N starts at 1.
+
+    Second-level granularity keeps IDs unique across cloud training containers,
+    where each job sees an empty models dir and the exists() counter cannot
+    de-duplicate against sibling jobs started in the same hour.
 
     Args:
         models_dir: Root models directory
@@ -70,7 +74,7 @@ def _generate_version_id(models_dir: Path, symbol: str, model_type: str) -> str:
     Raises:
         RuntimeError: If unable to generate unique version ID after max retries
     """
-    base_timestamp = datetime.now(UTC).strftime("%Y-%m-%d_%Hh")
+    base_timestamp = datetime.now(UTC).strftime("%Y-%m-%d_%Hh%Mm%Ss")
     version_counter = 1
 
     while version_counter <= MAX_VERSION_GENERATION_RETRIES:

--- a/tests/unit/cloud/test_latest_link.py
+++ b/tests/unit/cloud/test_latest_link.py
@@ -1,0 +1,57 @@
+"""Unit tests for the shared atomic 'latest' symlink helper."""
+
+from pathlib import Path
+
+import pytest
+
+from src.ml.cloud.artifacts.latest_link import update_latest_symlink
+
+
+@pytest.mark.fast
+class TestUpdateLatestSymlink:
+    """Tests for update_latest_symlink atomicity semantics."""
+
+    def test_creates_link_when_absent(self, tmp_path: Path) -> None:
+        (tmp_path / "v1").mkdir()
+
+        update_latest_symlink(tmp_path, "v1")
+
+        latest = tmp_path / "latest"
+        assert latest.is_symlink()
+        assert latest.resolve() == (tmp_path / "v1").resolve()
+
+    def test_replaces_existing_link(self, tmp_path: Path) -> None:
+        (tmp_path / "v1").mkdir()
+        (tmp_path / "v2").mkdir()
+        (tmp_path / "latest").symlink_to("v1")
+
+        update_latest_symlink(tmp_path, "v2")
+
+        latest = tmp_path / "latest"
+        assert latest.is_symlink()
+        assert latest.resolve() == (tmp_path / "v2").resolve()
+
+    def test_no_temp_link_left_behind(self, tmp_path: Path) -> None:
+        (tmp_path / "v1").mkdir()
+
+        update_latest_symlink(tmp_path, "v1")
+
+        leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".latest.")]
+        assert leftovers == []
+
+    def test_cleans_stale_temp_link(self, tmp_path: Path) -> None:
+        (tmp_path / "v1").mkdir()
+        # Stale temp link from an interrupted earlier update
+        (tmp_path / ".latest.v1.tmp").symlink_to("v1")
+
+        update_latest_symlink(tmp_path, "v1")
+
+        assert (tmp_path / "latest").is_symlink()
+        assert not (tmp_path / ".latest.v1.tmp").is_symlink()
+
+    def test_failure_cleans_temp_and_raises(self, tmp_path: Path) -> None:
+        # Missing type_dir makes symlink creation fail
+        missing_dir = tmp_path / "does-not-exist"
+
+        with pytest.raises(OSError):
+            update_latest_symlink(missing_dir, "v1")

--- a/tests/unit/cloud/test_orchestrator.py
+++ b/tests/unit/cloud/test_orchestrator.py
@@ -1,5 +1,6 @@
 """Unit tests for cloud training orchestrator."""
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -144,8 +145,10 @@ class TestSubmitJob:
             storage_config=CloudStorageConfig(s3_bucket="test-bucket"),
         )
 
+    @pytest.mark.fast
     def test_submit_job_returns_job_id(self, cloud_config: CloudTrainingConfig) -> None:
         """Verify submit_job returns job ID from provider."""
+        cloud_config.input_data_s3_uri = "s3://test-bucket/training-data/BTCUSDT"
         mock_provider = MagicMock()
         mock_provider.submit_training_job.return_value = "job-123"
 
@@ -154,6 +157,55 @@ class TestSubmitJob:
 
         assert job_id == "job-123"
         mock_provider.submit_training_job.assert_called_once()
+
+    @pytest.mark.fast
+    def test_submit_job_uploads_data_channel(self, cloud_config: CloudTrainingConfig) -> None:
+        """submit_job must run the same data-upload step as run_training.
+
+        Without an uploaded data channel the in-container Binance fetch fails
+        (AWS IPs are blocked), which is why --no-wait used to be broken.
+        """
+        mock_provider = MagicMock()
+        mock_provider.submit_training_job.return_value = "job-async"
+        mock_s3_manager = MagicMock()
+        mock_s3_manager.upload_training_data.return_value = "s3://test-bucket/data/BTCUSDT"
+
+        orchestrator = CloudTrainingOrchestrator(
+            cloud_config, mock_provider, s3_manager=mock_s3_manager
+        )
+
+        def mock_download_func(args: MagicMock) -> int:
+            csv_path = Path(args.output_dir) / "BTCUSDT_1h_2024.csv"
+            csv_path.write_text("timestamp,open,high,low,close,volume\n2024-01-01,1,1,1,1,1")
+            return 0
+
+        with patch("cli.commands.data._download", side_effect=mock_download_func):
+            job_id = orchestrator.submit_job()
+
+        assert job_id == "job-async"
+        mock_s3_manager.upload_training_data.assert_called_once()
+        spec = mock_provider.submit_training_job.call_args.args[0]
+        assert spec.input_data_s3_uri == "s3://test-bucket/data/BTCUSDT"
+
+    @pytest.mark.fast
+    def test_submit_job_skips_upload_when_uri_provided(
+        self, cloud_config: CloudTrainingConfig
+    ) -> None:
+        """Verify submit_job skips data prep when input_data_s3_uri is preset."""
+        cloud_config.input_data_s3_uri = "s3://existing-bucket/data"
+        mock_provider = MagicMock()
+        mock_provider.submit_training_job.return_value = "job-preset"
+        mock_s3_manager = MagicMock()
+
+        orchestrator = CloudTrainingOrchestrator(
+            cloud_config, mock_provider, s3_manager=mock_s3_manager
+        )
+        job_id = orchestrator.submit_job()
+
+        assert job_id == "job-preset"
+        mock_s3_manager.upload_training_data.assert_not_called()
+        spec = mock_provider.submit_training_job.call_args.args[0]
+        assert spec.input_data_s3_uri == "s3://existing-bucket/data"
 
 
 class TestRunTrainingNoWait:
@@ -542,3 +594,170 @@ class TestFindArtifactsRoot:
         result = orchestrator._find_artifacts_root(tmp_path)
 
         assert result == nested_dir
+
+
+def _make_orchestrator(symbol: str = "BTCUSDT") -> CloudTrainingOrchestrator:
+    """Build an orchestrator with a mocked provider for sync tests."""
+    training_config = TrainingConfig(
+        symbol=symbol,
+        timeframe="1h",
+        start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 12, 1),
+        epochs=50,
+    )
+    cloud_config = CloudTrainingConfig(
+        training_config=training_config,
+        storage_config=CloudStorageConfig(s3_bucket="test-bucket"),
+    )
+    return CloudTrainingOrchestrator(cloud_config, MagicMock())
+
+
+@pytest.mark.fast
+class TestSyncLocalArtifactsCollision:
+    """Version collisions must never destroy an existing model bundle."""
+
+    def test_existing_version_dir_is_never_deleted(self, tmp_path: Path) -> None:
+        orchestrator = _make_orchestrator()
+        registry = tmp_path / "registry"
+        existing = registry / "BTCUSDT" / "price" / "2026-07-05_10h_v1"
+        existing.mkdir(parents=True)
+        (existing / "model.onnx").write_text("first-job-model")
+
+        artifact = tmp_path / "artifact"
+        artifact.mkdir()
+        (artifact / "model.onnx").write_text("second-job-model")
+
+        result = orchestrator._sync_local_artifacts(
+            artifact_path=artifact,
+            local_registry=registry,
+            symbol="BTCUSDT",
+            model_type="price",
+            version_id="2026-07-05_10h_v1",
+        )
+
+        # The first bundle survives untouched.
+        assert (existing / "model.onnx").read_text() == "first-job-model"
+        # The second bundle lands in a distinct sibling directory.
+        assert result != existing
+        assert result.parent == existing.parent
+        assert (result / "model.onnx").read_text() == "second-job-model"
+
+    def test_collision_updates_latest_to_new_bundle(self, tmp_path: Path) -> None:
+        orchestrator = _make_orchestrator()
+        registry = tmp_path / "registry"
+        existing = registry / "BTCUSDT" / "price" / "2026-07-05_10h_v1"
+        existing.mkdir(parents=True)
+        (existing / "model.onnx").write_text("first")
+
+        artifact = tmp_path / "artifact"
+        artifact.mkdir()
+        (artifact / "model.onnx").write_text("second")
+
+        result = orchestrator._sync_local_artifacts(
+            artifact_path=artifact,
+            local_registry=registry,
+            symbol="BTCUSDT",
+            model_type="price",
+            version_id="2026-07-05_10h_v1",
+        )
+
+        latest = registry / "BTCUSDT" / "price" / "latest"
+        assert latest.is_symlink()
+        assert latest.resolve() == result.resolve()
+
+    def test_repeated_collisions_pick_next_free_suffix(self, tmp_path: Path) -> None:
+        orchestrator = _make_orchestrator()
+        registry = tmp_path / "registry"
+        base = registry / "BTCUSDT" / "price"
+        (base / "2026-07-05_10h_v1").mkdir(parents=True)
+        (base / "2026-07-05_10h_v1-2").mkdir()
+
+        artifact = tmp_path / "artifact"
+        artifact.mkdir()
+        (artifact / "model.onnx").write_text("third")
+
+        result = orchestrator._sync_local_artifacts(
+            artifact_path=artifact,
+            local_registry=registry,
+            symbol="BTCUSDT",
+            model_type="price",
+            version_id="2026-07-05_10h_v1",
+        )
+
+        assert result == base / "2026-07-05_10h_v1-3"
+
+
+@pytest.mark.fast
+class TestSyncArtifactsUsesMetadataSymbol:
+    """_sync_artifacts must trust the bundle's own symbol over the config."""
+
+    def test_symbol_from_metadata_wins(self, tmp_path: Path) -> None:
+        orchestrator = _make_orchestrator(symbol="BTCUSDT")
+        metadata = {
+            "symbol": "ETHUSDT",
+            "model_type": "price",
+            "version_id": "2026-07-05_10h00m00s_v1",
+        }
+
+        def fake_download(job_id: str, temp_dir: Path) -> Path:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            (temp_dir / "metadata.json").write_text(json.dumps(metadata))
+            (temp_dir / "model.onnx").write_text("model-bytes")
+            return temp_dir
+
+        orchestrator.provider.download_artifacts.side_effect = fake_download
+
+        with patch("src.ml.cloud.orchestrator.get_project_root", return_value=tmp_path):
+            result = orchestrator._sync_artifacts("job-1", "s3://bucket/out/model.tar.gz")
+
+        expected = (
+            tmp_path / "src" / "ml" / "models" / "ETHUSDT" / "price" / "2026-07-05_10h00m00s_v1"
+        )
+        assert result == expected
+        assert (expected / "model.onnx").exists()
+
+    def test_falls_back_to_config_symbol_without_metadata(self, tmp_path: Path) -> None:
+        orchestrator = _make_orchestrator(symbol="BTCUSDT")
+
+        def fake_download(job_id: str, temp_dir: Path) -> Path:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            (temp_dir / "model.onnx").write_text("model-bytes")
+            return temp_dir
+
+        orchestrator.provider.download_artifacts.side_effect = fake_download
+
+        with patch("src.ml.cloud.orchestrator.get_project_root", return_value=tmp_path):
+            result = orchestrator._sync_artifacts("job-2", "s3://bucket/out/model.tar.gz")
+
+        assert result.parent.parent.name == "BTCUSDT"
+
+
+@pytest.mark.fast
+class TestSyncArtifactsPublic:
+    """Tests for the public sync_artifacts entry point (cloud-status --sync)."""
+
+    def test_raises_for_unsuccessful_job(self) -> None:
+        orchestrator = _make_orchestrator()
+        orchestrator.provider.get_job_status.return_value = TrainingJobStatus(
+            job_name="job-1",
+            status="InProgress",
+        )
+
+        with pytest.raises(ArtifactSyncError, match="state"):
+            orchestrator.sync_artifacts("job-1")
+
+    def test_syncs_completed_job(self) -> None:
+        orchestrator = _make_orchestrator()
+        orchestrator.provider.get_job_status.return_value = TrainingJobStatus(
+            job_name="job-1",
+            status="Completed",
+            output_s3_path="s3://bucket/out/model.tar.gz",
+        )
+
+        with patch.object(
+            orchestrator, "_sync_artifacts", return_value=Path("/synced/path")
+        ) as mock_sync:
+            result = orchestrator.sync_artifacts("job-1")
+
+        assert result == Path("/synced/path")
+        mock_sync.assert_called_once_with("job-1", "s3://bucket/out/model.tar.gz")

--- a/tests/unit/cloud/test_orchestrator.py
+++ b/tests/unit/cloud/test_orchestrator.py
@@ -686,6 +686,32 @@ class TestSyncLocalArtifactsCollision:
 
         assert result == base / "2026-07-05_10h_v1-3"
 
+    def test_sync_updates_latest_via_atomic_helper(self, tmp_path: Path) -> None:
+        """The sync path must use the shared atomic symlink helper.
+
+        A plain unlink-then-symlink leaves a window where readers see no
+        'latest' at all.
+        """
+        orchestrator = _make_orchestrator()
+        registry = tmp_path / "registry"
+        artifact = tmp_path / "artifact"
+        artifact.mkdir()
+        (artifact / "model.onnx").write_text("model")
+
+        with patch("src.ml.cloud.orchestrator.update_latest_symlink") as mock_update:
+            result = orchestrator._sync_local_artifacts(
+                artifact_path=artifact,
+                local_registry=registry,
+                symbol="BTCUSDT",
+                model_type="price",
+                version_id="2026-07-06_10h00m00s_v1",
+            )
+
+        mock_update.assert_called_once_with(
+            registry / "BTCUSDT" / "price", "2026-07-06_10h00m00s_v1"
+        )
+        assert result == registry / "BTCUSDT" / "price" / "2026-07-06_10h00m00s_v1"
+
 
 @pytest.mark.fast
 class TestSyncArtifactsUsesMetadataSymbol:

--- a/tests/unit/cloud/test_promotion.py
+++ b/tests/unit/cloud/test_promotion.py
@@ -1,0 +1,113 @@
+"""Unit tests for cloud model promotion (price/ -> basic/)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.ml.cloud.exceptions import ModelPromotionError
+from src.ml.cloud.promotion import promote_model_version
+
+VERSION = "2026-07-05_10h00m00s_v1"
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Path:
+    """Create a registry with a cloud-trained bundle under BTCUSDT/price/."""
+    source_dir = tmp_path / "BTCUSDT" / "price" / VERSION
+    source_dir.mkdir(parents=True)
+    (source_dir / "model.onnx").write_text("onnx-bytes")
+    (source_dir / "feature_schema.json").write_text("{}")
+    metadata = {"symbol": "BTCUSDT", "training_date": "2026-07-05", "version_id": VERSION}
+    (source_dir / "metadata.json").write_text(json.dumps(metadata))
+    # price/latest points at the cloud-synced bundle
+    (tmp_path / "BTCUSDT" / "price" / "latest").symlink_to(VERSION)
+    return tmp_path
+
+
+@pytest.mark.fast
+class TestPromoteModelVersion:
+    """Tests for promote_model_version."""
+
+    def test_copies_bundle_to_target_type(self, registry: Path) -> None:
+        target = promote_model_version("BTCUSDT", VERSION, registry_root=registry)
+
+        expected = registry / "BTCUSDT" / "basic" / VERSION
+        assert target == expected
+        assert (expected / "model.onnx").read_text() == "onnx-bytes"
+        assert (expected / "metadata.json").exists()
+        assert (expected / "feature_schema.json").exists()
+
+    def test_source_bundle_left_intact(self, registry: Path) -> None:
+        promote_model_version("BTCUSDT", VERSION, registry_root=registry)
+
+        source = registry / "BTCUSDT" / "price" / VERSION
+        assert (source / "model.onnx").read_text() == "onnx-bytes"
+
+    def test_does_not_create_latest_by_default(self, registry: Path) -> None:
+        promote_model_version("BTCUSDT", VERSION, registry_root=registry)
+
+        assert not (registry / "BTCUSDT" / "basic" / "latest").is_symlink()
+        assert not (registry / "BTCUSDT" / "basic" / "latest").exists()
+
+    def test_preserves_existing_latest_by_default(self, registry: Path) -> None:
+        basic_dir = registry / "BTCUSDT" / "basic"
+        basic_dir.mkdir(parents=True)
+        live_version = basic_dir / "2025-10-30_12h_v1"
+        live_version.mkdir()
+        (basic_dir / "latest").symlink_to(live_version.name)
+
+        promote_model_version("BTCUSDT", VERSION, registry_root=registry)
+
+        assert (basic_dir / "latest").resolve() == live_version.resolve()
+
+    def test_set_latest_updates_symlink(self, registry: Path) -> None:
+        basic_dir = registry / "BTCUSDT" / "basic"
+        basic_dir.mkdir(parents=True)
+        live_version = basic_dir / "2025-10-30_12h_v1"
+        live_version.mkdir()
+        (basic_dir / "latest").symlink_to(live_version.name)
+
+        promote_model_version("BTCUSDT", VERSION, set_latest=True, registry_root=registry)
+
+        assert (basic_dir / "latest").resolve() == (basic_dir / VERSION).resolve()
+
+    def test_refuses_to_overwrite_existing_target(self, registry: Path) -> None:
+        existing = registry / "BTCUSDT" / "basic" / VERSION
+        existing.mkdir(parents=True)
+        (existing / "model.onnx").write_text("pre-existing")
+
+        with pytest.raises(ModelPromotionError, match="already exists"):
+            promote_model_version("BTCUSDT", VERSION, registry_root=registry)
+
+        assert (existing / "model.onnx").read_text() == "pre-existing"
+
+    def test_missing_source_rejected(self, registry: Path) -> None:
+        with pytest.raises(ModelPromotionError, match="not found"):
+            promote_model_version("BTCUSDT", "2099-01-01_00h00m00s_v1", registry_root=registry)
+
+    def test_source_without_model_file_rejected(self, registry: Path) -> None:
+        bad_version = "2026-07-05_11h00m00s_v1"
+        bad_dir = registry / "BTCUSDT" / "price" / bad_version
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "metadata.json").write_text("{}")
+
+        with pytest.raises(ModelPromotionError, match="model file"):
+            promote_model_version("BTCUSDT", bad_version, registry_root=registry)
+
+    @pytest.mark.parametrize("bad_component", ["..", "a/b", "", "x/../y"])
+    def test_unsafe_path_components_rejected(self, registry: Path, bad_component: str) -> None:
+        with pytest.raises(ModelPromotionError):
+            promote_model_version(bad_component, VERSION, registry_root=registry)
+
+    def test_custom_source_and_target_types(self, registry: Path) -> None:
+        target = promote_model_version(
+            "BTCUSDT",
+            VERSION,
+            source_type="price",
+            target_type="scratch",
+            registry_root=registry,
+        )
+
+        assert target == registry / "BTCUSDT" / "scratch" / VERSION
+        assert (target / "model.onnx").exists()

--- a/tests/unit/cloud/test_promotion.py
+++ b/tests/unit/cloud/test_promotion.py
@@ -92,8 +92,26 @@ class TestPromoteModelVersion:
         bad_dir.mkdir(parents=True)
         (bad_dir / "metadata.json").write_text("{}")
 
-        with pytest.raises(ModelPromotionError, match="model file"):
+        with pytest.raises(ModelPromotionError, match="model.onnx"):
             promote_model_version("BTCUSDT", bad_version, registry_root=registry)
+
+    def test_keras_only_bundle_refused(self, registry: Path) -> None:
+        """A bundle without model.onnx must never be promoted.
+
+        Live loading requires ONNX; promoting a keras-only bundle into basic/
+        (especially with --set-latest) would silently disable live trading.
+        """
+        keras_version = "2026-07-05_12h00m00s_v1"
+        keras_dir = registry / "BTCUSDT" / "price" / keras_version
+        keras_dir.mkdir(parents=True)
+        (keras_dir / "model.keras").write_text("keras-bytes")
+        (keras_dir / "metadata.json").write_text("{}")
+
+        with pytest.raises(ModelPromotionError, match="model.onnx"):
+            promote_model_version("BTCUSDT", keras_version, set_latest=True, registry_root=registry)
+
+        assert not (registry / "BTCUSDT" / "basic" / keras_version).exists()
+        assert not (registry / "BTCUSDT" / "basic" / "latest").is_symlink()
 
     @pytest.mark.parametrize("bad_component", ["..", "a/b", "", "x/../y"])
     def test_unsafe_path_components_rejected(self, registry: Path, bad_component: str) -> None:

--- a/tests/unit/cloud/test_s3_manager.py
+++ b/tests/unit/cloud/test_s3_manager.py
@@ -190,6 +190,63 @@ class TestSymlinkUpdate:
         assert latest_link.resolve() == new_version.resolve()
 
 
+@pytest.mark.fast
+class TestListTrainingJobs:
+    """Tests for listing SageMaker training-job outputs under models/."""
+
+    @pytest.fixture
+    def manager(self) -> S3ArtifactManager:
+        """Create a manager with a mocked S3 client and paginator."""
+        from unittest.mock import MagicMock
+
+        manager = S3ArtifactManager(bucket_name="test-bucket")
+        mock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "CommonPrefixes": [
+                    {"Prefix": "models/atb-btcusdt-1h-20260111-024904/"},
+                    {"Prefix": "models/atb-btcusdt-1h-20260704-215649/"},
+                    {"Prefix": "models/atb-ethusdt-1h-20260120-005532/"},
+                ]
+            }
+        ]
+        mock_client.get_paginator.return_value = paginator
+        manager._s3_client = mock_client
+        return manager
+
+    def test_lists_all_job_outputs_newest_first(self, manager: S3ArtifactManager) -> None:
+        jobs = manager.list_training_jobs()
+
+        assert jobs == [
+            "atb-ethusdt-1h-20260120-005532",
+            "atb-btcusdt-1h-20260704-215649",
+            "atb-btcusdt-1h-20260111-024904",
+        ]
+
+    def test_filters_by_symbol(self, manager: S3ArtifactManager) -> None:
+        jobs = manager.list_training_jobs(symbol="BTCUSDT")
+
+        assert jobs == [
+            "atb-btcusdt-1h-20260704-215649",
+            "atb-btcusdt-1h-20260111-024904",
+        ]
+
+    def test_uses_models_prefix_with_delimiter(self, manager: S3ArtifactManager) -> None:
+        manager.list_training_jobs()
+
+        assert manager._s3_client is not None
+        paginate_kwargs = manager._s3_client.get_paginator.return_value.paginate.call_args.kwargs
+        assert paginate_kwargs["Prefix"] == "models/"
+        assert paginate_kwargs["Delimiter"] == "/"
+
+    def test_returns_empty_list_on_error(self, manager: S3ArtifactManager) -> None:
+        assert manager._s3_client is not None
+        manager._s3_client.get_paginator.side_effect = RuntimeError("boom")
+
+        assert manager.list_training_jobs() == []
+
+
 class TestBoto3LazyLoading:
     """Tests for boto3 lazy loading behavior."""
 

--- a/tests/unit/cloud/test_train_cloud_cli.py
+++ b/tests/unit/cloud/test_train_cloud_cli.py
@@ -1,14 +1,23 @@
 """Unit tests for the `atb train cloud*` CLI helpers."""
 
+import argparse
 from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from cli.commands.train_cloud import (
     DEFAULT_TRAINING_DAYS,
+    _handle_cloud_list,
+    _handle_cloud_promote,
+    _handle_cloud_status,
     _parse_job_name,
     _resolve_date_range,
+    _sync_job_artifacts,
 )
+from src.ml.cloud.exceptions import ModelPromotionError
+from src.ml.cloud.providers.base import TrainingJobStatus
 
 
 @pytest.mark.fast
@@ -99,3 +108,205 @@ class TestParseJobName:
             "atb-btcusdt-1h-20260704-215649"
         )
         assert _parse_job_name(arn) == ("BTCUSDT", "1h")
+
+
+def _ns(args: list[str]) -> argparse.Namespace:
+    """Build the REMAINDER-style namespace the handlers receive."""
+    return argparse.Namespace(args=args)
+
+
+@pytest.mark.fast
+class TestHandleCloudPromote:
+    """Tests for the cloud-promote CLI handler."""
+
+    def test_promotes_with_defaults(self, tmp_path: Path) -> None:
+        with patch(
+            "src.ml.cloud.promotion.promote_model_version",
+            return_value=tmp_path / "BTCUSDT" / "basic" / "v1",
+        ) as mock_promote:
+            rc = _handle_cloud_promote(_ns(["BTCUSDT", "2026-07-05_10h00m00s_v1"]))
+
+        assert rc == 0
+        mock_promote.assert_called_once_with(
+            symbol="BTCUSDT",
+            version_id="2026-07-05_10h00m00s_v1",
+            source_type="price",
+            target_type="basic",
+            set_latest=False,
+        )
+
+    def test_set_latest_flag_is_threaded(self, tmp_path: Path) -> None:
+        with patch(
+            "src.ml.cloud.promotion.promote_model_version",
+            return_value=tmp_path / "BTCUSDT" / "basic" / "v1",
+        ) as mock_promote:
+            rc = _handle_cloud_promote(_ns(["BTCUSDT", "v1", "--set-latest"]))
+
+        assert rc == 0
+        assert mock_promote.call_args.kwargs["set_latest"] is True
+
+    def test_custom_source_and_target(self, tmp_path: Path) -> None:
+        with patch(
+            "src.ml.cloud.promotion.promote_model_version",
+            return_value=tmp_path / "BTCUSDT" / "scratch" / "v1",
+        ) as mock_promote:
+            rc = _handle_cloud_promote(_ns(["BTCUSDT", "v1", "--from", "price", "--to", "scratch"]))
+
+        assert rc == 0
+        assert mock_promote.call_args.kwargs["source_type"] == "price"
+        assert mock_promote.call_args.kwargs["target_type"] == "scratch"
+
+    def test_promotion_error_returns_1(self) -> None:
+        with patch(
+            "src.ml.cloud.promotion.promote_model_version",
+            side_effect=ModelPromotionError("Target version already exists"),
+        ):
+            rc = _handle_cloud_promote(_ns(["BTCUSDT", "v1"]))
+
+        assert rc == 1
+
+
+@pytest.mark.fast
+class TestSyncJobArtifacts:
+    """Tests for the cloud-status --sync round-trip helper."""
+
+    def test_syncs_using_symbol_from_job_name(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.sync_artifacts.return_value = tmp_path / "synced"
+
+        with (
+            patch.dict("os.environ", {"SAGEMAKER_S3_BUCKET": "test-bucket"}),
+            patch(
+                "src.ml.cloud.orchestrator.CloudTrainingOrchestrator",
+                return_value=mock_orchestrator,
+            ) as mock_cls,
+        ):
+            rc = _sync_job_artifacts(
+                "atb-btcusdt-1h-20260705-181756",
+                "atb-btcusdt-1h-20260705-181756",
+                None,
+                provider,
+            )
+
+        assert rc == 0
+        mock_orchestrator.sync_artifacts.assert_called_once_with("atb-btcusdt-1h-20260705-181756")
+        cloud_config = mock_cls.call_args.args[0]
+        assert cloud_config.training_config.symbol == "BTCUSDT"
+        assert cloud_config.training_config.timeframe == "1h"
+
+    def test_symbol_override_used_for_custom_job_names(self, tmp_path: Path) -> None:
+        provider = MagicMock()
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.sync_artifacts.return_value = tmp_path / "synced"
+
+        with (
+            patch.dict("os.environ", {"SAGEMAKER_S3_BUCKET": "test-bucket"}),
+            patch(
+                "src.ml.cloud.orchestrator.CloudTrainingOrchestrator",
+                return_value=mock_orchestrator,
+            ) as mock_cls,
+        ):
+            rc = _sync_job_artifacts("custom-job", "custom-job", "ethusdt", provider)
+
+        assert rc == 0
+        assert mock_cls.call_args.args[0].training_config.symbol == "ETHUSDT"
+
+    def test_underivable_symbol_returns_1(self) -> None:
+        rc = _sync_job_artifacts("custom-job", "custom-job", None, MagicMock())
+
+        assert rc == 1
+
+    def test_sync_failure_returns_1(self) -> None:
+        provider = MagicMock()
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.sync_artifacts.side_effect = RuntimeError("download failed")
+
+        with (
+            patch.dict("os.environ", {"SAGEMAKER_S3_BUCKET": "test-bucket"}),
+            patch(
+                "src.ml.cloud.orchestrator.CloudTrainingOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+        ):
+            rc = _sync_job_artifacts(
+                "atb-btcusdt-1h-20260705-181756",
+                "atb-btcusdt-1h-20260705-181756",
+                None,
+                provider,
+            )
+
+        assert rc == 1
+
+
+@pytest.mark.fast
+class TestHandleCloudStatusSync:
+    """Tests for --sync wiring in the cloud-status handler."""
+
+    def _provider_with_status(self, status: TrainingJobStatus) -> MagicMock:
+        provider = MagicMock()
+        provider.is_available.return_value = True
+        provider.get_job_status.return_value = status
+        return provider
+
+    def test_sync_dispatches_for_completed_job(self) -> None:
+        status = TrainingJobStatus(
+            job_name="atb-btcusdt-1h-20260705-181756",
+            status="Completed",
+            output_s3_path="s3://bucket/out/model.tar.gz",
+        )
+        provider = self._provider_with_status(status)
+
+        with (
+            patch("src.ml.cloud.providers.get_provider", return_value=provider),
+            patch("cli.commands.train_cloud._sync_job_artifacts", return_value=0) as mock_sync,
+        ):
+            rc = _handle_cloud_status(_ns(["atb-btcusdt-1h-20260705-181756", "--sync"]))
+
+        assert rc == 0
+        mock_sync.assert_called_once_with(
+            "atb-btcusdt-1h-20260705-181756",
+            "atb-btcusdt-1h-20260705-181756",
+            None,
+            provider,
+        )
+
+    def test_sync_refused_for_incomplete_job(self) -> None:
+        status = TrainingJobStatus(job_name="job-1", status="InProgress")
+        provider = self._provider_with_status(status)
+
+        with (
+            patch("src.ml.cloud.providers.get_provider", return_value=provider),
+            patch("cli.commands.train_cloud._sync_job_artifacts") as mock_sync,
+        ):
+            rc = _handle_cloud_status(_ns(["job-1", "--sync"]))
+
+        assert rc == 1
+        mock_sync.assert_not_called()
+
+
+@pytest.mark.fast
+class TestHandleCloudList:
+    """Tests for the cloud-list handler."""
+
+    def test_lists_jobs_from_s3(self) -> None:
+        mock_manager = MagicMock()
+        mock_manager.list_training_jobs.return_value = ["atb-btcusdt-1h-20260704-215649"]
+
+        with (
+            patch.dict("os.environ", {"SAGEMAKER_S3_BUCKET": "test-bucket"}),
+            patch(
+                "src.ml.cloud.artifacts.s3_manager.S3ArtifactManager",
+                return_value=mock_manager,
+            ),
+        ):
+            rc = _handle_cloud_list(_ns(["BTCUSDT"]))
+
+        assert rc == 0
+        mock_manager.list_training_jobs.assert_called_once_with(symbol="BTCUSDT")
+
+    def test_missing_bucket_env_returns_1(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            rc = _handle_cloud_list(_ns([]))
+
+        assert rc == 1

--- a/tests/unit/cloud/test_train_cloud_cli.py
+++ b/tests/unit/cloud/test_train_cloud_cli.py
@@ -1,0 +1,101 @@
+"""Unit tests for the `atb train cloud*` CLI helpers."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from cli.commands.train_cloud import (
+    DEFAULT_TRAINING_DAYS,
+    _parse_job_name,
+    _resolve_date_range,
+)
+
+
+@pytest.mark.fast
+class TestResolveDateRange:
+    """Tests for _resolve_date_range (date-window resolution for cloud training)."""
+
+    def test_days_only_ends_now(self) -> None:
+        before = datetime.now(UTC)
+        start, end = _resolve_date_range(days=30, start_date_str=None, end_date_str=None)
+        after = datetime.now(UTC)
+
+        assert before <= end <= after
+        assert (end - start).days == 30
+
+    def test_defaults_to_365_days(self) -> None:
+        start, end = _resolve_date_range(days=None, start_date_str=None, end_date_str=None)
+
+        assert (end - start).days == DEFAULT_TRAINING_DAYS
+
+    def test_explicit_start_and_end(self) -> None:
+        start, end = _resolve_date_range(
+            days=None, start_date_str="2026-05-01", end_date_str="2026-06-01"
+        )
+
+        assert start == datetime(2026, 5, 1, tzinfo=UTC)
+        assert end == datetime(2026, 6, 1, tzinfo=UTC)
+
+    def test_start_date_only_ends_now(self) -> None:
+        before = datetime.now(UTC)
+        start, end = _resolve_date_range(days=None, start_date_str="2026-05-01", end_date_str=None)
+        after = datetime.now(UTC)
+
+        assert start == datetime(2026, 5, 1, tzinfo=UTC)
+        assert before <= end <= after
+
+    def test_end_date_with_days_gives_fixed_cutoff_window(self) -> None:
+        start, end = _resolve_date_range(days=90, start_date_str=None, end_date_str="2026-06-01")
+
+        assert end == datetime(2026, 6, 1, tzinfo=UTC)
+        assert (end - start).days == 90
+
+    def test_days_and_start_date_are_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _resolve_date_range(days=30, start_date_str="2026-05-01", end_date_str=None)
+
+    def test_start_after_end_rejected(self) -> None:
+        with pytest.raises(ValueError, match="before"):
+            _resolve_date_range(days=None, start_date_str="2026-06-01", end_date_str="2026-05-01")
+
+    def test_start_equal_to_end_rejected(self) -> None:
+        with pytest.raises(ValueError, match="before"):
+            _resolve_date_range(days=None, start_date_str="2026-05-01", end_date_str="2026-05-01")
+
+    def test_invalid_date_string_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Invalid date"):
+            _resolve_date_range(days=None, start_date_str="not-a-date", end_date_str=None)
+
+    def test_timezone_aware_iso_input_preserved(self) -> None:
+        start, end = _resolve_date_range(
+            days=None,
+            start_date_str="2026-05-01T00:00:00+00:00",
+            end_date_str="2026-06-01T12:00:00+00:00",
+        )
+
+        assert start == datetime(2026, 5, 1, tzinfo=UTC)
+        assert end == datetime(2026, 6, 1, 12, tzinfo=UTC)
+
+
+@pytest.mark.fast
+class TestParseJobName:
+    """Tests for _parse_job_name (symbol/timeframe recovery from job names)."""
+
+    def test_parses_standard_job_name(self) -> None:
+        assert _parse_job_name("atb-btcusdt-1h-20260704-215649") == ("BTCUSDT", "1h")
+
+    def test_parses_eth_job_name(self) -> None:
+        assert _parse_job_name("atb-ethusdt-4h-20260120-005532") == ("ETHUSDT", "4h")
+
+    def test_rejects_non_atb_job_name(self) -> None:
+        assert _parse_job_name("custom-job-name") is None
+
+    def test_rejects_short_job_name(self) -> None:
+        assert _parse_job_name("atb-btcusdt") is None
+
+    def test_parses_full_sagemaker_arn(self) -> None:
+        arn = (
+            "arn:aws:sagemaker:us-east-1:123456789012:training-job/"
+            "atb-btcusdt-1h-20260704-215649"
+        )
+        assert _parse_job_name(arn) == ("BTCUSDT", "1h")

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -71,10 +71,28 @@ class TestGenerateVersionId:
         # Assert
         assert version_id.endswith("_v1")
         assert "_" in version_id
-        # Format: YYYY-MM-DD_HHh_vN
+        # Format: YYYY-MM-DD_HHhMMmSSs_vN
         parts = version_id.split("_")
         assert len(parts) == 3
         assert parts[2] == "v1"
+
+    def test_version_id_has_second_granularity(self, tmp_path):
+        """Two same-hour cloud containers must not generate colliding IDs.
+
+        Each container has an empty models dir, so the exists() counter cannot
+        de-duplicate across jobs — the timestamp itself must be unique.
+        """
+        import re
+
+        # Arrange
+        models_dir = tmp_path / "models"
+        models_dir.mkdir(parents=True, exist_ok=True)
+
+        # Act
+        version_id = _generate_version_id(models_dir, "BTCUSDT", "basic")
+
+        # Assert
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}_\d{2}h\d{2}m\d{2}s_v1", version_id)
 
     def test_increments_version_when_exists(self, tmp_path):
         # Arrange


### PR DESCRIPTION
## Summary

Makes SageMaker cloud training production-ready per #890 (all 5 fixes + the 2 stubs):

1. **`--start-date`/`--end-date`** on `atb train cloud` (UTC ISO dates, mutually exclusive with `--days`; `--end-date --days N` gives a fixed-cutoff N-day window). Unblocks fixed-cutoff experimental protocols — the container entrypoint already accepted ISO dates.
2. **`--no-wait` fixed**: `submit_job()` now runs the same local-download → S3-upload data-channel step as the blocking path (extracted as the shared submit path used by `run_training`). Previously async jobs always failed at the in-container Binance fetch (AWS IPs blocked).
3. **Version collisions**: in-container version IDs now include minutes/seconds (`YYYY-MM-DD_HHhMMmSSs_vN`) so two same-hour cloud jobs can't produce the same ID; as defense-in-depth (e.g. stale image), the local sync **never rmtrees an existing bundle** — it syncs to a `-2`/`-3` suffixed sibling and warns loudly.
4. **price/ vs basic/ namespace**: documented + implemented the promotion flow. Cloud syncs keep landing in `{SYMBOL}/price/` (only `price/latest` moves). New `atb train cloud-promote SYMBOL VERSION --to basic` copies the bundle into `basic/` **without touching `basic/latest`** unless `--set-latest` is passed. Never auto-promotes.
5. **Stubs fixed**: `cloud-status --sync` actually downloads + syncs (bundle's own `metadata.json` decides the registry location; job-name parse only seeds a placeholder); `cloud-list` lists the real S3 layout (`models/{job_name}/output/`), filterable by symbol.

Docs: cloud workflow, promotion flow, and cost expectations added to `docs/prediction.md` and `src/ml/cloud/README.md`; changelog updated.

## Testing

- TDD: new/updated unit tests in `tests/unit/cloud/` (`test_train_cloud_cli.py`, `test_promotion.py`, orchestrator submit/collision/metadata-symbol/sync tests, S3 job-listing tests) and version-ID format tests.
- Full `atb test unit` green locally; `atb dev quality --changed` green (black, ruff, mypy).
- End-to-end revalidation on a real SageMaker job (date-ranged smoke run exercising the new flags, sync, and promotion) — evidence in the PR comments.

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)