### PR TITLE
feat(live): name reconciliation-cycle findings + escalate persistent HIGH/CRITICAL (#892)

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -423,6 +423,10 @@ DEFAULT_RECONCILIATION_BALANCE_THRESHOLD_PCT = 0.05  # 5% balance discrepancy tr
 DEFAULT_RECONCILIATION_DUST_THRESHOLD = 0.00001  # Ignore dust-level asset discrepancies
 DEFAULT_RECONCILIATION_ORDER_MATCH_TOLERANCE_PCT = 0.01  # 1% qty tolerance for order matching
 DEFAULT_RECONCILIATION_ORDER_MATCH_TIME_WINDOW_MIN = 10  # Minutes for timestamp matching
+# A HIGH/CRITICAL reconciliation cycle pages once on the rising severity edge; if the
+# condition persists, re-surface it at this cadence so a stuck-degraded bot does not go
+# silent after the first alert. 1800s (30 min) sits well above the 300s alert-dedup window.
+RECONCILE_CYCLE_ESCALATION_SECONDS = 1800
 # Bound startup order reconciliation so a large stale-order backlog cannot block
 # the trading loop for hours (#628). Each unresolved order costs a REST round-trip;
 # excess beyond the cap / time budget is deferred to the next startup run.

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -35,6 +35,7 @@ from src.config.constants import (
     DEFAULT_STOP_LOSS_PCT,
     NET_FLAT_DUST_USD,
     ORPHANED_BORROW_SWEEP_COOLDOWN_SECONDS,
+    RECONCILE_CYCLE_ESCALATION_SECONDS,
 )
 from src.config.feature_flags import get_flag
 from src.data_providers.exchange_interface import OrderLookupError, SideEffectType
@@ -3123,6 +3124,9 @@ class PeriodicReconciler:
         # cycle-severity event so a persistent HIGH/CRITICAL condition pages/logs
         # once on the rising edge, not every cycle.
         self._last_cycle_severity = Severity.LOW
+        # Wall-clock of the last cycle-severity emit, so a persistent HIGH/CRITICAL
+        # re-pages on a cadence instead of going silent after the first rising edge.
+        self._last_cycle_emit_ts = 0.0
         self._symbols = symbols or []
 
         self._running = False
@@ -3368,6 +3372,10 @@ class PeriodicReconciler:
             return
 
         max_severity = Severity.LOW
+        # Short operator-facing descriptions of the CRITICAL corrections this cycle,
+        # named in the paged cycle-severity event so the operator sees WHAT broke
+        # without a DB round-trip. Bounded by the position count.
+        findings: list[str] = []
 
         # 1. Verify each position's entry order
         for order_key, position in positions_snapshot.items():
@@ -3746,6 +3754,7 @@ class PeriodicReconciler:
                         # escalates so close-only mode still fires on a real divergence.
                         if db_closed and self._reconcile_spot_balance():
                             max_severity = Severity.CRITICAL
+                            findings.append("spot balance corrected beyond tolerance")
                 except Exception as e:
                     logger.warning("Asset holdings check failed for %s: %s", order_key, e)
 
@@ -3917,6 +3926,11 @@ class PeriodicReconciler:
                                     position.symbol,
                                 )
                                 max_severity = Severity.CRITICAL
+                                findings.append(
+                                    self._audit_unprotected(
+                                        position, "exchange returned no order id"
+                                    )
+                                )
                         except Exception as e:
                             logger.critical(
                                 "Exception re-placing stop-loss for %s: %s — "
@@ -3925,6 +3939,9 @@ class PeriodicReconciler:
                                 e,
                             )
                             max_severity = Severity.CRITICAL
+                            findings.append(
+                                self._audit_unprotected(position, "exception during placement")
+                            )
                     else:
                         logger.critical(
                             "Cannot re-place stop-loss for %s — no stop_price "
@@ -3932,6 +3949,9 @@ class PeriodicReconciler:
                             position.symbol,
                         )
                         max_severity = Severity.CRITICAL
+                        findings.append(
+                            self._audit_unprotected(position, "no stop price or SL unsupported")
+                        )
 
             except Exception as e:
                 logger.warning(
@@ -3995,6 +4015,7 @@ class PeriodicReconciler:
         # correction escalates to close-only mode in step 5.
         if self._reconcile_spot_balance():
             max_severity = Severity.CRITICAL
+            findings.append("spot balance corrected beyond tolerance")
 
         # 5. Trigger close-only mode on CRITICAL
         if max_severity == Severity.CRITICAL and self.on_critical:
@@ -4007,28 +4028,43 @@ class PeriodicReconciler:
         # CRITICAL). Lock-free: positions were snapshotted at the top of the
         # cycle and per-item locks are released, so the alert webhook cannot
         # block a position mutation.
-        self._emit_cycle_severity(max_severity)
+        self._emit_cycle_severity(max_severity, findings)
 
-    def _emit_cycle_severity(self, max_severity: Severity) -> None:
+    def _emit_cycle_severity(
+        self, max_severity: Severity, findings: list[str] | None = None
+    ) -> None:
         """Emit a system_events row for a HIGH/CRITICAL reconciliation cycle.
 
         HIGH-severity drift (entry-price/qty mismatch, orphaned SL, external
         close) otherwise writes only ``reconciliation_audit_events`` + logs and
-        never reaches ``system_events`` or an operator. Edge-triggered against
-        the previous cycle's peak severity so a persistent condition surfaces
-        once on the rising edge rather than every ~60s cycle (proper
-        rate-limiting/escalation is tracked separately).
+        never reaches ``system_events`` or an operator.
+
+        Fires on the rising severity edge AND re-fires every
+        ``RECONCILE_CYCLE_ESCALATION_SECONDS`` while the condition persists, so a
+        stuck-degraded bot re-pages instead of going silent after the first alert.
+        The engine sink dedups repeat webhooks within its own short window, so the
+        escalation cadence — not per-cycle spam — sets how often an operator is paged.
+
+        ``findings`` are short operator-facing descriptions of the CRITICAL
+        corrections this cycle; when present they are named in the paged message so
+        the operator sees WHAT broke without querying ``reconciliation_audit_events``.
         """
         prev = self._last_cycle_severity
         self._last_cycle_severity = max_severity
-        if max_severity < Severity.HIGH or max_severity <= prev:
+        if max_severity < Severity.HIGH:
             return
+        now = time.time()
+        rising_edge = max_severity > prev
+        persisted = now - self._last_cycle_emit_ts >= RECONCILE_CYCLE_ESCALATION_SECONDS
+        if not (rising_edge or persisted):
+            return
+        self._last_cycle_emit_ts = now
         if max_severity == Severity.CRITICAL:
             _emit_event(
                 self.on_event,
                 EventType.ALERT,
-                "Reconciliation cycle detected a CRITICAL discrepancy — see "
-                "reconciliation_audit_events for the specific correction",
+                "Reconciliation cycle detected a CRITICAL discrepancy: "
+                + self._format_findings(findings),
                 severity="critical",
                 error_code="RECONCILE_CRITICAL",
                 alert=True,
@@ -4043,6 +4079,43 @@ class PeriodicReconciler:
                 error_code="RECONCILE_HIGH",
                 alert=False,
             )
+
+    @staticmethod
+    def _format_findings(findings: list[str] | None, limit: int = 3) -> str:
+        """Render the cycle's CRITICAL findings into a bounded, single-line summary."""
+        if not findings:
+            return "see reconciliation_audit_events for the specific correction"
+        unique = list(dict.fromkeys(findings))  # drop duplicates, preserve order
+        shown = "; ".join(unique[:limit])
+        extra = len(unique) - limit
+        return f"{shown} (+{extra} more)" if extra > 0 else shown
+
+    def _audit_unprotected(self, position: Any, cause: str) -> str:
+        """Persist a CRITICAL audit row for a position left without a stop-loss and
+        return a short operator-facing detail string.
+
+        The periodic SL re-placement failure paths previously only logged +
+        bumped the cycle severity, so the paged cycle-severity event pointed
+        operators at a ``reconciliation_audit_events`` table that held no row for
+        the cause. Writing the row here makes that pointer honest. Fault-isolated:
+        an audit-write failure must never break the reconcile cycle.
+        """
+        symbol = getattr(position, "symbol", "unknown")
+        detail = f"{symbol} unprotected — SL re-placement failed ({cause})"
+        try:
+            self.db_manager.log_audit_event(
+                session_id=self.session_id,
+                entity_type="position",
+                entity_id=getattr(position, "db_position_id", None),
+                field="stop_loss_order_id",
+                old_value=str(getattr(position, "stop_loss_order_id", None)),
+                new_value=None,
+                reason=detail,
+                severity=Severity.CRITICAL.value,
+            )
+        except Exception as e:
+            logger.error("Failed to persist unprotected-position audit: %s", e)
+        return detail
 
     def _place_missing_stop_loss(self, position: Any, order_key: str) -> None:
         """Place a stop-loss for a position that has none (e.g. phantom from timeout).

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -4039,6 +4039,58 @@ class TestReconcileCycleSeverityEvent:
         pr._emit_cycle_severity(Severity.HIGH)  # de-escalation -> silent
         assert on_event.call_count == 1
 
+    def test_persistent_critical_re_pages_after_escalation_interval(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """A CRITICAL that persists past the escalation interval re-pages, so a
+        stuck-degraded bot doesn't go silent after the first alert (#892)."""
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.CRITICAL)  # rising edge -> page
+        assert on_event.call_count == 1
+        # Simulate the escalation interval having elapsed since the last emit.
+        pr._last_cycle_emit_ts = 0.0
+        pr._emit_cycle_severity(Severity.CRITICAL)  # persistent + interval elapsed -> re-page
+        assert on_event.call_count == 2
+
+    def test_critical_findings_named_in_paged_message(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """Specific corrections are named in the paged message so the operator
+        sees WHAT broke without querying reconciliation_audit_events (#892)."""
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(
+            Severity.CRITICAL, ["BTCUSDT unprotected — SL re-placement failed (x)"]
+        )
+        message = on_event.call_args.args[1]
+        assert "BTCUSDT unprotected" in message
+
+    def test_findings_summary_is_bounded(self, mock_exchange, mock_position_tracker, mock_db):
+        """More findings than the display limit collapse to '(+N more)' so the
+        alert payload stays small."""
+        on_event = MagicMock()
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        pr._emit_cycle_severity(Severity.CRITICAL, [f"finding {i}" for i in range(5)])
+        message = on_event.call_args.args[1]
+        assert "(+2 more)" in message
+
+    def test_audit_unprotected_persists_critical_row(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        """An unprotected position writes a CRITICAL audit row so the paged event's
+        'see reconciliation_audit_events' pointer is honest (#892)."""
+        pr = self._reconciler(mock_exchange, mock_position_tracker, mock_db, MagicMock())
+        pos = MockPosition(db_position_id=99, stop_loss_order_id="sl_x")
+        detail = pr._audit_unprotected(pos, "exchange returned no order id")
+        assert "unprotected" in detail
+        mock_db.log_audit_event.assert_called_once()
+        _, kwargs = mock_db.log_audit_event.call_args
+        assert kwargs["entity_type"] == "position"
+        assert kwargs["entity_id"] == 99
+        assert kwargs["field"] == "stop_loss_order_id"
+        assert kwargs["severity"] == Severity.CRITICAL.value
+
 
 # ---------- SL Re-placement Naked-Position Guard (externally-closed positions) ----------
 


### PR DESCRIPTION
## What & why

Closes #892. Follow-up from the observability epic #853.

The periodic reconciliation cycle-severity event (#861) pages a **generic** "a CRITICAL/HIGH discrepancy happened — see `reconciliation_audit_events`", **once** on the rising severity edge. Two gaps this fixes:

- **Un-audited CRITICALs.** The stop-loss re-placement failure paths ("position is unprotected") only `logger.critical` + bumped severity — they wrote **no** audit row, so the paged event's "see reconciliation_audit_events" pointer led operators to an empty result.
- **Silent after first page.** A condition that stayed CRITICAL never re-paged, so a stuck-degraded bot went quiet after the first alert.

## Changes

- `_audit_unprotected(...)` writes a CRITICAL `reconciliation_audit_events` row at the three SL-unprotected sites, making the pointer honest.
- Per-cycle `findings` are collected (bounded, de-duplicated) and named in the paged CRITICAL message so the operator sees **what** broke without a DB round-trip.
- `_emit_cycle_severity` re-pages a persistent HIGH/CRITICAL every `RECONCILE_CYCLE_ESCALATION_SECONDS` (30 min). The engine alert-dedup (#882) throttles repeats within its 5-min window, so escalation cadence — not per-cycle spam — sets paging frequency.

**Periodic-path only.** The startup bulk reconcile (the 714-UNKNOWN-order storm) is already collapsed into one bounded summary by #884 and is untouched here. No change to the existing `max_severity` control flow — all additions are additive.

## Testing

- `tests/unit/live/test_reconciliation.py` — 169 pass, incl. 4 new: escalation re-page after interval, findings named in the paged message, bounded `(+N more)` summary, and the `_audit_unprotected` CRITICAL row.
- Full live-engine unit suite (`tests/unit/live/ tests/unit/engines/live/`) — 834 pass.
- `atb dev quality --changed` — black + ruff + mypy clean.

Reviewed with codex (gpt-5.5).
