### PR TITLE
feat(live): surface orphaned-borrow sweep results to operators (#893)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -3355,7 +3355,7 @@ class PeriodicReconciler:
         # orphaned borrow exists precisely when there is no tracked position. Must
         # run before the flat early-return below. No-op unless margin + flag enabled.
         if self._use_margin and self._symbols:
-            run_orphaned_borrow_sweep(
+            sweep_results = run_orphaned_borrow_sweep(
                 exchange=self.exchange,
                 position_tracker=self.position_tracker,
                 db_manager=self.db_manager,
@@ -3365,6 +3365,9 @@ class PeriodicReconciler:
                 cooldown_state=self._sweep_cooldown,
                 lock_registry=self._lock_registry,
             )
+            # Surface the sweep here — the flat early-return below (an orphaned borrow
+            # exists precisely when flat) would otherwise discard its severity.
+            surface_orphaned_borrow_sweep(self.on_event, sweep_results)
 
         # Snapshot positions (release lock before API calls)
         positions_snapshot = self.position_tracker.positions
@@ -4303,6 +4306,54 @@ def _base_asset_of(symbol: str) -> str:
     Single source of truth — avoids a divergent copy of the quote-stripping logic.
     """
     return PositionReconciler._extract_base_asset(symbol)
+
+
+def _describe_sweep_result(result: ReconciliationResult) -> str:
+    """One-line operator description of an orphaned-borrow sweep outcome."""
+    asset = result.entity_id
+    if result.severity >= Severity.CRITICAL:
+        return f"{asset} borrow exceeds auto-repay cap — manual review required"
+    if result.status == "corrected":
+        return f"{asset} borrow repaid"
+    return f"{asset} borrow {result.status}"
+
+
+def surface_orphaned_borrow_sweep(
+    on_event: Any, sweep_results: list[ReconciliationResult] | None
+) -> None:
+    """Surface the orphaned-borrow sweep's HIGH/CRITICAL outcomes to operators.
+
+    The sweep runs even when the bot is flat (an orphaned borrow exists precisely
+    when no position is tracked) and its return value is otherwise discarded, so an
+    over-cap CRITICAL borrow ("manual review required") never reached ``system_events``
+    or an operator. Pages on the over-cap CRITICAL; records a non-paging WARNING for a
+    completed repay or a failed/partial (``unresolved``) active repay. The dry-run
+    ``skipped`` outcome is left to ``reconciliation_audit_events`` only, so a borrow
+    sitting in dry-run does not emit a system_event every sweep window.
+
+    Rate-limiting is inherited: the sweep's per-base-asset cooldown yields a result at
+    most once per window, and the engine alert-dedup throttles repeat pages — so this
+    emits directly without its own edge-trigger. No-op when ``on_event`` is unset
+    (standalone use / tests); never raises.
+    """
+    for result in sweep_results or []:
+        if result.severity >= Severity.CRITICAL:
+            spec = (EventType.ALERT, "ORPHANED_BORROW_CRITICAL", "critical", True)
+        elif result.status == "corrected":
+            spec = (EventType.WARNING, "ORPHANED_BORROW_REPAID", "warning", False)
+        elif result.status == "unresolved":
+            spec = (EventType.WARNING, "ORPHANED_BORROW_UNRESOLVED", "warning", False)
+        else:
+            continue  # dry-run 'skipped' / LOW — left to reconciliation_audit_events only
+        event_type, error_code, severity, alert = spec
+        _emit_event(
+            on_event,
+            event_type,
+            f"Orphaned-borrow sweep: {_describe_sweep_result(result)}",
+            severity=severity,
+            error_code=error_code,
+            alert=alert,
+        )
 
 
 def run_orphaned_borrow_sweep(

--- a/src/engines/live/recovery.py
+++ b/src/engines/live/recovery.py
@@ -486,6 +486,7 @@ class LiveSessionRecoverer:
                     PositionReconciler,
                     Severity,
                     run_orphaned_borrow_sweep,
+                    surface_orphaned_borrow_sweep,
                 )
 
                 use_margin = getattr(state.exchange_interface, "is_margin_mode", False)
@@ -509,7 +510,7 @@ class LiveSessionRecoverer:
                     # position is adopted first), sweep any orphaned margin borrow.
                     # No-op unless margin + flag enabled; safe when flat.
                     if use_margin and state._active_symbol:
-                        run_orphaned_borrow_sweep(
+                        sweep_results = run_orphaned_borrow_sweep(
                             exchange=state.exchange_interface,
                             position_tracker=state.live_position_tracker,
                             db_manager=state.db_manager,
@@ -519,6 +520,9 @@ class LiveSessionRecoverer:
                             cooldown_state=state._orphan_sweep_cooldown,
                             lock_registry=state._base_asset_locks,
                         )
+                        # Surface an over-cap CRITICAL / failed repay to operators —
+                        # the sweep's return value was previously discarded here too.
+                        surface_orphaned_borrow_sweep(state._record_event, sweep_results)
 
                     # Process results even with no positions — a filled entry
                     # order may create a position, and critical issues must

--- a/tests/unit/live/test_orphaned_borrow_sweep.py
+++ b/tests/unit/live/test_orphaned_borrow_sweep.py
@@ -16,7 +16,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.engines.live import reconciliation
-from src.engines.live.reconciliation import BaseAssetLockRegistry, run_orphaned_borrow_sweep
+from src.engines.live.reconciliation import (
+    BaseAssetLockRegistry,
+    ReconciliationResult,
+    Severity,
+    run_orphaned_borrow_sweep,
+    surface_orphaned_borrow_sweep,
+)
 
 pytestmark = pytest.mark.fast
 
@@ -369,3 +375,70 @@ def test_active_without_lock_registry_refuses_to_repay():
     ex = _exchange()
     _run(ex, _tracker(), _db(), mode="active", lock_registry=None)
     ex.repay_margin_loan.assert_not_called()
+
+
+# ---- surfacing the sweep results to operators (#893) ----------------------- #
+
+
+class TestSurfaceOrphanedBorrowSweep:
+    """The sweep's return value must reach operators. An over-cap CRITICAL borrow
+    pages; a completed repay or a failed/partial (``unresolved``) repay records a
+    non-paging WARNING; a dry-run ``skipped`` outcome stays audit-only so a borrow
+    sitting in dry-run does not emit a system_event every sweep window (#893)."""
+
+    @staticmethod
+    def _result(severity, status):
+        return ReconciliationResult(
+            entity_type="balance", entity_id=BASE, status=status, severity=severity
+        )
+
+    def test_over_cap_critical_pages(self):
+        on_event = MagicMock()
+        surface_orphaned_borrow_sweep(on_event, [self._result(Severity.CRITICAL, "unresolved")])
+        on_event.assert_called_once()
+        args, kwargs = on_event.call_args
+        assert args[0] == reconciliation.EventType.ALERT
+        assert kwargs["error_code"] == "ORPHANED_BORROW_CRITICAL"
+        assert kwargs["alert"] is True
+        assert "manual review" in args[1]
+
+    def test_completed_repay_warns_without_paging(self):
+        on_event = MagicMock()
+        surface_orphaned_borrow_sweep(on_event, [self._result(Severity.HIGH, "corrected")])
+        _, kwargs = on_event.call_args
+        assert kwargs["error_code"] == "ORPHANED_BORROW_REPAID"
+        assert kwargs["alert"] is False
+
+    def test_failed_repay_warns_without_paging(self):
+        on_event = MagicMock()
+        surface_orphaned_borrow_sweep(on_event, [self._result(Severity.MEDIUM, "unresolved")])
+        on_event.assert_called_once()
+        _, kwargs = on_event.call_args
+        assert kwargs["error_code"] == "ORPHANED_BORROW_UNRESOLVED"
+        assert kwargs["alert"] is False
+
+    def test_dry_run_skipped_is_not_surfaced(self):
+        on_event = MagicMock()
+        surface_orphaned_borrow_sweep(on_event, [self._result(Severity.MEDIUM, "skipped")])
+        on_event.assert_not_called()
+
+    def test_none_sink_is_noop(self):
+        # Standalone / test use with no engine sink must never raise.
+        surface_orphaned_borrow_sweep(None, [self._result(Severity.CRITICAL, "unresolved")])
+
+    def test_empty_results_noop(self):
+        on_event = MagicMock()
+        surface_orphaned_borrow_sweep(on_event, [])
+        surface_orphaned_borrow_sweep(on_event, None)
+        on_event.assert_not_called()
+
+    def test_over_cap_end_to_end_pages(self):
+        # A real over-cap sweep result flows through the surfacing path and pages.
+        ex = _exchange(snapshot=_snapshot(borrowed="1.0", interest="0", free="1.0", net="0"))
+        results = _run(ex, _tracker(), _db(), mode="dry_run")
+        on_event = MagicMock()
+        surface_orphaned_borrow_sweep(on_event, results)
+        assert any(
+            c.kwargs.get("error_code") == "ORPHANED_BORROW_CRITICAL"
+            for c in on_event.call_args_list
+        )

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -4092,6 +4092,42 @@ class TestReconcileCycleSeverityEvent:
         assert kwargs["severity"] == Severity.CRITICAL.value
 
 
+class TestOrphanedBorrowSweepSurfacedInCycle:
+    """The periodic cycle runs the orphaned-borrow sweep BEFORE its flat early-return
+    (an orphaned borrow exists precisely when flat). An over-cap CRITICAL sweep result
+    must reach the operator even when no position is tracked (#893)."""
+
+    @staticmethod
+    def _margin_reconciler(mock_exchange, mock_position_tracker, mock_db, on_event):
+        return PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=mock_position_tracker,
+            db_manager=mock_db,
+            session_id=1,
+            on_event=on_event,
+            use_margin=True,
+            symbols=["ETHUSDT"],
+        )
+
+    def test_over_cap_sweep_pages_even_when_flat(
+        self, mock_exchange, mock_position_tracker, mock_db
+    ):
+        mock_position_tracker.positions = {}  # flat -> cycle returns early after the sweep
+        on_event = MagicMock()
+        pr = self._margin_reconciler(mock_exchange, mock_position_tracker, mock_db, on_event)
+        over_cap = ReconciliationResult(
+            entity_type="balance", entity_id="ETH", status="unresolved", severity=Severity.CRITICAL
+        )
+        with patch(
+            "src.engines.live.reconciliation.run_orphaned_borrow_sweep", return_value=[over_cap]
+        ):
+            pr._reconcile_cycle()
+        assert any(
+            c.kwargs.get("error_code") == "ORPHANED_BORROW_CRITICAL"
+            for c in on_event.call_args_list
+        ), on_event.call_args_list
+
+
 # ---------- SL Re-placement Naked-Position Guard (externally-closed positions) ----------
 
 


### PR DESCRIPTION
## What & why

Closes #893. Follow-up from the observability epic #853.

`run_orphaned_borrow_sweep()` returns per-asset `ReconciliationResult`s — including a **CRITICAL** "exceeds auto-repay cap — manual review required" — but **both call sites discarded the return value**:

- **Periodic** (`PeriodicReconciler._reconcile_cycle`): the sweep runs, then the cycle hits its **flat early-return** (`if not positions_snapshot: return`). Since an orphaned borrow exists *precisely when flat*, the sweep's severity never reached `system_events`. An over-cap orphaned borrow was completely invisible to operators.
- **Recovery/startup** (`recovery.py`): results were audited but never surfaced as a `system_event`.

## Changes

- New module helper `surface_orphaned_borrow_sweep(on_event, sweep_results)`:
  - **CRITICAL** (over-cap) → pages `ORPHANED_BORROW_CRITICAL` (ALERT).
  - **completed repay** → non-paging `ORPHANED_BORROW_REPAID` (WARNING).
  - **failed/partial** (`unresolved`) → non-paging `ORPHANED_BORROW_UNRESOLVED` (WARNING).
  - **dry-run `skipped`** → left to `reconciliation_audit_events` only (no per-window noise — the sweep is dry-run in prod).
- Both call sites now capture the results and surface them. The periodic call surfaces **before** the flat early-return.
- Rate-limiting is inherited: the sweep's per-base-asset cooldown yields a result at most once per window, and the engine alert-dedup (#882) throttles repeat pages — so no extra edge-trigger.

**Observability only.** Deliberately does **not** fold sweep severity into `max_severity` / recovery `critical_count`, so it does **not** change close-only/halt behavior (a risk decision, out of scope).

## Testing

- `tests/unit/live/test_orphaned_borrow_sweep.py` — +7 surfacing tests (over-cap pages, repaid/failed warn, dry-run silent, None-sink no-op, end-to-end).
- `tests/unit/live/test_reconciliation.py` — +1 integration test: the periodic cycle pages an over-cap CRITICAL **even when flat**.
- Full live-engine unit suite — 842 pass. `atb dev quality --changed` clean. Reviewed with codex (gpt-5.5).
