### PR TITLE
feat(live): audit the benign _realize_pnl_on_close skip guards (#894)

### DIFF
--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -2681,6 +2681,27 @@ class PositionReconciler:
 
         return result
 
+    def _audit_pnl_skip(self, position: Any, close_reason: str, detail: str) -> None:
+        """Record (queryable, non-paging) that P&L realization was skipped on close.
+
+        These guard paths are benign but were previously silent, leaving no trail to
+        distinguish "the close skipped realization" from "realization never ran" during
+        an incident. LOW severity, so it never pages — it lives only in
+        ``reconciliation_audit_events`` for forensics. ``_persist_audit`` is
+        fault-isolated, so this can never break a close.
+        """
+        self._persist_audit(
+            AuditEvent(
+                entity_type="position",
+                entity_id=getattr(position, "db_position_id", None),
+                field="realized_pnl",
+                old_value=None,
+                new_value=None,
+                reason=f"P&L not realized on {close_reason} close: {detail}",
+                severity=Severity.LOW,
+            )
+        )
+
     def _realize_pnl_on_close(
         self,
         position: Any,
@@ -2708,6 +2729,7 @@ class PositionReconciler:
                 ``order_id`` so a re-run dedups via ``uq_trade_order_session``.
         """
         if exit_price is None or exit_price <= 0:
+            self._audit_pnl_skip(position, reason, "no usable exit price")
             return
 
         # Coerce to float — DB-loaded positions carry Decimal (Numeric) fields,
@@ -2717,6 +2739,7 @@ class PositionReconciler:
         entry_price = float(getattr(position, "entry_price", 0) or 0.0)
         qty = float(getattr(position, "quantity", 0) or 0.0)
         if entry_price <= 0 or qty <= 0:
+            self._audit_pnl_skip(position, reason, "missing entry price or quantity")
             return
 
         # Scale quantity by current_size/original_size to account for partial
@@ -2778,6 +2801,7 @@ class PositionReconciler:
                     "Cannot realize P&L — unable to read current balance " "(session_id=%s)",
                     self.session_id,
                 )
+                self._audit_pnl_skip(position, reason, "could not read session balance")
                 return
 
             # Sanitize exit_fee — treat non-finite or negative as zero

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -3201,6 +3201,65 @@ class TestReconciliationFeeAccounting:
         call_kwargs = mock_pnl.call_args
         assert call_kwargs[1]["exit_fee"] == pytest.approx(0.35)
 
+    def _skip_audit_kwargs(self, mock_db):
+        """The single LOW-severity 'not realized' audit row, if one was written."""
+        skip_calls = [
+            c
+            for c in mock_db.log_audit_event.call_args_list
+            if "not realized" in (c.kwargs.get("reason") or "")
+        ]
+        assert len(skip_calls) == 1, mock_db.log_audit_event.call_args_list
+        return skip_calls[0].kwargs
+
+    def test_skip_on_missing_exit_price_audits_low(self, reconciler, mock_db):
+        """No usable exit price -> queryable, non-paging LOW audit row (#894)."""
+        reconciler._realize_pnl_on_close(
+            MockPosition(db_position_id=5), exit_price=None, reason="stop_loss_filled_offline"
+        )
+        mock_db.update_balance.assert_not_called()
+        kwargs = self._skip_audit_kwargs(mock_db)
+        assert kwargs["field"] == "realized_pnl"
+        assert kwargs["severity"] == Severity.LOW.value
+        assert "no usable exit price" in kwargs["reason"]
+        assert "stop_loss_filled_offline" in kwargs["reason"]
+
+    def test_skip_on_missing_entry_price_audits_low(self, reconciler, mock_db):
+        """Zero entry price -> LOW audit row, no balance mutation (#894)."""
+        reconciler._realize_pnl_on_close(
+            MockPosition(db_position_id=6, entry_price=0.0),
+            exit_price=100.0,
+            reason="exit_order_recovery",
+        )
+        mock_db.update_balance.assert_not_called()
+        assert "missing entry price or quantity" in self._skip_audit_kwargs(mock_db)["reason"]
+
+    def test_skip_on_unreadable_balance_audits_low(self, reconciler, mock_db):
+        """Unreadable session balance -> LOW audit row (#894)."""
+        mock_db.get_current_balance.return_value = None
+        reconciler._realize_pnl_on_close(
+            MockPosition(db_position_id=7, entry_price=100.0, quantity=1.0),
+            exit_price=110.0,
+            reason="exit_order_recovery",
+        )
+        mock_db.update_balance.assert_not_called()
+        assert "could not read session balance" in self._skip_audit_kwargs(mock_db)["reason"]
+
+    def test_successful_realization_writes_no_skip_row(self, reconciler, mock_db):
+        """The happy path realizes P&L and writes NO 'not realized' skip row (#894)."""
+        mock_db.get_current_balance.return_value = 1000.0
+        reconciler._realize_pnl_on_close(
+            MockPosition(entry_price=50000.0, quantity=0.001, current_size=0.1, original_size=0.1),
+            exit_price=51000.0,
+            reason="exit_order_recovery",
+        )
+        mock_db.update_balance.assert_called_once()
+        skip_calls = [
+            c
+            for c in mock_db.log_audit_event.call_args_list
+            if "not realized" in (c.kwargs.get("reason") or "")
+        ]
+        assert skip_calls == []
+
 
 class TestFailClosedSLLookup:
     """#713: a transient order-lookup failure must NOT be treated as a missing stop.


### PR DESCRIPTION
## What & why

Closes #894. Final follow-up from the observability epic #853.

`PositionReconciler._realize_pnl_on_close` silently `return`s on three benign guard paths, leaving **no trail** to tell "the close skipped realization" from "realization never ran" during an incident:

- no usable exit price (`exit_price is None or <= 0`),
- missing entry price or quantity (`entry_price <= 0 or qty <= 0`),
- unreadable session balance (`get_current_balance()` None/negative).

## Changes

- `_audit_pnl_skip(position, close_reason, detail)` writes a **LOW-severity** `reconciliation_audit_events` row on each skip.
  - **Queryable for forensics, never paged** — the periodic cycle-severity event only surfaces HIGH/CRITICAL, so LOW rows stay out of the alert channel (the "noise risk" this item was deferred for).
  - **Fault-isolated** via `_persist_audit` (swallows errors) — a skip audit can never break a close.
- No change to the happy path or the balance mutation.

Not a flood risk: the two callers are one-shot per close event (`exit_order_recovery`, which already guards `fill_price > 0`, and `stop_loss_filled_offline`), not loops.

## Testing

- `tests/unit/live/test_reconciliation.py::TestReconciliationFeeAccounting` — +4 tests: each skip writes exactly one LOW `realized_pnl` row with no balance mutation, and the happy path writes **no** skip row.
- Full live-engine unit suite — 846 pass. `atb dev quality --changed` clean. Reviewed with codex (gpt-5.5).
