### PR TITLE
fix(experiments): route min_confidence override to FlatRiskManager on hyper_growth

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Experiment runner: `hyper_growth.min_confidence` override now reaches
+  FlatRiskManager**: `ExperimentRunner._apply_strategy_attribute` routed
+  `min_confidence` to the position sizer only, which is correct for the
+  ConfidenceWeightedSizer-based ml_* strategies but rejected the override for
+  `hyper_growth`, whose confidence gate lives on `FlatRiskManager` (its
+  leveraged/fixed-fraction sizers have no such attribute). The target list now
+  falls back to the risk manager (mirroring `stop_loss_pct`), post-override
+  validation bounds the risk-manager-owned gate to [0, 1], and
+  `min_confidence_floor` intentionally stays sizer-only (FlatRiskManager does
+  no confidence scaling). Unblocks declarative YAML gate-calibration
+  experiments on hyper_growth (previously required hand-built strategy
+  scripts, as in the 2026-07-05 confidence-calibration study).
 - **Exposure-governor pre-enablement fixes** (#802 follow-ups, from the PR merge
   note): (P2) `src/engines/shared/exposure.py::position_notional` now uses a
   position's `current_size` (the live fraction after partial exits / scale-ins)

--- a/src/experiments/runner.py
+++ b/src/experiments/runner.py
@@ -179,7 +179,13 @@ class ExperimentRunner:
             "atr_multiplier": [risk_manager],
             # Position sizer attributes
             "base_fraction": [position_sizer],
-            "min_confidence": [position_sizer],
+            # min_confidence is owned by ConfidenceWeightedSizer on ml_*
+            # strategies but by FlatRiskManager on hyper_growth (its sizers
+            # have no confidence gate), so try both components.
+            "min_confidence": [position_sizer, risk_manager],
+            # min_confidence_floor stays sizer-only: it bounds the sizer's
+            # confidence *scaling factor*, a concept FlatRiskManager (flat
+            # sizing, no confidence scaling) does not have.
             "min_confidence_floor": [position_sizer],
             # Signal generator attributes
             "sequence_length": [signal_generator],
@@ -422,6 +428,9 @@ class ExperimentRunner:
 
         risk_manager = getattr(strategy, "risk_manager", None)
         if risk_manager is not None:
+            # FlatRiskManager owns the min_confidence gate on hyper_growth;
+            # mirror the [0, 1] bound applied to the sizer-owned gate above.
+            _check_numeric_bound(risk_manager, "min_confidence", 0.0, 1.0)
             _check_numeric_bound(risk_manager, "base_risk", 0.001, 0.1)
             _check_numeric_bound(risk_manager, "atr_multiplier", 0.5, 5.0)
             _check_numeric_bound(risk_manager, "min_risk", 0.001, 0.2)

--- a/src/strategies/hyper_growth.py
+++ b/src/strategies/hyper_growth.py
@@ -71,7 +71,7 @@ class FlatRiskManager(RiskManager):
     # The runner consults this set to decide whether a setattr-based
     # override (as opposed to a ``_strategy_overrides`` dict override) is
     # sufficient for this manager class.
-    _direct_runtime_overrides: frozenset[str] = frozenset({"stop_loss_pct"})
+    _direct_runtime_overrides: frozenset[str] = frozenset({"stop_loss_pct", "min_confidence"})
 
     def __init__(
         self,

--- a/tests/unit/experiments/test_overrides.py
+++ b/tests/unit/experiments/test_overrides.py
@@ -305,10 +305,13 @@ def test_hyper_growth_take_profit_override_does_not_require_strategy_overrides_d
 
 def test_flat_risk_manager_declares_direct_runtime_override_contract() -> None:
     """The runner gate checks this class attribute — it must include
-    ``stop_loss_pct`` so FlatRiskManager-backed strategies are honored."""
+    ``stop_loss_pct`` so FlatRiskManager-backed strategies are honored.
+    ``min_confidence`` is likewise read from ``self`` at trade time
+    (``calculate_position_size``), so the contract set must declare it."""
     from src.strategies.hyper_growth import FlatRiskManager
 
     assert "stop_loss_pct" in FlatRiskManager._direct_runtime_overrides
+    assert "min_confidence" in FlatRiskManager._direct_runtime_overrides
 
 
 def test_hyper_growth_min_confidence_override_lands_on_flat_risk_manager(
@@ -338,6 +341,33 @@ def test_hyper_growth_min_confidence_floor_override_rejected(
     cfg = _cfg("hyper_growth", {"hyper_growth.min_confidence_floor": 0.1})
     with pytest.raises(ValueError, match="min_confidence_floor"):
         runner._apply_parameter_overrides(strategy, cfg)
+
+
+def test_hyper_growth_min_confidence_override_changes_trade_gating(
+    runner: ExperimentRunner,
+) -> None:
+    """The overridden gate must actually filter trades, not just sit on the
+    attribute: FlatRiskManager.calculate_position_size reads
+    ``self.min_confidence`` at trade time."""
+    from src.strategies.components.signal_generator import Signal, SignalDirection
+
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.min_confidence": 0.12})
+    runner._apply_parameter_overrides(strategy, cfg)
+
+    rm = strategy.risk_manager
+
+    def size_for(confidence: float) -> float:
+        signal = Signal(
+            direction=SignalDirection.BUY,
+            strength=0.5,
+            confidence=confidence,
+            metadata={},
+        )
+        return rm.calculate_position_size(signal, balance=1000.0)
+
+    assert size_for(0.10) == 0.0  # below the raised gate -> filtered
+    assert size_for(0.15) > 0.0  # above the gate -> sized
 
 
 def test_hyper_growth_min_confidence_out_of_bounds_fails_invariant_check(

--- a/tests/unit/experiments/test_overrides.py
+++ b/tests/unit/experiments/test_overrides.py
@@ -311,6 +311,47 @@ def test_flat_risk_manager_declares_direct_runtime_override_contract() -> None:
     assert "stop_loss_pct" in FlatRiskManager._direct_runtime_overrides
 
 
+def test_hyper_growth_min_confidence_override_lands_on_flat_risk_manager(
+    runner: ExperimentRunner,
+) -> None:
+    """hyper_growth's confidence gate lives on FlatRiskManager, not the
+    position sizer (LeveragedPositionSizer has no ``min_confidence``). The
+    override must fall through to the risk manager instead of being
+    rejected as unknown."""
+    strategy = runner._load_strategy("hyper_growth")
+    assert not hasattr(strategy.position_sizer, "min_confidence")
+
+    cfg = _cfg("hyper_growth", {"hyper_growth.min_confidence": 0.12})
+    runner._apply_parameter_overrides(strategy, cfg)
+
+    assert pytest.approx(strategy.risk_manager.min_confidence, rel=1e-9) == 0.12
+
+
+def test_hyper_growth_min_confidence_floor_override_rejected(
+    runner: ExperimentRunner,
+) -> None:
+    """``min_confidence_floor`` is a ConfidenceWeightedSizer concept (lower
+    bound on the confidence *scaling factor*). FlatRiskManager never scales
+    by confidence, so no hyper_growth component accepts it — the override
+    must keep failing loudly rather than silently no-op."""
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.min_confidence_floor": 0.1})
+    with pytest.raises(ValueError, match="min_confidence_floor"):
+        runner._apply_parameter_overrides(strategy, cfg)
+
+
+def test_hyper_growth_min_confidence_out_of_bounds_fails_invariant_check(
+    runner: ExperimentRunner,
+) -> None:
+    """Post-override validation must bound FlatRiskManager.min_confidence to
+    [0, 1] just as it bounds the sizer-owned gate on ml_* strategies."""
+    strategy = runner._load_strategy("hyper_growth")
+    cfg = _cfg("hyper_growth", {"hyper_growth.min_confidence": 1.5})
+    runner._apply_parameter_overrides(strategy, cfg)
+    with pytest.raises(ValueError, match="min_confidence"):
+        runner._validate_post_override_invariants(strategy)
+
+
 # --------------------------------------------------------------------------
 # G3: ``base_fraction`` routing must walk ``LeveragedPositionSizer ->
 # base_sizer``, and alias to the underlying ``FixedFractionSizer.fraction``


### PR DESCRIPTION
## Description

The experiment runner's `component_targets` mapped `min_confidence` to the position sizer only. That is correct for ConfidenceWeightedSizer-based strategies (ml_basic, ml_adaptive, ml_sentiment) but rejected the override for hyper_growth with `Unknown override attribute 'min_confidence'`: its confidence gate lives on `FlatRiskManager.min_confidence`, and `LeveragedPositionSizer` / `FixedFractionSizer` have no such attribute. This silently blocked the declarative YAML path for hyper_growth gate-calibration experiments (hit during the 2026-07-05 confidence-calibration study, which had to construct the strategy by hand in a standalone script).

## Changes

- `min_confidence` now targets `[position_sizer, risk_manager]`, mirroring the existing `stop_loss_pct` fallback. No behavior change for ml_* strategies: their risk managers have no `min_confidence` attribute, so the fallback is a no-op there.
- `_validate_post_override_invariants` bounds a risk-manager-owned `min_confidence` to [0, 1], same as the sizer-owned gate.
- `min_confidence_floor` deliberately stays sizer-only: it bounds the sizer's confidence *scaling factor*, a concept FlatRiskManager (flat sizing, no confidence scaling) does not have. A test pins this so it keeps failing loudly instead of silently no-opping.

Research-tooling correctness fix only — no live-trading code touched.

## Testing

- New tests (written first, watched fail): `test_hyper_growth_min_confidence_override_lands_on_flat_risk_manager`, `test_hyper_growth_min_confidence_floor_override_rejected`, `test_hyper_growth_min_confidence_out_of_bounds_fails_invariant_check` in `tests/unit/experiments/test_overrides.py`.
- Full fast unit suite: 4576 passed, 1 skipped.
- black / ruff clean on changed files; the only mypy complaint is a pre-existing missing `types-PyYAML` stub in `suite_loader.py`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)