### PR TITLE
docs(agents): consolidate PM definition (repo agent = single source of truth)

### DIFF
--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -44,7 +44,27 @@ i. `git log --oneline -20` on `develop` — recent direction.
 j. `docs/project_status.md` + `docs/changelog.md` (top) — in-flight narrative.
 k. `CODE.md` + `CLAUDE.md` task matrix — coverage gates and section-routing.
 
-Parallelize a–k in one tool-call batch. The "Sources checked:" preamble of your output must show ✓ (or ✗ with reason) for every letter.
+**Memory:**
+k2. mem-search for prior decisions on the topic at hand. Loopholes closed:
+   auto-loaded memory/priming/system-reminder context does NOT satisfy this —
+   run an explicit search on the topic ("I already have the context" = skip =
+   invalid ranking). An empty result still counts as ✓ but say so explicitly.
+
+**Parallel sessions (added 2026-07-05 — a weekend of conflicting PRs, duplicated
+work, and a session switching the main checkout off `main` earned this gate):**
+l. Cross-session sweep — other Claude sessions may be working this repo RIGHT NOW:
+   - If session tooling is available (`ccd_session_mgmt` list_sessions): note every
+     RUNNING session in ai-trading-bot, its branch, and PR.
+   - Artifact fallback (always run, tool or not):
+     · open PRs from branches not accounted for in `.claude/state/log.md` — read
+       them before touching overlapping files;
+     · `git -C <main-checkout> branch --show-current` MUST print `main` — if not,
+       another session moved it: flag loudly; restore only if the tree is clean;
+     · `git -C <main-checkout> worktree list` — worktrees on unmerged branches are
+       someone's active workspace. NEVER start work a parallel session's open PR
+       already covers without reading it first.
+
+Parallelize a–l (including k2) in one tool-call batch. The "Sources checked:" preamble of your output must show ✓ (or ✗ with reason) for every letter.
 
 ## Scoring rubric
 
@@ -113,7 +133,7 @@ The daemon session acts as PM by default. When a card needs specialist work, dis
 ```
 Sources checked: charter ✓ | risk-limits ✓ | log.md ✓ | proposals/incidents ✓ |
                  wakeups ✓ | gh issues ✓ | open PRs ✓ | git log ✓ |
-                 project_status/changelog ✓ | CODE/CLAUDE.md ✓
+                 project_status/changelog ✓ | CODE/CLAUDE.md ✓ | memory ✓ | cross-session sweep ✓
 (ALL required. If any is ✗, STOP and re-read — do not publish a ranking.)
 
 TOP PICK: <title> [issue #N if exists]
@@ -144,6 +164,13 @@ Items with **ΔP ≤ 2 AND ΔR ≤ 1** are off-mission. Do not rank them against
 ## Finish-before-start override
 
 Finishing a near-done item beats starting new work ONLY when: the unpushed/almost-done item has ΔP ≥ 3 AND is <1 day from shippable. A Terraform push or docs tweak (ΔP ≤ 2, ΔR ≤ 1) does NOT get this override — it stays in HYGIENE.
+
+## Ordering when rules conflict
+
+If the priority formula and the finish-before-start override disagree:
+1. Formula wins by default.
+2. Finish-before-start overrides ONLY under its stated conditions (ΔP ≥ 3 AND <1 day from shippable).
+3. Never invoke "vibe" or "hygiene reasoning" to reorder. State which rule you applied.
 
 ## Recording decisions
 


### PR DESCRIPTION
Reconciles the duplicated PM definitions (global ~/.claude skill vs repo agent) into the repo agent only, per Board instruction 2026-07-05. Ports the skill's unique content (explicit mem-search gate with loophole-closure language; formula-vs-finish-first ordering rules) and adds the new cross-session sweep hard gate (source l): running-session enumeration + artifact fallback (unrecognized PRs, main-checkout branch integrity, active worktrees). Global skill deleted from ~/.claude after porting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)