### PR TITLE
docs(refactor): adopt backtest-live parity plan v2 (PM-ratified D1-D4)

### DIFF
--- a/docs/refactor/backtest_live_parity_plan.md
+++ b/docs/refactor/backtest_live_parity_plan.md
@@ -1,0 +1,305 @@
+# Backtest ↔ Live Parity: Unification Plan
+
+> **Status:** DRAFT v1 (pending adversarial review — see §10)
+> **Goal owner:** human. **Author:** Claude Code session `0188LNSixYW9Fa5hrJ7YWJoa` (2026-06-15).
+> **Prereq:** the live-engine slim-down in `docs/refactor/live_engine_modularization.md` (finish first — shared extractions should pull from tidy code).
+> **Branch base:** `develop`.
+
+---
+
+## 1. Goal and what "parity" means operationally
+
+**Ultimate goal:** the backtest engine is a faithful predictor of the live engine. Every
+economically meaningful thing that happens in live — fees, slippage, exchange rounding,
+margin interest, stop-order mechanics, partial operations — is either (a) **the same code**
+in both engines, or (b) **explicitly modeled** in backtest with a **measured, bounded,
+monitored** difference.
+
+"100% confidence" cannot mean "identical outcomes" — live trading has irreducible
+environmental facts (latency, intrabar tick paths, order-book liquidity, exchange outages)
+that no candle-level backtest can reproduce. It **can** mean:
+
+1. **Decision parity** — given identical market data, both engines make identical
+   entry/exit/sizing decisions. *Provable exactly* (same code + differential tests).
+2. **Execution parity** — given identical fills-physics, both book identical prices, fees,
+   slippage, quantities, P&L. *Provable exactly* (shared cost/fill model + equality tests).
+3. **Accounting parity** — balances, fee legs, interest legs, trade records evolve
+   identically. *Provable exactly.*
+4. **Environmental fidelity** — the residual live-vs-model gap (real ticks vs candles,
+   real borrow rates vs modeled, latency) is *quantified continuously* against production
+   data and stays inside ratified bounds. *Provable statistically, not exactly.*
+
+The plan drives 1–3 to **byte-exact, CI-enforced equality** and turns 4 into a
+**monitored number** instead of an unknown.
+
+---
+
+## 2. Current state (audited 2026-06-15)
+
+### Already unified (single shared implementation, both engines call it)
+- **Fees, slippage, fill price** — `src/engines/shared/cost_calculator.py` (entry
+  `:110-160`, exit `:162-214`), `execution/ohlc_fill_model.py`, `fill_policy.py`,
+  `execution_model.py`. Both engines' execution engines delegate here
+  (backtest `execution_engine.py:159,245,308`; live `execution_engine.py:241,338`).
+- **Models & P&L** — shared `models.py` (`Position`, `Trade`, `pnl_percent`).
+- **Entry-plan extraction + dynamic-risk sizing** — `SharedEntryHandlerMixin`
+  (byte-identical by construction), `dynamic_risk_handler.py`.
+- **Trailing stops, strategy-exit detection, partial-op *decisions*, correlation control,
+  risk-config merging, validation, side utils** — all in `engines/shared/`.
+
+≈65–70% of trading logic is shared. A real parity test suite exists
+(`test_backtest_live_parity.py`, `fee_accounting_parity`, `exit_handler_parity`,
+`sentiment_freshness_parity`, side-by-side integration tests, determinism fingerprint).
+
+### Duplicated (same concept, two implementations — drift risk)
+| Area | Backtest | Live |
+|---|---|---|
+| Entry orchestration | `backtest/execution/entry_handler.py` | `live/execution/entry_handler.py` + `entry_coordinator.py` |
+| Exit orchestration (SL→TP→trailing→strategy→time→partial ordering) | `backtest/execution/exit_handler.py` | `live/execution/exit_handler.py` + `exit_coordinator.py` |
+| SL/TP high/low fill detection | inline in each exit handler | (kept in sync only by tests) |
+| Partial exit/scale-in **execution** | inline | `_execute_partial_exit()` (shared `partial_exit_executor.py` stub underused) |
+
+### Live-only realities NOT modeled (or optionally modeled) in backtest
+Documented in `backtest/engine.py:135-158` ("Known parity caveats") and found in audit:
+1. **Exchange quantity/price quantization** — live rounds to `step_size`/`tick_size` and
+   enforces `min_qty`/`min_notional` (`live/execution/execution_engine.py::_normalize_quantity`;
+   see also `.claude/LESSONS.md` §1.1 — precision bugs come in pairs); backtest uses raw
+   floats.
+2. **Margin/borrow interest** — live queries the exchange (`margin_interest_tracker.py`);
+   backtest models via `annual_margin_interest_rate` (default **0.0** — silently optimistic
+   for margin strategies). Live does not stash interest to trade metadata the way backtest
+   does; acquisition methods and defaults diverge.
+3. **Single- vs multi-position** — backtest `PositionTracker` holds **one** `ActiveTrade`;
+   live holds N (`max_concurrent_positions`). A multi-position strategy is structurally
+   unrepresentable in backtest today. **Largest structural gap.**
+4. **Stop-loss as a real resting order** — live SL can fill mid-bar at the exchange, can
+   partially fill, can be cancelled/rejected (#741), reserves margin balance (#710);
+   backtest checks the SL level once per candle against high/low.
+5. **Partial-op cadence** — live evaluates every loop tick; backtest once per candle.
+6. **Sentiment freshness** — live overlays real-time sentiment (4h window); backtest is
+   all-historical (`sentiment_freshness=0`). Column-parity locked; value distributions
+   differ by design.
+7. **Reconciliation / recovery / order tracking** — live-only by nature (no broker to
+   diverge from in backtest). Correctly out of scope for sharing; their *economic effects*
+   (e.g. a reconciler-booked external close) are edge events, tracked in the ledger (§7).
+
+---
+
+## 3. Target architecture: thin drivers around a shared execution core
+
+```
+                 ┌───────────────────────────────────────────────────┐
+                 │            src/engines/shared/  (the core)         │
+                 │                                                    │
+                 │  CostCalculator · OHLCFillModel · FillPolicy  ✅   │
+                 │  Models/PnL · DynamicRisk · Correlation       ✅   │
+                 │  TrailingStops · StrategyExitChecker          ✅   │
+                 │  PartialOpsManager (decisions)                ✅   │
+                 │  ──────────── NEW in this plan ────────────        │
+                 │  ExchangeRules (stepSize/tickSize/minQty/          │
+                 │    minNotional + quantize_to_step)            🆕   │
+                 │  ExitTriggerEvaluator (one high/low fill fn,       │
+                 │    one SL/TP same-bar tie-break policy)       🆕   │
+                 │  SharedExitWorkflow (ordered pipeline)        🆕   │
+                 │  SharedEntryWorkflow (plan→risk→corr→size→         │
+                 │    rules→cost→intent)                         🆕   │
+                 │  PartialExitExecutor (finish the stub)        🆕   │
+                 │  FinancingCostProvider (margin interest,           │
+                 │    pluggable: queried vs modeled)             🆕   │
+                 └────────────▲──────────────────────▲───────────────┘
+                              │                      │
+              ┌───────────────┴───────┐   ┌──────────┴────────────────┐
+              │  Backtest driver      │   │  Live driver              │
+              │  candle iteration     │   │  real-time loop, WS       │
+              │  portfolio state      │   │  exchange I/O, SL orders  │
+              │  (multi-position 🆕)  │   │  reconciliation, recovery │
+              └───────────────────────┘   └───────────────────────────┘
+```
+
+An engine driver may **feed** the core (data, clock, portfolio state) and **effect** its
+decisions (simulated fill vs real order), but never re-implement a trading decision or a
+cost computation. Enforced by CI (§6, guard G).
+
+---
+
+## 4. Workstreams
+
+**Ordering principle: build the measuring instrument before touching the thing measured.**
+
+### Phase P0 — Parity harness first (measure, then refactor)
+- **P0.1 `SimulatedExchange`**: an implementation of the live `ExchangeInterface`
+  (`place_order`, `place_stop_loss_order`, `get_order`, `get_open_orders`, `cancel_order`,
+  balances…) whose fill physics are the **shared** `OHLCFillModel` + `ExchangeRules`, driven
+  by a scripted candle feed and an **injected clock** (the `LiveLoopTimingCoordinator` seam
+  makes the loop time-warpable; no wall-clock sleeps in tests).
+- **P0.2 Side-by-side equality harness**: run the *real live engine* (paper mode +
+  `SimulatedExchange`) and the backtest engine over identical candles; normalize both
+  outputs to a canonical `TradeRecord` tuple *(symbol, side, entry_ts, entry_px, qty,
+  exit_ts, exit_px, reason, fee_entry, fee_exit, slippage, interest, gross_pnl, net_pnl,
+  balance_after)*; assert **exact equality** of the sequences. Extends the existing
+  `tests/integration/parity/test_side_by_side_parity.py` from handler-level to
+  engine-level.
+- **P0.3 Scenario matrix** (each a golden fixture): trend→TP exit; SL via low breach;
+  **SL and TP inside one bar** (tie-break policy pinned); **gap open through SL** (fill at
+  open, not SL price); trailing ratchet→trigger; time exits (max-holding / end-of-day /
+  weekend); partial-exit ladder + scale-in; short with N-day margin-interest accrual;
+  entry rejected by `min_notional` after quantization; maker vs taker fee legs;
+  same-bar-entry protection; multi-position interleaving (added in P2.3).
+- **P0.4 Divergence report format**: when equality fails, the harness emits a per-trade
+  field-level diff (first divergent field, both values, candle index) — debugging tool and
+  later the production-replay report (§P4).
+
+*Exit criterion: harness red/green on today's code; every currently-known divergence either
+reproduced by a scenario or explicitly ledgered (§7).*
+
+### Phase P1 — Collapse duplication (decision parity by construction)
+- **P1.1 `ExitTriggerEvaluator`**: single shared function family for SL/TP/liquidation
+  trigger detection from candle high/low incl. the same-bar tie-break and gap-fill rules.
+  Both exit handlers call it. (The current duplicated logic is only held equal by tests.)
+- **P1.2 `SharedExitWorkflow`**: one ordered pipeline (SL → TP → trailing → strategy →
+  time → partial) with per-engine adapters. Backtest's monolithic `exit_handler.py` and
+  live's `exit_handler.py` become thin.
+- **P1.3 `SharedEntryWorkflow`**: plan → dynamic-risk → correlation → sizing →
+  ExchangeRules quantization → cost → `OrderIntent`. Both entry paths drive it.
+- **P1.4 `PartialExitExecutor`**: finish `shared/partial_exit_executor.py`; both engines
+  execute partials through it (decision logic already shared).
+- Discipline: same verbatim/parity method as #486 — AST-assisted moves, fingerprint +
+  harness byte-identical per PR, dual review on money paths.
+
+### Phase P2 — Model live realities in backtest (execution & accounting parity)
+- **P2.1 `ExchangeRules`** (shared): symbol filters (`step_size`, `tick_size`, `min_qty`,
+  `min_notional`) + `src/trading/precision.quantize_to_step`. Live sources it from
+  `exchangeInfo` (as today); backtest from a recorded/static filter set per symbol
+  (committed fixture, refreshable via a CLI). **Backtest applies the same rounding and
+  rejections as live.** Removes caveat #1. *Note: this intentionally changes backtest
+  results (more accurate); gated behind a config flag for one release with an A/B report,
+  then default-on.*
+- **P2.2 `FinancingCostProvider`**: one interface, two impls — live queries the exchange;
+  backtest accrues from a configured rate curve. **Both stash identically to trade
+  metadata** (extend the entry-fee metadata pattern), one event-logger read path. Add a
+  **calibration job**: compare modeled vs exchange-reported interest on real sessions;
+  auto-file drift beyond threshold.
+- **P2.3 Multi-position backtest** ⚠️ *largest item; own design doc before code.* Upgrade
+  backtest `PositionTracker`/portfolio to a dict of positions honoring
+  `max_concurrent_positions`, correlation caps, per-position SL orders — reusing live's
+  semantics via the shared workflows. **Decision point for the human:** (a) full
+  multi-position backtest (correct, ~3–5 PRs, touches portfolio accounting throughout), or
+  (b) explicitly scope parity claims to single-position strategies and have the harness
+  *enforce* `max_concurrent_positions == 1` when comparing. (a) is the only path to
+  "backtesting is representative" for multi-symbol; recommend (a), sequenced last.
+- **P2.4 Stop-order semantics tier** (config: `execution_fidelity`): default candle-level
+  (today, conservative tie-breaks); optional "resting-order" mode that models SL as an
+  order that can fill at the stop price intrabar with the same
+  reserve/cancel-before-close rules as live (#710) — closing caveat #4 to the extent
+  candles allow. Partial-fill modeling explicitly **out of scope** initially (ledgered).
+- **P2.5 Cadence alignment**: quantify the live-ticks-vs-per-candle partial-op gap (#5) in
+  the ledger; optionally add sub-candle evaluation points to backtest later. Not
+  parity-critical for candle-driven strategies (live decisions are gated per-candle too).
+
+### Phase P3 — Thin drivers + drift-proofing
+- **P3.1** Backtest `engine.py` (1,820 lines) reduces to: data iteration, portfolio state,
+  calls into shared workflows, reporting. Live engine (post-#486 slim-down): loop + I/O +
+  reconciliation around the same workflows.
+- **P3.2 Architectural guard**: import-linter/CI contract — `engines/backtest/**` and
+  `engines/live/**` may not define symbols in the "owned-by-shared" namespace (fees,
+  fill detection, sizing, workflows); plus a grep-gate for `round(`-near-`step` patterns
+  outside `trading/precision` (LESSONS §1.1 meta-rule).
+- **P3.3** Update `docs/architecture.md` + this doc; retire the "Known parity caveats"
+  docstring items as they close, moving residuals to the ledger.
+
+### Phase P4 — Continuous proof against production (environmental fidelity)
+- **P4.1 Production shadow replay**: `atb parity replay --session <id>` — replays a recorded
+  live session's exact candle window + strategy/config through the backtest engine and
+  emits the P0.4 divergence report (per-trade bps deltas on entry/exit/fees/interest;
+  cumulative P&L delta). Requires persisting the live session's input snapshot (candles
+  already cached; config already in `trading_sessions`).
+- **P4.2 Scheduled parity audit** (weekly, existing daemon/workflow infra): run replay over
+  the last N sessions; alert (webhook + GitHub issue, `source:parity-audit`) when any
+  unexplained per-trade delta > **T₁ bps** or cumulative > **T₂ %** *(thresholds are
+  placeholders — human ratifies in the ledger; suggest T₁=5 bps, T₂=0.1%/30d as openers)*.
+- **P4.3 Fee-truth reconciliation**: compare `CostCalculator` modeled fees vs
+  exchange-reported commissions per order (`orders.actual_commission`, unit-normalized);
+  detect maker/taker misclassification and BNB-discount drift; feed corrections into fee
+  config. This closes the loop between the *model* and *exchange truth* — the step that
+  makes "fees in backtest" mean *actual* fees.
+
+---
+
+## 5. What must NOT change (safety rails)
+
+- All refactor PRs are behavior-preserving; the determinism fingerprint
+  (`tests/integration/parity/test_backtest_determinism.py`) stays byte-identical **except**
+  where a phase deliberately improves fidelity (P2.1/P2.2/P2.4) — those land behind config
+  flags with a before/after A/B report and a human sign-off, then flip defaults in a
+  separate, loudly-labeled PR.
+- Live-capital paths keep the #486 discipline: verbatim moves, dual reviewer, hardening
+  follow-ups separate from extractions.
+- Backtest **performance** is a feature: benchmark gate (golden 600-candle run wall-time
+  budget ±20%) on every shared-workflow PR — shared code must not de-vectorize the hot loop.
+
+---
+
+## 6. The proof system (how we *know*, layer by layer)
+
+| # | Layer | Mechanism | Proves | Status |
+|---|---|---|---|---|
+| L0 | Determinism | fingerprint test (BLAS pinned) | the oracle itself is reproducible | ✅ exists |
+| L1 | Component differential | for every shared component: identical inputs → identical outputs via both engines' adapters; wiring tests pin both engines construct it with the same params | no adapter-level drift | partial → complete in P1 |
+| L2 | Scenario equality | P0 harness: real live engine (paper + SimulatedExchange) vs backtest on the scenario matrix; **exact `TradeRecord` equality** | decision+execution+accounting parity end-to-end | 🆕 P0 |
+| L3 | Property-based | Hypothesis: random OHLC walks × config space → invariants: (i) trade sequences equal, (ii) both satisfy balance conservation `final = initial + Σnet − Σfees − Σinterest`, (iii) no orphan trades either side | parity isn't fixture-shaped | 🆕 P0/P1 |
+| L4 | Production replay | P4.1/P4.2 scheduled divergence reports vs ratified bounds | the *model* tracks *reality* | 🆕 P4 |
+| L5 | Exchange-truth audit | P4.3 fee/interest reconciliation vs exchange-reported values | cost model calibrated to actual venue behavior | 🆕 P4 |
+| G | Architectural guard | import contracts + precision grep-gate in CI | duplication cannot silently return | 🆕 P3 |
+
+**CI policy:** L0–L3 are required checks on every PR touching `src/engines/**`. L4/L5 are
+scheduled; their alerts create `type:incident`-adjacent issues (`source:parity-audit`).
+
+---
+
+## 7. Parity Gap Ledger (living table — `docs/refactor/parity_gap_ledger.md`)
+
+Every irreducible or not-yet-closed difference gets a row:
+`id | description | direction of bias | quantified impact (method + number) | bound | monitor | status`.
+Seed rows: intrabar tick path vs candle SL fills; live partial fills; latency/slippage
+beyond model; partial-op cadence; sentiment freshness; reconciler-booked external closes;
+exchange outages/restarts mid-position. **Rule:** the harness and replay reports may only
+show divergences that map to a ledger row; anything unexplained is a failing check, not a
+shrug.
+
+---
+
+## 8. Sequencing, effort, dependencies
+
+| Phase | PRs (est.) | Depends on |
+|---|---|---|
+| P0 harness + scenarios | 2–3 | live slim-down done (clock seam) |
+| P1 shared workflows | 3–4 | P0 (measure first) |
+| P2.1 ExchangeRules | 1–2 | P0 |
+| P2.2 Financing provider | 1 | P0 |
+| P2.4 stop-order tier | 1–2 | P1.1 |
+| P2.3 multi-position | design doc + 3–5 | P1, human decision |
+| P3 thin drivers + guards | 2 | P1, P2 |
+| P4 replay + audits | 2–3 | P0.4, P2.2 |
+
+Total ≈ **15–20 PRs** over multiple sessions. Highest risk: P2.3 (multi-position) — do it
+last, behind its own design review. Fastest confidence wins: P0 + P2.1 + P4.3 (harness,
+rounding, fee truth) deliver most of the "backtests don't lie about costs" goal early.
+
+---
+
+## 9. Honest limits (what even this plan cannot promise)
+
+Candle-level simulation cannot see intrabar tick ordering (SL vs TP first when both are in
+range — we pin a *conservative* tie-break and measure the residual in L4), real order-book
+liquidity/partial fills, venue latency, or borrow-rate changes intra-session. The claim this
+plan supports is: *decisions, costs, and accounting are identical by construction; the
+remaining environment gap is measured weekly against production and bounded by numbers a
+human ratified.* That is the strongest form of "100% confidence" that exists in this
+domain; anything stronger is marketing.
+
+---
+
+## 10. Review log
+
+- v1: initial draft (2026-06-15). Adversarial review pending; findings and revisions will
+  be recorded here.

--- a/docs/refactor/backtest_live_parity_plan.md
+++ b/docs/refactor/backtest_live_parity_plan.md
@@ -449,3 +449,31 @@ the strongest honest form of confidence available in this domain (see the §1 la
   reports are committed as durable artifacts under **`docs/refactor/reviews/`**
   (`quant_review.md`, `architecture_review.md`, `risk_review.md`) — cite these for the full
   file:line evidence behind each finding.
+
+---
+
+## PM adoption notes (2026-07-05, ownership moved to the PM daemon session)
+
+The Board directed execution of this plan via the PM session's sub-agents. Amendments to
+the decision table, applied as adopted policy:
+
+- **D1 — ratified (a), argument strengthened**: the production model trains exclusively on
+  closed bars, so forming-bar evaluation is out-of-distribution input at every live
+  decision — this is model correctness, not just parity hygiene. Conditions: protection
+  paths (SL/trailing/exit) remain tick-driven; only signal/entry evaluation gates on
+  closed candles. Evidence: forming-bar flip-rate study (docs/research/experiments/
+  2026-07-06_forming-bar-fliprate.md) quantifies the blast radius and feeds the A/B prior.
+- **D2 — ratified end-state (a); sequencing amended**: design doc + risk-officer sign-off
+  proceed now, but implementation is timed to precede the first second-live-symbol or
+  portfolio-sizing change rather than blocking the single-symbol parity milestone —
+  current prod reality is single-position, so P4 replays of real sessions do not yet
+  require it. Interim banner-clamp stands, not as end state.
+- **D3 — ratified as written** (design the financing interface, defer funding-rate
+  implementation with a ledger row; zero live dollars touched today).
+- **D4 — ratified, bundled**: T₁/T₂ thresholds ratify in the SAME Board sitting as the
+  outstanding risk-limits.json corrections (max_position_size_pct 0.10→0.20 +
+  $last_reviewed stamp). Breach action = charter breach_action (halt entries + page),
+  wired through the alert-monitor/ALERT_WEBHOOK path — never just a filed issue.
+- **Reporting**: A/B results and the P4.2 weekly parity audit publish through the frozen-
+  exam/scoreboard system (docs/architecture/model_evaluation_system.md) — one append-only
+  evidence discipline for both model and parity claims.

--- a/docs/refactor/backtest_live_parity_plan.md
+++ b/docs/refactor/backtest_live_parity_plan.md
@@ -1,9 +1,25 @@
 # Backtest ↔ Live Parity: Unification Plan
 
-> **Status:** DRAFT v1 (pending adversarial review — see §10)
-> **Goal owner:** human. **Author:** Claude Code session `0188LNSixYW9Fa5hrJ7YWJoa` (2026-06-15).
-> **Prereq:** the live-engine slim-down in `docs/refactor/live_engine_modularization.md` (finish first — shared extractions should pull from tidy code).
-> **Branch base:** `develop`.
+> **Status:** v2 — revised after a three-agent adversarial panel review (risk-officer,
+> quant-researcher, architecture-reviewer; see §11). `/codex-review` was requested but is
+> unavailable in the authoring environment; run it locally against this doc as a further pass.
+> **Goal owner:** human. **Author:** Claude Code session `0188LNSixYW9Fa5hrJ7YWJoa` (v1
+> 2026-06-15, v2 2026-07-05).
+> **Prereq:** ✅ satisfied — the live-engine modularization (#486,
+> `docs/refactor/live_engine_modularization.md`) is COMPLETE as of 2026-07-05.
+> **Branch base:** `develop`. **Note:** parts of the v1 audit predate the #838 partial-exit
+> accounting fixes; P0 includes a re-verification of the duplication map.
+
+---
+
+## 0. Decisions required from the human before/at phase boundaries
+
+| # | Decision | Phase | Recommendation |
+|---|---|---|---|
+| D1 | **Closed-candle gating**: live currently acts on the *forming* candle (`kline_buffer` updates the in-progress bar on every WS event with no `is_closed` gate; the loop decides on `df.iloc[-1]`). Option (a): gate live decisions to closed candles — a **live behavior change** needing sign-off; likely also a correctness fix (deciding on mutating high/low/close). Option (b): keep intra-candle decisioning and model it as a permanent, ledgered divergence with its own scenarios. | before P1 | (a) |
+| D2 | **Multi-position backtest**: live's production default is `max_concurrent_positions = 3` (`src/risk/risk_manager.py`). Single-position-only parity would not describe how the bot actually trades. Commit to the full multi-position backtest (P2.3a)? | before P2.3 | yes — (a); interim runs must banner "PARITY NOT VALIDATED: multi-position config" |
+| D3 | **Futures/perpetuals scope**: funding-rate carry is unmodeled in both engines. In scope now, or explicitly deferred until futures go live-affecting? | P2.2 | design the financing interface to accommodate it; defer the implementation with a ledger row |
+| D4 | **Divergence bounds ratification**: T₁/T₂ thresholds and their alert action must be ratified in the same human-reviewed artifact as `.claude/state/risk-limits.json` (currently epoch-dated/unreviewed). Alert action should match the charter's `breach_action` (halt new entries + page), not just file an issue. | before P4.2 | ratify alongside a first real risk-limits review |
 
 ---
 
@@ -16,255 +32,323 @@ in both engines, or (b) **explicitly modeled** in backtest with a **measured, bo
 monitored** difference.
 
 "100% confidence" cannot mean "identical outcomes" — live trading has irreducible
-environmental facts (latency, intrabar tick paths, order-book liquidity, exchange outages)
-that no candle-level backtest can reproduce. It **can** mean:
+environmental facts (latency, intrabar tick paths, order-book liquidity, data-feed
+revisions, exchange outages). It **can** mean, precisely:
 
-1. **Decision parity** — given identical market data, both engines make identical
-   entry/exit/sizing decisions. *Provable exactly* (same code + differential tests).
-2. **Execution parity** — given identical fills-physics, both book identical prices, fees,
-   slippage, quantities, P&L. *Provable exactly* (shared cost/fill model + equality tests).
-3. **Accounting parity** — balances, fee legs, interest legs, trade records evolve
-   identically. *Provable exactly.*
+1. **Decision parity** — given identical *closed-candle* inputs, both engines make
+   identical entry/exit/sizing decisions. *Provable exactly* — **contingent on D1**; until
+   the closed-candle question is resolved, live's decision inputs are not the backtest's.
+2. **Execution parity** — given identical fill physics, both book identical prices, fees,
+   slippage, quantities, P&L. *Provable exactly **against the simulated venue** —
+   model-vs-model.* Whether the model matches the real venue is a separate, calibrated
+   claim (L5), which is therefore a **required milestone**, not an optional tail.
+3. **Accounting parity** — balances, fee legs, interest legs, quantization residuals,
+   trade records evolve identically. *Provable exactly (same caveat as 2).*
 4. **Environmental fidelity** — the residual live-vs-model gap (real ticks vs candles,
-   real borrow rates vs modeled, latency) is *quantified continuously* against production
-   data and stays inside ratified bounds. *Provable statistically, not exactly.*
+   spread/impact vs candle prices, real borrow/funding vs modeled, latency, data
+   revisions) is *quantified continuously* against production and stays inside ratified
+   bounds. *Provable statistically, never exactly.*
 
-The plan drives 1–3 to **byte-exact, CI-enforced equality** and turns 4 into a
-**monitored number** instead of an unknown.
+**Scope banner:** until P2.3(a) lands, all parity claims apply only to
+single-position configurations; any run with `max_concurrent_positions > 1` (the
+production default) must emit a loud "parity not validated" warning in harness and CLI.
 
 ---
 
-## 2. Current state (audited 2026-06-15)
+## 2. Current state (v1 audit 2026-06-15; env facts re-verified 2026-07-05)
 
 ### Already unified (single shared implementation, both engines call it)
-- **Fees, slippage, fill price** — `src/engines/shared/cost_calculator.py` (entry
-  `:110-160`, exit `:162-214`), `execution/ohlc_fill_model.py`, `fill_policy.py`,
-  `execution_model.py`. Both engines' execution engines delegate here
-  (backtest `execution_engine.py:159,245,308`; live `execution_engine.py:241,338`).
+- **Fees, slippage, fill price** — `src/engines/shared/cost_calculator.py`
+  (`calculate_entry_costs` / `calculate_exit_costs`), `execution/ohlc_fill_model.py`,
+  `fill_policy.py`. Both engines' execution engines
+  (`src/engines/{backtest,live}/execution/execution_engine.py`) construct and delegate to
+  the shared `CostCalculator` — verified by the panel; cite by symbol, not line number.
 - **Models & P&L** — shared `models.py` (`Position`, `Trade`, `pnl_percent`).
-- **Entry-plan extraction + dynamic-risk sizing** — `SharedEntryHandlerMixin`
-  (byte-identical by construction), `dynamic_risk_handler.py`.
+- **Entry-plan extraction + dynamic-risk sizing** — `SharedEntryHandlerMixin` (both entry
+  handlers subclass it; byte-identical by construction), `dynamic_risk_handler.py`.
 - **Trailing stops, strategy-exit detection, partial-op *decisions*, correlation control,
   risk-config merging, validation, side utils** — all in `engines/shared/`.
 
-≈65–70% of trading logic is shared. A real parity test suite exists
-(`test_backtest_live_parity.py`, `fee_accounting_parity`, `exit_handler_parity`,
-`sentiment_freshness_parity`, side-by-side integration tests, determinism fingerprint).
-
 ### Duplicated (same concept, two implementations — drift risk)
-| Area | Backtest | Live |
-|---|---|---|
-| Entry orchestration | `backtest/execution/entry_handler.py` | `live/execution/entry_handler.py` + `entry_coordinator.py` |
-| Exit orchestration (SL→TP→trailing→strategy→time→partial ordering) | `backtest/execution/exit_handler.py` | `live/execution/exit_handler.py` + `exit_coordinator.py` |
-| SL/TP high/low fill detection | inline in each exit handler | (kept in sync only by tests) |
-| Partial exit/scale-in **execution** | inline | `_execute_partial_exit()` (shared `partial_exit_executor.py` stub underused) |
+- Entry orchestration: `backtest/execution/entry_handler.py` vs live
+  `entry_handler.py` + `entry_coordinator.py`.
+- Exit orchestration (SL→TP→trailing→strategy→time→partial ordering): backtest
+  `exit_handler.py` (monolithic) vs live `exit_handler.py` + `exit_coordinator.py`.
+- SL/TP high/low fill detection: inline in each exit handler, equal only by tests.
+- Partial exit/scale-in **execution**: per-engine (`shared/partial_exit_executor.py` stub
+  underused). ⚠️ Re-audit post-#838 in P0 — this area changed after the v1 audit.
 
-### Live-only realities NOT modeled (or optionally modeled) in backtest
-Documented in `backtest/engine.py:135-158` ("Known parity caveats") and found in audit:
-1. **Exchange quantity/price quantization** — live rounds to `step_size`/`tick_size` and
-   enforces `min_qty`/`min_notional` (`live/execution/execution_engine.py::_normalize_quantity`;
-   see also `.claude/LESSONS.md` §1.1 — precision bugs come in pairs); backtest uses raw
-   floats.
-2. **Margin/borrow interest** — live queries the exchange (`margin_interest_tracker.py`);
-   backtest models via `annual_margin_interest_rate` (default **0.0** — silently optimistic
-   for margin strategies). Live does not stash interest to trade metadata the way backtest
-   does; acquisition methods and defaults diverge.
-3. **Single- vs multi-position** — backtest `PositionTracker` holds **one** `ActiveTrade`;
-   live holds N (`max_concurrent_positions`). A multi-position strategy is structurally
-   unrepresentable in backtest today. **Largest structural gap.**
-4. **Stop-loss as a real resting order** — live SL can fill mid-bar at the exchange, can
-   partially fill, can be cancelled/rejected (#741), reserves margin balance (#710);
-   backtest checks the SL level once per candle against high/low.
-5. **Partial-op cadence** — live evaluates every loop tick; backtest once per candle.
-6. **Sentiment freshness** — live overlays real-time sentiment (4h window); backtest is
-   all-historical (`sentiment_freshness=0`). Column-parity locked; value distributions
-   differ by design.
-7. **Reconciliation / recovery / order tracking** — live-only by nature (no broker to
-   diverge from in backtest). Correctly out of scope for sharing; their *economic effects*
-   (e.g. a reconciler-booked external close) are edge events, tracked in the ledger (§7).
+### Live↔backtest divergences (union of code caveats + panel findings)
+1. **Partial-candle decisioning (NEW, panel blocker)** — live acts on the forming candle
+   (`src/engines/live/kline_buffer.py` updates the current bar on every WS event; no
+   `is_closed` gate anywhere in `src/engines/live`); backtest sees only final bars.
+   Decision-*input* mismatch. → D1, P1.0.
+2. **Exchange quantity/price quantization** — live rounds to `step_size`/`tick_size` and
+   enforces `min_qty`/`min_notional` (`_normalize_quantity`; LESSONS §1.1); backtest uses
+   raw floats (documented caveat in `backtest/engine.py`). Additionally (panel): the
+   rounding is *asymmetric* (round-to-nearest on entry, floor on exit) and the resulting
+   **dust/residual is never booked back into balance or subsequent sizing** in either
+   engine's model — systematic one-directional drift. → P2.1.
+3. **Margin/borrow interest** — live queries the exchange (`margin_interest_tracker.py`);
+   backtest models via `annual_margin_interest_rate` **defaulting to 0.0** (silently
+   optimistic). Metadata stashing differs. → P2.2.
+4. **Funding-rate carry (NEW)** — futures/perp funding is unmodeled and unmentioned in
+   both engines. → D3, P2.2, ledger.
+5. **Warmup/lookback (NEW)** — backtest hard-skips the first `warmup_period` indices;
+   live has no equivalent gate (only NaN-drop). Early-session decisions can differ. → P2.6.
+6. **Single- vs multi-position** — backtest holds one `ActiveTrade`; live holds N
+   (production default 3). **Largest structural gap.** → D2, P2.3.
+7. **Stop-loss as a real resting order** — live SL can fill mid-bar, partially fill, be
+   cancelled/rejected (#741), reserves margin (#710); backtest checks per candle. → P0.1b/P2.4.
+8. **Bid/ask spread & order-book impact (NEW)** — absent from *both* engines
+   (`fill_policy.py` declares `"quote"`/`"order_book"` fidelity levels; only
+   `"ohlc_conservative"` exists). The proof system can therefore reach perfect
+   self-consistency while both engines are wrong vs real fills. → L5/P4.3+, ledger.
+9. **Data source (NEW)** — live consumes WS klines (REST seed/fallback); backtest
+   re-fetches REST history, which the venue can revise. Same timestamps ≠ same bytes. → P4.0.
+10. **Partial-op cadence** — live evaluates every loop tick; backtest once per candle. → ledger.
+11. **Sentiment freshness** — live overlays real-time sentiment; backtest is
+    all-historical. Column-parity locked; value distributions differ by design. → ledger.
+12. **Reconciliation / recovery / order tracking** — live-only by nature; their economic
+    effects (external closes, restart-mid-position) are edge events the harness must
+    *produce* and the ledger must bound. → P0.3 fault matrix.
 
 ---
 
-## 3. Target architecture: thin drivers around a shared execution core
+## 3. Target architecture: thin drivers around shared **decision producers**
+
+Panel-corrected shape: the engines' state models are irreconcilable (single-trade
+synchronous loop vs N-position dict under locks with exchange round-trips). Forcing one
+stateful "workflow object" over both would create adapter-soup and pressure live's
+safety-critical I/O ordering. The shared surface is therefore **pure, ordered decision
+functions** — state in, intents out — and each driver keeps its own effecting loop.
 
 ```
-                 ┌───────────────────────────────────────────────────┐
-                 │            src/engines/shared/  (the core)         │
-                 │                                                    │
-                 │  CostCalculator · OHLCFillModel · FillPolicy  ✅   │
-                 │  Models/PnL · DynamicRisk · Correlation       ✅   │
-                 │  TrailingStops · StrategyExitChecker          ✅   │
-                 │  PartialOpsManager (decisions)                ✅   │
-                 │  ──────────── NEW in this plan ────────────        │
-                 │  ExchangeRules (stepSize/tickSize/minQty/          │
-                 │    minNotional + quantize_to_step)            🆕   │
-                 │  ExitTriggerEvaluator (one high/low fill fn,       │
-                 │    one SL/TP same-bar tie-break policy)       🆕   │
-                 │  SharedExitWorkflow (ordered pipeline)        🆕   │
-                 │  SharedEntryWorkflow (plan→risk→corr→size→         │
-                 │    rules→cost→intent)                         🆕   │
-                 │  PartialExitExecutor (finish the stub)        🆕   │
-                 │  FinancingCostProvider (margin interest,           │
-                 │    pluggable: queried vs modeled)             🆕   │
-                 └────────────▲──────────────────────▲───────────────┘
-                              │                      │
-              ┌───────────────┴───────┐   ┌──────────┴────────────────┐
-              │  Backtest driver      │   │  Live driver              │
-              │  candle iteration     │   │  real-time loop, WS       │
-              │  portfolio state      │   │  exchange I/O, SL orders  │
-              │  (multi-position 🆕)  │   │  reconciliation, recovery │
-              └───────────────────────┘   └───────────────────────────┘
+                 ┌──────────────────────────────────────────────────────┐
+                 │           src/engines/shared/  (the core)             │
+                 │                                                       │
+                 │  CostCalculator · OHLCFillModel · FillPolicy     ✅   │
+                 │  Models/PnL · DynamicRisk · Correlation          ✅   │
+                 │  TrailingStops · StrategyExitChecker             ✅   │
+                 │  PartialOpsManager (decisions)                   ✅   │
+                 │  ─────────────── NEW in this plan ───────────         │
+                 │  Clock protocol (injectable time)            🆕 P0.0  │
+                 │  ExchangeRules (filters + quantization +              │
+                 │    dust accounting)                          🆕 P2.1  │
+                 │  ExitTriggerEvaluator (one high/low fill fn,          │
+                 │    one same-bar tie-break)                   🆕 P1.1  │
+                 │  ExitDecisionSequence — PURE ordered evaluator        │
+                 │    (position+candle → ExitPlan | None)       🆕 P1.2  │
+                 │  EntryDecisionSequence — PURE (context →              │
+                 │    OrderIntent | None)                       🆕 P1.3  │
+                 │  PartialExitAccounting (shared math; drivers          │
+                 │    effect)                                   🆕 P1.4  │
+                 │  FinancingCostProvider (borrow now; funding-          │
+                 │    ready interface)                          🆕 P2.2  │
+                 └──────────▲────────────────────────▲──────────────────┘
+                            │ decisions/intents      │ decisions/intents
+              ┌─────────────┴─────────┐   ┌──────────┴──────────────────┐
+              │  Backtest driver      │   │  Live driver                │
+              │  candle iteration     │   │  real-time loop, WS         │
+              │  portfolio state      │   │  exchange I/O + the SAFETY  │
+              │  (multi-position 🆕)  │   │  ORDERING: cancel-SL-before-│
+              │  effects fills via    │   │  close (#710), deferred     │
+              │  shared fill model    │   │  drain (#631), re-protect   │
+              └───────────────────────┘   │  (#741), locks — NEVER      │
+                                          │  moved into shared          │
+                                          └─────────────────────────────┘
 ```
 
-An engine driver may **feed** the core (data, clock, portfolio state) and **effect** its
-decisions (simulated fill vs real order), but never re-implement a trading decision or a
-cost computation. Enforced by CI (§6, guard G).
+**Boundary rule (protected):** shared code decides *what* to do; drivers decide *how and
+in what I/O order*. The live order-lifecycle safety steps are explicitly outside the
+shared surface, listed in §5 as protected invariants with named tests.
 
 ---
 
 ## 4. Workstreams
 
-**Ordering principle: build the measuring instrument before touching the thing measured.**
+**Ordering principle: build the measuring instrument first — against surfaces that won't
+be refactored out from under it.**
 
-### Phase P0 — Parity harness first (measure, then refactor)
-- **P0.1 `SimulatedExchange`**: an implementation of the live `ExchangeInterface`
-  (`place_order`, `place_stop_loss_order`, `get_order`, `get_open_orders`, `cancel_order`,
-  balances…) whose fill physics are the **shared** `OHLCFillModel` + `ExchangeRules`, driven
-  by a scripted candle feed and an **injected clock** (the `LiveLoopTimingCoordinator` seam
-  makes the loop time-warpable; no wall-clock sleeps in tests).
-- **P0.2 Side-by-side equality harness**: run the *real live engine* (paper mode +
-  `SimulatedExchange`) and the backtest engine over identical candles; normalize both
-  outputs to a canonical `TradeRecord` tuple *(symbol, side, entry_ts, entry_px, qty,
-  exit_ts, exit_px, reason, fee_entry, fee_exit, slippage, interest, gross_pnl, net_pnl,
-  balance_after)*; assert **exact equality** of the sequences. Extends the existing
-  `tests/integration/parity/test_side_by_side_parity.py` from handler-level to
-  engine-level.
-- **P0.3 Scenario matrix** (each a golden fixture): trend→TP exit; SL via low breach;
-  **SL and TP inside one bar** (tie-break policy pinned); **gap open through SL** (fill at
-  open, not SL price); trailing ratchet→trigger; time exits (max-holding / end-of-day /
-  weekend); partial-exit ladder + scale-in; short with N-day margin-interest accrual;
-  entry rejected by `min_notional` after quantization; maker vs taker fee legs;
-  same-bar-entry protection; multi-position interleaving (added in P2.3).
-- **P0.4 Divergence report format**: when equality fails, the harness emits a per-trade
-  field-level diff (first divergent field, both values, candle index) — debugging tool and
-  later the production-replay report (§P4).
+### Phase P0 — Parity harness (measure, then refactor) — est. 4–6 PRs
+- **P0.0 `Clock` protocol** *(new; the panel found the claimed seam doesn't exist —
+  `loop_timing.py` calls `time`/`datetime` directly)*: injectable clock through
+  `LiveLoopTimingCoordinator` and the freshness path (default real; scripted in tests).
+  Genuine first PR; P0.2 and L3 depend on it.
+- **P0.1a `SimulatedFillOracle`**: stateless fills for market/TP/time exits via the shared
+  `OHLCFillModel` + `ExchangeRules`.
+- **P0.1b `SimulatedExchange`**: stateful implementation of the full live
+  `ExchangeInterface` (~20 abstract methods): resting SL orders that fire intrabar per a
+  **fidelity tie-break committed here** (pulled forward from P2.4 — exact equality is
+  unassertable without it), order status transitions, cancels, margin reserve (#710),
+  `min_notional` rejection. **Plus a fault-injection mode**: order rejections (-2010),
+  failed cancels, partial SL fills, WS drops, injected external closes, kill/restart.
+- **P0.2 Side-by-side equality harness**: the *real live engine* (paper +
+  `SimulatedExchange` + scripted `Clock`) vs the backtest engine on identical candles,
+  compared as canonical `TradeRecord` tuples *(symbol, side, entry_ts, entry_px, qty,
+  exit_ts, exit_px, reason, fee_entry, fee_exit, slippage, interest, quantization_residual,
+  gross_pnl, net_pnl, balance_after)*. **Binds to the engine's public surface** (start →
+  loop → records out), never handler internals, so P1's refactor cannot invalidate it.
+  **Determinism statement required**: how live execution is pinned lock-step
+  (single-threaded drive of the loop; WS callbacks delivered synchronously between candles)
+  — or, failing that, an explicit tolerance/flake policy. Without this, L3 fuzzing produces
+  false positives that erode trust.
+- **P0.3 Scenario matrix** (golden fixtures): trend→TP; SL via low breach; SL+TP same bar
+  (tie-break pinned); gap through SL (fill at open); trailing ratchet→trigger; time exits
+  (max-holding/end-of-day/weekend); partial ladder + scale-in; short with N-day interest;
+  `min_notional` rejection after quantization; maker vs taker; same-bar-entry protection;
+  **session-start/warmup-boundary trades**; **fault sub-matrix** (each P0.1b fault fires
+  the live fail-closed branch and the books still reconcile); **restart-mid-position**
+  (kill live driver holding a position, restart, reconcile; balance delta compared against
+  `reconciliation_balance_critical_pct` — the kill-switch condition); multi-position
+  interleaving (activates with P2.3).
+- **P0.4 Divergence report**: on inequality, per-trade field-level diff (first divergent
+  field, both values, candle index). Also the P4 report format.
+- **P0.5 Duplication re-audit**: refresh the §2 map post-#838 before P1 slicing.
 
-*Exit criterion: harness red/green on today's code; every currently-known divergence either
-reproduced by a scenario or explicitly ledgered (§7).*
+*Exit criterion: harness green on current code for the happy-path matrix; every known
+divergence either reproduced by a scenario or ledgered; fault matrix demonstrates the
+live fail-closed branches actually run under the harness.*
 
-### Phase P1 — Collapse duplication (decision parity by construction)
-- **P1.1 `ExitTriggerEvaluator`**: single shared function family for SL/TP/liquidation
-  trigger detection from candle high/low incl. the same-bar tie-break and gap-fill rules.
-  Both exit handlers call it. (The current duplicated logic is only held equal by tests.)
-- **P1.2 `SharedExitWorkflow`**: one ordered pipeline (SL → TP → trailing → strategy →
-  time → partial) with per-engine adapters. Backtest's monolithic `exit_handler.py` and
-  live's `exit_handler.py` become thin.
-- **P1.3 `SharedEntryWorkflow`**: plan → dynamic-risk → correlation → sizing →
-  ExchangeRules quantization → cost → `OrderIntent`. Both entry paths drive it.
-- **P1.4 `PartialExitExecutor`**: finish `shared/partial_exit_executor.py`; both engines
-  execute partials through it (decision logic already shared).
-- Discipline: same verbatim/parity method as #486 — AST-assisted moves, fingerprint +
-  harness byte-identical per PR, dual review on money paths.
+### Phase P1 — Shared decision producers (decision parity by construction)
+- **P1.0 Closed-candle gating (D1)**: implement the human's choice — (a) gate live
+  decisions on closed candles (live behavior change: flag-gated, A/B'd, then default), or
+  (b) model intra-candle decisioning as a ledgered divergence with dedicated scenarios.
+  Decision parity claims are conditional until this lands.
+- **P1.1 `ExitTriggerEvaluator`**: single shared SL/TP/liquidation trigger detection from
+  candle high/low incl. same-bar tie-break and gap rules. Both exit handlers call it.
+- **P1.2 `ExitDecisionSequence`** *(pure)*: ordered evaluation (SL → TP → trailing →
+  strategy → time → partial) producing an `ExitPlan`; **owns the decision order only**.
+  Live's cancel-before-close / deferred-drain / re-protect stay in the live driver.
+- **P1.3 `EntryDecisionSequence`** *(pure)*: plan → dynamic-risk → correlation → sizing →
+  `ExchangeRules` quantization → cost preview → `OrderIntent`.
+- **P1.4 `PartialExitAccounting`**: shared math for partial exit/scale-in deltas
+  (sizes, fees, realized P&L, remaining qty); drivers effect them.
+- **Preconditions:** a short **threading & lock-ownership note** per shared producer
+  (which thread calls it in live, what state it may read, why it takes no locks — pure
+  functions should need none; that's the point), reviewed before code (CODE.md Thread
+  Safety). Same #486 discipline otherwise: AST-assisted moves, fingerprint + harness
+  byte-identical per PR, dual review on money paths.
 
 ### Phase P2 — Model live realities in backtest (execution & accounting parity)
-- **P2.1 `ExchangeRules`** (shared): symbol filters (`step_size`, `tick_size`, `min_qty`,
-  `min_notional`) + `src/trading/precision.quantize_to_step`. Live sources it from
-  `exchangeInfo` (as today); backtest from a recorded/static filter set per symbol
-  (committed fixture, refreshable via a CLI). **Backtest applies the same rounding and
-  rejections as live.** Removes caveat #1. *Note: this intentionally changes backtest
-  results (more accurate); gated behind a config flag for one release with an A/B report,
-  then default-on.*
-- **P2.2 `FinancingCostProvider`**: one interface, two impls — live queries the exchange;
-  backtest accrues from a configured rate curve. **Both stash identically to trade
-  metadata** (extend the entry-fee metadata pattern), one event-logger read path. Add a
-  **calibration job**: compare modeled vs exchange-reported interest on real sessions;
-  auto-file drift beyond threshold.
-- **P2.3 Multi-position backtest** ⚠️ *largest item; own design doc before code.* Upgrade
-  backtest `PositionTracker`/portfolio to a dict of positions honoring
-  `max_concurrent_positions`, correlation caps, per-position SL orders — reusing live's
-  semantics via the shared workflows. **Decision point for the human:** (a) full
-  multi-position backtest (correct, ~3–5 PRs, touches portfolio accounting throughout), or
-  (b) explicitly scope parity claims to single-position strategies and have the harness
-  *enforce* `max_concurrent_positions == 1` when comparing. (a) is the only path to
-  "backtesting is representative" for multi-symbol; recommend (a), sequenced last.
-- **P2.4 Stop-order semantics tier** (config: `execution_fidelity`): default candle-level
-  (today, conservative tie-breaks); optional "resting-order" mode that models SL as an
-  order that can fill at the stop price intrabar with the same
-  reserve/cancel-before-close rules as live (#710) — closing caveat #4 to the extent
-  candles allow. Partial-fill modeling explicitly **out of scope** initially (ledgered).
-- **P2.5 Cadence alignment**: quantify the live-ticks-vs-per-candle partial-op gap (#5) in
-  the ledger; optionally add sub-candle evaluation points to backtest later. Not
-  parity-critical for candle-driven strategies (live decisions are gated per-candle too).
+- **P2.1 `ExchangeRules`**: symbol filters (`step_size`, `tick_size`, `min_qty`,
+  `min_notional`) + `src/trading/precision.quantize_to_step`, sourced from `exchangeInfo`
+  in live and from a committed, refreshable fixture in backtest. Backtest applies the same
+  rounding and rejections as live **and books the quantization residual (dust) into
+  balance/next-sizing identically in both engines** — sharing the rounding without the
+  residual accounting would not close the drift. Flag-gated with an A/B report; see §5
+  default-flip quarantine.
+- **P2.2 `FinancingCostProvider`**: one interface — live queries the exchange; backtest
+  accrues from a configured rate curve; **both stash identically to trade metadata**; one
+  event-logger read path. Interface designed to also carry **funding-rate** cash flows
+  (D3): implement when futures are live-affecting; ledger row until then. Calibration job:
+  modeled vs exchange-reported interest per session; drift beyond threshold auto-files.
+- **P2.3 Multi-position backtest (D2)** ⚠️ **highest-severity item in the plan** — it
+  rewrites portfolio accounting for exactly the quantities `risk-limits.json` governs
+  (drawdown, correlated exposure, leverage). Own design doc **with risk-officer sign-off
+  before code**; the doc must show per-position SL orders + correlation caps composing
+  without double-counting exposure. Option (b) (clamp to single-position) is acceptable
+  only as an interim with the §1 scope banner — **not as an end state**, because live's
+  default is 3 concurrent positions. Sequenced **before P4** (replaying real multi-position
+  sessions requires it).
+- **P2.4 Backtest resting-order tier**: backtest-side counterpart of the fidelity
+  tie-break committed in P0.1b (config `execution_fidelity`): default candle-level
+  conservative; optional resting-order mode mirroring live SL semantics (#710 reserve,
+  cancel-before-close). Partial-fill modeling explicitly out of scope initially (ledgered).
+- **P2.5 Cadence**: quantify live-tick vs per-candle partial-op gap in the ledger;
+  optional sub-candle evaluation later.
+- **P2.6 Warmup unification**: one shared warmup/readiness gate (backtest's index skip and
+  live's context-readiness check driven by the same computed warmup), or an explicit
+  ledger row + session-start scenario if unified gating is rejected.
 
 ### Phase P3 — Thin drivers + drift-proofing
-- **P3.1** Backtest `engine.py` (1,820 lines) reduces to: data iteration, portfolio state,
-  calls into shared workflows, reporting. Live engine (post-#486 slim-down): loop + I/O +
-  reconciliation around the same workflows.
-- **P3.2 Architectural guard**: import-linter/CI contract — `engines/backtest/**` and
-  `engines/live/**` may not define symbols in the "owned-by-shared" namespace (fees,
-  fill detection, sizing, workflows); plus a grep-gate for `round(`-near-`step` patterns
-  outside `trading/precision` (LESSONS §1.1 meta-rule).
-- **P3.3** Update `docs/architecture.md` + this doc; retire the "Known parity caveats"
-  docstring items as they close, moving residuals to the ledger.
+- **P3.1** Backtest `engine.py` reduces to: data iteration, portfolio state, shared
+  decision calls, fill effecting via the shared model, reporting. Live engine: loop + I/O
+  + safety ordering + reconciliation around the same producers.
+- **P3.2 Ownership guard** *(corrected: import-linter is absent from the repo and can't
+  express this anyway)*: an AST-based pytest guard failing CI if
+  `engines/{backtest,live}/**` **define** symbols owned by shared (fee/fill/trigger/sizing
+  math), plus a regex CI gate for `round(x/step)*step` patterns outside
+  `trading/precision` (LESSONS §1.1).
+- **P3.3** Docs refresh; retire closed "Known parity caveats" docstring items into the ledger.
 
 ### Phase P4 — Continuous proof against production (environmental fidelity)
-- **P4.1 Production shadow replay**: `atb parity replay --session <id>` — replays a recorded
-  live session's exact candle window + strategy/config through the backtest engine and
-  emits the P0.4 divergence report (per-trade bps deltas on entry/exit/fees/interest;
-  cumulative P&L delta). Requires persisting the live session's input snapshot (candles
-  already cached; config already in `trading_sessions`).
-- **P4.2 Scheduled parity audit** (weekly, existing daemon/workflow infra): run replay over
-  the last N sessions; alert (webhook + GitHub issue, `source:parity-audit`) when any
-  unexplained per-trade delta > **T₁ bps** or cumulative > **T₂ %** *(thresholds are
-  placeholders — human ratifies in the ledger; suggest T₁=5 bps, T₂=0.1%/30d as openers)*.
-- **P4.3 Fee-truth reconciliation**: compare `CostCalculator` modeled fees vs
-  exchange-reported commissions per order (`orders.actual_commission`, unit-normalized);
-  detect maker/taker misclassification and BNB-discount drift; feed corrections into fee
-  config. This closes the loop between the *model* and *exchange truth* — the step that
-  makes "fees in backtest" mean *actual* fees.
+- **P4.0 Session input snapshot** *(panel: prerequisite, currently missing —
+  `TradingSession` persists no candle snapshot, model version, resolved config, or
+  point-in-time sentiment)*: persist per session the **raw candles actually consumed**
+  (WS-fed values, not a re-fetchable range — venues revise history), model/feature-schema
+  version + checksum, fully-resolved effective config, and sentiment values at decision
+  time. Replay is not well-posed without this.
+- **P4.1 `atb parity replay --session <id>`**: replay the snapshot through the backtest
+  engine; emit the P0.4 report.
+- **P4.2 Scheduled parity audit** (weekly): replay last N sessions. **Metrics (panel-
+  corrected):** signed *and* unsigned per-trade divergence (bps **and** absolute $),
+  split by side/regime/symbol, plus a **non-resetting cumulative unexplained-P&L drift
+  statistic since last human ratification** — rolling windows alone hide cancelling biases
+  and slow bleeds. Alert action per charter `breach_action` (halt new entries + page), not
+  merely a GitHub issue (D4).
+- **P4.3 Fee-truth reconciliation** *(required milestone before "backtest costs = real
+  costs" is claimed — L5 in §6)*: modeled fees vs exchange-reported commissions per order
+  (`orders.actual_commission` is unit-ambiguous/async — normalize first), maker/taker
+  misclassification, BNB-discount drift; corrections feed fee config.
+- **P4.4 Slippage-vs-book spot check**: for orders above a notional threshold, compare
+  modeled slippage against actual fill price vs best bid/ask at order time (data permitting)
+  — the only layer that touches divergence #8 (spread/impact).
 
 ---
 
 ## 5. What must NOT change (safety rails)
 
-- All refactor PRs are behavior-preserving; the determinism fingerprint
-  (`tests/integration/parity/test_backtest_determinism.py`) stays byte-identical **except**
-  where a phase deliberately improves fidelity (P2.1/P2.2/P2.4) — those land behind config
-  flags with a before/after A/B report and a human sign-off, then flip defaults in a
+- **Protected live invariants** (named tests; never moved into shared code; never
+  reordered): cancel-resting-SL-before-market-close precedes every live close (#710);
+  stop-loss fills are drained to the loop thread, never executed on the poll thread
+  (#631); SL-cancel escalation re-protects or alerts (#741); base-asset lock scope on
+  entry/exit (#703); fail-closed order-tracking-lost handling.
+- All refactor PRs behavior-preserving; determinism fingerprint stays byte-identical
+  **except** where a phase deliberately improves fidelity (P1.0a, P2.1, P2.2, P2.4) —
+  those land flag-gated with an A/B report and human sign-off, then flip defaults in a
   separate, loudly-labeled PR.
-- Live-capital paths keep the #486 discipline: verbatim moves, dual reviewer, hardening
-  follow-ups separate from extractions.
-- Backtest **performance** is a feature: benchmark gate (golden 600-candle run wall-time
-  budget ±20%) on every shared-workflow PR — shared code must not de-vectorize the hot loop.
+- **Default-flip quarantine:** when P2.1/P2.2/P1.0 defaults flip, every
+  `state:paper`/`state:building` strategy whose approval backtest predates the flip is
+  auto-flagged "requires re-backtest before promotion"; CI blocks model/strategy promotion
+  on a stale-parity-config check. Owner of the re-validation sweep: pm.
+- **Performance:** benchmark gate on a 2,000+-candle fixture at **±5%** (±20% on a
+  seconds-long run is noise), plus a structural de-vectorization assertion (bound
+  per-candle object allocations/dispatch in the hot SL/TP scan). Perf regressions are
+  fixed by optimization — **never by removing or thinning a fail-closed step**; benchmark
+  PRs touching money paths get dual review.
 
 ---
 
-## 6. The proof system (how we *know*, layer by layer)
+## 6. The proof system (layer by layer, with honest claims)
 
-| # | Layer | Mechanism | Proves | Status |
-|---|---|---|---|---|
-| L0 | Determinism | fingerprint test (BLAS pinned) | the oracle itself is reproducible | ✅ exists |
-| L1 | Component differential | for every shared component: identical inputs → identical outputs via both engines' adapters; wiring tests pin both engines construct it with the same params | no adapter-level drift | partial → complete in P1 |
-| L2 | Scenario equality | P0 harness: real live engine (paper + SimulatedExchange) vs backtest on the scenario matrix; **exact `TradeRecord` equality** | decision+execution+accounting parity end-to-end | 🆕 P0 |
-| L3 | Property-based | Hypothesis: random OHLC walks × config space → invariants: (i) trade sequences equal, (ii) both satisfy balance conservation `final = initial + Σnet − Σfees − Σinterest`, (iii) no orphan trades either side | parity isn't fixture-shaped | 🆕 P0/P1 |
-| L4 | Production replay | P4.1/P4.2 scheduled divergence reports vs ratified bounds | the *model* tracks *reality* | 🆕 P4 |
-| L5 | Exchange-truth audit | P4.3 fee/interest reconciliation vs exchange-reported values | cost model calibrated to actual venue behavior | 🆕 P4 |
-| G | Architectural guard | import contracts + precision grep-gate in CI | duplication cannot silently return | 🆕 P3 |
+| # | Layer | Mechanism | Proves | Does NOT prove | Status |
+|---|---|---|---|---|---|
+| L0 | Determinism | fingerprint test (BLAS pinned) | the oracle is reproducible | anything about live | ✅ |
+| L1 | Component differential | identical inputs → identical outputs through both engines' adapters; wiring tests | no adapter drift | model correctness | partial → P1 |
+| L2 | Scenario equality | P0.2 harness, happy-path matrix, exact `TradeRecord` equality | **the two drivers wire the shared core identically** | that the shared fill/cost model matches the real venue (common-mode bugs invisible — the sim *is* the model); any live fault path | 🆕 P0 |
+| L2b | Fault equality | P0.1b fault injection + fault sub-matrix | live fail-closed branches fire and the books reconcile under faults | venue-realistic fault timing | 🆕 P0 |
+| L3 | Property-based | Hypothesis: random OHLC × configs → (i) trade-sequence equality, (ii) balance conservation `final = initial + Σnet − Σfees − Σinterest − Σresiduals` in both, (iii) no orphan trades | parity isn't fixture-shaped | see L2 caveat; requires P0.2 determinism pinning | 🆕 P0/P1 |
+| L4 | Production replay | P4.0–P4.2 scheduled divergence reports vs ratified bounds | the *model* tracks *production reality* within bounds | exactness | 🆕 P4 |
+| L5 | Exchange-truth audit | P4.3 fees/interest + P4.4 slippage-vs-book | cost model calibrated to actual venue behavior — **required before relying on backtest cost realism** | future venue changes | 🆕 P4 |
+| G | Ownership guard | AST definition guard + precision regex gate in CI | duplication can't silently return | — | 🆕 P3 |
 
-**CI policy:** L0–L3 are required checks on every PR touching `src/engines/**`. L4/L5 are
-scheduled; their alerts create `type:incident`-adjacent issues (`source:parity-audit`).
+**CI policy:** L0–L3 (incl. L2b) required on every PR touching `src/engines/**`. L4/L5
+scheduled; alerts follow charter `breach_action`.
 
 ---
 
 ## 7. Parity Gap Ledger (living table — `docs/refactor/parity_gap_ledger.md`)
 
-Every irreducible or not-yet-closed difference gets a row:
-`id | description | direction of bias | quantified impact (method + number) | bound | monitor | status`.
-Seed rows: intrabar tick path vs candle SL fills; live partial fills; latency/slippage
-beyond model; partial-op cadence; sentiment freshness; reconciler-booked external closes;
-exchange outages/restarts mid-position. **Rule:** the harness and replay reports may only
-show divergences that map to a ledger row; anything unexplained is a failing check, not a
-shrug.
+Row schema: `id | description | direction of bias | quantified impact (method + number) |
+bound | monitor | status`. Seed rows: intrabar tick path vs candle SL fills; live partial
+fills; **spread/order-book impact vs candle prices (both engines)**; **funding-rate carry
+(if D3 defers)**; **partial-candle decisioning (if D1 chooses (b))**; **warmup boundary
+(if P2.6 ledgers instead of unifies)**; **WS-vs-REST candle revisions**; quantization-dust
+residual (until P2.1 books it); latency; partial-op cadence; sentiment freshness;
+reconciler-booked external closes; exchange outages/restarts mid-position.
+**Rule:** harness and replay reports may only show divergences that map to a ledger row;
+anything unexplained is a failing check, not a shrug.
 
 ---
 
@@ -272,34 +356,63 @@ shrug.
 
 | Phase | PRs (est.) | Depends on |
 |---|---|---|
-| P0 harness + scenarios | 2–3 | live slim-down done (clock seam) |
-| P1 shared workflows | 3–4 | P0 (measure first) |
-| P2.1 ExchangeRules | 1–2 | P0 |
-| P2.2 Financing provider | 1 | P0 |
-| P2.4 stop-order tier | 1–2 | P1.1 |
-| P2.3 multi-position | design doc + 3–5 | P1, human decision |
+| P0 harness (incl. Clock, sim, fault mode, scenarios, re-audit) | 4–6 | #486 done ✅ |
+| P1.0 closed-candle decision (D1) | 1–2 | P0 harness, human D1 |
+| P1 decision producers | 3–4 | P0, P1.0 |
+| P2.1 ExchangeRules + dust accounting | 2 | P0 |
+| P2.2 Financing provider (+ funding-ready interface) | 1–2 | P0 |
+| P2.4 resting-order tier (backtest side) | 1–2 | P0.1b tie-break |
+| P2.6 warmup unification | 1 | P0 |
+| P2.3 multi-position (design doc + risk sign-off first) | 3–5 | P1; human D2 |
 | P3 thin drivers + guards | 2 | P1, P2 |
-| P4 replay + audits | 2–3 | P0.4, P2.2 |
+| P4.0 session snapshot persistence | 1–2 | — (can start early) |
+| P4.1–P4.4 replay + audits | 2–3 | P4.0, P2.2, **P2.3** (production runs multi-position) |
 
-Total ≈ **15–20 PRs** over multiple sessions. Highest risk: P2.3 (multi-position) — do it
-last, behind its own design review. Fastest confidence wins: P0 + P2.1 + P4.3 (harness,
-rounding, fee truth) deliver most of the "backtests don't lie about costs" goal early.
+Total ≈ **21–29 PRs** over multiple sessions. Fastest confidence wins early: P0 harness +
+P2.1 rounding + P4.3 fee-truth. Highest risk: P2.3 — own design review, sequenced after
+the decision producers exist but **before** production replay can be trusted.
 
 ---
 
 ## 9. Honest limits (what even this plan cannot promise)
 
-Candle-level simulation cannot see intrabar tick ordering (SL vs TP first when both are in
-range — we pin a *conservative* tie-break and measure the residual in L4), real order-book
-liquidity/partial fills, venue latency, or borrow-rate changes intra-session. The claim this
-plan supports is: *decisions, costs, and accounting are identical by construction; the
-remaining environment gap is measured weekly against production and bounded by numbers a
-human ratified.* That is the strongest form of "100% confidence" that exists in this
-domain; anything stronger is marketing.
+Candle-level simulation cannot see intrabar tick ordering (we pin a conservative tie-break
+and measure the residual in L4), real order-book liquidity/partial fills, spread at the
+moment of fill (L5/P4.4 samples it; nothing proves it continuously), venue latency, or
+intra-session borrow/funding-rate changes. L2's exactness is model-vs-model by
+construction; only L4/L5 connect the model to the venue, statistically. The claim this
+plan supports when complete: *decisions, costs, and accounting are identical by
+construction; the remaining environment gap is measured continuously against production
+and bounded by numbers a human ratified.* That is the strongest form of "100% confidence"
+available in this domain; anything stronger is marketing.
 
 ---
 
-## 10. Review log
+## 10. Relationship to existing docs
+- `docs/refactor/live_engine_modularization.md` — completed prerequisite; its extraction
+  discipline (AST moves, fingerprint, dual review, hardening-followups) carries over.
+- `backtest/engine.py` "Known parity caveats" docstring — items migrate to the ledger as
+  they close.
+- `.claude/LESSONS.md` §1.1 — quantization rules; enforced by the P3.2 precision gate.
 
-- v1: initial draft (2026-06-15). Adversarial review pending; findings and revisions will
-  be recorded here.
+## 11. Review log
+
+- **v1** (2026-06-15): initial draft.
+- **v2** (2026-07-05): revised per three-agent adversarial panel (risk-officer,
+  quant-researcher, architecture-reviewer), `/codex-review` being unavailable in the
+  authoring environment. Substantive changes: partial-candle decisioning surfaced as a
+  blocker (new D1/P1.0); multi-position re-scoped — option (b) demoted to interim-only,
+  P2.3 re-ranked before P4 (live default is 3 concurrent positions); stateful shared
+  workflows replaced by **pure decision producers** with live safety ordering explicitly
+  protected (§5); L2 claims re-scoped (model-vs-model, circularity acknowledged) and a
+  fault-equality layer (L2b) + fault-injection sim mode added; `Clock` protocol added as
+  P0.0 (claimed seam did not exist); SimulatedExchange split and re-estimated, fidelity
+  tie-break pulled into P0; harness re-bound to the engine public surface; P4 made
+  well-posed via session input snapshots (P4.0) and upgraded divergence statistics
+  (signed/unsigned, per-segment, non-resetting cumulative drift); spread/impact, funding,
+  warmup, quantization-dust, and WS-vs-REST divergences added to §2/§7; default-flip
+  quarantine + promotion gate added; benchmark gate tightened (2k candles, ±5%,
+  de-vectorization assertion); import-linter replaced by an AST ownership guard; threshold
+  ratification tied to a reviewed risk artifact with charter-consistent alerting; effort
+  re-estimated 15–20 → 21–29 PRs. Panel also *verified*: shared cost path, shared entry
+  mixin, duplication map, single-vs-multi as largest gap, #486 prereq complete.

--- a/docs/refactor/backtest_live_parity_plan.md
+++ b/docs/refactor/backtest_live_parity_plan.md
@@ -53,6 +53,21 @@ revisions, exchange outages). It **can** mean, precisely:
 single-position configurations; any run with `max_concurrent_positions > 1` (the
 production default) must emit a loud "parity not validated" warning in harness and CLI.
 
+**Sizing guardrail (hard rule — risk review finding #1):** the residual this plan cannot
+close is biased *optimistic* (a candle backtest cannot see the worst intrabar fill, so a
+pass makes a strategy look *safer* than live — the direction that historically bled capital:
+SL-placement failure → emergency-close cascade with phantom balance). Therefore **a
+parity-passing backtest is NOT authorization to increase live position size, risk-per-trade,
+leverage, or `max_concurrent_positions` beyond `risk-limits.json`.** Sizing changes remain a
+separate, human-ratified decision gated by the charter's `>$50 / 24h` and irreversible-action
+rules. Parity green ⇏ size up.
+
+**Language rule (governance):** the bare tokens **"100% confidence"** and **"byte-exact
+parity"** are banned from human-facing artifacts (CI output, replay reports, dashboards).
+Surface results only as the scoped claim: *"Decision/cost/accounting parity: proven
+model-vs-model within declared tolerance. Fill/slippage/liquidity/concurrency fidelity:
+bounded & monitored (L4/L5), NOT guaranteed."*
+
 ---
 
 ## 2. Current state (v1 audit 2026-06-15; env facts re-verified 2026-07-05)
@@ -75,8 +90,12 @@ production default) must emit a loud "parity not validated" warning in harness a
 - Exit orchestration (SL→TP→trailing→strategy→time→partial ordering): backtest
   `exit_handler.py` (monolithic) vs live `exit_handler.py` + `exit_coordinator.py`.
 - SL/TP high/low fill detection: inline in each exit handler, equal only by tests.
-- Partial exit/scale-in **execution**: per-engine (`shared/partial_exit_executor.py` stub
-  underused). ⚠️ Re-audit post-#838 in P0 — this area changed after the v1 audit.
+- Partial exit/scale-in **execution**: `shared/partial_exit_executor.py` is **not a stub** —
+  it is ~205 lines of complete P&L/fee/slippage logic already wired into the backtest tracker,
+  but it **duplicates fee/slippage math** (`exit_fee = abs(exit_notional * self.fee_rate)`,
+  `slippage_cost = abs(exit_notional * self.slippage_rate)`) instead of delegating to
+  `CostCalculator` — a live CODE.md "never duplicate financial logic" violation, and the real
+  P1.4 target. ⚠️ Re-audit post-#838 in P0 — this area changed after the v1 audit.
 
 ### Live↔backtest divergences (union of code caveats + panel findings)
 1. **Partial-candle decisioning (NEW, panel blocker)** — live acts on the forming candle
@@ -278,7 +297,12 @@ live fail-closed branches actually run under the harness.*
   point-in-time sentiment)*: persist per session the **raw candles actually consumed**
   (WS-fed values, not a re-fetchable range — venues revise history), model/feature-schema
   version + checksum, fully-resolved effective config, and sentiment values at decision
-  time. Replay is not well-posed without this.
+  time. Replay is not well-posed without this. *Partial reuse (verified):* the immutable,
+  INSERT-only `strategy_executions` table already persists per-decision OHLCV
+  (`indicators`) and `sentiment_data` FK'd to each trade — P4.0 should extend that record
+  (add model `version_id` + config checksum) rather than build a parallel snapshot store,
+  and must NOT rely on the mutable `cached_data_provider` parquet cache (overwritten in
+  place via `os.replace`, no provenance) as the candle source.
 - **P4.1 `atb parity replay --session <id>`**: replay the snapshot through the backtest
   engine; emit the P0.4 report.
 - **P4.2 Scheduled parity audit** (weekly): replay last N sessions. **Metrics (panel-
@@ -382,9 +406,10 @@ moment of fill (L5/P4.4 samples it; nothing proves it continuously), venue laten
 intra-session borrow/funding-rate changes. L2's exactness is model-vs-model by
 construction; only L4/L5 connect the model to the venue, statistically. The claim this
 plan supports when complete: *decisions, costs, and accounting are identical by
-construction; the remaining environment gap is measured continuously against production
-and bounded by numbers a human ratified.* That is the strongest form of "100% confidence"
-available in this domain; anything stronger is marketing.
+construction (model-vs-model, within declared tolerance); the remaining environment gap is
+measured continuously against production and bounded by numbers a human ratified.* That is
+the strongest honest form of confidence available in this domain (see the §1 language rule —
+"100% confidence" is not a claim we make); anything stronger is marketing.
 
 ---
 
@@ -416,3 +441,11 @@ available in this domain; anything stronger is marketing.
   ratification tied to a reviewed risk artifact with charter-consistent alerting; effort
   re-estimated 15–20 → 21–29 PRs. Panel also *verified*: shared cost path, shared entry
   mixin, duplication map, single-vs-multi as largest gap, #486 prereq complete.
+- **v2 merge** (2026-07-05): two sessions independently ran the three-lens panel and drafted
+  a v2 in parallel; this document is the reconciled union. Grafted from the sibling draft:
+  the explicit **sizing guardrail** and "100% confidence" language ban (risk finding #1);
+  the corrected `PartialExitExecutor` characterization (implemented-but-duplicates-fees, not
+  a stub); and the `strategy_executions` reuse note for P4.0. The three code-verified panel
+  reports are committed as durable artifacts under **`docs/refactor/reviews/`**
+  (`quant_review.md`, `architecture_review.md`, `risk_review.md`) — cite these for the full
+  file:line evidence behind each finding.

--- a/docs/refactor/backtest_live_parity_plan.md
+++ b/docs/refactor/backtest_live_parity_plan.md
@@ -477,3 +477,11 @@ the decision table, applied as adopted policy:
 - **Reporting**: A/B results and the P4.2 weekly parity audit publish through the frozen-
   exam/scoreboard system (docs/architecture/model_evaluation_system.md) — one append-only
   evidence discipline for both model and parity claims.
+
+**D1 mechanism correction (2026-07-06, flip-rate study)**: the feature window is exclusive
+of the forming bar — the model's prediction is FIXED within the hour; decisions flip because
+the live reference price (predicted_return denominator) mutates tick-by-tick. The gate is
+therefore "freeze the decision reference price to the closed bar," not "avoid OOD features"
+(the adoption note above overstated the OOD mechanism). Study also shows neither mode beats
+coin-flip on H+1 direction: the gate removes churn/whipsaw and buys input parity; it does not
+claim edge. Evidence: docs/research/experiments/2026-07-06_forming-bar-fliprate.md.

--- a/docs/refactor/reviews/architecture_review.md
+++ b/docs/refactor/reviews/architecture_review.md
@@ -1,0 +1,348 @@
+# Adversarial Architecture Review — Backtest ↔ Live Parity Plan
+
+> **Reviewer:** architecture / trading-system-safety lens (read-only; no source changed).
+> **Target:** `docs/refactor/backtest_live_parity_plan.md` (DRAFT v1, 2026-06-15).
+> **Base:** git worktree `backtest-live-parity` on top of #486 live-engine modularization.
+> **Date:** 2026-07-05. Every citation below was verified against code in this worktree.
+
+Findings are ranked most-severe first. Severity: **BLOCKER** (invalidates a P0 claim / must be
+resolved before the plan is executed), **MAJOR** (significant architectural or safety gap that
+needs a plan revision), **MINOR** (over-claim, mis-citation, or scope nit).
+
+---
+
+## 1. [BLOCKER] The P0 harness cannot exercise live's concurrency — no clock seam exists, and a single-threaded SimulatedExchange serializes away exactly the races that cause live-only bugs
+
+**Rationale:** P0.1/§L2 rest on two premises that are both false against the code: (a) that a
+`LiveLoopTimingCoordinator` "clock seam" makes the loop "time-warpable … no wall-clock sleeps,"
+and (b) that a `SimulatedExchange` driven by a scripted candle feed can faithfully exercise the
+live engine. It cannot reproduce the multi-threaded reality.
+
+**Evidence — there is no injectable clock:** `LiveLoopTimingCoordinator`
+(`src/engines/live/loop_timing.py:46`) is a *cadence/freshness helper*, not a clock. It calls
+`time.time()`, `time.sleep()` and `datetime.now(UTC)` directly (`loop_timing.py:56,58,61,71,88,113,132`).
+The trading loop sleeps on `stop_event.wait(seconds)` (wall-clock; `trading_engine.py:1481+`), and
+the periodic reconciler sleeps on `time.sleep(1)` (`reconciliation.py:3234`). Nothing here accepts
+an injected clock — "time-warpable via the coordinator seam" is not supported by the current code.
+
+**Evidence — live is genuinely multi-threaded, and mutations happen OFF the loop:** the engine
+spawns ≥6 long-lived threads: main loop (`startup.py:470`), WS-health (`ws_health.py:195`),
+order-tracker poll (`order_tracker.py:201`), UserDataProcessor (`user_data_processor.py:15`),
+periodic reconciler (`reconciliation.py:3190`), plus fire-and-forget alert threads
+(`trading_engine.py:2318`). Position/balance/order state is mutated *off the trading-loop thread*:
+order-tracker fill callbacks fire "outside any lock" on the poll thread
+(`order_tracker.py:446,454`), WS user-stream fills dispatch on the UserDataProcessor thread
+(`user_data_processor.py:73`), and the reconciler books trades and mutates balance on its own
+thread (`reconciliation.py:1111,2146,2661,2813`). A scripted-clock, single-threaded driver
+executes all of this in one deterministic order — the fill-vs-loop-drain interleave, the
+WS-poll-vs-user-stream race on the same order (`order_tracker._order_locks`, line 126), and the
+reconciler-vs-fill race (`_position_mutation_locks`, `reconciliation.py:3160`) simply never occur.
+The harness would be **green while the live-only bug classes it is meant to catch (#741 reject,
+#710 margin-reserve, partial-fill, cancel race) remain invisible.**
+
+**Suggested plan revision (§P0.1, §6 L2):** Split the claim explicitly. (1) Rename what the harness
+proves from "engine-level parity" to **"driver-level determinism parity"** — real financial
+*calculations* run through both engines, single-threaded, on identical candles. That is valuable and
+achievable. (2) Add a *separate* prerequisite workstream, **P0.0 "inject a Clock"**: introduce a
+`Clock` protocol (`now()`, `sleep()`) threaded through `loop_timing`, the reconciler, and the
+order-tracker poll loop, defaulting to a real-time impl. Without it, "no wall-clock sleeps in tests"
+is unattainable and P0 will either hang on real sleeps or fake the timing. (3) State plainly in §9
+that concurrency races are **out of scope for the equality harness** and belong to a distinct
+thread-fuzzing/fault-injection suite (see Finding 4) — do not let §L2's "exact equality end-to-end"
+imply the threading model is covered.
+
+---
+
+## 2. [BLOCKER] "Byte-exact TradeRecord equality" between the real live engine and backtest is unachievable as written, and the P0.2 normalization tuple is under-specified in a way that will either fail spuriously or mask real divergence
+
+**Rationale:** §1 ("Provable exactly"), §L2 and §L3(i) promise *exact* `TradeRecord` equality
+between a run of the **real live engine** and the backtest. Live mints non-deterministic identifiers
+and wall-clock-derived fields that backtest cannot match; the canonical tuple in P0.2 must exclude
+them — but the excluded fields are load-bearing, and excluding them silently removes real signal.
+
+**Evidence:** paper order ids are `f"paper_{int(time.time()*1000)}"`
+(`execution_engine.py:452,658`); live entry ids are
+`f"atb_{timestamp_ms:x}_{uuid.uuid4().hex[:8]}"` (`execution_engine.py:746-748`) and exit ids
+`f"atbx_{timestamp_ms:x}_{uuid.uuid4().hex[:8]}"` (`execution_engine.py:897-899`). These are pure
+wall-clock + `uuid4` — never reproducible in a candle-driven backtest. The canonical tuple already
+omits `order_id`, which is correct; but it *includes* `entry_ts`/`exit_ts`, and the live path's
+timestamps are driven by loop wall-clock, whereas backtest's come from the candle index
+(`exit_handler.py:173-174,188`). To make them comparable the harness must force the live clock to
+the candle clock — which requires the Clock seam that does not exist (Finding 1). Absent that,
+timestamps will differ and the "exact equality" check is a fiction.
+
+**The masking risk is the real danger.** Once you normalize away `order_id` *and* timestamps *and*
+whatever else refuses to match, the remaining tuple *(symbol, side, entry_px, qty, exit_px, reason,
+fees, slippage, interest, gross/net pnl, balance)* can be byte-equal while a genuine divergence
+hides in a field the normalizer dropped (e.g. a stop-order that filled at a *different time* within
+the bar in live vs a candle-close in backtest — same price, same pnl, different exit_ts, silently
+equal).
+
+**Suggested plan revision (§P0.2, §1, §6 L2/L3):** Downgrade the language from "byte-exact
+equality" to **"exact equality on a pinned economic-field set, with excluded fields enumerated and
+justified in the doc."** Specifically: (a) list every excluded field (`order_id`,
+`client_order_id`, `exchange_order_id`, and — until the Clock seam lands — the raw timestamps),
+each with a one-line reason; (b) replace raw `entry_ts`/`exit_ts` equality with **candle-index
+equality** (which bar the entry/exit booked on) so timing divergence is still caught at candle
+resolution rather than silently normalized out; (c) add a positive assertion that no *other* field
+is dropped — the normalizer is a closed, reviewed allowlist, not a "strip whatever differs" helper.
+
+---
+
+## 3. [MAJOR] The P3.2 import-linter "shared owns X" contract is violated by the shared layer *today* — `engines/shared` already reaches down into both `engines/backtest` and `engines/live`, and backtest imports live
+
+**Rationale:** P3.2 proposes a CI contract that `engines/backtest/**` and `engines/live/**` may not
+define "owned-by-shared" symbols, framed as making the shared core a clean upper layer. But the
+actual layering is already inverted in places, so the guard as described would either fail on day
+one or require moving code the live engine cannot cleanly give up — the plan does not acknowledge
+this.
+
+**Evidence:** `src/engines/shared/execution/snapshot_builder.py` imports **both**
+`from src.engines.backtest.models import ActiveTrade` and
+`from src.engines.live.execution.position_tracker import LivePosition, PositionSide`
+(`snapshot_builder.py:19-20`, and again at `:193,215`). These are `TYPE_CHECKING`-guarded — but
+import-linter analyzes `TYPE_CHECKING` imports by default, so a naïve "shared must not depend on
+live/backtest" contract flags them immediately. Separately, backtest imports live at runtime:
+`engines/backtest/engine.py:565-566` imports `RegimeStrategySwitcher` and `StrategyManager` from
+`src.engines.live` (also `backtest/regime/regime_handler.py:21-22`). So the dependency graph today is
+`backtest → live` and `shared → {backtest, live}`, the opposite of the plan's clean stack.
+
+**Suggested plan revision (§P3.2, add a step to §P1):** Make the layering explicit and sequence the
+guard *after* the coupling is removed, not before. Add a prerequisite: (a) invert
+`snapshot_builder`'s dependency — define the position/trade shapes it needs as a `Protocol` in
+`shared` and have both drivers satisfy it, so shared stops importing down; (b) move
+`RegimeStrategySwitcher`/`StrategyManager` (currently in `live`, consumed by `backtest`) into
+`shared` or a neutral module, or the `backtest → live` edge stays. Only then enable the
+import-linter contract, and scope its first version to `--ignore` the known remaining edges with
+tracking issues rather than presenting it as a clean green gate. Also note import-linter is not
+currently a dependency (absent from `setup.cfg`/requirements) — P3.2 adds a new tool + config.
+
+---
+
+## 4. [MAJOR] The harness proves only the happy path — none of live's hardest bug classes (reject, partial fill, cancel race, margin-reserve, phantom-order UNKNOWN) are in the P0 scenario matrix except as passive ledger rows
+
+**Rationale:** Principle §"Assume Malicious Markets" / CODE.md "Planning Complex Features" both
+demand enumerating failure scenarios (timeout, partial fill, reject, crash-mid-op, external close).
+The P0.3 matrix is entirely clean-execution scenarios; the failure modes are pushed to the §7 ledger
+as "edge events … out of scope for sharing." But these are the exact paths that lost real capital
+(capital-erosion postmortem; #741 order-reject; #710 margin-reserve) and where backtest most
+dangerously over-promises returns.
+
+**Evidence the code has rich failure handling worth testing:** `_execute_live_order` distinguishes
+definitive reject (`ValueError` → mark FAILED, no position; `execution_engine.py:779-801`) from
+ambiguous `None` (→ mark UNKNOWN, return client_order_id to block dupes;
+`execution_engine.py:803-823`) — the phantom-order window. Partial fills are first-class
+(`_is_filled_status` accepts `PARTIALLY_FILLED`, `execution_engine.py:199-207`; journal stays
+SUBMITTED until fully filled, `:837-841`). `_normalize_quantity` rejects on `min_qty`/`min_notional`
+(`:1035-1054`). The reconciler books balance-neutral external-close rows
+(`reconciliation.py:2369-2375`). A `SimulatedExchange` implementing `ExchangeInterface` is the
+*ideal* place to inject these — it is the seam through which every one of these paths runs.
+
+**Argument for adding it (not against):** the marginal cost is low because the harness already has to
+implement the full `ExchangeInterface` (`place_order`, `place_stop_loss_order`, `get_order`,
+`cancel_order`, balances). Making fills *scriptable per order* (this order rejects; this one fills
+40% then the rest next poll; this `place_order` returns `None`) is a small extension of a component
+being built anyway, and it is the only way to prove the live engine's failure-recovery code without
+a real exchange. Leaving it out means the plan's flagship safety artifact never touches the code
+that actually loses money.
+
+**Suggested plan revision (§P0.1 and §P0.3):** Add to `SimulatedExchange` a **fault-injection
+script** — a per-`client_order_id` policy of `{fill_full | partial(fraction) | reject(reason) |
+return_none_ambiguous | cancel_before_fill}`. Add four scenarios to P0.3: (i) entry rejected by
+exchange (`ValueError`) → assert no position, FAILED journal; (ii) `place_order` returns `None` →
+assert UNKNOWN journal + phantom-block, then reconciler resolves; (iii) partial entry fill →
+assert position sized to filled qty, journal SUBMITTED; (iv) stop-loss `place_stop_loss_order`
+returns a bare id then `get_order` shows fill (note the return-type asymmetry: `place_order` →
+`Order | None` but `place_stop_loss_order` → `str | None`, `exchange_interface.py:242` vs `:285` —
+the harness must model the follow-up `get_order`). These assert *live-only* behavior, so they run
+against the live driver only (backtest has no exchange to reject), which is fine — the ledger then
+records the residual, but the *code path* is now covered by a test.
+
+---
+
+## 5. [MAJOR] Sequencing risk: P0 builds the SimulatedExchange against the live `ExchangeInterface`, but P1/P3 reshape the surfaces the harness binds to — the "measure before you refactor" instrument will need rework mid-flight
+
+**Rationale:** §"Ordering principle: build the measuring instrument before touching the thing
+measured" is sound in spirit, but the instrument (P0) is coupled to two things that later phases
+explicitly change: (a) the `ExchangeInterface` surface, and (b) the per-engine handler internals the
+equality harness asserts against. The plan treats P0 as a stable foundation; it is partly built on
+sand that P1/P2/P3 stir.
+
+**Evidence:** P1.1-P1.4 replace both engines' exit/entry/partial handlers with shared workflows —
+so the intermediate states the P0 harness observes (and the divergence-report field diff, P0.4)
+shift underneath it. P2.1 (`ExchangeRules`) and P2.3 (multi-position `PositionTracker`) *deliberately
+change backtest outputs* (P2.1 note: "intentionally changes backtest results"; the backtest tracker
+is single-slot today — `current_trade: ActiveTrade | None`, `position_tracker.py:64`). So the
+"golden fixtures" pinned in P0.3 must be re-baselined at P2.1, P2.3, and P2.4 by design. And the
+`SimulatedExchange` binds to `ExchangeInterface`, whose `place_stop_loss_order`/`get_order` shape is
+in scope for the stop-order-tier work (P2.4). This is not fatal — but "measure first, then refactor"
+implies the measurement is stable, and it is not.
+
+**Suggested plan revision (§4 preamble, §8 dependency table):** Reframe P0 as **two layers**: a
+*stable* layer (balance-conservation invariants, L3 property tests, the divergence-report *format*)
+that survives refactors, and a *volatile* layer (golden fixtures with exact values) that is
+explicitly expected to re-baseline at each fidelity-improving phase. In §8, add the missing edges:
+P0.1 `SimulatedExchange` → depends on a *frozen* `ExchangeInterface` (declare it frozen for the
+duration, or accept P0 rework at P2.4); P0.3 golden fixtures → re-baseline gates at P2.1/P2.3/P2.4.
+Consider building `SimulatedExchange` against a **thin adapter** you own rather than binding directly
+to `ExchangeInterface`, so P2.4's interface changes touch one adapter, not the whole harness.
+
+---
+
+## 6. [MAJOR] `PartialExitExecutor` is mischaracterized as a "stub," and it computes fees with its own `fee_rate` rather than delegating to `CostCalculator` — a genuine parity hazard the plan misses while chasing a non-problem
+
+**Rationale:** §2 calls `partial_exit_executor.py` a "stub underused" and P1.4 says "finish the
+stub." That is factually wrong and, worse, it points effort at the wrong risk. The class is fully
+implemented and *already wired into the backtest tracker*; the real hazard is that it duplicates fee/
+slippage math instead of using the shared `CostCalculator`, which is precisely the drift the whole
+plan exists to kill.
+
+**Evidence:** `partial_exit_executor.py` is 205 lines of complete P&L/fee/slippage logic
+(`execute_partial_exit`, `:91-176`), and the backtest `PositionTracker` already imports and uses it
+(`position_tracker.py:23`). But it computes costs locally: `exit_fee = abs(exit_notional *
+self.fee_rate)` and `slippage_cost = abs(exit_notional * self.slippage_rate)`
+(`partial_exit_executor.py:154-155`) — a *second* implementation of fee/slippage, parallel to
+`CostCalculator.calculate_exit_costs` (`cost_calculator.py:162`). CODE.md "Backtest-Live Parity":
+"Never duplicate financial logic — use `src/engines/shared/` … (`cost_calculator`)." This is a live
+CODE.md violation the plan should target, not a stub to finish.
+
+**Suggested plan revision (§2 table and §P1.4):** Correct the description from "stub underused" to
+"implemented but computes fees/slippage independently of `CostCalculator`." Rescope P1.4 from
+"finish the stub" to **"route `PartialExitExecutor`'s cost math through `CostCalculator` and wire
+both engines' partial paths through the executor."** Add a parity test that a full exit executed as
+one 100% partial slice equals a normal exit through `CostCalculator` to the cent — that pins the two
+fee paths together.
+
+---
+
+## 7. [MAJOR] §1 claims backtest models "every economically meaningful thing," but bid-ask spread (paid on every market fill) and perp funding are modeled by neither engine and are absent from the §7 ledger seed
+
+**Rationale:** §1 enumerates "fees, slippage, exchange rounding, margin interest, stop-order
+mechanics, partial operations" as the economically meaningful set. For a 24/7 crypto system trading
+market orders, **bid-ask spread is a real per-fill cost** and (for any perpetual/futures venue)
+**funding** is a real carry cost. Neither is in `CostCalculator`, and neither appears in the ledger's
+seed rows — so the plan's own "every economically meaningful thing is modeled or ledgered" invariant
+is already breached on the modeling side, not just the environmental side.
+
+**Evidence:** `cost_calculator.py` contains no spread/bid/ask/funding logic (grep across the file:
+zero hits for `spread|bid|ask|funding`); nothing in `engines/shared/` references funding. The §7
+seed list names intrabar ticks, partial fills, latency, cadence, sentiment, reconciler closes,
+outages — but not spread or funding. Slippage (`slippage_rate`) is modeled as a symmetric adverse
+move, which is not the same as the half-spread crossed on entry *and* exit.
+
+**Suggested plan revision (§1, §7, §P2):** Either (a) add spread and funding as explicit ledger rows
+(`id | description | bias | quantified impact | bound | monitor | status`) with the fee-truth
+reconciliation (P4.3) measuring realized spread from `orders.actual_commission`-adjacent fill data,
+or (b) if a future phase will model half-spread inside `CostCalculator`, name it as a P2 item. What
+the plan must not do is claim §1 completeness while two first-order market costs are silently
+unmodeled and unledgered.
+
+---
+
+## 8. [MINOR] Over-claim: "byte-exact, CI-enforced equality" for accounting parity ignores float non-associativity across two independently-ordered summation paths
+
+**Rationale:** §1(3) and §5 promise the determinism fingerprint stays "byte-identical" and accounting
+evolves "identically." Even with identical inputs and shared cost code, the live driver and backtest
+driver accumulate balance through *different call sequences* (live: async fill callbacks + reconciler
+adjustments; backtest: in-loop). IEEE-754 addition is not associative, so `a+b+c` booked in a
+different order can differ in the last ULP. CODE.md itself mandates `pytest.approx` for financial
+calculations and epsilon tolerance for float comparison — "byte-exact" contradicts the house rule.
+
+**Evidence:** CODE.md "Tests": "Use `pytest.approx` for financial calculations, not exact float
+equality"; "Arithmetic": "Use epsilon tolerance for float comparisons." The live path applies fee
+deltas incrementally via `_adjust_cost_totals` on out-of-order fills (`execution_engine.py:430,588`),
+a different accumulation order than backtest's.
+
+**Suggested plan revision (§1, §5, §6):** Replace "byte-exact equality" with **"equality within a
+declared ULP/epsilon tolerance"** for monetary aggregates, reserving exact equality for integer/
+identifier/enum fields and discrete decisions. Keep the determinism *fingerprint* byte-exact only for
+a *single engine's* reproducibility (L0, which is legitimately exact); cross-engine (L2) should be
+epsilon-based, consistent with CODE.md.
+
+---
+
+## 9. [MINOR] Line-reference drift in §2 and the docstring citation will rot; the plan hard-codes many `file:NNN` refs that are already slightly off
+
+**Rationale:** The plan is dense with exact line citations, several of which have already drifted in
+this worktree — a maintenance hazard for a doc meant to guide multi-session execution.
+
+**Evidence:** plan cites the "Known parity caveats" docstring at `backtest/engine.py:135-158`; it is
+actually at `:141-162`. Plan says `engine.py` is "1,820 lines"; it is 1,898. Plan cites live
+execution delegation at "`execution_engine.py:241,338`"; the live entry cost call is at `:367` in
+this worktree. The backtest delegations (`:159,245,308`) and the uuid/timestamp sites
+(`:452,658,746-748,897-899`) *do* verify — so the refs are mostly right, which makes the stale ones
+more misleading.
+
+**Suggested plan revision (throughout):** Cite by **symbol** (`Backtester` docstring;
+`LiveExecutionEngine._execute_live_order`; `PositionTracker.current_trade`) rather than line number,
+or add a "verified against commit `<sha>`" stamp so readers know line numbers are point-in-time.
+
+---
+
+## 10. [MINOR] P0.1 implies a greenfield `SimulatedExchange`, but stateful/`Mock`-based exchange doubles already exist in the test tree and should be reconciled, not duplicated
+
+**Rationale:** Building a third, parallel notion of "fake exchange" risks the same duplication the
+plan is trying to eliminate — this time in test infrastructure.
+
+**Evidence:** `tests/integration/live/test_reconciliation_integration.py:42` defines
+`MockExchangeOrder` and drives `mock_exchange.place_order/get_order/get_order_by_client_id`
+extensively; `tests/integration/live_trading/test_engine_core.py:112` wires a `MockExchange`. These
+are per-test `Mock`s with no stateful fill engine — so `SimulatedExchange` is genuinely new (a
+stateful, `OHLCFillModel`-backed implementation), but the plan should say it *supersedes/absorbs*
+these doubles rather than adding a fourth pattern.
+
+**Suggested plan revision (§P0.1):** Add a sentence: "the `SimulatedExchange` becomes the single
+exchange test-double; migrate `MockExchangeOrder`/`MockExchange` call sites to it (or a thin
+factory over it) so there is one fake-exchange implementation, not several."
+
+---
+
+## Verified Correct (parts of the plan that hold up against the code)
+
+- **Shared-core inventory (§2 "Already unified") is accurate.** `engines/shared/` contains
+  `cost_calculator.py`, `models.py`, `dynamic_risk_handler.py`, `correlation_handler.py`,
+  `trailing_stop_manager.py`, `strategy_exit_checker.py`, `partial_operations_manager.py`,
+  `validation.py`, `side_utils.py` — as claimed. Both engines' execution engines delegate cost/fill
+  to `CostCalculator` (backtest `execution_engine.py:159,245,308`; live `execution_engine.py:367`).
+- **The duplication table (§2) is real.** Backtest `exit_handler.py` (876 lines) contains inline
+  SL/TP high/low fill detection (`~:546-625`) that mirrors the live exit path — held equal only by
+  tests, exactly as the plan says. P1.1's `ExitTriggerEvaluator` targets a genuine hazard.
+- **The single-position structural gap (§2 #3, P2.3) is verified and correctly flagged as the
+  largest item.** Backtest `PositionTracker` holds `self.current_trade: ActiveTrade | None`
+  (`position_tracker.py:64`, `POSITION_KEY = "active"`), while live holds N keyed by order_id and
+  honors `get_max_concurrent_positions()` (`entry_coordinator.py:524`, `trading_engine.py:1608`).
+  Recommending option (a) *sequenced last, behind its own design doc* is the right call.
+- **The exchange-rounding gap (§2 #1, P2.1) is verified.** Live applies `step_size` rounding +
+  `quantize_to_step` + `min_qty`/`min_notional` rejection (`execution_engine.py:1005-1054`); the
+  backtest path calls `quantize_to_step` **nowhere** (zero hits under `engines/backtest/`) and uses
+  raw floats. P2.1 addresses a real divergence, and gating it behind a flag with an A/B report before
+  flipping defaults (§5) is the correct discipline.
+- **The margin-interest asymmetry (§2 #2) is real.** Backtest defaults
+  `annual_margin_interest_rate = 0.0` (silently optimistic for shorts), documented in the caveats
+  docstring; live queries the exchange. P2.2's shared `FinancingCostProvider` + calibration job is
+  the right shape.
+- **Layered proof system (§6) and the parity-gap ledger (§7) are the right architecture** for a
+  domain where exact reproduction is impossible — the honest framing in §9 ("anything stronger is
+  marketing") is correct and should be preserved. The findings above tighten *which* claims can be
+  called "exact"; they do not dispute the layered approach.
+- **Existing parity test surface is as described.** `tests/integration/parity/` contains
+  `test_side_by_side_parity.py`, `test_engine_parity.py`, `test_backtest_determinism.py`; the
+  side-by-side suite already instantiates `LiveTradingEngine` (at the calculation/method level with
+  `Mock`s) — so P0.2's "extend from handler-level to engine-level" starts from a real base, even
+  though the end-to-end leap is larger than "extend" implies (Finding 1).
+
+---
+
+## Bottom line
+
+The plan's *direction* is right — collapse the duplicated exit/entry/partial logic into shared
+workflows, model the known backtest gaps (rounding, interest, multi-position), and prove it with
+layered tests. The **fidelity gaps in three "Provable exactly" claims are the problem**: (1) the P0
+harness cannot exercise live concurrency because no clock seam exists and a single-threaded driver
+serializes the races (Finding 1); (2) "byte-exact TradeRecord equality" against a uuid/wall-clock-
+minting live engine is unachievable and, as normalized, risks masking divergence (Finding 2); and
+(3) the P3.2 layering guard is already violated by `shared → {live, backtest}` and `backtest → live`
+edges (Finding 3). Add fault injection to the one component built to carry it (Finding 4), fix the
+sequencing so the harness isn't rebuilt mid-refactor (Finding 5), and correct the
+`PartialExitExecutor` and spread/funding characterizations (Findings 6-7). With those revisions the
+plan is executable; as written, its headline safety guarantees over-promise.

--- a/docs/refactor/reviews/quant_review.md
+++ b/docs/refactor/reviews/quant_review.md
@@ -1,0 +1,136 @@
+# Adversarial Review: Backtest ↔ Live Parity Plan — Quant / Backtest-Fidelity Lens
+
+> Reviewer: quant-researcher (adversarial pass, read-only). Target: `docs/refactor/backtest_live_parity_plan.md` v1 (2026-06-15 draft).
+> All file:line citations verified against the worktree at
+> `/Users/alex/Sites/ai-trading-bot/.claude/worktrees/backtest-live-parity` on 2026-07-05. No source files were changed to produce this review.
+
+---
+
+## Finding 1 — BLOCKER: §P2.5's core premise ("live decisions are gated per-candle too") is FALSE
+
+**Rationale:** The plan's entire argument that partial-op/decision cadence isn't "parity-critical for candle-driven strategies" rests on live being gated to one decision per closed candle, same as backtest. It is not. Live re-runs the *entire* decision pipeline — entries, exits, partial-ops — on a wall-clock poll timer (30–300s), independent of candle boundaries, and can (and normally does) re-evaluate the same still-open candle many times before it closes.
+
+**Evidence:**
+- `src/engines/live/trading_engine.py:1554-1560` — `_runtime_process_decision(...)` (the live analogue of `strategy.process_candle()`) runs unconditionally every loop iteration, gated only by `safety_mode`/data-readiness — no `if new_candle_closed:` anywhere in the file (confirmed by grep, zero matches).
+- `src/engines/live/trading_engine.py:1586-1593` — `_check_exit_conditions(...)` and `src/engines/live/trading_engine.py:1597-1604` — `check_partial_operations(...)` run at the identical uncontrolled cadence, also with no candle-close gate.
+- `src/engines/live/loop_timing.py:94-133` (`is_data_fresh`) is an **age-threshold** check (`age_seconds <= state.data_freshness_threshold`, line 133), not a "did the candle change" check. The same closed (or still-forming) candle stays "fresh" and is reprocessed repeatedly until it ages out.
+- `src/config/constants.py` (`DEFAULT_CHECK_INTERVAL=60`, `DEFAULT_MIN_CHECK_INTERVAL=30`, `DEFAULT_MAX_CHECK_INTERVAL=300`) and `loop_timing.py:63-92` (`calculate_adaptive_interval`) confirm the poll cadence is seconds-scale, not candle-period-scale (e.g. 3600s for 1h). For a 1h timeframe, live evaluates the same bar up to ~60-120 times before it closes.
+- Verified independently twice: once via direct read of `trading_engine.py:1442-1621`, once via a fresh isolated subagent — both concur.
+
+**Suggested plan revision:** Rewrite §P2.5 entirely. Drop the "not parity-critical... live decisions are gated per-candle too" claim. Reframe the cadence gap as a **first-class, high-priority item**, not an optional afterthought: (a) it means live's *effective* decision rate is far higher than backtest's, so any per-candle-only backtest strategy is not actually being tested against the loop cadence live runs at; (b) it means strategies whose signal logic is not idempotent across repeated evaluation of the same candle (e.g. state that mutates on each `process_candle` call) will behave differently in live than backtest assumes. Add this as its own ledger row in §7 with "live re-evaluates every 30-300s vs backtest once per closed bar" as the description, and make quantifying its effect a **P0/P1** priority (harness scenario), not a "later, optional" P2 line.
+
+---
+
+## Finding 2 — BLOCKER: Three-way (not two-way) exit-timing asymmetry; live can act on a mutating, still-forming candle
+
+**Rationale:** §2 item #4 says "live SL can fill mid-bar at the exchange... backtest checks the SL level once per candle against high/low" — correctly identifying that SL is a resting order, but it understates the mechanism and misses that live's own bot-side TP/SL polling loop reads a candle buffer whose **last row mutates in place from partial (unclosed) WebSocket kline events**. This is not just "SL fills mid-bar" — it's that live's own `candle_high`/`candle_low` inputs to exit-condition checks can be a live-updating, not-yet-final value, structurally different from backtest's frozen, closed-bar high/low.
+
+**Evidence:**
+- `src/engines/live/execution/market_data_coordinator.py:127-170` (`get_latest_data`) — no `is_closed`/`close_time` filter anywhere in the file.
+- `kline_buffer.py:205-218` (`_update_current_candle`) — docstring: *"Update the tail row's OHLCV in-place from a partial kline event."* `on_kline` treats `event_ts == tail_ts` as "current candle (open or closed — same OHLCV write)."
+- `src/engines/live/execution/stop_loss_manager.py:95` → `place_stop_loss_order` — SL is a real resting exchange order, confirmed independent of the bot loop (cancel-before-close handling at `exit_coordinator.py:388-424` exists precisely because the order lives on the exchange, not in-process).
+- No `place_take_profit_order` exists on `ExchangeInterface` — TP is bot-side only, polled via `exit_handler.py:648-680` (`_check_take_profit`) against `candle_high`/`candle_low`, which per the kline-buffer finding above can be a still-forming candle's live-mutating high/low.
+- `src/engines/backtest/execution/exit_handler.py:534-620` (`check_exit_conditions`) reads `candle["high"]`/`candle["low"]` exactly once per call (lines 577-578, 596, 603, 616, 618) from a frozen, closed historical bar — strictly discrete, coarse-grained.
+- No mention of "resting order," "forming candle," or "intrabar" timing asymmetry anywhere in `docs/architecture.md`, `docs/live_trading.md`, or `docs/backtesting.md` today.
+
+**Suggested plan revision:** In §2, replace item #4's framing with a three-tier taxonomy: (1) SL = continuous, exchange-side, any timestamp; (2) bot-side TP (and any bot-side SL re-check) = discrete-but-frequent, loop-cadence, **potentially against a still-forming candle**; (3) backtest = discrete-and-coarse, always closed data. Add a dedicated Parity Gap Ledger (§7) row for "live TP/exit polling can read a mutating forming candle" — this is a distinct mechanism from "SL fills mid-bar" and needs its own scenario in the P0.3 matrix (e.g., a candle whose high briefly exceeds TP mid-formation, then retraces before close — live may exit, backtest never sees it because backtest only sees the final closed high, which by construction would also breach TP... but the exit *price and timing* would differ). Also feeds directly into P0.1's `SimulatedExchange` design: it must model a mutating current-bar buffer if it's to reproduce this behavior, not just closed-bar candles.
+
+---
+
+## Finding 3 — BLOCKER: L3's "trade sequences equal" invariant will be flaky/unachievable as stated — wall-clock order-ids and exit timestamps are structurally non-reproducible
+
+**Rationale:** The plan's canonical `TradeRecord` tuple and L3 Hypothesis invariant "(i) trade sequences equal" imply exact equality across fields including timestamps. Several fields are generated from `time.time()`/`uuid4()` directly in live's execution path, with no clock-injection seam threaded through yet — meaning two runs of the identical scripted scenario through a `SimulatedExchange`-backed live engine will not produce identical records, even before comparing to backtest.
+
+**Evidence:**
+- `src/engines/live/execution/execution_engine.py:658` and `:452` — paper order id: `f"paper_{int(time.time() * 1000)}"`.
+- `src/engines/live/execution/execution_engine.py:746-748` — entry `client_order_id`: `timestamp_ms = int(time.time() * 1000); unique_suffix = uuid.uuid4().hex[:8]`.
+- `src/engines/live/execution/execution_engine.py:897-899` — exit `client_order_id`, same pattern.
+- `src/engines/live/execution/position_tracker.py:365`, `exit_coordinator.py:564,620`, `recovery.py:751,778`, `reconciliation.py:2958` — all stamp `exit_time = datetime.now(UTC)` (wall clock at code-execution instant), vs. backtest's `src/engines/backtest/execution/exit_handler.py:809,821` — `exit_time=current_time`, which is the **candle timestamp** passed in from `engine.py`.
+- `entry_time` fares better: `trading_engine.py:1544-1552` derives it from `current_candle.name` (candle-derived), falling back to `datetime.now(UTC)` only on an anomalous path — likely safe, but the fallback should be asserted-against in the harness, not assumed unreachable.
+- Backtest has no order-id concept at all (`src/engines/backtest/models.py`, `execution_engine.py`) — trades are identified positionally, so any future extension of the tuple to include order id is a non-starter by construction.
+
+**Suggested plan revision:** In §6 (L3 row) and §P0.1, add an explicit prerequisite: retrofit the four `datetime.now(UTC)` call sites above to consume the injected clock from `LiveLoopTimingCoordinator` before any exact-equality trade-sequence assertion is attempted — otherwise L3 will be red by construction, independent of whether the strategy logic is actually correct. Redefine the invariant itself as **tiered**, not blanket `==`:
+- **Exact equality**: `symbol`, `side`, `entry_px`, `qty`, `exit_px`, `reason`, `entry_ts` (after verifying the fallback path is unreachable in the harness).
+- **Exact equality contingent on clock-injection retrofit**: `exit_ts`.
+- **Tolerance-based** (`math.isclose`, e.g. 1e-9 absolute): `fee_entry`, `fee_exit`, `slippage`, `interest`, `gross_pnl`, `net_pnl`, `balance_after` — these are chained float arithmetic through two independently-coded wrapper paths (e.g. live's `scaled_entry_fee = entry_fee * close_portion` at `exit_coordinator.py:546` vs backtest's direct sum at `engine.py:1402-1408`); a few ULPs of difference is plausible and economically meaningless.
+- **Excluded from the tuple entirely**: any order-id field (already correctly absent, but state this explicitly as a design decision, not an oversight).
+
+---
+
+## Finding 4 — MAJOR: P4.1 production shadow replay is not well-posed today — model version resolved via `latest` symlink is never persisted per session/trade
+
+**Rationale:** §P4.1 claims replay "requires persisting the live session's input snapshot (candles already cached; config already in `trading_sessions`)" — implying only candles need work. In fact the ML model version is a silent, unlogged input: `latest` is a mutable symlink, `_load_bundle` resolves it to a concrete `version_id` at load time, but that resolved id is never written to any table. If `latest` gets repointed between when a session ran and when someone replays it, the replay will silently use the WRONG model and produce a divergence that looks like a live/backtest bug but is actually a resolved-model mismatch.
+
+**Evidence:**
+- `src/prediction/models/registry.py:109-128` — `_load()` loads concrete version dirs first, then applies `latest` last so "latest symlink assignment wins" (comment, line 112); `_load_bundle` at line 138-152 does `real_dir = vdir.resolve()` and extracts `version_id = real_dir.name` — the concrete version IS known in-process at load time.
+- `src/database/models.py:543-594` (`TradingSession`) — has `strategy_name`, `strategy_config` (JSONType), `symbol`, `timeframe`, but **no** `model_version`/`version_id` column.
+- `src/database/models.py:134-203` (`Trade`) — has `strategy_config` (JSONType, strategy hyperparameters only) and `confidence_score`, but **no** `model_version`/`version_id` column anywhere. Confirmed via grep across `models.py`: zero matches for `version_id`/`model_version`.
+- This is exactly the trap the review brief warned about: "is the model version even recorded per session?" — verified: **no**.
+
+**Suggested plan revision:** Add an explicit P4.1 sub-task (before the replay CLI is built): stamp the resolved concrete `version_id` (per symbol/model_type) into `TradingSession` (new column or a JSON field) at session start, and ideally per-trade if hot-swap (`strategy_hot_swap.py`) can change the model mid-session — otherwise a session that hot-swaps models mid-flight cannot be replayed at all, since there's no record of *which trades used which model version*. Without this, P4.1's replay is unimplementable as scoped; it needs its own short design note, not a one-line "requires persisting... config already in trading_sessions" hand-wave.
+
+---
+
+## Finding 5 — MAJOR: Candle cache is a mutable, overwritten-in-place file — "candles already cached" does not mean "candles as-seen-live are preserved"
+
+**Rationale:** P4.1 assumes the candle window for a past session can be reconstructed from cache. The cache is not an immutable ledger — it's a single parquet file per key that gets atomically **overwritten** on every refresh, and live's own loop re-pulls the latest candle via REST on every tick and merges it in. There is no versioning of "what the cache contained at time T" vs. "what it contains now." For the most recent candles in a session (which were still forming or freshly closed when live acted on them), replaying today may read a value that was revised after the fact — silently breaking the replay's well-posedness for exactly the trades where timing matters most.
+
+**Evidence:**
+- `src/data_providers/cached_data_provider.py:182-218` (`_save_to_cache`) — atomic write via `os.replace(temp_path, cache_path)` (line 218): each refresh **replaces** the file in place; no historical snapshot retained.
+- Live's `update_live_data` re-pulls the latest candle via REST every loop tick and merges by index (dedup + `sort_index`) regardless of what the WS stream delivered — meaning the cache's most recent rows are a moving target during the exact window a replay would need to be stable.
+
+**Suggested plan revision:** P4.1 must explicitly snapshot (not just "reference") the candle window at trade-decision time — e.g., append-only per-session candle archive keyed by `(session_id, symbol, timeframe)` written once at first use, immune to later cache overwrites — rather than relying on the live cache-manager's current file as a stand-in for history. State this as a required schema/storage addition in §P4.1, not assume it's already covered by "candles already cached."
+
+---
+
+## Finding 6 — MAJOR: Sensitivity/impact-scaling and dust/residual gaps missing from §2 and the (not-yet-created) ledger
+
+**Rationale:** Two real, currently-unlisted divergence sources were found in the cost model and quantization logic:
+
+**(a) Order-book impact / size-dependent slippage is absent from both engines identically.** `CostCalculator` (`src/engines/shared/cost_calculator.py:110-214`) and `execution_engine.py:294-297` (`calculate_slippage_cost`) apply a flat `slippage_rate` × notional with no order-size, book-depth, or ADV term. Since both engines share this blind spot, it's not a live-vs-backtest *divergence* per se — but it means neither engine's slippage number is trustworthy for larger position sizes, and the plan's "measured, bounded, monitored difference" framing (§1) implicitly assumes the *model* itself is sound, which it isn't for size-scaling. This is a calibration-risk gap, distinct from the mechanism gaps already ledgered, and belongs in §7 as its own row so it doesn't get silently conflated with "parity is proven" once L0-L3 go green.
+
+**(b) Dust/residual base-asset from partial-close rounding is not tracked or fed back into sizing.** `_normalize_quantity` (`execution_engine.py:986-1030`) recomputes `quantity = value / price` fresh at each call site — it does not take a prior-position residual as input, and no `dust`/`residual` field exists on `position_tracker`. Rounding residue from a partial close (leftover base qty that doesn't round cleanly to `step_size`) silently sits as unaccounted holdings; over many partial-exit cycles, live's actual position/exposure can drift from backtest's exact-float assumption in ways P2.1 ("ExchangeRules... quantize_to_step") does not address, since P2.1 only covers forward-rounding, not residual carry-forward.
+
+**Evidence:** as cited above; also confirmed via grep that no `market_impact`/`depth` size-scaling logic exists anywhere in `src/engines/`, and the only "dust" references found are a `$1 free-balance dust threshold` guard (`execution_engine.py:730`, unrelated) and `BORROW_DUST_EPSILON` (`stop_loss_manager.py:209-228`, a borrow-repayment completeness epsilon, not position-size dust).
+
+**Suggested plan revision:** Add two new rows to §7's seed list: "flat slippage model — no size/impact scaling (shared blind spot, not a divergence)" and "partial-close rounding residual not tracked or fed to subsequent sizing (dust accumulation)." Scope the latter into P2.1 or split it into its own item — as written, P2.1's "Removes caveat #1" claim is only true for forward quantization, not the residual-carry failure mode.
+
+---
+
+## Finding 7 — MINOR: T1 (bps/trade) and T2 (%/30d cumulative) thresholds can hide sign-cancelling divergence; propose a distribution/worst-case metric alongside the mean
+
+**Rationale:** §P4.2's headline metrics — per-trade bps delta and cumulative %/30d delta — are both susceptible to a classic offsetting-errors failure mode: N trades with large, opposite-signed per-trade deltas (e.g., +40bps, −38bps, +41bps, −39bps...) can net to a cumulative delta well under T2 while every individual trade blows past T1, or conversely a handful of trades with consistent one-directional bias could stay under a naive "average bps/trade" if it's computed as a mean rather than checked per-trade. The plan does gate on **per-trade** bps (good), but the cumulative %/30d check as the *only* aggregate statistic will not surface a systematic bias that's small per-trade but persistent in one direction (e.g., a small, permanent live-slippage-model miscalibration) if T1 happens to bound each individual instance just under threshold while T2's cumulative check is satisfied by chance cancellation with unrelated noise from other trades.
+
+**Suggested plan revision:** In §P4.2, augment the two scalar thresholds with: (i) the full distribution of `|delta|` per trade (not just a pass/fail against T1) so a human can see if the divergence is concentrating in a subset of trade types (e.g., all partial-exits, or all short entries); (ii) a **sign-preserving cumulative sum** (not just net %) to distinguish "small consistent bias, same direction, every trade" from "large but random, cancelling" — these have very different implications for whether backtest is trustworthy going forward. A rolling worst-case (max |delta| in the window) alongside the mean/median closes the "diluted by cancellation" hole. This is a metric-design fix, not a blocker — the mechanism (weekly replay + ledger) is sound, only the choice of summary statistic needs sharpening.
+
+---
+
+## Finding 8 — MINOR: Funding rates correctly out of scope; confirm this explicitly rather than leaving silent
+
+**Rationale:** The review brief asked whether funding-rate accrual (perpetual futures) is a missed divergence source. It is not applicable: this system trades spot/cross-margin only. `src/data_providers/binance_provider.py` routes exclusively via `BINANCE_ACCOUNT_TYPE` (spot/margin); no perpetual-futures client, and no `fundingRate`/`premiumIndex` API calls exist anywhere in `src/`. The single "futures" hit found (`src/data_providers/exchange_interface.py:189`) is a stale, generic docstring phrase ("Get open positions (for futures/margin trading)"), not a real code path.
+
+**Suggested plan revision:** No action needed on funding rates themselves. But add one sentence to §2 or §9 explicitly stating "this system trades spot/cross-margin only; perpetual-futures funding-rate accrual is out of scope by design, not an oversight" — a future reader auditing the plan without this context (as I was asked to do) would otherwise reasonably flag its total absence as a gap. Making the scope boundary explicit costs one sentence and forecloses a repeat of this exact audit question.
+
+---
+
+## Finding 9 — MINOR: Spread/bid-ask reference price is correctly a non-issue today, but the plan should say so explicitly to close off a plausible-sounding false lead
+
+**Rationale:** Neither engine ever references a live bid/ask quote or order-book snapshot — both apply slippage as `price × (1 ± slippage_rate)` off a candle-derived close/open (`cost_calculator.py:135-160`; live's `execution_engine.py` `apply_entry_slippage`/`apply_exit_slippage`, lines 236-278, same candle-derived price). So "spread" is not an *extra* divergence source beyond what's already modeled by the shared slippage rate — but this also means the flat slippage constant is not validated against real spread-widening in thin books/volatile regimes, which is really the same calibration-risk theme as Finding 6(a).
+
+**Suggested plan revision:** Merge this into Finding 6's ledger row rather than treating as separate — "flat slippage/spread model, not validated against real bid-ask behavior in thin or volatile conditions" is one calibration-risk item, not two. Flagging here only so the plan doesn't need a separate investigation later; no structural change required beyond what Finding 6 already proposes.
+
+---
+
+## Summary table
+
+| # | Severity | One-line issue |
+|---|---|---|
+| 1 | BLOCKER | §P2.5's "gated per-candle too" claim is false — live polls every 30-300s regardless of candle state |
+| 2 | BLOCKER | Exit timing is a 3-way asymmetry (continuous SL / frequent-on-forming-candle TP / discrete backtest), not the 2-way the plan describes |
+| 3 | BLOCKER | L3 exact trade-sequence equality is unachievable as stated — wall-clock order-ids/exit-timestamps need a clock-injection retrofit + tiered tolerance, not blanket `==` |
+| 4 | MAJOR | P4.1 replay is unimplementable today — resolved `latest`-symlink model version is never persisted per session/trade |
+| 5 | MAJOR | Candle cache is mutable/overwritten-in-place — "candles already cached" ≠ a stable replay input |
+| 6 | MAJOR | Flat slippage (no size/impact scaling) and untracked rounding-residual dust are real gaps, absent from §2/§7 |
+| 7 | MINOR | T1/T2 thresholds can hide sign-cancelling divergence — add distribution + sign-preserving cumulative metrics |
+| 8 | MINOR | Funding rates correctly out of scope (spot/margin only) — state this explicitly |
+| 9 | MINOR | Spread/bid-ask correctly a non-issue today — fold into the slippage-calibration ledger row (Finding 6) |

--- a/docs/refactor/reviews/risk_review.md
+++ b/docs/refactor/reviews/risk_review.md
@@ -1,0 +1,261 @@
+# Risk Review — Backtest↔Live Parity Unification Plan (v1) — 2026-07-05 21:50 UTC
+
+**Reviewer:** risk-officer (independent — no coordination with other reviewers)
+**Target:** `docs/refactor/backtest_live_parity_plan.md` (DRAFT v1, 2026-06-15)
+**Lens:** capital protection. This bot trades live capital; the plan's product is *trust in backtest numbers used to size real risk*. That trust is the risk surface.
+
+**Overall verdict:** APPROVE-WITH-CONDITIONS (of the *plan*, not of any code). The engineering
+is sound and the phase ordering (measure-before-refactor) is correct. But the plan has one
+BLOCKER-class governance gap (the "100% confidence" framing is a live-sizing hazard) and
+several MAJOR gaps around default-flip governance, threshold ownership, and the seam between
+"backtest accuracy change" and "I just changed live sizing." Each is fixable with language and
+process, not redesign.
+
+Verified against source (not taken on faith):
+- `annual_margin_interest_rate` default **is** `0.0` (`backtest/execution/exit_handler.py:117`) — margin backtests are silently optimistic today, as §2 claims.
+- `orders.actual_commission` **exists** (`database/models.py:373`) — P4.3 fee-truth source is real.
+- Determinism fingerprint **is** a real BLAS-pinned byte-identical test (`tests/integration/parity/test_backtest_determinism.py`).
+- `DEFAULT_MAX_DRAWDOWN = 0.20` (`config/constants.py:128`) **matches** `risk-limits.json` `max_drawdown_pct: 0.20`. No divergence — good.
+- The drawdown-guard / circuit-breaker hard halt lives in `src/engines/live/monitoring/` (live-only), but consumes sizing/fee/SL-detection from the code this plan moves into `engines/shared/`. This is the load-bearing fact behind finding #4.
+
+---
+
+## Findings (ranked most-severe first)
+
+### 1. [BLOCKER] "100% confidence" / "byte-exact parity" framing will be read as "safe to size up" — the exact residual gap that bleeds capital is the part parity does NOT cover.
+
+**Rationale:** §1 and §6 lead with "100% confidence," "byte-exact, CI-enforced equality,"
+"the strongest form of 100% confidence that exists." A human (or a future PM/daemon) who reads
+"parity proven" and up-sizes live risk is betting capital on a guarantee that covers only
+*decisions + costs + accounting on candle-level data*. The money historically bled in exactly
+the uncovered residual: intrabar SL fills, SL-placement failure → emergency-close cascade
+(capital-erosion postmortem, ~15% loss), phantom balance, gap-through-SL, real slippage/partial
+fills. §9 "Honest limits" is correct and well-written — but it is one section at the *bottom*,
+while the headline oversell is at the *top* and in the proof table (§6). In a risk sense the
+document's center of gravity is on the wrong side of the residual.
+
+**Suggested revision:**
+- **§1 (top of doc):** Replace every literal "100% confidence" with a **scoped** claim.
+  Mandate the exact phrase everywhere the parity result is surfaced (CI output, replay report,
+  docs, any dashboard): *"Decision/cost/accounting parity: proven. Fill/slippage/liquidity
+  fidelity: bounded & monitored, NOT guaranteed."* Ban the bare token "100% confidence" and
+  "byte-exact parity" as standalone phrases in any human-facing artifact.
+- **Promote §9 to §1.5** (right after the definition), not buried at the end. The honest-limits
+  fence must be co-located with the claim it fences.
+- **Add an explicit sizing guardrail to §9:** a one-line rule that **"a parity-passing backtest
+  is NOT authorization to increase live position size, risk-per-trade, leverage, or
+  `max_concurrent_positions` beyond `risk-limits.json`. Sizing changes remain a separate,
+  human-ratified decision gated by the charter's >$50/24h and irreversible-action rules."**
+  This severs the mental link "parity green → size up" that the current framing invites.
+- **Add a ledger row (§7) for the sizing hazard itself:** direction of bias = *optimistic*
+  (candle backtest cannot see the worst intrabar fill), so the residual is asymmetric — it
+  makes strategies look *safer* than live, which is the dangerous direction for up-sizing.
+
+---
+
+### 2. [MAJOR] The P2.1 / P2.2 / P2.4 "flip defaults" step can silently change every strategy's reported edge — and thus its already-live sizing — between two releases, with no per-strategy sign-off.
+
+**Rationale:** §5 says fidelity flips "land behind config flags … then flip defaults in a
+separate, loudly-labeled PR." Good, but "loudly-labeled PR" is not a control. ExchangeRules
+rounding + `min_notional` rejection (P2.1) and non-zero financing (P2.2) will change *reported
+returns and reported max-drawdown* for **every** margin/small-notional strategy at once. If a
+live strategy's position size was ever justified by a pre-flip backtest number, the flip
+retroactively invalidates that justification — and nobody re-checks, because the flip PR is
+framed as "backtest accuracy," not "live risk re-baseline." The A/B report proves the *magnitude*
+of the change but does not force anyone to *act* on it for live-sized strategies.
+
+**Suggested revision (amend §5 and each P2 item):**
+- The default-flip PR MUST include a **per-live-strategy delta table**: for every strategy
+  currently running live capital, old vs new backtest CAGR, max-drawdown, and 99th-pct daily
+  loss. Any strategy whose new max-drawdown crosses a `risk-limits.json` threshold
+  (e.g. `max_drawdown_pct 0.20`) or whose edge drops >X% is **flagged for human sizing review
+  before the flip merges** — the flip is *blocked* on that review, not merely annotated.
+- Each flip PR carries a **git-recorded "backtest epoch" tag** (e.g. `parity-epoch: 2`) that is
+  stamped into every backtest report artifact. This makes "which fidelity assumptions produced
+  this number" auditable forever, and makes cross-epoch comparisons refuse-by-default.
+- **Rollback must be a config flip, not a revert.** §5 should state the flag stays wired
+  (not deleted) for ≥2 releases after the default flip, so a discovered regression is a
+  one-line env change, not a code rollback under pressure. Matches LESSONS §4 "ship inert,
+  flip a flag."
+
+---
+
+### 3. [MAJOR] Until T₁/T₂ are ratified, the P4.2 scheduled parity audit is a no-op alarm — and an un-tuned threshold is itself a capital risk in both directions.
+
+**Rationale:** §P4.2 ships T₁ (bps/trade) and T₂ (%/30d) as "placeholders — human ratifies,"
+suggesting 5 bps / 0.1%/30d. Two failure modes, both real: (a) if the audit ships *before*
+ratification with placeholders, and nobody wires the halt-decision, the "continuous proof"
+is decorative — it alerts into a channel no one owns, replicating the *double-blind alerting*
+failure already in institutional memory (observability audit). (b) An un-tuned threshold either
+fires constantly (alert fatigue → the one real divergence is ignored — this is how the
+capital-erosion incident's early signals got lost) or is set so loose that a systematic
+live-worse-than-backtest drift never trips. Critically, **the plan never says who owns the
+kill-decision when replay shows live systematically worse than backtest.** That is the whole
+point of the audit and it has no owner.
+
+**Suggested revision (amend §P4.2 and add to §6 CI policy):**
+- **Do not enable alerting until T₁/T₂ are ratified in `parity_gap_ledger.md` with a named
+  human owner and a dated review.** Until then the audit runs in **dry-run/report-only** mode
+  (compute + log the deltas, page no one) — same "ship inert" discipline as money-movers
+  (LESSONS §4). An unratified audit must be explicitly a no-op, not a silent maybe.
+- **Bootstrap the thresholds empirically, don't guess.** Run the replay over the last 30–90d
+  of real sessions first; set T₁/T₂ from the observed p95/p99 of *explained* divergence + a
+  margin, so day-one alerts mean "worse than the historical norm," not "hit an arbitrary 5 bps."
+- **Name the escalation owner and the decision rule in the plan:** parity-audit alerts route
+  to `risk-officer` (assessment) → `pm` (action). Add the decision rule explicitly: **"if
+  replay shows live realized P&L systematically worse than backtest by > T₂ over the trailing
+  window on a *live-capital* strategy, that is an incident (`type:incident`), risk-officer
+  recommends entry-halt / size-down, human ratifies."** Directional asymmetry matters: live
+  *better* than backtest is a modeling curiosity; live *worse* is money leaving. The threshold
+  should be **tighter on the live-worse side.**
+
+---
+
+### 4. [MAJOR] The seam between "harmless backtest accuracy change" and "I just changed live sizing" is not drawn — and the safety rail (§5 fingerprint "identical except where fidelity improves") has a hole exactly there.
+
+**Rationale:** The refactor moves fees, sizing, SL-fill detection, and financing into
+`engines/shared/`, consumed by BOTH engines. The live drawdown-guard / circuit-breaker
+(`src/engines/live/monitoring/`, hard halt at 2.5% daily / 15% drawdown per LESSONS §5.2) acts
+on numbers produced by that shared code. So a P1/P2 PR that is *motivated* by backtest fidelity
+can change a live number (a rounded quantity, a financing leg, an SL trigger comparison) that
+shifts realized P&L, the drawdown-guard's peak/trough inputs, or the daily-loss baseline — i.e.
+it changes *when the live kill-halt fires*. §5's guarantee is "fingerprint byte-identical
+**except where fidelity improves**" — but the "except" clause is precisely the live-affecting
+set. The determinism fingerprint is a **backtest** oracle; it says nothing about whether the
+live path's behavior moved. There is currently no equivalent "live behavior unchanged" gate for
+the shared extractions.
+
+**Suggested revision (amend §5 and §6):**
+- **Add a live-side invariant gate to L1/L2.** For every shared extraction that the live engine
+  consumes, add a test that pins the *live* adapter's output byte-identical pre/post-refactor on
+  a fixed input (the same discipline as the backtest fingerprint, applied to the live path).
+  A "verbatim move" PR must prove *both* engines unchanged, not just the backtest.
+- **Classify every PR in this plan as either `parity:refactor-only` (fingerprint identical BOTH
+  sides — no live behavior change) or `parity:fidelity-change` (deliberately moves a number).**
+  The two classes get different review + rollback treatment. A `fidelity-change` PR that touches
+  a live-consumed symbol (fees, sizing, SL detection, financing) is a **live-capital change** and
+  must carry the full money-path discipline: dual reviewer + codex-review-to-APPROVE
+  (LESSONS §4) + explicit statement of the live behavioral delta and its effect on the
+  drawdown-guard / circuit-breaker inputs. The plan currently reserves "dual review on money
+  paths" (§P1) for extractions but does not name the fidelity-change → live-halt-timing link.
+- **§5 should state explicitly:** *the determinism fingerprint proves backtest reproducibility,
+  NOT live-path invariance; live invariance is proven separately by the live-adapter pin.*
+  As written, §5 implies the fingerprint covers the safety concern. It does not.
+
+---
+
+### 5. [MAJOR] P4 scheduled replay + fee-truth jobs are an operational risk to the RUNNING bot if they share the prod DB or exchange rate-limit budget with live trading.
+
+**Rationale:** §P4.1/P4.2/P4.3 run scheduled jobs that read the prod DB (`trading_sessions`,
+`orders`, cached candles) and, for fee-truth (P4.3), normalize `orders.actual_commission`
+against exchange-reported commissions — which implies either DB reads or exchange API calls.
+The plan does not address contention. Institutional memory is emphatic that the live bot has
+been taken down by infra it shared: a DB/DNS outage killed the loop while Railway reported
+SUCCESS (bots-down-railway-dns); the user-stream degrades to REST under stress. A replay/audit
+job that (a) runs a heavy read against the prod DB during a live trading cycle, (b) holds a
+long transaction/lock, or (c) burns Binance REST weight that the live reconciler needs, can
+*cause* the incident the audit is meant to detect. The plan's own §P4 requires "persisting the
+live session's input snapshot" — writing to prod adds write contention too.
+
+**Suggested revision (add a new bullet to §P4 and to §5 safety rails):**
+- **P4 jobs run read-only against a replica / snapshot, never a lock-taking transaction on the
+  primary during live hours.** If no replica exists, they run against a point-in-time export,
+  and their DB user is read-only-scoped. State this as a hard constraint, not a preference.
+- **Fee-truth (P4.3) must NOT call the exchange with the live API key/weight budget.** Source
+  commissions from already-persisted `orders.actual_commission` (it exists — verified) or a
+  separate read-only key with its own rate budget. Never let an audit job compete with the live
+  reconciler for Binance weight.
+- **Schedule P4 jobs in a low-activity window and make them pre-emptible** — if the live engine
+  signals a busy/degraded cycle, the audit defers. A monitoring job must never be able to starve
+  the thing it monitors.
+
+---
+
+### 6. [MAJOR] P2.1 ExchangeRules uses a *committed static filter fixture* for backtest — a stale fixture silently re-opens the precision bug class the plan claims to close, and directionally biases backtests optimistic.
+
+**Rationale:** §P2.1 sources live filters from `exchangeInfo` (live truth) but backtest from
+"a recorded/static filter set per symbol (committed fixture, refreshable via a CLI)." Binance
+changes `step_size` / `tick_size` / `min_notional` over time. A stale fixture means the backtest
+quantizes and rejects `min_notional` against *yesterday's* rules while live uses *today's* — so
+the plan claims "removes caveat #1" but actually introduces a **new, silent** divergence that
+looks like parity (the code path is shared) while the *data* diverges. LESSONS §1.1 is explicit
+that precision bugs come in pairs and must be grepped as a class; a stale filter fixture is the
+data-layer sibling of that bug. Direction of bias matters: if `min_notional` rose on the venue
+but not in the fixture, the backtest will *accept* trades live now rejects → optimistic phantom
+edge.
+
+**Suggested revision (amend §P2.1):**
+- **The fixture must carry a capture timestamp and the audit (§P4.2) must diff the committed
+  fixture against live `exchangeInfo` on schedule**, filing drift as a `source:parity-audit`
+  issue exactly like a threshold breach. A stale filter set is a parity failure, not a
+  housekeeping chore.
+- **Add a ledger row (§7):** "backtest symbol-filter fixture staleness — direction: optimistic
+  if venue min_notional/step rose — monitor: scheduled fixture-vs-exchangeInfo diff."
+- Extend the P3.2 precision grep-gate to also fail CI if a symbol is backtested with **no**
+  committed filter fixture (fail-closed: no filters ≠ "raw floats OK", it means "reject").
+
+---
+
+### 7. [MINOR] `parity_gap_ledger.md` bounds have no owner, no review cadence, and no "unbounded until measured" default — a ledger row without a ratified number is false comfort.
+
+**Rationale:** §7 is the right instrument, but a ledger whose `bound` column contains guesses or
+blanks is worse than none — it *looks* governed. The seed rows (intrabar tick path, partial
+fills, latency) are exactly the capital-bleed residuals from finding #1; if their bounds are
+placeholders, the whole "measured and bounded" claim is unbacked.
+
+**Suggested revision (amend §7):**
+- Add columns: `owner`, `last_reviewed`, `ratified (y/n)`. A row with `ratified=n` renders as
+  **UNBOUNDED** in every report (not as a small number), so unmeasured risk reads as risk, not
+  as "≈0". Mirror the `risk-limits.json` convention (`$last_reviewed`, `$last_reviewer`) — that
+  file's own `$last_reviewed` is `1970-01-01`, a cautionary example of an unreviewed control.
+
+---
+
+### 8. [MINOR] P2.3 multi-position is deferred to last, but the harness's `max_concurrent_positions == 1` enforcement (option b) must be a HARD, tested gate, not a documentation note — or single-position parity silently "covers" a multi-position live strategy.
+
+**Rationale:** §P2.3 correctly flags that backtest is structurally single-position today and
+recommends full multi-position (option a) sequenced last, with option (b) as the interim scope
+fence. The risk is the *interim*: if any live strategy runs `max_concurrent_positions > 1` while
+the backtest can only represent one, a parity-passing backtest is affirmatively misleading about
+that strategy's real (correlated, concurrent) risk — the correlation-cluster exposure limit
+(`max_correlated_exposure_pct: 0.15`) is unrepresentable in backtest.
+
+**Suggested revision (amend §P2.3):**
+- Until option (a) lands, the harness and the parity-audit MUST **hard-fail** (not warn) when
+  asked to compare any strategy whose *live* config has `max_concurrent_positions > 1`, and the
+  parity claim for that strategy is explicitly stamped **"NOT PARITY-COVERED — single-position
+  backtest only."** No live strategy should be able to cite a parity pass it isn't covered by.
+
+---
+
+### 9. [MINOR] The plan has no explicit "parity check FAILS → what happens to live?" runbook. Silence here defaults to "keep trading," which is the wrong default for a capital system.
+
+**Rationale:** The plan defines exhaustively what "parity proven" means, but not the negative:
+when the scheduled audit (P4.2) shows a real, unexplained, live-worse divergence on a
+live-capital strategy, what is the operational response? Finding #3 assigns the owner; this is
+the missing *action*. Absent a stated runbook, the default is inertia (keep trading on a backtest
+we now know is lying), which is the opposite of capital-protective.
+
+**Suggested revision (add a short runbook subsection to §P4):**
+- Tiered response: (1) divergence > T₁ single-trade → log + ledger classification;
+  (2) cumulative > T₂ live-worse on a live strategy over the window → risk-officer incident +
+  recommend `atb live-control halt` / entry-pause on that strategy pending root-cause;
+  (3) divergence pattern matches a known capital-bleed signature (SL-fill mismatch, phantom
+  balance) → escalate at MAXIMUM urgency per the risk charter, recommend immediate halt.
+  The kill-switch stays human-triggered (per `risk-limits.json` `authorized_actors: [human]`),
+  but the recommendation path must be pre-written, not improvised during an event.
+
+---
+
+## What I could not verify (data/scope limits)
+- I did not run the existing parity suite or the determinism fingerprint (read-only review of
+  the *plan*, not the code). I confirmed the tests *exist* and assert what the plan claims, not
+  that they currently pass on this worktree.
+- I could not confirm whether a prod DB read-replica exists (finding #5's cleanest mitigation
+  depends on it) — the plan should state the answer.
+- I did not audit whether any *currently-live* strategy runs `max_concurrent_positions > 1`
+  or a margin/short config with non-zero real borrow (which would make findings #2/#6/#8 live
+  today, not hypothetical). The PM should establish this before P2 flips any default.
+- The suggested opener thresholds (T₁=5 bps, T₂=0.1%/30d) are unvalidated by me; finding #3
+  requires empirical bootstrap before they mean anything.
+```


### PR DESCRIPTION
Adopts the parity session's plan v2 + adversarial panel reviews into develop, with PM ratification notes on D1-D4 (closed-candle gating ratified with the OOD-training argument; multi-position resequenced to business need; funding deferred; divergence bounds bundled into the pending Board risk-limits ratification). Execution proceeds from the PM session per Board directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)