### PR TITLE
fix(live): hold user-data WS subscription (#907)

### DIFF
--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -442,6 +442,16 @@ DEFAULT_WS_USER_STALENESS_THRESHOLD = (
     120  # Seconds before user stream considered stale (only when orders tracked)
 )
 DEFAULT_WS_HEALTH_CHECK_INTERVAL = 30  # Seconds between health monitor checks
+# Bounded wall-clock timeout (seconds) for the user-stream liveness ping (#907).
+# A user-data stream has NO heartbeat: a quiet margin account legitimately emits
+# zero events for hours, so wall-clock silence past the staleness threshold must
+# not be read as death (doing so tore every subscription down ~120 s after
+# creation overnight — the -2036 churn). On staleness the watchdog instead
+# round-trips a ws-api `ping` on the TWM loop and holds the subscription if it
+# succeeds; only a failed/timed-out ping (or a provider-reported error /
+# eventStreamTerminated) enters the reconnect cascade. The ping doubles as cheap
+# keepalive traffic on the ws-api TCP path (~1 ping per staleness window).
+DEFAULT_WS_USER_LIVENESS_PROBE_TIMEOUT = 10
 DEFAULT_WS_RECONNECT_MAX_RETRIES = 3  # Maximum reconnect attempts before REST_DEGRADED
 # Consecutive unproductive user-stream reconnects (stale again with no real event)
 # before the watchdog opens a circuit breaker: stop the futile ~2-min reconnect loop

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -32,6 +32,7 @@ from src.config.constants import (
     DEFAULT_STARTUP_BAN_MAX_WAIT,
     DEFAULT_WS_KLINE_STALENESS_THRESHOLD,
     DEFAULT_WS_RECONNECT_MAX_RETRIES,
+    DEFAULT_WS_USER_LIVENESS_PROBE_TIMEOUT,
     DEFAULT_WS_USER_STALENESS_THRESHOLD,
 )
 from src.infrastructure.timeout import TimeoutError as InfraTimeoutError
@@ -108,6 +109,11 @@ DEFINITIVE_REJECT_CODES = {
 # Stop-loss limit price slippage to ensure fills
 # For sells: limit below stop price, for buys: limit above stop price
 STOP_LOSS_LIMIT_SLIPPAGE_FACTOR = 0.005  # 0.5% slippage
+
+# ws-api "User Data Stream subscription not active" — the server no longer holds
+# the subscription being unsubscribed (it died with its connection). Expected
+# during socket teardown after a transport drop/full rebuild (#907).
+_BINANCE_SUBSCRIPTION_NOT_ACTIVE = -2036
 
 
 _BAN_EXPIRY_PATTERN = re.compile(r"banned until (\d{13})")
@@ -310,6 +316,10 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         self._last_user_event_time = datetime.now(UTC)
         self._kline_event_received = False  # True after first kline WS event
         self._user_event_received = False  # True after first user WS event
+        # When the CURRENT user-stream subscription was created; None while no
+        # subscription is active. Diagnostic only (#907): logged at each degrade
+        # so prod logs show whether subscription lifetimes are minutes or hours.
+        self._user_stream_subscribed_at: datetime | None = None
         # Monotonic token identifying the current user-socket "generation" (#717).
         # Bumped before every teardown (stop_user_stream / stop_streams) and on
         # each (re)start; the user callback captures the generation live at start
@@ -2175,11 +2185,34 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         delegated to asyncio's default handler so genuine errors keep their
         normal ERROR visibility.
         """
-        if self._is_socket_teardown_keyerror(context.get("exception")):
+        exc = context.get("exception")
+        if self._is_socket_teardown_keyerror(exc):
             logger.debug(
                 "Suppressed python-binance socket-teardown KeyError(%s) on stop (#716)",
-                self._keyerror_path(context.get("exception")),
+                self._keyerror_path(exc),
             )
+            return
+        if self._is_teardown_unsubscribe_error(exc):
+            # Exceptions escaping KeepAliveWebsocket.__aexit__'s exit-unsubscribe
+            # are teardown noise by construction — the socket is being discarded.
+            # The canonical case is -2036 "subscription not active": the server-
+            # side subscription is already gone (it died with its ws-api
+            # connection, or TWM.stop() closed the AsyncClient before the
+            # listener exited so the unsubscribe went out over a fresh connection
+            # that never held it). Surfacing it as "Task exception was never
+            # retrieved" spams ERROR+Traceback and masks real errors (#907).
+            if getattr(exc, "code", None) == _BINANCE_SUBSCRIPTION_NOT_ACTIVE:
+                logger.debug(
+                    "User-stream teardown unsubscribe: subscription already "
+                    "inactive server-side (-2036) — expected after a transport "
+                    "drop or full teardown; suppressed (#907)"
+                )
+            else:
+                logger.warning(
+                    "User-stream teardown unsubscribe failed (suppressed — socket "
+                    "already being discarded, #907): %s",
+                    exc,
+                )
             return
         loop.default_exception_handler(context)
 
@@ -2212,6 +2245,35 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             and filename.endswith("threaded_stream.py")
             and "binance" in filename
         )
+
+    @staticmethod
+    def _is_teardown_unsubscribe_error(exc: BaseException | None) -> bool:
+        """True iff ``exc`` escaped python-binance's exit-unsubscribe teardown path.
+
+        ``KeepAliveWebsocket.__aexit__`` unconditionally awaits
+        ``_unsubscribe_from_user_data_stream``; when the server-side subscription
+        is already gone the ws-api answers 400/-2036 and the exception propagates
+        out of the listener task as an unretrieved task exception (#907). That
+        frame runs ONLY while a socket is being torn down and never invokes our
+        callbacks, so any exception whose traceback passes through it is teardown
+        noise by construction — matched by walking the frames for
+        ``_unsubscribe_from_user_data_stream`` in python-binance's
+        ``keepalive_websocket.py`` (separator-agnostic path anchor, as #716).
+        """
+        if exc is None:
+            return False
+        tb = exc.__traceback__
+        while tb is not None:
+            code = tb.tb_frame.f_code
+            filename = code.co_filename
+            if (
+                code.co_name == "_unsubscribe_from_user_data_stream"
+                and filename.endswith("keepalive_websocket.py")
+                and "binance" in filename
+            ):
+                return True
+            tb = tb.tb_next
+        return False
 
     @staticmethod
     def _keyerror_path(exc: BaseException | None) -> str:
@@ -2319,7 +2381,16 @@ class BinanceProvider(DataProvider, ExchangeInterface):
 
             def _user_callback(msg: dict) -> None:
                 """Route user data events, handling errors before user callback."""
-                is_error = msg.get("e") == "error"
+                event_type = msg.get("e")
+                is_error = event_type == "error"
+                # eventStreamTerminated is the ws-api server declaring THIS
+                # subscription dead (the ws-api analogue of listenKeyExpired, e.g.
+                # listenToken expiry). It must drive the RESYNCING recovery path
+                # like an error — counting it as a healthy event would fake
+                # freshness on a stream that just died (#907). Our own unsubscribe
+                # also triggers one server-side, but the generation bump in stop_*
+                # drops it below before it can flip state.
+                is_terminated = event_type == "eventStreamTerminated"
                 # Drop events from a superseded socket, and record freshness/the
                 # event flag, atomically w.r.t. the generation bump in start/stop. A
                 # python-binance read_ready callback can still fire on the shared TWM
@@ -2329,7 +2400,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 with self._user_stream_lock:
                     if generation != self._user_stream_generation:
                         return
-                    if is_error:
+                    if is_error or is_terminated:
                         self._on_user_disconnect()
                     else:
                         self._last_user_event_time = datetime.now(UTC)
@@ -2338,6 +2409,12 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                 # or long-running work under a lock).
                 if is_error:
                     logger.error("User data WS error: %s", msg.get("m", "unknown"))
+                    return
+                if is_terminated:
+                    logger.warning(
+                        "User data stream terminated server-side "
+                        "(eventStreamTerminated) — entering RESYNCING (#907)"
+                    )
                     return
                 on_user_event(msg)
 
@@ -2352,6 +2429,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
                     lambda: cast(Any, self._twm).start_user_socket(callback=_user_callback)
                 )
             self._last_user_event_time = datetime.now(UTC)
+            self._user_stream_subscribed_at = datetime.now(UTC)
             self._user_ws_state = WebSocketState.PRIMARY
             return True
         except Exception as e:
@@ -2366,6 +2444,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         with self._user_stream_lock:
             self._user_stream_generation += 1
             self._user_event_received = False
+        self._user_stream_subscribed_at = None
         if self._user_socket_key and self._twm:
             try:
                 self._twm.stop_socket(self._user_socket_key)
@@ -2382,6 +2461,7 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         with self._user_stream_lock:
             self._user_stream_generation += 1
             self._user_event_received = False
+        self._user_stream_subscribed_at = None
         if self._twm:
             twm, loop = self._twm, self._twm_loop
             twm.stop()
@@ -2466,6 +2546,65 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             return False
         user_age = (datetime.now(UTC) - self._last_user_event_time).total_seconds()
         return user_age < DEFAULT_WS_USER_STALENESS_THRESHOLD
+
+    def verify_user_stream_alive(self) -> bool:
+        """Actively verify the user-stream transport with a bounded ws-api ping (#907).
+
+        A user-data stream has NO heartbeat: a quiet margin account legitimately
+        emits zero events for hours, so the watchdog must not read wall-clock
+        silence as death (doing so tore every subscription down ~120 s after
+        creation on quiet nights — the -2036 churn). This round-trips the ws-api
+        ``ping`` method on the TWM loop: success proves the loop, the shared
+        ws-api transport, and its read loop (response futures resolve) are all
+        functioning, so a silent stream is idle-healthy and the subscription is
+        held. Fails CLOSED — any doubt (no TWM/loop/client, timeout, error)
+        returns False and the watchdog runs the existing reconnect cascade.
+
+        Transport drops cannot hide behind a successful ping: python-binance
+        propagates every read-loop error/reconnect into the subscription queue
+        (→ our error callback → RESYNCING, checked BEFORE staleness), and a
+        server-side kill emits ``eventStreamTerminated`` (handled as a
+        disconnect). On success the provider freshness timestamp is refreshed
+        under the generation guard — but never ``_user_event_received``, so a
+        ping can NOT fake the real-event confirmation that gates disabling REST
+        polling (#717). Bounded (#631): total wall clock ≤ the probe timeout.
+
+        Returns:
+            True iff a ws-api ping round-tripped within the timeout.
+        """
+        twm = self._twm
+        loop = self._twm_loop
+        if twm is None or loop is None or not loop.is_running():
+            return False
+        client = getattr(twm, "_client", None)
+        if client is None:
+            return False  # AsyncClient still being created on the TWM thread
+        with self._user_stream_lock:
+            generation = self._user_stream_generation
+        future = asyncio.run_coroutine_threadsafe(client.ws_ping(), loop)
+        try:
+            future.result(timeout=DEFAULT_WS_USER_LIVENESS_PROBE_TIMEOUT)
+        except Exception as e:
+            future.cancel()
+            logger.warning("User-stream liveness ping failed: %s", e)
+            return False
+        with self._user_stream_lock:
+            # A stop/start racing the ping supersedes it: the refresh belongs to
+            # the generation the ping was issued under, never the new one (#717).
+            if generation == self._user_stream_generation:
+                self._last_user_event_time = datetime.now(UTC)
+        return True
+
+    def user_stream_age_seconds(self) -> float | None:
+        """Age of the current user-stream subscription; None when inactive.
+
+        Diagnostic only (#907): the WS health monitor logs it at each degrade so
+        prod logs show whether subscription lifetimes are minutes or hours.
+        """
+        subscribed_at = self._user_stream_subscribed_at
+        if subscribed_at is None:
+            return None
+        return (datetime.now(UTC) - subscribed_at).total_seconds()
 
     def mark_kline_degraded(self) -> None:
         """Transition kline stream to REST_DEGRADED state (thread-safe)."""

--- a/src/data_providers/binance_provider.py
+++ b/src/data_providers/binance_provider.py
@@ -2567,7 +2567,13 @@ class BinanceProvider(DataProvider, ExchangeInterface):
         disconnect). On success the provider freshness timestamp is refreshed
         under the generation guard — but never ``_user_event_received``, so a
         ping can NOT fake the real-event confirmation that gates disabling REST
-        polling (#717). Bounded (#631): total wall clock ≤ the probe timeout.
+        polling (#717). Bounded (#631): the timeout is enforced ON the TWM loop
+        via ``asyncio.wait_for``, which cancels a hung ping coroutine loop-side —
+        a ``concurrent.futures.Future.cancel()`` from the waiting thread cannot
+        interrupt an already-running coroutine, so thread-side-only enforcement
+        would let a hung ws-api accumulate orphaned pending pings on the loop
+        across health cycles. The outer ``future.result`` timeout (+1 s) is only
+        a belt against a stalled loop.
 
         Returns:
             True iff a ws-api ping round-tripped within the timeout.
@@ -2581,9 +2587,12 @@ class BinanceProvider(DataProvider, ExchangeInterface):
             return False  # AsyncClient still being created on the TWM thread
         with self._user_stream_lock:
             generation = self._user_stream_generation
-        future = asyncio.run_coroutine_threadsafe(client.ws_ping(), loop)
+        future = asyncio.run_coroutine_threadsafe(
+            asyncio.wait_for(client.ws_ping(), DEFAULT_WS_USER_LIVENESS_PROBE_TIMEOUT),
+            loop,
+        )
         try:
-            future.result(timeout=DEFAULT_WS_USER_LIVENESS_PROBE_TIMEOUT)
+            future.result(timeout=DEFAULT_WS_USER_LIVENESS_PROBE_TIMEOUT + 1)
         except Exception as e:
             future.cancel()
             logger.warning("User-stream liveness ping failed: %s", e)

--- a/src/engines/live/ws_health.py
+++ b/src/engines/live/ws_health.py
@@ -229,7 +229,15 @@ class WebSocketHealthMonitor:
             logger.error("Failed to restart WS health monitor: %s", e)
 
     def ws_health_loop(self) -> None:
-        """Monitor WebSocket streams and trigger reconnection on failure."""
+        """Monitor WebSocket streams and trigger reconnection on failure.
+
+        The user-stream liveness ping (#907) is this loop's first bounded-
+        blocking call: on a wall-clock-stale user stream, a cycle may block
+        inside ``check_user_stream_health`` for up to the ping timeout (+1 s
+        belt, ≤ ~10 s), delaying the next kline check by that much. Future
+        reductions of the staleness thresholds or the health interval must
+        account for it.
+        """
         state = self._state
         from src.config.constants import DEFAULT_WS_HEALTH_CHECK_INTERVAL
 

--- a/src/engines/live/ws_health.py
+++ b/src/engines/live/ws_health.py
@@ -386,6 +386,12 @@ class WebSocketHealthMonitor:
         ``_handle_user_stream_disconnect``) and ``disable_polling`` is flipped only
         by ``_restore_user_ws_primary``, gated on a confirmed real event.
 
+        Also unlike kline, the user-data stream has NO event cadence: a quiet
+        account emits nothing for hours, so wall-clock staleness is only a
+        *trigger to verify*, not a death verdict (#907). PRIMARY + stale first
+        runs ``verify_user_stream_alive`` (bounded ws-api ping); the reconnect
+        cascade below is entered only when verification fails or is unsupported.
+
         Runs only on the WS health-monitor thread (the single writer of
         ``_user_reconnect_failures``), matching the lock-free convention; main-loop
         reads of the polling flag are GIL-atomic.
@@ -414,7 +420,11 @@ class WebSocketHealthMonitor:
 
         # RESYNCING (set by the error callback) needs an immediate recovery cycle.
         if getattr(exchange, "_user_ws_state", None) == WebSocketState.RESYNCING:
-            logger.warning("User data stream in RESYNCING state — triggering recovery")
+            logger.warning(
+                "User data stream in RESYNCING state — triggering recovery "
+                "(subscription age %s)",
+                self._user_stream_age(exchange),
+            )
             state._handle_user_stream_disconnect()
             return
 
@@ -461,20 +471,65 @@ class WebSocketHealthMonitor:
         if age <= DEFAULT_WS_USER_STALENESS_THRESHOLD:
             return
 
-        # Stale while PRIMARY with tracked orders means the previous reconnect
-        # produced no real events. python-binance's start_margin_socket is
-        # fire-and-forget and reports success even on a dead multiplexed ws_api
-        # socket, so reconnect_user returns True and this watchdog would otherwise
-        # reconnect every ~2 min forever (spewing asyncio re-entrancy errors).
-        # After a few unproductive reconnects, open the circuit: tear down the dead
-        # socket, mark REST_DEGRADED, and run REST-polling-only. Unlike #616, the
-        # REST_DEGRADED branch above now keeps throttled-probing, so this is the
-        # fast-phase boundary, not a terminal state (#717).
+        # THE #907 FIX — silence is not death on an event-driven stream. A quiet
+        # margin account legitimately emits ZERO user events for hours (no fills,
+        # no balance changes — a user-data stream has no heartbeat), so wall-clock
+        # staleness alone guaranteed every subscription was torn down ~2 min after
+        # creation overnight (the -2036 churn: stale → 3 futile reconnects →
+        # circuit → hard probes, forever). Before assuming death, actively verify
+        # the transport with a bounded ws-api ping; a verified round-trip refreshes
+        # provider freshness, deferring the next check one staleness window.
+        # Genuine failures still recover promptly: transport drops surface as
+        # error events (→ the RESYNCING branch above) and server-side kills as
+        # eventStreamTerminated (handled as a disconnect by the provider) — the
+        # cascade below remains the safety net when verification fails.
+        verify = getattr(exchange, "verify_user_stream_alive", None)
+        if callable(verify):
+            try:
+                alive = bool(verify())
+            except Exception as e:
+                # A broken verifier must never crash the health thread nor hold a
+                # possibly-dead subscription — treat as failed verification.
+                alive = False
+                logger.error("User-stream liveness verification errored: %s", e)
+            if alive:
+                if state._user_reconnect_failures:
+                    logger.info(
+                        "User data stream verified alive mid-cascade — holding "
+                        "subscription, breaker reset (%d failures cleared, #907)",
+                        state._user_reconnect_failures,
+                    )
+                state._user_reconnect_failures = 0
+                logger.debug(
+                    "User data stream quiet (%ds) but transport verified alive — "
+                    "holding subscription (age %s, #907)",
+                    int(age),
+                    self._user_stream_age(exchange),
+                )
+                return
+
+        # Subscription age at degrade (#907 observability): captured BEFORE the
+        # teardown below clears it, so every degrade logs how long the
+        # subscription actually held (the fix's empirical success metric).
+        sub_age = self._user_stream_age(exchange)
+
+        # Stale while PRIMARY with tracked orders — and NOT verifiably alive —
+        # means the previous reconnect produced no real events. python-binance's
+        # start_margin_socket is fire-and-forget and reports success even on a
+        # dead multiplexed ws_api socket, so reconnect_user returns True and this
+        # watchdog would otherwise reconnect every ~2 min forever (spewing asyncio
+        # re-entrancy errors). After a few unproductive reconnects, open the
+        # circuit: tear down the dead socket, mark REST_DEGRADED, and run
+        # REST-polling-only. Unlike #616, the REST_DEGRADED branch above now keeps
+        # throttled-probing, so this is the fast-phase boundary, not a terminal
+        # state (#717).
         if state._user_reconnect_failures >= DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT:
             logger.warning(
                 "User data stream did not recover after %d reconnects — circuit open, "
-                "falling back to REST polling and throttled-probing the WS (#717).",
+                "falling back to REST polling and throttled-probing the WS "
+                "(subscription age %s, #717).",
                 state._user_reconnect_failures,
+                sub_age,
             )
             # Tear down the dead user socket BEFORE marking degraded so the terminal
             # state is REST_DEGRADED, not DISCONNECTED (stop_user_stream sets
@@ -496,7 +551,8 @@ class WebSocketHealthMonitor:
             state._record_event(
                 EventType.ALERT,
                 f"User data stream circuit-open after {state._user_reconnect_failures} "
-                "reconnects — REST-degraded; real-time fills/balance updates unavailable",
+                "reconnects — REST-degraded; real-time fills/balance updates unavailable "
+                f"(subscription age {sub_age})",
                 severity="critical",
                 component="connectivity",
                 error_code="USER_WS_DEGRADED",
@@ -506,12 +562,32 @@ class WebSocketHealthMonitor:
 
         state._user_reconnect_failures += 1
         logger.warning(
-            "User data stream stale (%ds) with tracked orders — reconnecting (attempt %d/%d)",
+            "User data stream stale (%ds) with tracked orders and not verifiably "
+            "alive — reconnecting (attempt %d/%d, subscription age %s)",
             int(age),
             state._user_reconnect_failures,
             DEFAULT_WS_USER_RECONNECT_CIRCUIT_LIMIT,
+            sub_age,
         )
         state._handle_user_stream_disconnect()
+
+    @staticmethod
+    def _user_stream_age(exchange: Any) -> str:
+        """Current user-stream subscription age as a compact string, or "n/a".
+
+        Diagnostic only (#907): logged at each degrade/recovery so prod logs
+        prove whether the liveness fix moved subscription lifetimes from
+        ~minutes to hours. Never raises — providers without the accessor (or
+        with no active subscription) yield "n/a".
+        """
+        try:
+            age_fn = getattr(exchange, "user_stream_age_seconds", None)
+            age = age_fn() if callable(age_fn) else None
+            if age is None:
+                return "n/a"
+            return f"{age / 60.0:.1f}m"
+        except Exception:
+            return "n/a"
 
     def should_probe_user_reconnect(self, failures: int) -> bool:
         """Whether to probe a user-stream WS reconnect on this degraded cycle (#717/#723).

--- a/tests/unit/test_binance_provider_websocket.py
+++ b/tests/unit/test_binance_provider_websocket.py
@@ -1058,3 +1058,351 @@ class TestCircuitOpenTeardownNoUncaughtKeyError:
 
         assert len(delegated) == 1
         assert isinstance(delegated[0].get("exception"), KeyError)
+
+
+def _run_twm_loop_on_thread():
+    """Real event loop running on a background thread, as the TWM does.
+
+    Returns (loop, stop) — call ``stop()`` to tear it down.
+    """
+    import threading
+
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+
+    def stop() -> None:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        loop.close()
+
+    return loop, stop
+
+
+class TestVerifyUserStreamAlive:
+    """#907: active liveness verification for the user-data stream.
+
+    A quiet margin account legitimately emits ZERO user events for hours (a
+    user-data stream has no heartbeat), so wall-clock silence must not be read
+    as death. ``verify_user_stream_alive`` round-trips a ws-api ``ping`` on the
+    TWM loop: True refreshes freshness (holding the subscription); False/raise
+    lets the watchdog run the existing reconnect cascade.
+    """
+
+    @pytest.mark.fast
+    def test_returns_false_without_twm(self, provider):
+        """No TWM/loop → cannot verify → False (watchdog reconnects as before)."""
+        provider._twm = None
+        provider._twm_loop = None
+        assert provider.verify_user_stream_alive() is False
+
+    @pytest.mark.fast
+    def test_returns_false_when_loop_not_running(self, provider):
+        """A stopped TWM loop cannot run the ping — verification fails closed."""
+        provider._twm = MagicMock()
+        loop = asyncio.new_event_loop()
+        try:
+            provider._twm_loop = loop
+            assert provider.verify_user_stream_alive() is False
+        finally:
+            loop.close()
+
+    @pytest.mark.fast
+    def test_returns_false_when_async_client_not_ready(self, provider):
+        """TWM started but AsyncClient not yet created → fail closed."""
+        loop, stop = _run_twm_loop_on_thread()
+        try:
+            twm = MagicMock()
+            twm._client = None
+            provider._twm = twm
+            provider._twm_loop = loop
+            assert provider.verify_user_stream_alive() is False
+        finally:
+            stop()
+
+    @pytest.mark.fast
+    def test_ping_roundtrip_refreshes_freshness_but_never_event_flag(self, provider):
+        """A verified ping refreshes _last_user_event_time (holding the
+        subscription for another staleness window) but must NEVER set
+        _user_event_received — WS-primary promotion stays real-event-gated so a
+        ping can't disable REST polling on a never-delivering socket (#717)."""
+        loop, stop = _run_twm_loop_on_thread()
+        try:
+            twm = MagicMock()
+            client = MagicMock()
+
+            async def ws_ping(**params):
+                return {}
+
+            client.ws_ping = ws_ping
+            twm._client = client
+            provider._twm = twm
+            provider._twm_loop = loop
+            provider._user_event_received = False
+            stale = datetime.now(UTC) - timedelta(seconds=999)
+            provider._last_user_event_time = stale
+
+            assert provider.verify_user_stream_alive() is True
+            assert provider._last_user_event_time > stale
+            assert provider._user_event_received is False
+        finally:
+            stop()
+
+    @pytest.mark.fast
+    def test_ping_failure_returns_false_and_keeps_freshness(self, provider):
+        """A failed ping (dead ws-api) returns False and leaves freshness stale
+        so the watchdog proceeds to reconnect."""
+        loop, stop = _run_twm_loop_on_thread()
+        try:
+            twm = MagicMock()
+            client = MagicMock()
+
+            async def ws_ping(**params):
+                raise RuntimeError("ws-api down")
+
+            client.ws_ping = ws_ping
+            twm._client = client
+            provider._twm = twm
+            provider._twm_loop = loop
+            stale = datetime.now(UTC) - timedelta(seconds=999)
+            provider._last_user_event_time = stale
+
+            assert provider.verify_user_stream_alive() is False
+            assert provider._last_user_event_time == stale
+        finally:
+            stop()
+
+    @pytest.mark.fast
+    def test_generation_change_mid_ping_skips_freshness_refresh(self, provider):
+        """A stop/start racing the ping supersedes it: the ping's freshness
+        refresh must not be attributed to the NEW generation (#717 discipline)."""
+        loop, stop = _run_twm_loop_on_thread()
+        try:
+            twm = MagicMock()
+            client = MagicMock()
+
+            async def ws_ping(**params):
+                provider._user_stream_generation += 1  # concurrent teardown/restart
+                return {}
+
+            client.ws_ping = ws_ping
+            twm._client = client
+            provider._twm = twm
+            provider._twm_loop = loop
+            stale = datetime.now(UTC) - timedelta(seconds=999)
+            provider._last_user_event_time = stale
+
+            assert provider.verify_user_stream_alive() is True
+            assert provider._last_user_event_time == stale  # refresh skipped
+        finally:
+            stop()
+
+
+class TestUserStreamSubscriptionAge:
+    """#907 observability: subscription age is logged at each degrade so prod
+    logs can prove the fix moved lifetimes from ~minutes to hours."""
+
+    @pytest.mark.fast
+    def test_age_none_before_start(self, provider):
+        assert provider.user_stream_age_seconds() is None
+
+    @pytest.mark.fast
+    def test_start_records_subscription_time(self, provider):
+        mock_twm = MagicMock()
+        mock_twm.start_user_socket.return_value = "k"
+        provider._twm = mock_twm
+        provider._use_margin = False
+
+        provider.start_user_stream(MagicMock())
+
+        age = provider.user_stream_age_seconds()
+        assert age is not None
+        assert 0 <= age < 5
+
+    @pytest.mark.fast
+    def test_stop_user_stream_clears_subscription_time(self, provider):
+        mock_twm = MagicMock()
+        mock_twm.start_user_socket.return_value = "k"
+        provider._twm = mock_twm
+        provider._use_margin = False
+        provider.start_user_stream(MagicMock())
+        provider._user_socket_key = "k"
+
+        provider.stop_user_stream()
+
+        assert provider.user_stream_age_seconds() is None
+
+    @pytest.mark.fast
+    def test_stop_streams_clears_subscription_time(self, provider):
+        mock_twm = MagicMock()
+        mock_twm.start_user_socket.return_value = "k"
+        provider._twm = mock_twm
+        provider._use_margin = False
+        provider.start_user_stream(MagicMock())
+
+        provider.stop_streams()
+
+        assert provider.user_stream_age_seconds() is None
+
+
+class TestUserCallbackEventStreamTerminated:
+    """#907: ``eventStreamTerminated`` is the ws-api server declaring THIS
+    subscription dead (the ws-api analogue of listenKeyExpired). It must drive
+    the RESYNCING recovery path like an error — counting it as a healthy event
+    would fake freshness on a stream that just died."""
+
+    @pytest.mark.fast
+    def test_terminated_event_enters_resyncing_without_faking_freshness(self, provider):
+        cb, sink = TestUserStreamGeneration._capture_user_callback(provider)
+        provider._user_event_received = False
+        stale = datetime.now(UTC) - timedelta(seconds=999)
+        provider._last_user_event_time = stale
+
+        cb({"e": "eventStreamTerminated", "E": 1751760000000})
+
+        assert provider._user_ws_state == WebSocketState.RESYNCING
+        assert sink == []  # never forwarded as a data event
+        assert provider._user_event_received is False
+        assert provider._last_user_event_time == stale
+
+    @pytest.mark.fast
+    def test_stale_generation_terminated_event_is_dropped(self, provider):
+        """Our own unsubscribe also triggers a server-side termination event; the
+        generation bump in stop_* must drop it before it flips state."""
+        cb, _sink = TestUserStreamGeneration._capture_user_callback(provider)
+        provider._user_stream_generation += 1  # superseded socket
+        provider._user_ws_state = WebSocketState.PRIMARY
+
+        cb({"e": "eventStreamTerminated"})
+
+        assert provider._user_ws_state == WebSocketState.PRIMARY
+
+
+def _make_subscription_not_active_exc():
+    """Real BinanceAPIException carrying the prod -2036 payload."""
+    from binance.exceptions import BinanceAPIException
+
+    return BinanceAPIException(
+        MagicMock(),
+        400,
+        '{"code": -2036, "msg": "User Data Stream subscription not active."}',
+    )
+
+
+def _capture_real_teardown_unsubscribe_error(inner_exc: Exception) -> BaseException:
+    """Drive the REAL ``KeepAliveWebsocket.__aexit__`` exit-unsubscribe path.
+
+    Reproduces the #907 prod signature: tearing down a socket whose server-side
+    subscription is already gone raises through
+    ``_unsubscribe_from_user_data_stream`` inside the library's listener task —
+    surfacing as "Task exception was never retrieved". The captured exception
+    carries the genuine ``keepalive_websocket.py`` frames the discriminator
+    anchors on.
+    """
+    from binance.ws.keepalive_websocket import KeepAliveWebsocket
+
+    captured: dict[str, BaseException] = {}
+
+    async def scenario() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_exception_handler(lambda _loop, ctx: captured.__setitem__("exc", ctx["exception"]))
+        kaw = KeepAliveWebsocket.__new__(KeepAliveWebsocket)
+        kaw._timer = None
+        kaw._subscription_id = 7
+        kaw._uses_ws_api_subscription = True
+        kaw._path = "margin_subscription:7"
+        client = MagicMock()
+
+        async def failing_ws_api_request(*args, **kwargs):
+            raise inner_exc
+
+        client._ws_api_request = failing_ws_api_request
+        client.ws_api = MagicMock()
+        kaw._client = client
+
+        task = asyncio.create_task(kaw.__aexit__(None, None, None))
+        await asyncio.sleep(0.05)
+        del task  # drop ref → exception reported as "never retrieved"
+        gc.collect()
+        await asyncio.sleep(0.05)
+
+    asyncio.run(scenario())
+    exc = captured.get("exc")
+    assert exc is not None, "expected a teardown unsubscribe error"
+    return exc
+
+
+class TestTeardownUnsubscribeSuppression:
+    """#907: exceptions escaping python-binance's exit-unsubscribe (notably the
+    -2036 'subscription not active' on an already-dead subscription) are
+    teardown noise by construction — the socket is being discarded — and must
+    never surface as unretrieved task exceptions."""
+
+    @pytest.mark.fast
+    def test_detects_real_teardown_unsubscribe_2036(self, provider):
+        exc = _capture_real_teardown_unsubscribe_error(_make_subscription_not_active_exc())
+        assert provider._is_teardown_unsubscribe_error(exc) is True
+
+    @pytest.mark.fast
+    def test_detects_non_api_teardown_unsubscribe_error(self, provider):
+        """A ws-api timeout through the same teardown path is also teardown noise."""
+        exc = _capture_real_teardown_unsubscribe_error(RuntimeError("Request timed out"))
+        assert provider._is_teardown_unsubscribe_error(exc) is True
+
+    @pytest.mark.fast
+    def test_does_not_match_error_without_teardown_frames(self, provider):
+        """The same -2036 raised OUTSIDE the teardown path is not matched."""
+        try:
+            raise _make_subscription_not_active_exc()
+        except Exception as e:
+            caught = e
+        assert provider._is_teardown_unsubscribe_error(caught) is False
+        assert provider._is_teardown_unsubscribe_error(None) is False
+
+    @pytest.mark.fast
+    def test_handler_suppresses_2036_at_debug(self, provider, caplog):
+        """The prod -2036 teardown signature is downgraded to DEBUG, never
+        delegated to the default handler (no more 'Task exception was never
+        retrieved' ERROR + Traceback)."""
+        mock_loop = MagicMock()
+        exc = _capture_real_teardown_unsubscribe_error(_make_subscription_not_active_exc())
+        context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        with caplog.at_level(logging.DEBUG, logger="src.data_providers.binance_provider"):
+            provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_not_called()
+        assert any(
+            "-2036" in rec.getMessage() and rec.levelno == logging.DEBUG for rec in caplog.records
+        )
+
+    @pytest.mark.fast
+    def test_handler_warns_other_teardown_unsubscribe_errors(self, provider, caplog):
+        """Non--2036 failures on the teardown path are suppressed too (the socket
+        is already being discarded) but stay visible at WARNING."""
+        mock_loop = MagicMock()
+        exc = _capture_real_teardown_unsubscribe_error(RuntimeError("Request timed out"))
+        context = {"message": "Task exception was never retrieved", "exception": exc}
+
+        with caplog.at_level(logging.DEBUG, logger="src.data_providers.binance_provider"):
+            provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_not_called()
+        assert any(
+            "teardown unsubscribe" in rec.getMessage() and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        )
+
+    @pytest.mark.fast
+    def test_unrelated_exception_still_delegates(self, provider):
+        """An exception without teardown frames keeps full ERROR visibility."""
+        mock_loop = MagicMock()
+        try:
+            raise _make_subscription_not_active_exc()
+        except Exception as e:
+            caught = e
+        context = {"message": "boom", "exception": caught}
+
+        provider._twm_loop_exception_handler(mock_loop, context)
+
+        mock_loop.default_exception_handler.assert_called_once_with(context)

--- a/tests/unit/test_binance_provider_websocket.py
+++ b/tests/unit/test_binance_provider_websocket.py
@@ -1197,6 +1197,51 @@ class TestVerifyUserStreamAlive:
         finally:
             stop()
 
+    @pytest.mark.fast
+    def test_hung_ping_times_out_on_the_loop_and_cancels_the_coroutine(self, provider):
+        """The ping timeout is enforced ON the TWM loop (asyncio.wait_for), not
+        merely by the waiting thread: concurrent.futures.Future.cancel() cannot
+        interrupt an already-running coroutine, so thread-side-only enforcement
+        would leave a hung ping orphaned-pending on the loop every health cycle.
+        A hung ws-api must yield False AND a loop-side CancelledError in the ping."""
+        import threading
+
+        loop, stop = _run_twm_loop_on_thread()
+        try:
+            twm = MagicMock()
+            client = MagicMock()
+            started = threading.Event()
+            cancelled = threading.Event()
+
+            async def ws_ping(**params):
+                started.set()
+                try:
+                    await asyncio.sleep(60)  # hung ws-api: never responds
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+                return {}
+
+            client.ws_ping = ws_ping
+            twm._client = client
+            provider._twm = twm
+            provider._twm_loop = loop
+            stale = datetime.now(UTC) - timedelta(seconds=999)
+            provider._last_user_event_time = stale
+
+            with patch(
+                "src.data_providers.binance_provider.DEFAULT_WS_USER_LIVENESS_PROBE_TIMEOUT",
+                0.2,
+            ):
+                assert provider.verify_user_stream_alive() is False
+
+            assert started.wait(timeout=1)  # the ping actually ran on the loop
+            # wait_for cancelled it loop-side — no orphaned pending coroutine.
+            assert cancelled.wait(timeout=2)
+            assert provider._last_user_event_time == stale  # no freshness refresh
+        finally:
+            stop()
+
 
 class TestUserStreamSubscriptionAge:
     """#907 observability: subscription age is logged at each degrade so prod

--- a/tests/unit/test_trading_engine_ws_health.py
+++ b/tests/unit/test_trading_engine_ws_health.py
@@ -105,9 +105,11 @@ class TestCheckUserStreamHealth:
         mock_exchange = MagicMock()
         mock_exchange._user_ws_state = WebSocketState.PRIMARY
         # Stale stream → NOT healthy (no real event), so the recovery branch is
-        # skipped and the staleness/reconnect path runs.
+        # skipped and the staleness/reconnect path runs. Liveness verification
+        # fails too (#907) — a genuinely dead socket must still reconnect.
         mock_exchange.user_ws_healthy = False
         mock_exchange._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        mock_exchange.verify_user_stream_alive.return_value = False
         mock_engine.exchange_interface = mock_exchange
 
         mock_tracker = MagicMock()
@@ -144,6 +146,9 @@ class TestCheckUserStreamHealth:
         ex._user_ws_state = WebSocketState.PRIMARY
         ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
         ex.user_ws_healthy = False
+        # A dead multiplexed ws_api socket fails active liveness verification
+        # too (#907) — this fixture models the genuine-death cascade.
+        ex.verify_user_stream_alive.return_value = False
         mock_engine.exchange_interface = ex
         tracker = MagicMock()
         tracker.get_tracked_count.return_value = 2
@@ -528,6 +533,7 @@ class TestUserStreamRecoveringRestFallback:
         ex._user_ws_state = WebSocketState.PRIMARY
         ex.user_ws_healthy = False
         ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        ex.verify_user_stream_alive.return_value = False  # genuinely dead (#907)
         # mark_user_degraded flips to REST_DEGRADED like the real method.
         ex.mark_user_degraded.side_effect = lambda: setattr(
             ex, "_user_ws_state", WebSocketState.REST_DEGRADED
@@ -1153,6 +1159,7 @@ class TestUserHardReconnectMode:
         ex._user_ws_state = WebSocketState.PRIMARY
         ex.user_ws_healthy = False
         ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        ex.verify_user_stream_alive.return_value = False  # genuinely dead (#907)
         mock_engine.exchange_interface = ex
         tracker = MagicMock()
         tracker.get_tracked_count.return_value = 2
@@ -1235,3 +1242,131 @@ class TestUserHardReconnectMode:
         mock_engine._ws_kline_provider = MagicMock()
         with patch("src.config.feature_flags.is_enabled", return_value=True):
             assert mock_engine._should_hard_reconnect_user() is False
+
+
+class TestUserStreamLivenessVerification:
+    """#907: silence on the user-data stream is not death.
+
+    A quiet margin account legitimately produces zero user events for hours
+    (there is no heartbeat on a user-data stream), so the 120 s wall-clock
+    staleness alone guaranteed every subscription was torn down ~2 min after
+    creation overnight — the -2036 churn. When PRIMARY goes wall-clock stale
+    the watchdog now actively verifies the transport (bounded ws-api ping) and
+    HOLDS the subscription if it round-trips; only failed verification enters
+    the existing #717/#723 reconnect cascade, which is preserved untouched as
+    the safety net.
+    """
+
+    @staticmethod
+    def _stale_engine(mock_engine, verified: bool):
+        """PRIMARY + wall-clock-stale + tracked orders, with a liveness verdict."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.PRIMARY
+        ex.user_ws_healthy = False
+        ex._last_user_event_time = datetime.now(UTC) - timedelta(seconds=300)
+        ex.verify_user_stream_alive.return_value = verified
+        ex.user_stream_age_seconds.return_value = 300.0
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        return ex
+
+    @pytest.mark.fast
+    def test_stale_but_verified_alive_holds_subscription(self, mock_engine):
+        """Quiet-but-alive: no reconnect, no breaker increment — the subscription
+        is held instead of being churned every staleness window."""
+        ex = self._stale_engine(mock_engine, verified=True)
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as mock_disconnect:
+            mock_engine._check_user_stream_health()
+
+        mock_disconnect.assert_not_called()
+        ex.verify_user_stream_alive.assert_called_once()
+        assert mock_engine._user_reconnect_failures == 0
+
+    @pytest.mark.fast
+    def test_verified_alive_resets_breaker_mid_cascade(self, mock_engine):
+        """A verification success mid-cascade clears accumulated failures so a
+        transient blip doesn't keep counting toward the circuit."""
+        self._stale_engine(mock_engine, verified=True)
+        mock_engine._user_reconnect_failures = 2
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as mock_disconnect:
+            mock_engine._check_user_stream_health()
+
+        mock_disconnect.assert_not_called()
+        assert mock_engine._user_reconnect_failures == 0
+
+    @pytest.mark.fast
+    def test_verification_failure_enters_reconnect_cascade(self, mock_engine):
+        """A failed liveness check is a REAL problem — the existing reconnect
+        cascade (fast phase → circuit → throttled probes) runs unchanged."""
+        self._stale_engine(mock_engine, verified=False)
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as mock_disconnect:
+            mock_engine._check_user_stream_health()
+
+        mock_disconnect.assert_called_once()
+        assert mock_engine._user_reconnect_failures == 1
+
+    @pytest.mark.fast
+    def test_verification_raising_is_treated_as_failed(self, mock_engine):
+        """A verifier that raises must never crash the health thread — treat it
+        as a failed verification and reconnect."""
+        ex = self._stale_engine(mock_engine, verified=False)
+        ex.verify_user_stream_alive.side_effect = RuntimeError("boom")
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as mock_disconnect:
+            mock_engine._check_user_stream_health()
+
+        mock_disconnect.assert_called_once()
+
+    @pytest.mark.fast
+    def test_exchange_without_verifier_keeps_legacy_reconnect(self, mock_engine):
+        """Providers without verify_user_stream_alive keep today's behavior."""
+        ex = self._stale_engine(mock_engine, verified=True)
+        del ex.verify_user_stream_alive  # getattr now raises AttributeError
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as mock_disconnect:
+            mock_engine._check_user_stream_health()
+
+        mock_disconnect.assert_called_once()
+
+    @pytest.mark.fast
+    def test_degrade_logs_subscription_age(self, mock_engine, caplog):
+        """#907 observability: every degrade logs the subscription age so prod
+        logs can prove lifetimes moved from ~minutes to hours."""
+        import logging
+
+        self._stale_engine(mock_engine, verified=False)
+
+        with (
+            patch.object(mock_engine, "_handle_user_stream_disconnect"),
+            caplog.at_level(logging.WARNING),
+        ):
+            mock_engine._check_user_stream_health()
+
+        assert any("subscription age 5.0m" in rec.getMessage() for rec in caplog.records)
+
+    @pytest.mark.fast
+    def test_rest_degraded_probe_path_unaffected_by_verifier(self, mock_engine):
+        """REST_DEGRADED probing (#717/#723) is not gated on liveness pings —
+        there is no held subscription to verify while degraded."""
+        mock_engine.enable_live_trading = True
+        ex = MagicMock()
+        ex._user_ws_state = WebSocketState.REST_DEGRADED
+        ex.user_ws_healthy = False
+        ex.verify_user_stream_alive.return_value = True
+        mock_engine.exchange_interface = ex
+        tracker = MagicMock()
+        tracker.get_tracked_count.return_value = 2
+        mock_engine.order_tracker = tracker
+        mock_engine._user_reconnect_failures = 9  # next cycle hits boundary 10
+
+        with patch.object(mock_engine, "_handle_user_stream_disconnect") as mock_disconnect:
+            mock_engine._check_user_stream_health()
+
+        mock_disconnect.assert_called_once()
+        ex.verify_user_stream_alive.assert_not_called()


### PR DESCRIPTION
Fixes #907.

## Root cause (log + code evidence)

**Ours — silence treated as death on a stream that has no heartbeat.** `DEFAULT_WS_USER_STALENESS_THRESHOLD = 120` (`src/config/constants.py:441`) drives the PRIMARY-stale branch of `WebSocketHealthMonitor.check_user_stream_health` (`src/engines/live/ws_health.py:~460`). A user-data stream is event-driven: a quiet margin account (position open, SL resting, no fills/balance changes) legitimately emits **zero events for hours**. With orders tracked, every subscription was therefore judged dead exactly 120 s after creation. Prod logs 2026-07-05/06 show the deterministic cycle: `23:41:46` stream started → `23:43:46` "stale (120s)" → 3 futile reconnects at 120 s intervals → `23:49:50` circuit open → hard probes at failures #10/#20/#40/#80, each opening a perfectly good subscription that was again torn down ~2 min later. Recovery to WS-primary was *impossible* overnight regardless of transport health, because promotion requires a real event and none exist on a quiet account. This also explains the pre-rotation -2036 signatures and the historic #616/#617 churn family.

**Library — the -2036 unretrieved task exception on teardown.** python-binance 1.0.37 (== installed 1.0.36 for all `ws/*` files; 1.0.37 is the latest release, so no upgrade path exists):
- `binance/ws/threaded_stream.py:107-122` — `ThreadedApiManager.stop()` closes the AsyncClient (and its shared `ws_api` connection) **before** flipping `_socket_running[...] = False`.
- `binance/ws/keepalive_websocket.py:44-48` — the listener's `__aexit__` then unconditionally awaits `_unsubscribe_from_user_data_stream()`.
- `binance/ws/websocket_api.py:107-151` — `_ensure_ws_connection` silently reconnects a **fresh** ws-api connection just to send that unsubscribe; the server never held the subscription on that connection → 400/-2036 → raises inside the library task → "Task exception was never retrieved" (exact prod traceback at 00:00:39/00:12:52/00:35:05).
- `binance/ws/keepalive_websocket.py:247-251` — `_keepalive_socket` explicitly skips all keepalive for ws-api subscriptions, and nothing re-subscribes after a ws-api transport reconnect: the subscription lifecycle has no library-side resilience at all.

## The fix

1. **Active liveness verification instead of silence=death** (`BinanceProvider.verify_user_stream_alive`, `src/data_providers/binance_provider.py`): on PRIMARY+stale the watchdog now round-trips a ws-api `ping` on the TWM loop (bounded, 10 s). Success proves loop + shared ws-api transport + read loop are functioning → the subscription is **held** and provider freshness refreshed (next verify one staleness window later; the ping doubles as keepalive traffic on the ws-api TCP path). It **never** sets `_user_event_received`, so disabling REST polling stays strictly real-event-gated (#717 invariant preserved).
2. **Genuine failures still recover promptly** — nothing about the safety nets changed: transport drops propagate as error events → RESYNCING branch (checked before staleness); failed verification enters the existing #717 fast-phase → circuit → #723 exponential-backoff hard probes, all untouched; REST polling/fallback machinery unchanged; rate-limit posture unchanged (~1 weight-1 ping per 2 min when quiet).
3. **`eventStreamTerminated` handled as a disconnect** (RESYNCING), not as a healthy event — covers server-side subscription kills (e.g. listenToken expiry) that a transport ping cannot see. Our own unsubscribes are dropped by the #717 generation guard.
4. **Teardown hardening**: `_twm_loop_exception_handler` (the only interception point for library-task exceptions, per #716) now suppresses exceptions whose traceback passes through `_unsubscribe_from_user_data_stream` in `keepalive_websocket.py` — that frame only runs during socket teardown and never invokes our callbacks, so it is teardown noise by construction. -2036 → DEBUG; anything else on that path → single-line WARNING. All other exceptions still delegate to the default handler (the #716 callback-KeyError safety tests still pass).
5. **Observability**: the provider records `_user_stream_subscribed_at`; `user_stream_age_seconds()` is logged at every degrade (stale-reconnect, RESYNCING, circuit-open WARNING + operator ALERT). Acceptance metric: age at degrade should move from ~2-7 min to hours.

## Testing

- TDD: 19 new unit tests written red-first — watchdog verification semantics (hold / cascade / raise-defensive / legacy-provider fallback / REST_DEGRADED probes unaffected / age logging), provider ping semantics (round-trip refresh, failure, no-TWM, generation race), subscription-age lifecycle, `eventStreamTerminated` (incl. stale-generation drop), and -2036 suppression driven through the **real** `KeepAliveWebsocket.__aexit__` teardown path.
- Full `atb test unit`: ✅ all pass (219 s). `atb dev quality --changed`: ✅ black + ruff + mypy.

## Staging soak plan

1. Deploy this branch to staging via the standard parity sync (staging = develop, paper).
2. Ensure the bot has tracked orders (open paper position + SL) so the user-stream watchdog is active, then leave it untouched overnight.
3. **Acceptance:** ≥ 6 h with (a) no `REST_DEGRADED`/`USER_WS_DEGRADED` transition, (b) zero `Task exception was never retrieved`, (c) degrade logs (if any) showing subscription age in hours, (d) periodic `quiet ... transport verified alive — holding subscription` at DEBUG (or absence of churn at INFO).
4. On a real fill during the soak, confirm the `executionReport` arrives via WS (`User data WebSocket recovered — real event confirmed` if polling was on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)