### PR TITLE
fix(logging): populate ml_predictions in strategy execution rows (#914)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,6 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backtest determinism fingerprint byte-identical.
 
 ### Fixed
+- **#914 `strategy_executions.ml_predictions` no longer always null**: every row
+  ever written (151k+ in prod) carried JSON `null` because the logging call sites
+  extracted prediction data from dataframe columns (`onnx_pred`, `ml_prediction`)
+  that component strategies never populate — model outputs live on `Signal.metadata`.
+  A new shared extractor (`extract_ml_predictions_from_signal` in
+  `src/tech/adapters/row_extractors.py`) pulls the predicted price/return, model
+  identity (`engine_model_name`, `model_type`, `model_timeframe`, symbol-guard
+  stamps), and generator from the decision's signal metadata, and both engines
+  merge it into the logged dict (live entry/exit coordinators; backtest
+  entry/no-action/exit sites). Failed predictions now persist
+  `{prediction_failed: true, reason: ...}` (plus `error`/`error_type` when
+  generators provide them) instead of null, so prediction-path defects like the
+  #913 phantom-short class are visible in the DB.
 - **Experiment runner: `hyper_growth.min_confidence` override now reaches
   FlatRiskManager**: `ExperimentRunner._apply_strategy_attribute` routed
   `min_confidence` to the position sizer only, which is correct for the

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -52,6 +52,9 @@ from src.engines.backtest.regime import RegimeHandler
 from src.engines.backtest.risk import CorrelationHandler
 from src.engines.backtest.utils import extract_indicators as util_extract_indicators
 from src.engines.backtest.utils import extract_ml_predictions as util_extract_ml
+from src.engines.backtest.utils import (
+    extract_ml_predictions_from_signal as util_extract_ml_from_signal,
+)
 from src.engines.backtest.utils import extract_sentiment_data as util_extract_sentiment
 from src.engines.shared.execution.execution_model import ExecutionModel
 from src.engines.shared.execution.fill_policy import FillPolicy, resolve_fill_policy
@@ -1355,7 +1358,12 @@ class Backtester:
         # Log exit decision
         if self.event_logger.enabled:
             sentiment_data = util_extract_sentiment(df, index)
-            ml_predictions = util_extract_ml(df, index)
+            # Signal metadata carries the model outputs (or failure reason)
+            # that the dataframe columns don't (#914).
+            ml_predictions = {
+                **util_extract_ml(df, index),
+                **util_extract_ml_from_signal(getattr(runtime_decision, "signal", None)),
+            }
             current_pnl_pct = self.exit_handler.calculate_current_pnl_pct(current_price)
 
             self.event_logger.log_exit_decision(
@@ -1471,7 +1479,12 @@ class Backtester:
             if self.event_logger.should_log_candle(index):
                 indicators = util_extract_indicators(df, index)
                 sentiment_data = util_extract_sentiment(df, index)
-                ml_predictions = util_extract_ml(df, index)
+                # Signal metadata carries the model outputs (or failure reason)
+                # that the dataframe columns don't (#914).
+                ml_predictions = {
+                    **util_extract_ml(df, index),
+                    **util_extract_ml_from_signal(getattr(runtime_decision, "signal", None)),
+                }
 
                 self.event_logger.log_entry_decision(
                     strategy_name=self.strategy.__class__.__name__,
@@ -1511,7 +1524,12 @@ class Backtester:
             # Log entry
             indicators = util_extract_indicators(df, index)
             sentiment_data = util_extract_sentiment(df, index)
-            ml_predictions = util_extract_ml(df, index)
+            # Signal metadata carries the model outputs (or failure reason)
+            # that the dataframe columns don't (#914).
+            ml_predictions = {
+                **util_extract_ml(df, index),
+                **util_extract_ml_from_signal(getattr(runtime_decision, "signal", None)),
+            }
 
             self.event_logger.log_entry_decision(
                 strategy_name=self.strategy.__class__.__name__,

--- a/src/engines/backtest/utils.py
+++ b/src/engines/backtest/utils.py
@@ -22,6 +22,7 @@ from src.tech.adapters import row_extractors
 extract_indicators = row_extractors.extract_indicators
 extract_sentiment_data = row_extractors.extract_sentiment_data
 extract_ml_predictions = row_extractors.extract_ml_predictions
+extract_ml_predictions_from_signal = row_extractors.extract_ml_predictions_from_signal
 
 
 def compute_performance_metrics(

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -37,6 +37,7 @@ from src.engines.shared.models import PositionSide
 from src.infrastructure.logging.events import log_order_event
 from src.strategies.components import Signal, SignalDirection
 from src.strategies.components import Strategy as ComponentStrategy
+from src.tech.adapters.row_extractors import extract_ml_predictions_from_signal
 
 if TYPE_CHECKING:
     from src.data_providers.data_provider import DataProvider
@@ -190,6 +191,10 @@ class LiveEntryCoordinator:
         indicators = state._extract_indicators(df, current_index)
         sentiment_data = state._extract_sentiment_data(df, current_index)
         ml_predictions = state._extract_ml_predictions(df, current_index)
+        # Signal whose metadata carries the model outputs (or failure reason)
+        # for ml_predictions logging (#914); the component path overwrites it
+        # with its locally produced decision below.
+        decision_signal = getattr(runtime_decision, "signal", None)
 
         if use_runtime:
             perf_metrics = state.performance_tracker.get_metrics()
@@ -248,6 +253,7 @@ class LiveEntryCoordinator:
                     state.current_balance,
                     current_positions or None,
                 )
+                decision_signal = decision.signal
                 state._apply_policies_from_decision(decision)
 
                 notional_size = float(decision.position_size or 0.0)
@@ -284,6 +290,13 @@ class LiveEntryCoordinator:
             position_size = state._apply_dynamic_risk_adjustment(position_size, current_time)
 
         if state.db_manager:
+            # Enrich with model outputs from the signal metadata — the
+            # dataframe columns the extractor reads are never populated by
+            # component strategies, which left ml_predictions null (#914).
+            signal_ml = extract_ml_predictions_from_signal(decision_signal)
+            if signal_ml:
+                ml_predictions = {**ml_predictions, **signal_ml}
+
             # Prepare logging data - include TradingDecision data if available
             log_reasons = [
                 (

--- a/src/engines/live/execution/exit_coordinator.py
+++ b/src/engines/live/execution/exit_coordinator.py
@@ -44,6 +44,7 @@ from src.engines.shared.models import PositionSide
 from src.engines.shared.validation import is_same_bar_entry
 from src.infrastructure.logging.events import log_order_event
 from src.performance.metrics import Side, pnl_percent
+from src.tech.adapters.row_extractors import extract_ml_predictions_from_signal
 
 if TYPE_CHECKING:
     from src.data_providers.data_provider import DataProvider
@@ -158,6 +159,13 @@ class LiveExitCoordinator:
 
         component_strategy = None if safety_mode else state._component_strategy
         decision_for_exit = None if safety_mode else runtime_decision
+
+        # Enrich with model outputs from the signal metadata — the dataframe
+        # columns the extractor reads are never populated by component
+        # strategies, which left ml_predictions null (#914).
+        signal_ml = extract_ml_predictions_from_signal(getattr(decision_for_exit, "signal", None))
+        if signal_ml:
+            ml_predictions = {**ml_predictions, **signal_ml}
 
         # Get current candle timestamp for same-bar exit protection
         candle_time = None

--- a/src/tech/adapters/row_extractors.py
+++ b/src/tech/adapters/row_extractors.py
@@ -113,8 +113,62 @@ def extract_ml_predictions(df: pd.DataFrame, index: int) -> dict[str, float]:
     return ml
 
 
+# Metadata keys the ML signal generators attach to their Signals
+# (src/strategies/components/ml_signal_generator.py). "error"/"error_type" are
+# included so richer failure detail flows through if generators start emitting it.
+_ML_SIGNAL_METADATA_KEYS = (
+    "prediction",
+    "predicted_return",
+    "current_price",
+    "engine_model_name",
+    "model_type",
+    "model_timeframe",
+    "model_symbol",
+    "trading_symbol",
+    "generator",
+    "error",
+    "error_type",
+)
+
+# Failure reasons only the ML generators emit. Generic reasons such as
+# "insufficient_history" are shared with technical generators and would
+# mislabel non-ML decisions as prediction failures.
+_ML_FAILURE_REASONS = frozenset({"prediction_failed", "invalid_prediction_or_price"})
+
+
+def extract_ml_predictions_from_signal(signal: Any) -> dict[str, Any]:
+    """Extract ML prediction context from a Signal's metadata for DB logging.
+
+    Model outputs (predicted price/return, model identity) live on Signal
+    metadata rather than dataframe columns, so the column-based extractor
+    above never sees them (#914). Returns ``{}`` for signals that no ML
+    prediction informed; failed predictions return their failure reason with
+    ``prediction_failed=True`` so they stay visible in ``strategy_executions``
+    instead of persisting as null.
+    """
+
+    metadata = getattr(signal, "metadata", None)
+    if not isinstance(metadata, dict):
+        return {}
+
+    reason = metadata.get("reason")
+    is_failure = reason in _ML_FAILURE_REASONS
+    has_prediction = "prediction" in metadata or "predicted_return" in metadata
+    if not has_prediction and not is_failure:
+        return {}
+
+    extracted: dict[str, Any] = {
+        key: metadata[key] for key in _ML_SIGNAL_METADATA_KEYS if metadata.get(key) is not None
+    }
+    if is_failure:
+        extracted["prediction_failed"] = True
+        extracted["reason"] = reason
+    return extracted
+
+
 __all__ = [
     "extract_indicators",
     "extract_sentiment_data",
     "extract_ml_predictions",
+    "extract_ml_predictions_from_signal",
 ]

--- a/tests/unit/backtesting/test_ml_predictions_logging.py
+++ b/tests/unit/backtesting/test_ml_predictions_logging.py
@@ -262,3 +262,60 @@ class TestBacktestEngineMlPredictionsLogging:
         kwargs = bt.event_logger.log_exit_decision.call_args.kwargs
         assert kwargs["ml_predictions"]["prediction"] == 101.5
         assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v1"
+
+    def test_exit_decision_attributes_prediction_to_exit_signal_not_entry(self):
+        """The logged ml_predictions belong to the CURRENT exit decision's
+        signal, not the (different) prediction that opened the trade."""
+        bt = _make_backtester_stub()
+        bt.exit_handler.update_trailing_stop.return_value = (False, None)
+        partial_result = MagicMock()
+        partial_result.realized_pnl = 0.0
+        partial_result.scale_in_fees = 0.0
+        bt.exit_handler.check_partial_operations.return_value = partial_result
+        # Open trade carrying entry-time prediction context; must not leak
+        # into the exit row.
+        open_trade = MagicMock()
+        open_trade.current_size = 1.0
+        open_trade.original_size = 1.0
+        open_trade.size = 0.1
+        open_trade.partial_exits_taken = 0
+        open_trade.metadata = {
+            "prediction": 98.0,
+            "predicted_return": -0.02,
+            "engine_model_name": "BTCUSDT:1h:basic:v1",
+        }
+        bt.position_tracker.current_trade = open_trade
+        exit_check = MagicMock()
+        exit_check.should_exit = False
+        bt.exit_handler.check_exit_conditions.return_value = exit_check
+        bt.exit_handler.calculate_current_pnl_pct.return_value = 0.01
+
+        exit_signal = Signal(
+            direction=SignalDirection.HOLD,
+            strength=0.0,
+            confidence=0.3,
+            metadata={
+                "generator": "ml_basic_signal_generator",
+                "prediction": 104.0,
+                "predicted_return": 0.015,
+                "engine_model_name": "BTCUSDT:1h:basic:v2",
+            },
+        )
+
+        df = _sample_df()
+        bt._process_position_exit(
+            runtime_decision=_runtime_decision(exit_signal),
+            candle=df.iloc[2],
+            current_price=102.5,
+            current_time=datetime(2024, 1, 1, 2, tzinfo=UTC),
+            df=df,
+            index=2,
+            symbol="BTCUSDT",
+            timeframe="1h",
+        )
+
+        kwargs = bt.event_logger.log_exit_decision.call_args.kwargs
+        assert kwargs["ml_predictions"]["prediction"] == 104.0
+        assert kwargs["ml_predictions"]["predicted_return"] == 0.015
+        assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v2"
+        assert kwargs["position_size"] == 0.1

--- a/tests/unit/backtesting/test_ml_predictions_logging.py
+++ b/tests/unit/backtesting/test_ml_predictions_logging.py
@@ -1,0 +1,264 @@
+"""Tests for wiring ML prediction outputs into strategy-execution logging (#914).
+
+``strategy_executions.ml_predictions`` was JSON null in every row ever written
+because the column-based extractor looks for dataframe columns the strategies
+never produce — model outputs live on Signal metadata. These tests pin the
+signal-metadata extractor and the backtest engine call sites that merge it
+into the logged ``ml_predictions`` dict, including the failed-prediction case
+(which must be visible in the DB rather than logged as null).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from src.engines.backtest.utils import extract_ml_predictions_from_signal
+from src.strategies.components import Signal, SignalDirection
+
+pytestmark = pytest.mark.fast
+
+
+def _ml_success_signal() -> Signal:
+    """Signal shaped like MLBasicSignalGenerator's successful-prediction output."""
+    return Signal(
+        direction=SignalDirection.BUY,
+        strength=0.5,
+        confidence=0.42,
+        metadata={
+            "generator": "ml_basic_signal_generator",
+            "prediction": 101.5,
+            "current_price": 100.0,
+            "predicted_return": 0.015,
+            "index": 42,
+            "sequence_length": 120,
+            "long_entry_threshold": 0.001,
+            "engine_model_name": "BTCUSDT:1h:basic:v1",
+            "engine_batch": False,
+            "model_type": "basic",
+            "model_timeframe": "1h",
+            "trading_symbol": "BTCUSDT",
+            "model_symbol": "BTCUSDT",
+        },
+    )
+
+
+def _ml_failure_signal() -> Signal:
+    """Signal shaped like the ML generators' prediction-failed output."""
+    return Signal(
+        direction=SignalDirection.HOLD,
+        strength=0.0,
+        confidence=0.0,
+        metadata={
+            "generator": "ml_basic_signal_generator",
+            "reason": "prediction_failed",
+            "index": 42,
+            "trading_symbol": "BTCUSDT",
+            "model_symbol": None,
+        },
+    )
+
+
+class TestExtractMlPredictionsFromSignal:
+    def test_successful_prediction_extracts_model_outputs(self):
+        result = extract_ml_predictions_from_signal(_ml_success_signal())
+
+        assert result["prediction"] == 101.5
+        assert result["predicted_return"] == 0.015
+        assert result["current_price"] == 100.0
+        assert result["engine_model_name"] == "BTCUSDT:1h:basic:v1"
+        assert result["model_type"] == "basic"
+        assert result["model_timeframe"] == "1h"
+        assert result["model_symbol"] == "BTCUSDT"
+        assert result["generator"] == "ml_basic_signal_generator"
+        assert "prediction_failed" not in result
+
+    def test_failed_prediction_is_visible_not_empty(self):
+        result = extract_ml_predictions_from_signal(_ml_failure_signal())
+
+        assert result["prediction_failed"] is True
+        assert result["reason"] == "prediction_failed"
+        assert result["generator"] == "ml_basic_signal_generator"
+
+    def test_invalid_prediction_or_price_is_flagged_as_failure(self):
+        signal = Signal(
+            direction=SignalDirection.HOLD,
+            strength=0.0,
+            confidence=0.0,
+            metadata={
+                "generator": "ml_signal_generator",
+                "reason": "invalid_prediction_or_price",
+                "prediction": float("nan"),
+                "current_price": 100.0,
+                "predicted_return": 0,
+                "index": 42,
+            },
+        )
+
+        result = extract_ml_predictions_from_signal(signal)
+
+        assert result["prediction_failed"] is True
+        assert result["reason"] == "invalid_prediction_or_price"
+
+    def test_error_fields_flow_through_when_present(self):
+        signal = Signal(
+            direction=SignalDirection.HOLD,
+            strength=0.0,
+            confidence=0.0,
+            metadata={
+                "generator": "ml_basic_signal_generator",
+                "reason": "prediction_failed",
+                "error": "ONNX session timed out",
+                "error_type": "TimeoutError",
+            },
+        )
+
+        result = extract_ml_predictions_from_signal(signal)
+
+        assert result["error"] == "ONNX session timed out"
+        assert result["error_type"] == "TimeoutError"
+
+    def test_non_ml_signal_returns_empty(self):
+        # "insufficient_history" is also emitted by technical generators, so a
+        # bare reason without prediction keys must not be treated as ML output.
+        signal = Signal(
+            direction=SignalDirection.HOLD,
+            strength=0.0,
+            confidence=0.0,
+            metadata={"generator": "rsi_signal_generator", "reason": "insufficient_history"},
+        )
+
+        assert extract_ml_predictions_from_signal(signal) == {}
+
+    def test_none_signal_returns_empty(self):
+        assert extract_ml_predictions_from_signal(None) == {}
+
+    def test_non_dict_metadata_returns_empty(self):
+        assert extract_ml_predictions_from_signal(MagicMock(metadata="not-a-dict")) == {}
+
+
+def _sample_df() -> pd.DataFrame:
+    idx = pd.date_range("2024-01-01", periods=3, freq="1h")
+    return pd.DataFrame(
+        {
+            "open": [100.0, 101.0, 102.0],
+            "high": [101.0, 102.0, 103.0],
+            "low": [99.0, 100.0, 101.0],
+            "close": [100.5, 101.5, 102.5],
+            "volume": [1000.0, 1100.0, 1200.0],
+        },
+        index=idx,
+    )
+
+
+def _make_backtester_stub():
+    """Backtester with only the attributes the decision-logging paths touch."""
+    from src.engines.backtest.engine import Backtester
+
+    bt = object.__new__(Backtester)
+    bt.balance = 1000.0
+    bt.peak_balance = 1000.0
+    bt.trading_session_id = None
+    bt.enable_dynamic_risk = False
+    bt.dynamic_risk_adjustments = []
+    bt.strategy = MagicMock()
+    bt._component_strategy = None
+    bt.entry_handler = MagicMock()
+    bt.exit_handler = MagicMock()
+    bt.position_tracker = MagicMock()
+    bt.event_logger = MagicMock()
+    return bt
+
+
+def _runtime_decision(signal: Signal) -> MagicMock:
+    decision = MagicMock()
+    decision.signal = signal
+    decision.regime = None
+    decision.risk_metrics = None
+    decision.metadata = {}
+    return decision
+
+
+class TestBacktestEngineMlPredictionsLogging:
+    def test_entry_no_action_logs_signal_ml_predictions(self):
+        bt = _make_backtester_stub()
+        entry_signal = MagicMock()
+        entry_signal.should_enter = False
+        entry_signal.reasons = ["entry_conditions_not_met"]
+        bt.entry_handler.process_runtime_decision.return_value = entry_signal
+        bt.event_logger.should_log_candle.return_value = True
+
+        df = _sample_df()
+        bt._process_entry_signal(
+            runtime_decision=_runtime_decision(_ml_success_signal()),
+            df=df,
+            index=2,
+            candle=df.iloc[2],
+            current_price=102.5,
+            current_time=datetime(2024, 1, 1, 2, tzinfo=UTC),
+            symbol="BTCUSDT",
+            timeframe="1h",
+        )
+
+        kwargs = bt.event_logger.log_entry_decision.call_args.kwargs
+        assert kwargs["ml_predictions"]["prediction"] == 101.5
+        assert kwargs["ml_predictions"]["predicted_return"] == 0.015
+        assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v1"
+
+    def test_entry_no_action_logs_prediction_failure(self):
+        bt = _make_backtester_stub()
+        entry_signal = MagicMock()
+        entry_signal.should_enter = False
+        entry_signal.reasons = ["entry_conditions_not_met"]
+        bt.entry_handler.process_runtime_decision.return_value = entry_signal
+        bt.event_logger.should_log_candle.return_value = True
+
+        df = _sample_df()
+        bt._process_entry_signal(
+            runtime_decision=_runtime_decision(_ml_failure_signal()),
+            df=df,
+            index=2,
+            candle=df.iloc[2],
+            current_price=102.5,
+            current_time=datetime(2024, 1, 1, 2, tzinfo=UTC),
+            symbol="BTCUSDT",
+            timeframe="1h",
+        )
+
+        kwargs = bt.event_logger.log_entry_decision.call_args.kwargs
+        assert kwargs["ml_predictions"]["prediction_failed"] is True
+        assert kwargs["ml_predictions"]["reason"] == "prediction_failed"
+
+    def test_exit_decision_logs_signal_ml_predictions(self):
+        bt = _make_backtester_stub()
+        bt.exit_handler.update_trailing_stop.return_value = (False, None)
+        partial_result = MagicMock()
+        partial_result.realized_pnl = 0.0
+        partial_result.scale_in_fees = 0.0
+        bt.exit_handler.check_partial_operations.return_value = partial_result
+        bt.position_tracker.current_trade = None
+        exit_check = MagicMock()
+        exit_check.should_exit = False
+        bt.exit_handler.check_exit_conditions.return_value = exit_check
+        bt.exit_handler.calculate_current_pnl_pct.return_value = 0.01
+
+        df = _sample_df()
+        exited, trade = bt._process_position_exit(
+            runtime_decision=_runtime_decision(_ml_success_signal()),
+            candle=df.iloc[2],
+            current_price=102.5,
+            current_time=datetime(2024, 1, 1, 2, tzinfo=UTC),
+            df=df,
+            index=2,
+            symbol="BTCUSDT",
+            timeframe="1h",
+        )
+
+        assert exited is False
+        assert trade is None
+        kwargs = bt.event_logger.log_exit_decision.call_args.kwargs
+        assert kwargs["ml_predictions"]["prediction"] == 101.5
+        assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v1"

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -549,3 +549,167 @@ def test_component_path_entry_size_below_cap_unclamped():
 
     coordinator.execute_entry.assert_called_once()
     assert coordinator.execute_entry.call_args.kwargs["size"] == pytest.approx(0.15)
+
+
+# ---------------------------------------------------------------------------
+# ml_predictions logging (#914): signal-metadata prediction context must reach
+# the strategy_executions row instead of the historical always-null value.
+# ---------------------------------------------------------------------------
+
+
+def _ml_signal(metadata: dict, *, confidence: float = 0.42):
+    from src.strategies.components import Signal
+
+    return Signal(
+        direction=SignalDirection.HOLD, strength=0.0, confidence=confidence, metadata=metadata
+    )
+
+
+def _make_runtime_entry_state() -> MagicMock:
+    """Backref for the runtime-strategy path of check_entry_conditions."""
+    state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = False
+    state._is_runtime_strategy.return_value = True
+    state.current_balance = 1000.0
+    state.max_position_size = 0.2
+    state.timeframe = "1h"
+    state.trading_session_id = 7
+    state.db_manager = MagicMock()
+    state.live_position_tracker = MagicMock()
+    state.live_position_tracker.position_count = 0
+    state.risk_manager = MagicMock()
+    state.risk_manager.get_max_concurrent_positions.return_value = 1
+    state.performance_tracker = MagicMock()
+    state.performance_tracker.get_metrics.return_value = MagicMock(peak_balance=1000.0)
+    state.live_entry_handler = MagicMock()
+    no_entry = MagicMock()
+    no_entry.should_enter = False
+    no_entry.side = None
+    state.live_entry_handler.process_runtime_decision.return_value = no_entry
+    state._extract_indicators.return_value = {}
+    state._extract_sentiment_data.return_value = {}
+    state._extract_ml_predictions.return_value = {}
+    state._strategy_name.return_value = "ml_basic"
+    return state
+
+
+def _run_runtime_entry(state: MagicMock, runtime_decision: MagicMock) -> None:
+    import pandas as pd
+
+    coordinator = LiveEntryCoordinator(engine_state=state)
+    coordinator.execute_entry = MagicMock()  # type: ignore[method-assign]
+    df = pd.DataFrame({"close": [50000.0]})
+    coordinator.check_entry_conditions(
+        df=df,
+        current_index=0,
+        symbol="BTCUSDT",
+        current_price=50000.0,
+        current_time=datetime(2024, 1, 1, tzinfo=UTC),
+        runtime_decision=runtime_decision,
+    )
+
+
+def _runtime_decision_with(signal) -> MagicMock:
+    decision = MagicMock()
+    decision.signal = signal
+    decision.regime = None
+    decision.risk_metrics = None
+    decision.metadata = {}
+    return decision
+
+
+def test_runtime_entry_logs_signal_ml_predictions():
+    state = _make_runtime_entry_state()
+    decision = _runtime_decision_with(
+        _ml_signal(
+            {
+                "generator": "ml_basic_signal_generator",
+                "prediction": 50750.0,
+                "current_price": 50000.0,
+                "predicted_return": 0.015,
+                "engine_model_name": "BTCUSDT:1h:basic:v1",
+            }
+        )
+    )
+
+    _run_runtime_entry(state, decision)
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"]["prediction"] == 50750.0
+    assert kwargs["ml_predictions"]["predicted_return"] == 0.015
+    assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v1"
+
+
+def test_runtime_entry_logs_prediction_failure():
+    state = _make_runtime_entry_state()
+    decision = _runtime_decision_with(
+        _ml_signal(
+            {"generator": "ml_basic_signal_generator", "reason": "prediction_failed", "index": 0},
+            confidence=0.0,
+        )
+    )
+
+    _run_runtime_entry(state, decision)
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"]["prediction_failed"] is True
+    assert kwargs["ml_predictions"]["reason"] == "prediction_failed"
+
+
+def test_runtime_entry_merges_signal_over_dataframe_columns():
+    state = _make_runtime_entry_state()
+    state._extract_ml_predictions.return_value = {"onnx_pred": 50700.0}
+    decision = _runtime_decision_with(
+        _ml_signal(
+            {
+                "generator": "ml_basic_signal_generator",
+                "prediction": 50750.0,
+                "predicted_return": 0.015,
+            }
+        )
+    )
+
+    _run_runtime_entry(state, decision)
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"]["onnx_pred"] == 50700.0
+    assert kwargs["ml_predictions"]["prediction"] == 50750.0
+
+
+def test_runtime_entry_non_ml_signal_logs_null_ml_predictions():
+    state = _make_runtime_entry_state()
+    decision = _runtime_decision_with(
+        _ml_signal({"generator": "rsi_signal_generator", "reason": "insufficient_history"})
+    )
+
+    _run_runtime_entry(state, decision)
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"] is None
+
+
+def test_component_entry_logs_signal_ml_predictions():
+    state = _make_component_entry_state(max_position_size=0.2, notional=150.0)
+    # _make_component_entry_state skips DB logging; enable it and provide the
+    # state the logging block reads.
+    state.db_manager = MagicMock()
+    state.live_position_tracker = MagicMock()
+    state.live_position_tracker.position_count = 0
+    state.risk_manager = MagicMock()
+    state.risk_manager.get_max_concurrent_positions.return_value = 1
+    state._strategy_name.return_value = "ml_basic"
+    decision = state.strategy.process_candle.return_value
+    decision.signal = _ml_signal(
+        {
+            "generator": "ml_basic_signal_generator",
+            "prediction": 50750.0,
+            "predicted_return": 0.015,
+            "engine_model_name": "BTCUSDT:1h:basic:v1",
+        }
+    )
+
+    _run_component_entry(state)
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"]["prediction"] == 50750.0
+    assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v1"

--- a/tests/unit/engines/live/test_exit_coordinator.py
+++ b/tests/unit/engines/live/test_exit_coordinator.py
@@ -219,3 +219,78 @@ def test_execute_exit_locked_returns_on_failed_close():
     # skip_live_close -> filled-exit path; failure means no trade recorded.
     state.live_exit_handler.execute_filled_exit.assert_called_once()
     assert state.completed_trades == []
+
+
+# ---------------------------------------------------------------------------
+# ml_predictions logging (#914): signal-metadata prediction context must reach
+# the strategy_executions row instead of the historical always-null value.
+# ---------------------------------------------------------------------------
+
+
+def _exit_runtime_decision(metadata: dict, *, confidence: float = 0.42) -> MagicMock:
+    from src.strategies.components import Signal, SignalDirection
+
+    decision = MagicMock()
+    decision.signal = Signal(
+        direction=SignalDirection.HOLD, strength=0.0, confidence=confidence, metadata=metadata
+    )
+    decision.regime = None
+    decision.risk_metrics = None
+    return decision
+
+
+def test_check_exit_conditions_logs_signal_ml_predictions():
+    position = _make_position()
+    state = _make_state(position, _make_exit_check(should_exit=False))
+    decision = _exit_runtime_decision(
+        {
+            "generator": "ml_basic_signal_generator",
+            "prediction": 50750.0,
+            "current_price": 50000.0,
+            "predicted_return": 0.015,
+            "engine_model_name": "BTCUSDT:1h:basic:v1",
+        }
+    )
+
+    LiveExitCoordinator(engine_state=state).check_exit_conditions(
+        _make_df(), 0, 50100.0, runtime_decision=decision
+    )
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"]["prediction"] == 50750.0
+    assert kwargs["ml_predictions"]["predicted_return"] == 0.015
+    assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v1"
+
+
+def test_check_exit_conditions_logs_prediction_failure():
+    position = _make_position()
+    state = _make_state(position, _make_exit_check(should_exit=False))
+    decision = _exit_runtime_decision(
+        {"generator": "ml_basic_signal_generator", "reason": "prediction_failed", "index": 0},
+        confidence=0.0,
+    )
+
+    LiveExitCoordinator(engine_state=state).check_exit_conditions(
+        _make_df(), 0, 50100.0, runtime_decision=decision
+    )
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"]["prediction_failed"] is True
+    assert kwargs["ml_predictions"]["reason"] == "prediction_failed"
+
+
+def test_check_exit_conditions_safety_mode_keeps_dataframe_ml_predictions():
+    """Safety mode drops the runtime decision, so only df-column values remain."""
+    position = _make_position()
+    state = _make_state(position, _make_exit_check(should_exit=False))
+    state._extract_ml_predictions.return_value = {"onnx_pred": 50700.0}
+    decision = _exit_runtime_decision(
+        {"generator": "ml_basic_signal_generator", "prediction": 50750.0}
+    )
+
+    LiveExitCoordinator(engine_state=state).check_exit_conditions(
+        _make_df(), 0, 50100.0, runtime_decision=decision, safety_mode=True
+    )
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"] == {"onnx_pred": 50700.0}

--- a/tests/unit/engines/live/test_exit_coordinator.py
+++ b/tests/unit/engines/live/test_exit_coordinator.py
@@ -294,3 +294,61 @@ def test_check_exit_conditions_safety_mode_keeps_dataframe_ml_predictions():
 
     kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
     assert kwargs["ml_predictions"] == {"onnx_pred": 50700.0}
+
+
+def test_check_exit_conditions_attributes_prediction_to_exit_decision_not_entry():
+    """The persisted ml_predictions belong to the CURRENT exit decision's
+    signal, not the (different) prediction that opened the position."""
+    position = _make_position()
+    # Entry-time prediction context carried on the position; must not leak
+    # into the exit row.
+    position.metadata = {
+        "prediction": 48000.0,
+        "predicted_return": -0.04,
+        "engine_model_name": "BTCUSDT:1h:basic:v1",
+    }
+    state = _make_state(position, _make_exit_check(should_exit=True, reason="take_profit"))
+    decision = _exit_runtime_decision(
+        {
+            "generator": "ml_basic_signal_generator",
+            "prediction": 52000.0,
+            "predicted_return": 0.038,
+            "engine_model_name": "BTCUSDT:1h:basic:v2",
+        }
+    )
+
+    LiveExitCoordinator(engine_state=state).check_exit_conditions(
+        _make_df(), 0, 50100.0, runtime_decision=decision
+    )
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["signal_type"] == "exit"
+    assert kwargs["action_taken"] == "closed_position"
+    assert kwargs["ml_predictions"]["prediction"] == 52000.0
+    assert kwargs["ml_predictions"]["predicted_return"] == 0.038
+    assert kwargs["ml_predictions"]["engine_model_name"] == "BTCUSDT:1h:basic:v2"
+
+
+def test_check_exit_conditions_logs_prediction_error_details_end_to_end():
+    """error/error_type metadata reaches the persisted ml_predictions dict
+    through the real logging call site (helper-level coverage is not enough)."""
+    position = _make_position()
+    state = _make_state(position, _make_exit_check(should_exit=False))
+    decision = _exit_runtime_decision(
+        {
+            "generator": "ml_basic_signal_generator",
+            "reason": "prediction_failed",
+            "error": "ONNX session timed out",
+            "error_type": "TimeoutError",
+        },
+        confidence=0.0,
+    )
+
+    LiveExitCoordinator(engine_state=state).check_exit_conditions(
+        _make_df(), 0, 50100.0, runtime_decision=decision
+    )
+
+    kwargs = state.db_manager.log_strategy_execution.call_args.kwargs
+    assert kwargs["ml_predictions"]["prediction_failed"] is True
+    assert kwargs["ml_predictions"]["error"] == "ONNX session timed out"
+    assert kwargs["ml_predictions"]["error_type"] == "TimeoutError"


### PR DESCRIPTION
## Summary

Fixes #914 — `strategy_executions.ml_predictions` was the literal JSON `null` in all 151k+ production rows (and staging) because every logging call site extracted prediction data from dataframe columns (`onnx_pred`, `ml_prediction`, `prediction_confidence`) that component strategies never write. Model outputs live on `Signal.metadata` (set by `MLSignalGenerator` / `MLBasicSignalGenerator`), so the column-based extractor always returned `{}` and the manager coerced it to null.

## What changed

- **New shared extractor** `extract_ml_predictions_from_signal` in `src/tech/adapters/row_extractors.py` (the existing shared home of the column-based extractor, already consumed by both engines). It pulls from the decision signal's metadata:
  - `prediction` (predicted price), `predicted_return`, `current_price`
  - model identity: `engine_model_name`, `model_type`, `model_timeframe`, `model_symbol`, `trading_symbol`, `generator`
  - failure visibility: signals with `reason` = `prediction_failed` / `invalid_prediction_or_price` persist `{prediction_failed: true, reason: ...}` instead of null; `error`/`error_type` metadata keys flow through when generators emit them (forward-compatible with richer failure detail).
  - Non-ML signals still log null: extraction keys off prediction metadata and ML-specific failure reasons, not the generic `reason` key that technical generators share (`insufficient_history` etc.).
- **Live engine**: `LiveEntryCoordinator.check_entry_conditions` (runtime + direct component paths) and `LiveExitCoordinator.check_exit_conditions` merge the signal-derived dict over the column-based extraction before `db_manager.log_strategy_execution`. Safety-mode exits (no runtime decision) keep column-only behavior.
- **Backtest engine** (parity): the entry-executed, entry-no-action, and exit logging sites in `Backtester` do the same merge, so backtest rows carry identical prediction context.
- NaN/inf values (e.g. from the `invalid_prediction_or_price` case) are handled by the existing `DatabaseManager._sanitize_for_json` (converts to JSON null per-key).

## User-facing impact

Every `strategy_executions` row whose decision an ML prediction informed now records what the model predicted and which model produced it — and failed predictions are visible in the DB instead of indistinguishable from "no ML involved". This closes the observability gap that blinded the #913 forensics.

## Testing performed

- New tests (18):
  - `tests/unit/backtesting/test_ml_predictions_logging.py` — extractor behavior (success, both failure reasons, error passthrough, non-ML/None/no-metadata → empty) + backtest engine call sites (entry no-action, prediction-failure, exit).
  - `tests/unit/engines/live/test_entry_coordinator.py` — runtime path success/failure/merge/non-ML-null, direct component path.
  - `tests/unit/engines/live/test_exit_coordinator.py` — exit logging success/failure, safety-mode fallback.
  - TDD: all new tests confirmed failing before the fix (ml_predictions was `None`).
- `pytest -m "not integration and not slow" tests/unit/engines tests/unit/database tests/unit/backtesting` → **834 passed, 1 failed**: `test_backtesting_comprehensive_edge_cases.py::TestTimeframeEdgeCases::test_one_minute_timeframe` times out (>120s) — pre-existing environmental failure, reproduced on clean `origin/develop` in the same environment (193s baseline vs 174s on this branch).
- `pytest -m "not integration and not slow" tests/unit/live tests/unit/trading tests/unit/backtesting/test_utils.py` → **551 passed**.
- `atb dev quality --changed` → black, ruff, mypy all passed.

## Deliberately left out

- `src/engines/live/logging/event_logger.py:425/484` and `src/infrastructure/logging/decision_logger.py` already accept/forward `ml_predictions` but have **no callers** (the live coordinators call `db_manager` directly) — left untouched.
- `Strategy._generate_signal`'s generic exception path (`metadata={"error": ..., "component": "signal_generator"}`) is not logged into `ml_predictions`: it fires for any generator crash and can't be attributed to a model at this layer without touching `ml_signal_generator.py`, which a parallel session (`fix/deterministic-backtest-inference`) is actively changing. The extractor's `error`/`error_type` passthrough means richer failure metadata from that branch will flow through automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)