### PR TITLE
docs(skills): operational + self-management skill suite (13 skills)

### DIFF
--- a/.claude/skills/agent-fleet-health/SKILL.md
+++ b/.claude/skills/agent-fleet-health/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: agent-fleet-health
+description: The stall sweep for the agent fleet — find silent/stuck agents, salvage completed work from wake-loss, prune orphaned worktrees, catch dangling PRs, and guard the main checkout's branch. Use on a periodic cadence, when a dispatched agent has gone quiet, or when worktrees/PRs are accumulating.
+---
+
+# Agent Fleet Health
+
+Dispatched agents fail in two opposite ways: they die silently (work lost), or they finish and
+the wake-up link dies (work COMPLETED but never collected — the 2026-07-04 exit-sweep agent had
+finished all 18 runs; only the notification broke; results were salvaged from its scratchpad).
+And sometimes they neither die nor finish: a session that shipped #855 kept churning ~13% CPU
+for 7h after its purpose completed and had to be killed (PID hunt, 2026-07-04 ops entry).
+This sweep tells the three apart. Operates on layer 4 (working state); material actions
+(kills, salvages) log to layer 2. See `docs/architecture/memory_system.md`.
+
+## The sweep
+
+**1. Inventory the fleet (three sources, cross-referenced):**
+```bash
+ps aux | grep -E "claude" | grep -v grep                     # owning processes
+git -C /Users/alex/Sites/ai-trading-bot worktree list        # workspaces
+ls -lt /private/tmp/claude-501/*/*/scratchpad/ 2>/dev/null   # state files, by mtime
+```
+Plus session tooling if available (`ccd_session_mgmt` list_sessions), and the log.md tail for
+what was dispatched and why.
+
+**2. Classify each lane:**
+
+| Signal | Meaning | Action |
+|---|---|---|
+| Process alive, state file mtime fresh | working | leave alone |
+| Process alive, silent >90min, state stale, no recent tool activity | STALLED or purpose-complete churn | read its state file + transcript; if purpose complete (its PR merged, its report filed) → kill it; else resume with a state recap |
+| No process, state file shows unfinished stage | wake-loss OR crash | check for completed outputs FIRST (the exit-sweep lesson: the background job may have finished) — salvage results before re-running anything |
+| No process, outputs complete, never reported | wake-loss after success | collect results, log the salvage, close the lane |
+
+**Resume-with-state:** when resuming/re-dispatching, feed the agent its own crash-safe state
+JSON + a recap of stage/next-action (the `delegation-protocol` contract requires agents to
+maintain these precisely so this step works statelessly).
+
+**3. Orphaned worktrees.** For each worktree: branch merged or PR closed → remove
+(`git worktree remove <path>` + `git worktree prune`; the `clean_gone` command handles [gone]
+branches). Worktrees on UNMERGED branches are someone's active workspace — never delete without
+matching them to a lane (pm.md gate l). Tournament/smoke worktrees also need artifact hygiene:
+no stray model dirs, no `latest` symlink moved (`model-tournament` deliverable 3).
+
+**4. Dangling PRs.** `gh pr list --state open` — every open PR maps to a live lane, a log.md
+entry, or gets flagged. A PR whose branch's worktree is gone and whose author-session is dead is
+a decision for the PM: adopt, close, or re-dispatch. Check `mergeable_state` — a conflicted PR
+runs NO CI and looks deceptively "pending forever" (LESSONS §2.6).
+
+**5. Main-checkout guard.** `git -C /Users/alex/Sites/ai-trading-bot branch --show-current`
+MUST print `main`. A parallel session once switched it (the weekend that earned pm.md gate l);
+the main checkout is the production reference — flag loudly, restore only if its tree is clean,
+and never run git mutations there (LESSONS §3).
+
+## The wake-loss reality (why backstops, not trust)
+
+Wake-ups are lossy: scheduled tasks run only while the app is open (flagged to the Board
+2026-07-03), background-completion notifications can break, and compaction can eat a
+coordinator's context. Backstop pattern for every long-running dispatch:
+- the WORKER runs long steps as a single background process and END TURNS (never polls), with a
+  crash-safe state JSON updated after every stage;
+- the PM arms a **backstop watcher** — `run_in_background` + notify — on every long dispatch,
+  so a lost wake-up degrades to a late collection, not lost work;
+- **never detached/nohup processes** — they survive their owner with no collection path and
+  become the 7h-churn class.
+
+## Record
+
+Sweep summary (lanes found, classifications, kills, salvages, worktrees pruned) — one log.md
+entry if anything material happened; routine clean sweeps don't need one. Update
+`.claude/state/handover.md` if lane states changed (`session-handover`). Kills of live-capital-
+relevant agents are decisions (`decision-record`).
+
+## Red flags
+
+- Killing a lane without reading its state file first (may be mid-critical-section on prod).
+- Re-running an expensive job before checking whether the "dead" agent already finished it.
+- A worktree removal that takes uncommitted work with it — `git -C <wt> status` first.
+- "The agent said it's done" without artifacts — verify relayed claims (LESSONS §2.5).

--- a/.claude/skills/capital-review/SKILL.md
+++ b/.claude/skills/capital-review/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: capital-review
+description: Monthly Board pack — equity curve vs charter KPIs, full cost accounting, risk posture, live-expectancy evidence, and an explicit scale/hold/reduce recommendation with pre-committed gates. Use on the monthly cadence, when the Board asks "should we add capital?", or before any proposal that changes capital under management.
+---
+
+# Capital Review
+
+The monthly sitting where the Board decides scale/hold/reduce on evidence, not narrative. Reads
+layers 1+2, produces a pack that is itself layer-2 record (dated file + log entry). The daemon
+recommends; capital changes above the charter's autonomy envelope are the human's call.
+See `docs/architecture/memory_system.md`.
+
+## 1. Equity truth first
+
+Build the equity curve from `account_history` — but apply the pinned-book-value check before
+trusting ANY historical point (`prod-forensics`): true equity reads begin 2026-06-03 (#655);
+the drawdown baseline is peak TRUE equity since the last reconciled reset (2026-06-05 /
+session 20 ≈ $84.40 — pm policy, log.md 2026-07-04). A review that quotes the phantom $103.82
+April "peak" repeats the exact error the 2026-07-04 13:55 correction withdrew. Cross-check the
+month's net change against the `account_balances` ledger decomposition (where the money actually
+went: P&L vs fees vs sync corrections).
+
+## 2. Charter KPI scorecard (charter.md §KPIs, in priority order)
+
+| KPI | Target (charter v0.1) | This month | Evidence |
+|---|---|---|---|
+| Capital preservation | no risk-limits.json breach | | ledger + guard logs |
+| Backtest/live parity | variance ≤15% | | `trade-review` pass 3 |
+| Sharpe (rolling 30d) | target 1.5 / min 0.5 | | equity curve |
+| Win rate | target 55% / min 45% | | closed trades (state n!) |
+| Max drawdown (rolling) | target <15%, hard 20% | | true-equity baseline |
+| Cost per decision | <$0.50 | | see cost accounting |
+
+Every cell carries its artifact (file/query/log ref) or is marked UNVERIFIED — the pm.md
+confidence-cap rule applies to Board packs too.
+
+## 3. Full cost accounting
+
+Cost/decision includes EVERYTHING: exchange fees (ledger `entry_fee_*` + `orders.actual_
+commission`, mind the received-asset denomination), margin interest, Railway hosting, AWS/
+SageMaker training spend (cloud training ≈ $0.10/candidate, $0.37 full retrain — real July
+numbers), and inference/agent costs. The charter caps inference spend >$50/24h as a
+human-approval item — report actuals against it.
+
+## 4. Risk posture
+
+Current sizing vs limits (as-deployed AND as-written — the risk-limits.json 0.10 vs deployed
+0.20 divergence stayed open for weeks; if a divergence exists, this pack escalates it to
+`risk-ratification`), guard status (drawdown guard armed at correct peak, tiers), tripwire table
+status (standup tripwires: soft $80.18 / reduce $75.96 / hard floor $67.52), open incidents,
+event-window calendar (FOMC/CPI pauses armed?).
+
+## 5. Live-expectancy evidence
+
+The live record's n, win rate, avg win/loss, and what it does NOT yet prove (5 wins =
+"favorable sample", per the 2026-07-03 log). Latest shared-exam results for the deployed
+model/strategy (`docs/research/experiments/`, scoreboard) and staging paper status. Structural
+findings that reframe expectancy (e.g. the cross-symbol-model P0: 8 months of prod decisions
+were noise-trading — a fact any capital decision that month had to know).
+
+## 6. The recommendation — gated, not vibed
+
+**The standing capital gate:** new capital is added only when ALL hold —
+1. the deployed model/strategy is a current shared-exam winner (L2 of
+   `docs/architecture/model_evaluation_system.md`), not just incumbent-by-default;
+2. ≥48h clean staging paper on the exact deployed configuration (L3a);
+3. 3–4 weeks AND 20+ trades of live-positive performance at current size (L3b evidence);
+4. no open P0/P1 incident, no unratified risk-limit divergence, no breached tripwire.
+
+**Reduce/halt triggers:** tripwire breach, parity blown past 15% unexplained, a
+`kill-switch-drill` FAIL on a delivery/trip path, or the structural-expectancy class of finding
+(the −20.15%/365d backtest with a 21.84% MaxDD breach was treated as a reduce-candidate signal
+even while live was green). Recommendation is one of SCALE / HOLD / REDUCE with the gate
+checklist shown pass/fail. Precedent for honesty: the 2026-07-03 assessment told the Board the
+£85→£1,000-in-9-days ask was infeasible (~8.5% success even at zero-edge all-in) rather than
+pretending — that candor is the product.
+
+## Record
+
+Pack → `docs/research/notes/YYYY-MM-DD_capital-review.md`; decision + rationale → log.md via
+`decision-record` (`[D-…]`); anything needing a charter/risk-limits edit → `risk-ratification`.

--- a/.claude/skills/decision-record/SKILL.md
+++ b/.claude/skills/decision-record/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: decision-record
+description: How material decisions get made and recorded — when a decision record is required, the ΔP/ΔR/C/E rubric applied inline, the log.md entry format with [D-YYYY-MM-DD-NN] ids, and the append-only correction norm. Use whenever deciding on live-capital changes, promotions, halts, experiment verdicts, proposal approve/reject, or escalations — and whenever correcting an earlier recorded claim.
+---
+
+# Decision Record
+
+If it changed what the system does with money, models, or risk — and it isn't in log.md — it
+didn't happen. log.md is layer 2: append-only, corrections as new entries
+(`docs/architecture/memory_system.md`). This skill is the write-path counterpart to
+`pm-session-boot` (the read path).
+
+## When a record is REQUIRED
+
+- Live-capital changes (sizing, strategy activation/swap, symbol add, flag flips on prod).
+- Model promotions at any gate (exam winner, staging trial start/verdict, prod promote).
+- Halts and containment (entry-pause, close-only, kill-switch recommendation) and their lifts.
+- Experiment verdicts that change direction (GO/NO-GO, keep-incumbent, category-killed).
+- Proposal approve/reject/defer; escalations to the Board; stale-item closures.
+- Ratifications (`risk-ratification`), drill results (`kill-switch-drill`), retro diffs
+  (`weekly-retro`), material fleet actions (`agent-fleet-health`).
+
+Routine mechanics (a green deploy poll, a clean monitor tick) do NOT get entries — the log
+stays scannable because it records decisions, not activity.
+
+## The rubric, applied inline
+
+For anything scoreable, show the pm.md arithmetic in the entry — bare verdicts are unauditable:
+
+- **ΔP** capital protection (×2 weight, the veto axis) · **ΔR** profitability · **C**
+  confidence · **E** effort; priority = `((ΔP×2)+ΔR)×C/E`.
+- **Confidence cap:** C ≥ 3 requires a cited artifact (file:line, backtest metric, issue/PR,
+  incident id) — no artifact ⇒ C ≤ 2. This rule is what kept the fabricated "+16.67%" from
+  becoming a live swap: the number had no verifiable artifact behind it.
+- **Hard veto:** ΔP ≤ 2 on anything touching live trading / recon / risk / margin / orders →
+  reject or demand a mitigation plan; don't score around it.
+- Decisions above the charter's autonomy envelope additionally record WHO approved (the human,
+  in which session/PR) — e.g. the #835 entry names the human approval and its option text.
+
+## Entry format (state README base + decision ids)
+
+```markdown
+## [D-2026-07-06-01] 2026-07-06 14:00 · decision · daemon(PM)
+<one-line summary of what was decided>
+Rationale: <why — rubric arithmetic if scored; the losing options and why they lost>
+Ref: <issues/#N, proposals/<file>, incidents/<file>, experiment file, PR>
+```
+
+- **Id:** `D-YYYY-MM-DD-NN`, NN per-day sequence from 01, assigned at append time, never
+  reused. Cite ids from issues/PRs/skills so decisions are cross-referenceable. Pre-convention
+  entries are cited by their `YYYY-MM-DD HH:MM` header.
+- **Kind vocabulary** (extends README): `decision`, `escalation`, `proposal-open`,
+  `incident-open/close`, `post-mortem`, `note`, `track-record`, `deploy-verify`, `correction`.
+- Timestamps UTC always. Newest last. Refs are load-bearing — an entry whose evidence can't be
+  followed is a claim, not a record.
+
+## Corrections — the honest-correction norm
+
+When later evidence contradicts a recorded claim, correct the record EXPLICITLY — new entry,
+own id, kind `correction`, naming what it corrects:
+
+```markdown
+## [D-2026-07-06-02] 2026-07-06 15:00 · correction · risk-officer
+Corrects [D-…]/2026-07-04 13:20: <withdrawn claim> is withdrawn because <evidence>.
+Still standing: <the claims that survive>. Ref: <verification artifact>
+```
+
+The two reference specimens, both in log.md:
+- **Phantom-peak** (2026-07-04 13:55): the 13:20 "20.33% cap breach off a $103.82 peak" was
+  withdrawn same-day after the ledger showed the peak was pinned book value — the correction
+  names exactly which claims fell AND which still stand (the 365d backtest breach, the four
+  control failures). That partition is the craft: a correction that nukes everything is as
+  lazy as no correction.
+- **WS-triage** (2026-07-06 nightcap): "Correction to earlier triage: identical -2036
+  signatures predate the IP rotation" — reclassified a fresh incident as a chronic defect,
+  changing the fix's urgency and owner.
+
+Never edit the wrong entry. The record's value is that it shows reasoning being corrected —
+launder it once and every past entry becomes untrustworthy.
+
+## Red flags
+
+- A prod flag flip, merge-to-main, or model symlink move with no `[D-…]` entry.
+- "Approved by human" with no pointer to where/how the human approved.
+- A verdict entry with C ≥ 3 and no artifact ref.
+- Fixing a typo'd number in place "because it's just a typo" — append the correction.

--- a/.claude/skills/delegation-protocol/SKILL.md
+++ b/.claude/skills/delegation-protocol/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: delegation-protocol
+description: The dispatch contract between the PM and specialist agents — what every dispatch prompt must contain (isolation, compute discipline, crash-safe state, reporting) and what the PM owes every dispatch (backstop watchers, review gauntlet for money-path code, consolidated fix rounds, resume-with-state). Use when dispatching any agent, writing a dispatch prompt, or diagnosing why a delegation failed.
+---
+
+# Delegation Protocol
+
+Every clause below was earned by a real delegation failure: a session moved the main checkout
+off `main`; parallel heavy backtests cooked the machine and broke determinism; a 7h agent
+churned CPU after finishing; wake-loss stranded completed work; a reviewer read a worktree
+mid-fix and filed phantom findings; relayed claims turned out fabricated or wrong. State JSONs
+are layer 4, dispatch decisions layer 2 (`docs/architecture/memory_system.md`).
+
+## The dispatch prompt — mandatory clauses (copy into every long/consequential dispatch)
+
+1. **Isolation.** Work in a disposable worktree from `origin/develop`
+   (`git worktree add .claude/worktrees/<name> origin/develop --detach` or `-b <branch>`).
+   NEVER touch `/Users/alex/Sites/ai-trading-bot` (the main checkout IS the prod reference —
+   a cherry-pick scare and a branch-switch incident earned this), never staging/prod, never a
+   shared registry's `latest` symlink. The prompt must be self-contained: paths absolute,
+   context included — the agent has none of yours.
+2. **Compute discipline.** Heavy jobs (training, backtests) STRICTLY SEQUENTIAL — one at a
+   time machine-wide (thermal + the 0.1s-timeout non-determinism under CPU contention, #913;
+   also the standing "run backtests sequentially" feedback). Expect 1.5–4x nominal durations
+   under load. Cloud (SageMaker) jobs may parallelize.
+3. **Long steps: background + END TURN.** One background process per long step, then end the
+   turn — never poll, never `sleep`-loop, NEVER detached/nohup (no collection path — the
+   7h-churn class).
+4. **Crash-safe state.** Maintain an incremental state JSON in the scratchpad, updated after
+   EVERY stage (stage completed, artifact paths, next action). Wake-ups are lossy; this file
+   is how `agent-fleet-health` / `pm-session-boot` salvage or resume the lane statelessly —
+   it saved the 18-run exit sweep.
+5. **Continuation recap every turn.** Each turn ends with a one-block recap (done / doing /
+   next / state-file path) so any resumer — including you after a wake-loss — picks up cold.
+6. **No chips / no scope-spawning.** Out-of-scope findings go in the report to the PM, who
+   decides; don't spawn side-tasks from inside a dispatch.
+7. **Report to PM, claims with evidence.** Final message = what was done + artifact paths +
+   verification performed. Never relay another agent's claim as fact — verify against
+   filesystem/logs first. Precedents: a "coordinator" message fabricated a cache-data claim
+   (2026-07-05 ml-engineer note); a "zero callers" claim grepped the wrong class (2026-07-04);
+   a cron premise asserted a phantom orphan (LESSONS §2.5).
+8. **Repo rules travel with the dispatch.** CODE.md applies; quality gate via
+   `atb dev quality --changed` (bare form black-formats the whole tree in place); money-path
+   code needs the gauntlet below — say so in the prompt so the agent budgets for it.
+
+## The PM side — what you owe every dispatch
+
+- **Backstop watcher on every long-running dispatch**: `run_in_background` + notify, so a lost
+  wake-up degrades to late collection, not lost work (`agent-fleet-health` has the sweep).
+  Record the lane in `.claude/state/handover.md` (`session-handover`) at dispatch time.
+- **Review gauntlet — mandatory for money-path code** (live trading, risk, reconciliation,
+  margin, order execution): TWO reviewers minimum (code-reviewer + architecture-reviewer;
+  risk-officer for live-affecting proposals, dispatched FRESH — adversarial rule: it forms its
+  own view before reading the proposer's). No exceptions for "small" changes (`deploy-prod`
+  precondition). The codex loop until APPROVE is the proven extra layer for live-capital logic
+  (LESSONS §4 — it runs pytest and caught what local review missed).
+- **Single consolidated fix rounds.** Collect ALL review findings, then dispatch ONE fix round.
+  Never push fixes into a worktree a reviewer is still reading — the #843 second arch review
+  filed its P0 against in-flight state (log.md 2026-07-04 lesson verbatim: "don't dispatch fix
+  rounds into a worktree reviewers are still reading").
+- **Resume-with-state after wake-loss.** Before re-running ANYTHING: read the lane's state
+  JSON + outputs — the job may have finished (exit-sweep). Resume by feeding the agent its own
+  state file + recap; re-dispatch from scratch only if the state file is unusable.
+- **Verify the report.** Spot-check claimed artifacts exist and claimed results match raw
+  outputs (the window tournament re-verified every relayed number against backtest JSONs).
+  Material outcomes → log.md via `decision-record`; worktree cleanup after collection.
+
+## Sizing the ceremony
+
+Short read-only lookups (an Explore query, a one-file question) need none of this — clauses
+1–8 are for dispatches that mutate, run long, or feed decisions. When in doubt, the cost of
+clauses 4–5 is two paragraphs; the cost of their absence was a weekend of duplicated work.
+
+## Red flags
+
+- A dispatch prompt that says "as discussed" — the agent wasn't in the discussion.
+- Two heavy jobs running because each agent didn't know about the other (the PM serializes).
+- A money-path PR merging with one review because "it's tiny."
+- Acting on a relayed claim (even from a coordinator) without an evidence check.

--- a/.claude/skills/experiment-preregister/SKILL.md
+++ b/.claude/skills/experiment-preregister/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: experiment-preregister
+description: Pre-register every experiment BEFORE it runs — hypothesis, exam window, metrics, success thresholds, and the decision each outcome triggers, written to docs/research/experiments/ first. Use before ANY backtest study, tournament, calibration test, or parameter sweep; also the reference for anti-p-hacking rules (no post-hoc thresholds, candidate counting, negative results get full write-ups).
+---
+
+# Experiment Pre-registration
+
+No experiment runs before its file exists. The un-preregistered path produced the fabricated
+kelly "+16.67%" (real: +0.02%) that nearly earned a live swap, and the in-sample-contaminated
+model validation (−1.31% leaked vs −7.43% clean). The preregistered path (window tournament,
+calibration study) produced verdicts nobody could argue with — including negative ones. Files
+are layer-2 record: append-only, corrections as new sections
+(`docs/architecture/memory_system.md`).
+
+## Before the first run: write `docs/research/experiments/YYYY-MM-DD_<name>.md`
+
+Required sections (the template is `2026-07-05_window-tournament.md` — copy its shape):
+
+1. **Hypothesis** — falsifiable H1 AND the competing H0, each with a mechanism ("shorter
+   windows win because market structure shifted"), plus explicit "falsified if / supported if"
+   conditions (the flip-rate study's are the model).
+2. **Metric** — ONE primary (money metrics on the shared exam: OOS return / PF / MTM MaxDD /
+   win rate, prod-matched flags), secondaries labeled as secondaries. Holdout RMSE is a health
+   check, never the decision metric (it ranked the window tournament exactly backwards).
+3. **Success threshold** — numeric, pre-committed, including minimum trade count (≥15; a high
+   return on a handful of trades is not a result) and the statistical bar (n≈4,400 hourly bars
+   → directional-accuracy SE ≈0.75pp; differences under ~1.5pp are noise; Wilson CIs + trend
+   test for gradient claims).
+4. **Decision each outcome triggers** — pre-commit ALL branches: "clears threshold → staging
+   paper trial proposal; fails → keep incumbent, close issue; inconclusive → what specifically
+   gets run next." An outcome without a pre-committed decision invites motivated re-analysis.
+5. **Risks of false positive** — single-window/single-regime draw, trade-count risk, leakage
+   vectors, cache/provider drift. Naming them up front is what let the window tournament call
+   its own winner "promising but not ready."
+6. **Protocol** — data windows with hard cutoffs, exam window strictly after every training
+   cutoff, engine version (post-#838 only), worktree isolation, compute plan (sequential heavy
+   jobs). For model comparisons the protocol IS `model-tournament` — reference it, don't fork it.
+
+Then register: GH issue (`type:experiment`, owner label), and run.
+
+## Anti-p-hacking rules (each traceable to a real save)
+
+- **No post-hoc threshold moves.** The calibration study's Phase-3 gates were pre-selected from
+  training-period data and held even when the vol-normalized variant came out "directionally
+  favorable but sub-threshold" (+1.45pp vs required ≥3pp) — it was reported as noise, not
+  shipped. If a threshold turns out wrong, write a NEW preregistration; never edit the old one
+  after seeing results.
+- **Candidate-count tracking per exam window.** Every candidate that faces a frozen exam
+  increments its count; rotate/retire the window after ~10 (multiple-comparisons discipline,
+  `model-tournament` rule 10, `docs/architecture/model_evaluation_system.md`).
+- **Negative results get FULL write-ups.** The exit-geometry sweep (every variant strictly worse;
+  NO-GO), tournament-v2 (all "winners" collapse to ~0%), and the calibration study (H0
+  supported) are among the most-cited files in the record — they killed whole categories of
+  wasted work. "Didn't work" without a write-up = the experiment will be re-run by someone else.
+- **Determinism guard before trusting any result.** Re-run the first exam twice; identical or
+  stop (the 0.1s inference-timeout bug produced 46 trades/−11.36% vs 55/−10.33% on IDENTICAL
+  runs and threatened every frozen-exam comparison — #913).
+- **Verify relayed numbers against artifacts.** Read the raw backtest JSONs / metadata.json
+  yourself, "not taken from any relayed summary at face value" (window-tournament practice;
+  a relayed "zero callers" claim once grepped the wrong class).
+
+## After the run
+
+Append (never rewrite) to the same file: results tables, verdict vs the pre-registered
+thresholds, explicit answer to the hypothesis. Update status in the header line. Log a
+track-record entry to log.md (the `2026-07-05 11:00 · track-record · quant-researcher` entry is
+the reference shape: hypothesis → verdict → evidence path → recommendation). Scoreboard row if
+model-related. Experiment verdicts that change what we do are material decisions —
+`decision-record`.
+
+## Red flags
+
+- "Let's just run it quickly first to see if it's worth preregistering." That IS the p-hack.
+- A success threshold that appears for the first time in the results section.
+- An experiment whose file was created after its result timestamps.
+- Reusing an exam window past its candidate budget because "it's convenient."

--- a/.claude/skills/incident-response/SKILL.md
+++ b/.claude/skills/incident-response/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: incident-response
+description: P0/P1 incident playbook for the live trading bot — classify by log signature, capture evidence BEFORE containment destroys it, apply the pre-committed containment for that class (entry-pause / close-only / kill-switch), open the incident record, escalate per charter. Use when a monitor, standup, or human reports capital at risk, a down bot, an order storm, auth failures, or DB/exchange divergence.
+---
+
+# Incident Response
+
+The playbook for "something is wrong in production." Detection lives in `bot-monitor-live`
+(signatures: `.claude/LESSONS.md` §5); this skill is what the RESPONDER does next. Memory layers
+per `docs/architecture/memory_system.md`: you append to layer 2 (incident file, log.md, GH issue);
+lessons reach LESSONS.md via `weekly-retro`, not mid-incident edits.
+
+## 1. Evidence FIRST — containment actions destroy it
+
+`railway logs` serves ONLY the current deployment, and `railway variables --set` (any flag flip)
+triggers a redeploy — so the act of containing erases the logs of the thing you're containing
+(learned the hard way in the #913 forensics: no `--since` value reaches prior containers).
+
+```bash
+railway logs -e production -s "Trading Bot" -n 1000 > /tmp/incident-$(date -u +%Y%m%dT%H%M).log 2>&1
+# Read-only DB snapshot (positions, balances, recent events) — psql via the PUBLIC proxy URL:
+# first statement ALWAYS: SET default_transaction_read_only = on;
+```
+
+Snapshot: open `positions` rows, last 5 `account_balances` rows, last 20 `system_events`, the
+`account_history` heartbeat timestamps. Seconds of work; do it before ANY mutation. Exception:
+if capital is actively bleeding (repeated emergency-close churn), contain first — a lost log is
+cheaper than a lost account. Forensics then run from Postgres (`prod-forensics` skill).
+
+## 2. Classify by signature
+
+| Class | Signature (grep the log dump) | Real precedent |
+|---|---|---|
+| SL-fail cascade | `emergency.close` / "Stop-loss placement failed", repeating | 2026-06-02: ~15% capital erosion ($100→$84) while reporting phantom $99.89 |
+| Close-only trip | `CLOSE-ONLY MODE ACTIVATED` | reconcile/DB problem; entries already halted |
+| Circuit breaker | `ACCOUNT_CIRCUIT_BREAKER_TRIP` / `risk_event=account_circuit_breaker_trip` | #807 daily-loss/drawdown halt; operator reviews & clears |
+| Order storm | Same CRITICAL repeating per-cycle (e.g. "Order UNKNOWN… manual intervention") | 06-01: 714 CRITICAL rows in a 33-min storm, paged nobody |
+| Auth failure | `-2015` / signature/IP-restriction errors with open positions | kill-switch auto-trigger condition per risk-limits.json |
+| Precision regression | `code=-1111` / `code=51077` (ANCHORED grep — bare digits match timestamps) | LESSONS §1.1; recurrence = regression |
+| DB divergence | "No active trading session for balance update"; balance ≠ exchange equity | #693; phantom-balance era |
+| Zombie bot | Deploy API SUCCESS but no `Decision:` lines and no hourly `account_history` row | 2026-05-19: both bots dead for days, API said SUCCESS |
+| Degraded-not-down | WS churn + REST fallback, fills still polling, SL intact | 2026-07-05 IP transition: correctly NOT treated as P0 |
+
+## 3. Contain — pre-committed action per class
+
+- **Entries are the risk, protection intact** → `FEATURE_ENTRY_PAUSE`:
+  `railway variables --set "FEATURE_ENTRY_PAUSE=true" -e production -s "Trading Bot"`
+  (this restarts the bot — restart-with-position is safe by design: re-adoption #677 + dedup
+  guards; never wait for a "flat window", you can't catch one — LESSONS §2.4).
+- **State integrity suspect (DB divergence, reconcile errors)** → close-only mode. It trips
+  itself via `_enter_close_only_mode`; if it hasn't, escalate rather than hand-rolling writes.
+- **Kill-switch criteria** (risk-limits.json `auto_trigger_conditions`): db/memory divergence,
+  duplicate-order storm, auth failure with open positions, data corruption. Kill-switch is
+  `authorized_actors: ["human"]` — you recommend, the human pulls it. NOTE: the documented
+  `atb live-control halt` does not exist (see `kill-switch-drill`); the real levers are
+  entry-pause, close-only, and stopping the Railway service.
+- **Degraded-not-down** → no midnight heroics on a protected account (2026-07-06 nightcap
+  precedent): designed-degraded + monitoring + a daylight fix issue.
+- **NEVER** manually flatten to "help", never repay/sell margin dust without `free` vs
+  `borrowed` vs `netAsset` analysis (LESSONS §1.5 — selling held dust creates a naked short).
+
+## 4. Verify the premise before paging (P-phantom class)
+
+Cron/relayed premises have repeatedly evaporated (LESSONS §5.5, §2.5; the 2026-06-05 "orphan"
+was a phantom DB row, not double-exposure). Confirm against live state: `get_open_orders`, the
+actual order id, tracked `Positions:` count, heartbeat row, UTC clock math (`date -u` — a GMT+1
+scheduler makes a live bot look 1h stale).
+
+## 5. Record + escalate
+
+1. `.claude/state/incidents/YYYY-MM-DDTHHMM-P<n>-<slug>.md` — `status: open` frontmatter,
+   timeline (UTC), evidence paths, containment applied, severity rationale.
+2. GH issue, labels `type:incident` + `priority:p<n>` + `area:live-ops`. P0 scopes the whole
+   session to it (CLAUDE.md daemon rule).
+3. `log.md` append via `decision-record` (`[D-…]` id, kind `incident-open`).
+4. Escalate per charter.md Escalation section (method + SLA); while waiting: freeze new
+   entries, maintain stops, keep monitoring. One escalation per state, not per tick.
+
+## 6. Postmortem (before `status: closed`)
+
+Template: impact ($ and duration) · timeline · root cause (5-whys until a code/process defect)
+· why detection missed it (compare vs the 2026-06-08 observability audit — most misses were
+"emitted but never delivered") · fixes as GH issues with owners (the #626–#631 hardening series
+is the reference shape) · corrections to any wrong mid-incident claims, appended per the
+phantom-peak pattern (memory_system.md discipline 1). Feed durable rules to `weekly-retro`.

--- a/.claude/skills/kill-switch-drill/SKILL.md
+++ b/.claude/skills/kill-switch-drill/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: kill-switch-drill
+description: Quarterly staging fire-drill for the safety stack — prove the drawdown guard trips close-only, alerts actually reach Slack, entry-pause round-trips, and rollback works, then record the results. Use on the quarterly cadence, after any change to guards/alerting/close-only code, or when anyone asks "would the kill switch actually fire?".
+---
+
+# Kill-Switch Drill
+
+**Safety code rots invisibly unless fired.** June 2026 proved it four ways: the 20% max-drawdown
+"kill switch" (`check_drawdown`) was dead code with zero callers; `EmergencyControls` was never
+wired into any engine; the alert webhook was unset in prod → 0 of 20 system_events delivered in
+14 days including 2 criticals (the double-blind finding, `docs/observability_audit_2026-06-08.md`);
+and the drawdown guard's seed defect (peak=$100 vs true $84.42) only surfaced the day the guard
+first armed (2026-07-04). None of these were visible in CI. A drill fires each mechanism on
+staging (paper, ~$1,000) and watches it actually work.
+
+Run quarterly, and after any change under `src/engines/live/monitoring/` or to alerting.
+All mutations are STAGING-ONLY. Results append to layer 2 (log.md + issues); see
+`docs/architecture/memory_system.md`.
+
+## Drill checklist
+
+**0. Baseline.** `deploy-staging` boot verification passes; note deployment id for rollback.
+
+**1. Entry-pause round trip.**
+```bash
+railway variables --set "FEATURE_ENTRY_PAUSE=true" -e staging -s "Trading Bot"   # = a redeploy
+```
+Verify the boot log shows the pause armed and entry evaluation logs the paused skip (EntryPauseGate
+also gates scale-ins — that was a review catch on #835, confirm it still holds). Flip back off;
+verify entries resume. Each `--set` is a restart — batch flags into one command.
+
+**2. Drawdown guard trips close-only.** The guard recomputes its peak from session
+`account_history` on boot (`drawdown_guard.py`; #850/#851 seed fix). Simulate breach-distance by
+re-baselining with the purpose-built flag rather than faking balances:
+`FEATURE_MAX_DRAWDOWN_RESET_PEAK=true` re-baselines the peak (misuse-safe: it can only ever make
+the guard MORE likely to be correct after a reconciled reset — never fabricate DB rows to force a
+trip). Verify: arm banner shows the expected peak + 20% cap and the 10%/16% warning tiers; if a
+paper drawdown can be arranged, confirm the trip enters close-only and emits the alert event.
+At minimum, assert the wiring: the guard is constructed, armed, and its trip path calls
+`_enter_close_only_mode` (the June lesson was precisely that this call-path check never happened).
+
+**3. Alert delivery, end-to-end.** A drill-triggered alert (or the startup `NO_ALERT_CHANNEL`
+guard warning if the webhook is deliberately unset) must produce: a `system_events` row with
+`alert_sent=true` AND a visible Slack message. `alert_sent` records the real webhook outcome
+(2xx-only), so a `true` row is proof of delivery. Staging webhook parity is tracked in #915 —
+if staging has no webhook, that's a drill FINDING, not a skip. Verify the alert self-check:
+prod's 07-04/07-05 startups fired `NO_ALERT_CHANNEL` loudly; a silent unset channel = regression.
+
+**4. Documented manual trigger exists.** risk-limits.json names
+`manual_trigger_command: "atb live-control halt"`. As of 2026-07-06 that command DOES NOT EXIST,
+and `atb live-control emergency-stop` prints "(simulated)" and exits 0 — a vapor kill-switch.
+Run the documented command; if it doesn't exist or doesn't halt, file the issue and flag the
+risk-limits.json line to `risk-ratification`. The real levers today: FEATURE_ENTRY_PAUSE,
+close-only mode, Railway service stop.
+
+**5. Circuit breakers.** `account_circuit_breakers` flag (`off`/`dry_run`/`on`): in dry_run,
+verify the `🟡 … WOULD HALT (dry_run)` line appears on a simulated-threshold day (LESSONS §5.2
+lists the live trip signatures: `ACCOUNT_CIRCUIT_BREAKER_TRIP`).
+
+**6. Rollback/redeploy drill.** Redeploy the previous SUCCESS deployment via Railway, verify
+re-boot: session reuse, position re-adoption (`Positions:` count survives, new opens = 0), guard
+re-arms at the correct peak. This is the same muscle `deploy-prod` rollback needs; exercise it
+where it's free.
+
+## Record
+
+- log.md entry (kind `note`, via `decision-record`, `[D-…]` id): date, each mechanism
+  PASS/FAIL, evidence lines (log timestamps, system_events ids, Slack permalink).
+- Every FAIL → GH issue (`priority:p1` if it's a delivery or trip-path failure — a dead alert
+  channel is the double-blind incident again), linked from the log entry.
+- Restore ALL staging flags to their pre-drill values; verify with a final boot check.
+
+## Red flags
+
+- A mechanism "passes" without an artifact (no event row, no Slack message, no log line) —
+  that's a fail. The audit's core finding was mechanisms that *looked* wired.
+- Drill left staging flags dirty (next trial inherits them silently).
+- Anyone proposing to drill on production. Never. Prod validation is boot verification
+  (`deploy-prod`) + the standup tripwires, not induced failures.

--- a/.claude/skills/pm-session-boot/SKILL.md
+++ b/.claude/skills/pm-session-boot/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pm-session-boot
+description: Deterministic PM session initialization — the pm.md hard-gate reads (a–l) plus scheduled-task inventory plus in-flight-work recovery, producing a standard state-of-the-world summary BEFORE any decision. Use at the start of every daemon/PM session, after compaction, after a crash/restart, or whenever the current picture feels stale.
+---
+
+# PM Session Boot
+
+Same inputs → same picture, any session, post-compaction included. The PM is memoryless between
+sessions; everything it needs is in files, and this skill is the deterministic order to read
+them. Boot is READ-ONLY across layers 1, 2, 4, and 5 (`docs/architecture/memory_system.md`) —
+the first write of a session is a decision, and decisions come AFTER the picture, via
+`decision-record`.
+
+## The gate: nothing material before all boxes tick
+
+Run the pm.md required reads a–l — they are a HARD GATE, "not optional, not time-boxable, not
+satisfiable by 'I already have the context'" — plus two boot-specific additions (m, n).
+Parallelize into one batch:
+
+**Identity (layer 1):**
+- a. `.claude/state/charter.md` — unfilled TODO in mission/autonomy/escalation → STOP, page human.
+- b. `.claude/state/risk-limits.json` — the hard lines. Missing/invalid → refuse material decisions.
+
+**Record (layer 2):**
+- c. Tail `.claude/state/log.md` (~50 lines) — recent decisions, open threads, corrections.
+- d. `proposals/` + `incidents/` filtered `status: open`. Any P0 → the session scopes to it.
+- e. `.claude/state/wakeups.jsonl` — lines with `wake_at <= now` are this tick's top priority.
+
+**Backlog + code momentum:**
+- f. `gh issue list --state open --label state:researching,state:proposed,state:building,state:paper`
+- g. `gh issue list --state open --label needs:human-approval` — blocked-on-human set.
+- h. `gh pr list --state open --json number,title,isDraft,statusCheckRollup` (mind
+  `mergeable_state` — conflicted PRs run no CI, LESSONS §2.6).
+- i. `git log --oneline -20` on develop. j. `docs/project_status.md` + changelog top.
+- k. CODE.md / CLAUDE.md task matrix (coverage gates).
+
+**Retrieval (layer 5):**
+- k2. Explicit mem-search on the session's topic — auto-loaded context does NOT satisfy this
+  (pm.md loophole rule). Empty result still counts, but say so.
+
+**Parallel-session sweep (earned by the weekend of conflicting PRs + a session moving the main
+checkout off `main`):**
+- l. RUNNING sessions (if session tooling available) + always: open PRs from branches not in
+  log.md; `git -C /Users/alex/Sites/ai-trading-bot branch --show-current` MUST print `main`;
+  `git -C /Users/alex/Sites/ai-trading-bot worktree list` — unmerged-branch worktrees are
+  someone's active workspace.
+
+**Boot additions:**
+- m. **Scheduled-task inventory**: `ls ~/.claude/scheduled-tasks` — know what's armed
+  (standup, alert-monitor, event-window pause flips, retrains) and check each expected firing
+  actually fired (tasks run only while the app is open — the known silent-miss mode). A pause
+  flag that should have flipped and didn't is an immediate action item.
+- n. **In-flight recovery (layer 4)**: read `.claude/state/handover.md` (a `session-handover`
+  snapshot, if present), then scan scratchpad state JSONs + background-task outputs for
+  interrupted lanes. Layer 4 is a HINT — verify each claimed lane against ground truth
+  (ps/worktrees/gh) before adopting it; the exit-sweep job once completed while its handover
+  state said "running." Full triage of stalls → `agent-fleet-health`.
+
+## Output: the state-of-the-world summary
+
+Standard block, before any recommendation or dispatch:
+
+```
+Sources checked: charter ✓ | risk-limits ✓ | log ✓ | proposals/incidents ✓ | wakeups ✓ |
+  gh issues ✓ | PRs ✓ | git log ✓ | status/changelog ✓ | CODE/CLAUDE ✓ | memory ✓ |
+  cross-session ✓ | scheduled-tasks ✓ | in-flight ✓        (✗ = say why; ✗ on a/b = STOP)
+POSTURE: live equity + open position + guard state + active pauses/flags (one line)
+DUE NOW: expired wakeups, missed scheduled firings, open P0/P1
+IN FLIGHT: lanes (agent/worktree/PR/stage) adopted from recovery, each marked verified/stale
+BLOCKED ON HUMAN: the needs:human-approval set + unratified layer-1 items
+NEXT: the single top action and why (rubric via decision-record if it's material)
+```
+
+## Red flags
+
+- Making any dispatch/merge/deploy before the summary exists.
+- Trusting handover.md lanes without verification (layer 4 is never authoritative).
+- A boot that skips m because "the tasks always fire" — the 2026-07-03 Board flag says otherwise.
+- Two boots in one session producing different pictures from the same files — that's a skill
+  bug; fix it in `weekly-retro`.

--- a/.claude/skills/prod-forensics/SKILL.md
+++ b/.claude/skills/prod-forensics/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: prod-forensics
+description: Read-only production forensics toolkit — decompose "where did the money go" from the account_balances ledger, locate fees, detect phantom positions/balances, and reconstruct history after logs are gone. Use for money-flow questions, balance discrepancies, position-truth disputes (DB vs exchange), or any historical incident investigation on prod/staging Postgres.
+---
+
+# Prod Forensics
+
+Answering "what actually happened to the money/positions" with zero mutation risk. Every recipe
+here was used on a real investigation (the −$16.71 two-week decomposition, the 2026-06-05
+phantom position #12, the #913 latency-error hunt). Writes findings to layer 2 (a note under
+`docs/research/notes/` + a log.md entry); never writes to prod. See
+`docs/architecture/memory_system.md`.
+
+## Read-only discipline (non-negotiable)
+
+```bash
+# Get the PUBLIC proxy URL (the bot's own DATABASE_URL is internal-only, unreachable locally):
+railway variables -e production -s Postgres --json | jq -r .DATABASE_PUBLIC_URL
+psql "$URL"
+-- FIRST statement, before anything else:
+SET default_transaction_read_only = on;
+```
+
+- `railway ssh` / `railway run` are policy-denied (LESSONS §3). The variables-read + local psql
+  path is the allowed route; the prod-variables dump may still prompt — that's correct, get the
+  human OK. Same recipe for staging via `-e staging`.
+- Logs are NOT a historical source: `railway logs` serves only the current deployment and
+  `--since` never reaches prior containers (#913 lesson). History lives in Postgres:
+  `strategy_executions`, `system_events`, `reconciliation_audit_events`, `orders`, `trades`.
+
+## Money flow: the `account_balances` ledger
+
+`account_balances.update_reason` summed deltas = the authoritative "where money went":
+`entry_fee_<SYM>`, `realized_pnl_<SYM>_<exit_reason>` (gross pnl net of exit fee),
+`margin_equity_sync_correction`, `session_start`. Reference finding: the 2-week −$16.71 to
+2026-06-08 was −$17.12 of `margin_equity_sync_correction` (phantom $100 → true $84 books
+catching up), realized P&L +$0.53, fees ≈ $0.17 — NOT fees, NOT trading.
+
+**THE LAG PITFALL:** computing `total_balance - lag(total_balance) OVER (ORDER BY last_updated,
+id)` AFTER a `WHERE update_reason = …` filter makes `lag` span unrelated events → fake
+cross-event deltas (produced phantom −$15.76 "entry fee" rows once). Compute `lag` over the
+FULL ordered table in a CTE, THEN filter/group.
+
+## Fees: three locations, two denominations
+
+- `orders.actual_commission` — authoritative, **denominated in the RECEIVED asset**: base
+  (ETH) on buys, quote (USDT) on sells. NEVER sum raw across both sides.
+- `account_balances` `entry_fee_*` rows — USD, ledger-consistent.
+- `trades.commission`/`quantity` — populated only since #731/#831; older rows are 0/NULL, so
+  historical fee analysis must use the two sources above.
+
+## Position truth: phantom detection
+
+DB `positions` rows are claims; the exchange is truth. The 2026-06-05 read-only reconciliation
+proved DB row #12 a phantom (2 OPEN rows vs 0.00378 ETH held and ONE live SL order): compare
+per-symbol DB OPEN quantity vs exchange holdings, and each row's SL `order_id` vs
+`get_open_orders`. On margin, split `free` vs `borrowed` vs `netAsset` before calling anything
+a position — "dust" is usually an un-repaid borrow (LESSONS §1.5). Aggregate-balance checks
+can't see phantoms (a phantom "borrows" the real position's holdings — the #679 adopt-all trap).
+
+## Balance truth: the pinned-book-value check
+
+Pre-2026-06-03 `account_history` equity is BOOK VALUE, not a live read (May 2026: ONE distinct
+balance value across 451 hourly rows). Before trusting any peak/trough/drawdown:
+
+```sql
+SELECT date_trunc('month', timestamp) m, count(DISTINCT round(balance::numeric,4))
+FROM account_history GROUP BY 1 ORDER BY 1;
+```
+
+Near-constant months = software-pinned; do not compute drawdowns across them. This check is what
+withdrew the false "20.33% breach" claim (log.md 2026-07-04 13:55 correction). Adopted baseline:
+peak = peak TRUE equity since the last reconciled reset (2026-06-05 / session 20).
+
+## Sessions & liveness
+
+Prod REUSES its active `trading_sessions` row across restarts — a missing "new session row" is
+not an outage signal. Liveness ground truth: the hourly `account_history` heartbeat row + recent
+`strategy_executions`. A gap in heartbeats brackets an outage window precisely (the 2026-05-19
+zombie-bot class, where the deploy API said SUCCESS throughout).
+
+## Decision forensics (what was the bot thinking)
+
+`strategy_executions` carries per-decision signal/confidence/price rows — good enough to
+reconstruct a 30-min entry decision trail (done for suspect position 22 in the #913 hunt, which
+cleared prod of ever trading a latency-error result). Note `ml_predictions` is null before
+#914/#917 landed. Anchor error-code greps in any log dump you do have (`code=51077`, not bare
+digits — a nanosecond suffix once matched).
+
+## Output
+
+A dated note under `docs/research/notes/` (evidence: queries + row counts, not vibes) + a log.md
+entry via `decision-record` if the finding is material. Corrections to earlier claims follow the
+append-only correction pattern (memory_system.md discipline 1).

--- a/.claude/skills/risk-ratification/SKILL.md
+++ b/.claude/skills/risk-ratification/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: risk-ratification
+description: Guided Board sitting for the human-owned identity files (charter.md, risk-limits.json) — assemble every pending divergence and proposed change into one reviewable diff with evidence, verify constants.py mirrors risk-limits.json, get the human's edit/merge, stamp $last_reviewed, log the ratification. Use when a limit divergence is flagged, when charter TODOs block decisions, or on the periodic charter re-read.
+---
+
+# Risk Ratification
+
+`charter.md` and `risk-limits.json` are layer 1 — IDENTITY, human-owned, read-only to every
+agent (`docs/architecture/memory_system.md`). The daemon's job is to make the Board sitting
+CHEAP: one reviewable diff, every line backed by evidence, so ratification takes minutes instead
+of rotting for weeks. The cautionary tale: risk-limits.json `max_position_size_pct` 0.10 vs
+deployed 0.20 was flagged 2026-07-03, re-flagged twice on 07-04 by two different agents, and
+stayed unreconciled — with `$last_reviewed: 1970-01-01` — because nobody packaged the decision.
+
+## 1. Assemble the pending set
+
+Sweep for every open item that needs a layer-1 edit:
+- log.md entries with "escalated to Board" / divergence flags still unresolved;
+- risk-officer verdicts conditioned on a limit change;
+- charter TODOs (an unfilled mission/autonomy/escalation TODO BLOCKS all material decisions —
+  state README rule; the daemon must refuse and page rather than improvise);
+- `capital-review` / `kill-switch-drill` findings tagged for ratification.
+
+## 2. Verify the constants mirror — divergence is P0 by the file's own words
+
+risk-limits.json's `$source_of_truth_note`: "Must match src/config/constants.py. Any divergence
+is a P0." Check EVERY key against its constant, plus the as-deployed value (railway.json
+startCommand flags and env vars can silently override both — prod ran `--max-position 0.5` via
+startCommand for weeks before #835/#836 caught it). Known traps from the 2026-07-03/04 reviews:
+- `DEFAULT_MAX_CORRELATED_RISK` (0.10) and `DEFAULT_MAX_CORRELATED_EXPOSURE` (0.15) are TWO
+  distinct constants — verify which one a JSON key means before declaring a match;
+- strategy-level hardcodes can shadow both (kelly_momentum's `fallback_fraction=0.03` vs
+  `DEFAULT_KELLY_FALLBACK_FRACTION=0.02`; HyperGrowth's dynamic_risk override loosening the
+  drawdown tiers past the kill line — the #845 control-failure #3);
+- `kill_switch.manual_trigger_command` must name a command that EXISTS and acts
+  (`atb live-control halt` does not exist; `emergency-stop` is simulated — `kill-switch-drill`
+  finding). A dead reference in the risk file is itself a ratification item.
+
+Three-way rule: JSON ↔ constants.py ↔ as-deployed. Any mismatch goes in the diff with its
+evidence line.
+
+## 3. Package one reviewable diff
+
+For each proposed change: current value → proposed value → evidence (issue/experiment/incident
+ref, the risk-officer verdict, the deployed reality) → consequence of NOT changing. Two delivery
+modes, human's choice:
+- **PR the human merges** (preferred — the merge IS the ratification signature), branch
+  containing ONLY layer-1 edits + the constants.py mirror updates in the same diff so they
+  cannot diverge; or
+- **exact file edits** spelled out (old line → new line) for the human to apply by hand.
+
+Include the stamp in the same diff: `$last_reviewed: YYYY-MM-DD`, `$last_reviewer`, and
+charter.md's "*Last updated by human:*" footer. A ratification that doesn't move the stamp
+didn't happen.
+
+## 4. The sitting
+
+Present the diff + a one-screen summary (what changes, why, what it unblocks). The human edits
+or merges — the daemon NEVER commits to layer 1 itself, even with in-session verbal approval;
+the file history must show the human's hand (charter hard rule + CLAUDE.md daemon rules). If
+the human rejects an item, that's a decision too — record it so the flag stops re-firing.
+
+## 5. Record
+
+log.md entry via `decision-record` (`[D-…]`, kind `decision`): items ratified/rejected/deferred,
+the new stamp values, refs. Close the loop: update any GH issues waiting on `needs:human-input`
+/ `needs:human-approval`; notify `capital-review` inputs if limits changed; if a limit change
+alters guard behavior, schedule a `kill-switch-drill` pass on staging.
+
+## Red flags
+
+- An agent "temporarily" editing risk-limits.json or charter.md to unblock work. Never — halt
+  and page instead.
+- Ratifying the JSON without the constants.py mirror in the same diff (creates the next P0).
+- A verbal "yes, change it" with no file edit by the human — that ratifies nothing.
+- `$last_reviewed` older than the last known divergence flag: the backlog exists; run this skill.

--- a/.claude/skills/session-handover/SKILL.md
+++ b/.claude/skills/session-handover/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: session-handover
+description: Serialize in-flight state before context loss — write a snapshot of every live lane (agent, worktree, stage, state file, next action), armed watchers, and pending Board items to .claude/state/handover.md. Use before ending a session with work in flight, when compaction looms, before a risky long-running step, or on request ("hand over", "checkpoint the session").
+---
+
+# Session Handover
+
+Context is the most perishable asset in this system: compaction, crashes, and app closes eat it
+without warning, and wake-ups are lossy (the exit-sweep agent finished all 18 runs while its
+wake-link was dead — only its scratchpad state made the results salvageable, 2026-07-04).
+This skill serializes the CURRENT session's picture so `pm-session-boot` step (n) can rebuild
+it in seconds.
+
+**Layer discipline:** this skill writes ONLY layer 4 — `.claude/state/handover.md` is an
+overwrite-ok SNAPSHOT, not a log (`docs/architecture/memory_system.md`). It is never
+authoritative: boot verifies every lane against ground truth. Anything that must survive
+authoritatively (decisions, verdicts, incident state) belongs in layer 2 via `decision-record`
+— write those FIRST, then snapshot. A handover is not a substitute for logging.
+
+## When to write
+
+- Before deliberately ending a session with unfinished lanes.
+- When context pressure is visible (long session, big tool outputs) — don't wait for compaction.
+- Immediately after dispatching a long-running background job (the snapshot is the backstop's
+  map if the wake-up never arrives).
+- After any lane changes state materially (stage advanced, PR opened, agent died).
+
+Overwrite the whole file each time — stale partial snapshots are worse than none.
+
+## Format: `.claude/state/handover.md`
+
+```markdown
+# Session Handover — <UTC timestamp> — session <id/description>
+STALENESS WARNING: snapshot, not truth. Verify every lane before acting (pm-session-boot n).
+
+## Live lanes
+### <lane name> (one block per lane)
+- owner: <agent id/name or "this session">
+- worktree/branch: <path> / <branch>          # or "none"
+- PR/issue: #NNN (state)
+- stage: <last KNOWN completed stage — completed, not attempted>
+- state file: <absolute path to its crash-safe JSON in scratchpad>
+- next action: <the single next step, executable without this session's context>
+- verify by: <ground-truth check: file that must exist, PR state, process name>
+
+## Armed watchers / background jobs
+- <job>: started <time>, expected done <time>, output lands at <path>, backstop: <what/when>
+
+## Pending Board items
+- <item> — waiting since <date>, ref <issue/log entry>
+
+## Scheduled expectations
+- <task>: should fire at <time UTC>; if missed → <action>
+
+## Do-NOT list (session-specific live hazards)
+- e.g. "worktree X is mid-rebase — don't prune"; "staging flag Y deliberately ON for trial Z"
+```
+
+Rules for content:
+- **Stage = last verifiable checkpoint**, phrased against artifacts ("bundle synced, model.onnx
+  verified") not intentions ("training almost done"). The reader must be able to verify without
+  trusting you — relayed claims have been wrong before (LESSONS §2.5, the 2026-07-05
+  session-integrity note).
+- **Next action must be self-contained**: paths absolute, commands concrete, no "continue as
+  discussed." Assume the reader has zero conversational context — same standard as the
+  `delegation-protocol` dispatch prompt.
+- Point at each lane's own crash-safe state JSON rather than duplicating its contents — one
+  definition per fact; the JSON is maintained by the lane owner after every stage
+  (`delegation-protocol` contract).
+- Include the Do-NOT list: the most expensive handover failures are a successor "cleaning up"
+  something deliberately in flight (a reviewer mid-read worktree — the #843 review-collision
+  class).
+
+## The contract with boot
+
+`pm-session-boot` (n) reads this file, then VERIFIES each lane (process alive? artifact exists?
+PR state matches?) before adopting it — because between snapshot and boot, lanes finish, die,
+or get collected by watchers. A handover lane that fails verification goes to
+`agent-fleet-health` for triage, not straight to re-dispatch (the work may already be done).
+
+## Red flags
+
+- Recording a decision or verdict ONLY here — layer 4 evaporates by design; log.md or it
+  didn't happen.
+- A lane with no state file and no verify-by — unrecoverable by construction; fix the lane's
+  discipline, not just the snapshot.
+- Appending history to handover.md — it's a snapshot; history lives in log.md.
+- Handing over an unpushed branch as a lane — push first; a worktree-only branch dies with
+  the machine.

--- a/.claude/skills/trade-review/SKILL.md
+++ b/.claude/skills/trade-review/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: trade-review
+description: Periodic autopsy of live trades — MFE/MAE capture ratios, exit-reason P&L decomposition, live-vs-backtest divergence spot checks, regime attribution. Use on a weekly/biweekly cadence or after any notable win/loss streak; output is hypotheses that feed experiment-preregister, never direct strategy changes.
+---
+
+# Trade Review
+
+Where live P&L evidence turns into research hypotheses. Read-only against prod; output goes to
+layer 2 (a dated review note + hypotheses handed to `experiment-preregister`). This skill never
+changes a parameter — the 2026-07-04 exit-geometry sweep exists because a trade review asked
+"are we exiting too early?" and the preregistered answer was NO (every tighter variant strictly
+worse; the problem was the signal, #867). Hunches go through the pipeline.
+
+## Data access
+
+Read-only prod psql per `prod-forensics` (public proxy URL, `SET default_transaction_read_only
+= on;` first). Tables: `trades` (exit_reason, pnl; commission/quantity only post-#731),
+`positions`, `strategy_executions` (per-decision signal/confidence trail), `account_balances`
+(ledger truth), `account_history` (hourly equity). Candle data from the local parquet cache
+(`atb data prefill-cache`) for MFE/MAE reconstruction.
+
+## The four passes
+
+**1. MFE/MAE capture per trade.** For each closed trade, reconstruct from cached 1h candles:
+max favorable excursion, max adverse excursion, and capture ratio (realized P&L / MFE).
+Reference finding: all 5 winners of the June–July streak exited via trailing stop at +3.1–3.8%
+— below the first partial-exit target (8%), which is why live had zero partials ever (log.md
+2026-07-03 verification entry). Low capture across many trades = exit-geometry hypothesis;
+deep MAE on winners = entry-timing/stop hypothesis. Either way: hypothesis, not tweak.
+
+**2. Exit-reason P&L decomposition.** Group realized P&L by `exit_reason` (trailing stop, SL,
+TP, emergency close, external_close_recovery). Emergency-close P&L is an ops signal, not a
+strategy signal (the 2026-06-02 cascade). Fees from the ledger, not `trades.commission`
+(pre-#731 rows are 0 — see `prod-forensics` for denominations).
+
+**3. Live-vs-backtest divergence spot check.** Replay the review window through the corrected
+backtest engine (post-#838 ONLY — every pre-#838 partial-exit backtest return is fabricated)
+with prod-matched flags, and compare trade-by-trade: same entries taken? same exits? Charter KPI:
+parity variance ≤15%. Known structural divergences to check against before alarming: backtest
+force-injected default partial targets ignoring strategy overrides (fixed in #838); forming-bar
+decisions — live evaluates against a mutating tail candle, so live entries can fire intra-bar
+on decisions a closed-bar backtest never sees (`2026-07-06_forming-bar-fliprate.md`: large flip
+rates, mostly direction reversals; churn risk, not hidden edge).
+
+**4. Regime attribution.** Tag each trade with the regime slice (bull/bear/chop by monthly
+return — the simple deterministic labels, not the live detector, per
+`docs/architecture/model_evaluation_system.md`). A strategy positive in one regime and bleeding
+in another is a leverage-map/gating hypothesis. Check conviction too: the #913 forensics
+reconstructed position 22's full 30-min strengthening decision trail from
+`strategy_executions` — entry conviction (confidence/strength at entry) vs outcome is a real
+axis; prod's confidence median has sat at noise level (~0.03–0.04), which reframed a "weak
+strategy" as "no signal" (the cross-symbol model P0).
+
+## Sample-size honesty
+
+The live record is TINY (tens of trades). 5 consecutive wins moved the account +$1.11 and was
+correctly logged as "a short favorable win-streak sample", not edge. Never conclude expectancy
+from <20 trades; flag direction-of-evidence only. The standing capital gate (see
+`capital-review`) requires 20+ live trades before scaling — this review is how those trades get
+counted and characterized.
+
+## Output
+
+`docs/research/notes/YYYY-MM-DD_trade-review.md`: per-trade table (entry/exit, reason, P&L,
+MFE/MAE/capture, regime, entry confidence), the four-pass findings, and an explicit
+**Hypotheses** section — each one phrased ready for `experiment-preregister` (falsifiable, with
+a candidate metric). Material findings (parity breach, unexplained exit class, tripwire-adjacent
+drawdown) → log.md entry via `decision-record`; capital-risk findings → `incident-response`.
+
+## Red flags
+
+- Reviewing with pre-#838 backtest numbers as the comparison baseline.
+- A "fix" ships from this review without passing through `experiment-preregister`.
+- Trusting `trades` rows alone for money math — the ledger (`account_balances`) is truth.
+- Concluding from an exit-reason mix that includes emergency closes without separating ops
+  failures from strategy behavior.

--- a/.claude/skills/weekly-retro/SKILL.md
+++ b/.claude/skills/weekly-retro/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: weekly-retro
+description: The weekly consolidation pass — review the week's log, incidents, agent failures, and prediction-vs-outcome record, then distill them into LESSONS.md appends and skill amendments. Use on the weekly cadence (charter review rhythm) or after an unusually dense week. This is the ONLY routine editor of the distillate layer; output is concrete process diffs, not prose.
+---
+
+# Weekly Retro
+
+Episodic → semantic. The week's events live in layer 2 (log.md, incidents, experiments); this
+skill distills them into layer 3 (LESSONS.md, the skills themselves) — and it is the only skill
+that routinely edits layer 3, which is what keeps the distillate curated instead of accreted
+(`docs/architecture/memory_system.md`, discipline 4). A retro that produces "we should be more
+careful" has failed; the unit of output is a DIFF — a LESSONS append, a skill amendment, a
+checklist line, a new tripwire.
+
+## Inputs (all layer 2 + working state)
+
+1. **log.md** — the week's entries end to end, not just the tail.
+2. **Incidents + corrections** — anything opened/closed/corrected. Corrections are retro gold:
+   the phantom-peak withdrawal (2026-07-04 13:55) became LESSONS §5.6 (the distinct-count check)
+   — that's the pipeline working as designed.
+3. **Agent failures** — stalls, wake-losses, kills, review collisions, fabricated/wrong relayed
+   claims (`agent-fleet-health` findings; the 2026-07-05 ml-engineer session-integrity note).
+4. **Prediction-vs-outcome record** — every dated prediction made in the log (deploy will be
+   healthy, model will beat incumbent, "no midnight heroics" calls) vs what happened. Agents'
+   calibration is a charter review item (monthly: "review calibration of each agent"); the
+   risk-officer's own calibration note (2026-07-04: "consistent, not a reversal") is the format.
+5. **Experiments** — verdicts vs their preregistered thresholds; any p-hacking drift.
+6. **Scheduled tasks** — `ls ~/.claude/scheduled-tasks` + each task's expected trace (did the
+   standup run daily? did the FOMC pause flip fire?). Tasks run only while the app is open —
+   silent non-firing is a known failure mode; a task that didn't fire is a finding.
+7. **Model scoreboard** — new rows this week; stale `latest` claims.
+
+## The distillation pass
+
+For each notable event, ask: **which layer-3 artifact would have prevented it or captured it?**
+
+| Event class | Distills into |
+|---|---|
+| New bug class / trap → rule | LESSONS.md append (its "the trap → the rule" format, newest at section bottom) |
+| A skill's procedure was wrong or incomplete | Amend the SKILL.md (PR like any code change) |
+| A monitoring signature learned | LESSONS §5 (NOT the bot-monitor-live skill — method vs specifics, one-definition rule) |
+| A process gap with no owner skill | Proposal for a new skill or checklist (Board-visible) |
+| One-off with no generalizable rule | Nothing — resist the urge; a lessons file full of episodes is an unread lessons file |
+
+Rules for editing layer 3:
+- Every new rule cites its earned event (issue #, log date, incident id) — untraceable rules
+  rot into superstition; the existing LESSONS/skills style is "each one paid for."
+- Prefer amending an existing rule over adding a near-duplicate (consolidation, not accretion).
+- Deleting a rule is allowed when its precondition died (e.g. a fixed bug's workaround) — note
+  the removal in the retro log entry so the record explains the edit.
+- Mid-week emergency LESSONS appends are legal; the retro reconciles/merges them.
+
+## Scoreboard + tracker updates
+
+Update `docs/research/model-scoreboard.md` rows for the week's exam results (append-only);
+verify the deployed model's row matches reality (`atb live-control list-models` / registry
+symlinks). Check the standup tripwire table is still the ratified one.
+
+## Output (the definition of done)
+
+A log.md entry (kind `note`, via `decision-record`) listing, as diffs:
+- LESSONS.md sections appended/amended (with the earning event for each);
+- skills amended (PR links);
+- calibration verdicts per agent (over/under-confident, with the week's examples);
+- scheduled-task audit result (fired/missed);
+- process changes proposed to the Board (anything touching layer 1 → `risk-ratification`).
+
+Zero diffs is a legitimate outcome for a quiet week — say so explicitly rather than
+manufacturing lessons.
+
+## Red flags
+
+- A retro entry that is narrative summary without a single artifact diff.
+- Editing log.md or closed incidents "while we're at it" — layer 2 is append-only, always.
+- A lesson written into two places (skill + LESSONS) — pick the right layer, link the other.
+- Skipping the prediction-vs-outcome pass because the week "went fine" — calibration drift is
+  invisible exactly when things go fine.

--- a/docs/architecture/memory_system.md
+++ b/docs/architecture/memory_system.md
@@ -1,0 +1,89 @@
+# Memory System
+
+*Status: ADOPTED (2026-07-06, Board-approved alongside the operational skill suite). This is the
+reference model every skill in `.claude/skills/` reads and writes against. When a skill and this
+doc disagree about which layer owns a file, this doc wins and the skill gets amended.*
+
+The daemon + agent fleet is memoryless between sessions except for what lands in files. Every
+production incident this system has survived (phantom positions, phantom balances, wake-loss,
+compaction) traces back to memory discipline — or its absence. Five layers, strict ownership.
+
+## The five layers
+
+| # | Layer | Files | Owner | Mutation rule |
+|---|-------|-------|-------|---------------|
+| 1 | **IDENTITY** | `.claude/state/charter.md`, `.claude/state/risk-limits.json` | human Board | **Read-only to all agents.** Changes only via a Board sitting (`risk-ratification` skill). Missing/TODO-laden identity blocks material decisions. |
+| 2 | **RECORD** | `.claude/state/log.md`, `.claude/state/incidents/`, `.claude/state/proposals/`, `docs/research/experiments/`, `docs/research/notes/`, `docs/research/model-scoreboard.md` | writing agent | **Append-only.** Corrections are NEW entries referencing the old one — never edits. Proposal/incident lifecycle moves via `status:` frontmatter, body history stays. |
+| 3 | **DISTILLATE** | `.claude/LESSONS.md`, the `.claude/skills/*/SKILL.md` files themselves (procedural memory) | daemon, via retro | **Curated and edited in place** — but routinely only by `weekly-retro` (the consolidation engine). Mid-week emergency lessons are allowed; the retro reconciles them. |
+| 4 | **WORKING STATE** | scratchpad state JSONs, `.claude/state/handover.md` | owning session | **Overwritable ephemera. Never authoritative.** Always verify against ground truth (git/gh/ps/DB) before acting on it. Safe to delete once its lane completes. |
+| 5 | **INDEX / RETRIEVAL** | one-line indexes (memory `MEMORY.md` index, scoreboard header rows), mem-search as the semantic layer | daemon | Kept to one line per entry; points into layers 1–3. An explicit mem-search is required before ranking work (`pm.md` gate k2) — auto-loaded context does not count. |
+
+## Disciplines (each paid for)
+
+1. **Append-only records, corrections as new entries.** The reference pattern is the phantom-peak
+   correction: the 2026-07-04 13:20 incident-open claimed a 20.33% drawdown breach off a $103.82
+   April peak; the 13:55 entry *withdrew* it ("CORRECTION to the 13:20 entry... ledger-verified")
+   after the peak proved to be pinned book value, and stated exactly which claims stood and which
+   fell. The wrong entry stays; the record shows the reasoning was corrected, not laundered.
+   Same-day WS-triage correction (2026-07-06 nightcap, -2036 signatures predating the IP rotation)
+   follows the same form. **Honest correction is a norm, not an embarrassment.**
+2. **Pre-registration.** Hypothesis, metrics, thresholds, and the decision each outcome triggers
+   are written to layer 2 *before* an experiment runs (`experiment-preregister` skill). Post-hoc
+   threshold moves are how the fabricated "+16.67%" kelly result nearly reached live capital.
+3. **One definition per process.** A durable *method* lives in exactly one skill; volatile
+   *specifics* live in exactly one distillate section that the skill points at. Reference:
+   `bot-monitor-live` (method) + LESSONS.md §5 (the evolving signature list). Never fork a second
+   copy of either — divergent copies caused the `_extract_base_asset` USDC regression (LESSONS §2.2).
+4. **Weekly retro is the consolidation engine.** Episodic memory (layer 2: what happened) is
+   distilled into semantic memory (layer 3: what we now do differently) on a weekly cadence by
+   `weekly-retro`. That's the only routine layer-3 write path; it keeps LESSONS.md curated instead
+   of accreted.
+5. **Working state is a hint, not a fact.** Handover files and scratchpad JSONs let a resumed or
+   post-compaction session rebuild the picture fast — but they can be stale the moment they're
+   written (the exit-sweep agent's background job *completed* while its wake-up link was lost,
+   2026-07-04). Boot verifies layer 4 against the filesystem before trusting it.
+6. **Identity gates everything.** If charter.md has unfilled TODOs or risk-limits.json is missing,
+   the daemon refuses material decisions and pages the human (state README rule). No agent edits
+   layer 1 — the daemon proposes, the human merges (`risk-ratification`).
+
+## Decision IDs
+
+Material decisions (defined in the `decision-record` skill) get a stable ID so issues, PRs, and
+skills can cite them:
+
+```
+## [D-2026-07-06-01] 2026-07-06 14:00 · decision · daemon(PM)
+```
+
+`D-YYYY-MM-DD-NN`, NN = per-day sequence starting 01. IDs are assigned at append time and never
+reused; a correcting entry gets its own ID and names the ID it corrects. Entries predating this
+convention are cited by their `YYYY-MM-DD HH:MM` header.
+
+## Which skill touches which layer
+
+| Skill | Reads | Writes |
+|---|---|---|
+| `pm-session-boot` | 1, 2, 4, 5 | nothing (boot is read-only) |
+| `decision-record` | 1, 2 | 2 (log.md, with decision ID) |
+| `incident-response` | 1, 2 | 2 (incident file, log.md, GH issue); layer-3 lessons flow via retro |
+| `prod-forensics` | 2 + prod DB (read-only) | 2 (notes/log) |
+| `kill-switch-drill` | 1, 2 | 2 (drill record in log.md + issues for failures) |
+| `experiment-preregister` | 2, 5 | 2 (experiments/, BEFORE the run) |
+| `trade-review` | 2 + prod DB (read-only) | 2 (review note; hypotheses → preregister) |
+| `capital-review` | 1, 2 | 2 (Board pack + log entry) |
+| `agent-fleet-health` | 4 + ps/git/gh | 4 (state cleanup); 2 for material actions |
+| `session-handover` | own session state | **4 only** (`handover.md`, overwrite-ok) |
+| `delegation-protocol` | — (contract) | dispatches write 4; decisions write 2 |
+| `weekly-retro` | 2, 4, 5 | **3 (the only routine editor)** + 2 (retro log entry) |
+| `risk-ratification` | 1, 2 | assembles the diff; **human** writes 1; 2 (ratification log) |
+
+## Anti-patterns
+
+- Editing a past log.md entry "to fix a number" — that's how audit trails die. Append.
+- Treating a handover.md or coordinator-relayed claim as ground truth. Verify first: a relayed
+  "main checkout has ETHUSDT cache data" claim was fabricated (2026-07-05 ml-engineer log note);
+  a relayed "zero callers" claim had grepped the wrong class (2026-07-04 Kelly evaluation).
+- Writing lessons into a skill body when they're volatile specifics (they belong in LESSONS.md),
+  or into LESSONS.md when they're a one-off episode (they belong in the log).
+- A "temporary" divergence between risk-limits.json and `src/config/constants.py` — the JSON's
+  own `$source_of_truth_note` declares divergence a P0 (`risk-ratification` owns the check).


### PR DESCRIPTION
## Summary

Board-approved (2026-07-06) operational skill suite: 13 repo skills under `.claude/skills/<name>/SKILL.md`, matching the `model-tournament` / `deploy-prod` house style (terse, checklist-driven, every rule traceable to a real event, concrete commands, earned gotchas). Plus one Board-added scope item: `docs/architecture/memory_system.md`, the five-layer memory architecture all 13 skills reference consistently.

## The 13 skills

- **incident-response** — P0/P1 playbook: evidence capture BEFORE containment (flag flips redeploy and destroy logs), signature-based classification (LESSONS §5 + risk-limits kill-switch conditions), pre-committed containment per class, incident file + issue + charter escalation, postmortem template.
- **prod-forensics** — read-only money-flow + position-truth toolkit: `account_balances` ledger decomposition (LAG-over-full-table pitfall), fee locations/denominations, phantom-position and pinned-book-value detection, session/heartbeat forensics, the psql read-only discipline.
- **kill-switch-drill** — quarterly staging fire-drill: entry-pause round trip, drawdown-guard trip path, end-to-end alert delivery, rollback drill; includes the finding that risk-limits.json's documented `atb live-control halt` doesn't exist (and `emergency-stop` is simulated).
- **experiment-preregister** — hypothesis/metrics/thresholds/decision-per-outcome written to `docs/research/experiments/` BEFORE any run; anti-p-hacking rules (no post-hoc thresholds, candidate counting, negative results get full write-ups, determinism guard).
- **trade-review** — periodic live-trade autopsy: MFE/MAE capture, exit-reason P&L decomposition, live-vs-backtest parity spot checks, regime attribution; output = hypotheses feeding experiment-preregister.
- **capital-review** — monthly Board pack: equity truth (pinned-book-value check), charter KPI scorecard, full cost accounting, and the gated SCALE/HOLD/REDUCE recommendation (exam-winner + ≥48h paper + 20+ live trades gate).
- **agent-fleet-health** — the stall sweep: classify silent agents (stalled vs wake-loss vs done-but-uncollected), salvage before re-running, orphaned-worktree/dangling-PR hygiene, main-checkout branch guard, backstop-watcher patterns.
- **weekly-retro** — the consolidation engine: week's record → LESSONS.md appends + skill amendments + calibration verdicts + scheduled-task audit; output is diffs, not prose; the only routine editor of the distillate layer.
- **risk-ratification** — guided Board sitting for charter.md/risk-limits.json: one evidence-backed diff, three-way JSON↔constants.py↔as-deployed verification, `$last_reviewed` stamp, ratification logged.
- **pm-session-boot** — deterministic session init: pm.md hard-gate reads (a–l) + scheduled-task inventory + in-flight recovery from handover/scratchpad state → standard state-of-the-world summary before any decision.
- **session-handover** — serialize in-flight lanes (owner, worktree, stage, state file, next action, verify-by) to `.claude/state/handover.md` — overwrite-ok layer-4 snapshot the boot skill reads and verifies.
- **delegation-protocol** — the dispatch contract (isolation, sequential heavy compute, background+END-TURN, crash-safe state JSON, recap every turn, evidence-verified reporting) + PM obligations (backstop watchers, two-reviewer gauntlet for money-path code, consolidated fix rounds, resume-with-state).
- **decision-record** — when a record is required, the ΔP/ΔR/C/E rubric inline, the log.md entry format with `[D-YYYY-MM-DD-NN]` ids, and the append-only honest-correction norm (phantom-peak + WS-triage specimens).

## 14th artifact (Board scope addition)

- **docs/architecture/memory_system.md** — five layers (IDENTITY / RECORD / DISTILLATE / WORKING STATE / INDEX), the disciplines (append-only corrections, pre-registration, one-definition-per-process, retro-as-consolidation, working-state-is-a-hint), decision-id convention, and a per-skill layer read/write matrix all 13 skills conform to.

## Testing performed

Docs-only change — no code touched; `atb dev quality` N/A. Verified: frontmatter name matches directory for all 13; each skill 76–94 lines (spec 60–120); cross-references (skills↔skills, LESSONS.md sections, state README, model_evaluation_system.md, observability audit) checked against source material; codebase claims verified by grep (feature flag names, `_enter_close_only_mode`, `ALERT_WEBHOOK_URL`, absent `live-control halt` / simulated `emergency-stop`).

Note: `docs/architecture/model_evaluation_system.md` is referenced by several skills; it exists in the elated-vaughan session's branch and lands with that PR — the reference is forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)