### PR TITLE
fix(prediction): deterministic backtest inference; loud live timeout accounting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Deterministic backtest inference; loud live timeout accounting** (#912
+  side-finding): `PredictionEngine` gated every model inference behind
+  `run_with_timeout(max_prediction_latency)` — a 0.1s latency-*alerting*
+  budget misused as a hard abort — and additionally replaced *completed*
+  predictions with a zeroed error result whenever total wall time exceeded
+  that budget. Under CPU load, identical backtests diverged (measured 46 vs
+  55 trades on the same model/window/code), breaking the frozen-exam
+  evaluation guarantee. Worse, ML signal generators consumed errored results'
+  placeholder `price=0.0` as a real prediction, fabricating a −100% predicted
+  return (full-strength phantom SELL). Now: a process-wide
+  `InferenceContext` (`src/prediction/inference_context.py`) defaults to
+  DETERMINISTIC (no inference deadline, no latency-based substitution or
+  logging) and is pinned by `Backtester.__init__`; `LiveTradingEngine`
+  pins LIVE, where inference runs under a new
+  `PredictionConfig.live_inference_timeout` (default 5s, env
+  `LIVE_INFERENCE_TIMEOUT`) with loud accounting on timeout — WARNING log,
+  `inference_timeouts` counter in `get_performance_stats()`, `timed_out`
+  stamp on the error result, and a `timed_out` stamp on the degraded HOLD
+  signal's metadata. `max_prediction_latency` is now alert-only (live-context
+  WARNING, never gates a result), and both ML signal generators treat any
+  errored `PredictionResult` as a failed prediction (explicit HOLD) instead
+  of a phantom price.
+
 ### Added
 - **Cloud training hardening (#890)**: `atb train cloud` accepts `--start-date`/`--end-date`
   (UTC, mutually exclusive with `--days`) for fixed-cutoff experiments; `--no-wait` now uploads

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,7 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   signal's metadata. `max_prediction_latency` is now alert-only (live-context
   WARNING, never gates a result), and both ML signal generators treat any
   errored `PredictionResult` as a failed prediction (explicit HOLD) instead
-  of a phantom price.
+  of a phantom price. The `timed_out` stamp also flows into
+  `strategy_executions.ml_predictions` rows via the #917 signal extractor,
+  so degraded live decisions are attributable in the database. Closes #913.
 
 ### Added
 - **Cloud training hardening (#890)**: `atb train cloud` accepts `--start-date`/`--end-date`

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -7,7 +7,14 @@ DEFAULT_INITIAL_BALANCE: float = 1000  # Default starting balance in USD
 # Prediction Engine Constants
 DEFAULT_PREDICTION_HORIZONS = [1]  # Single horizon for MVP
 DEFAULT_MIN_CONFIDENCE_THRESHOLD = 0.6
-DEFAULT_MAX_PREDICTION_LATENCY = 0.1  # seconds
+# Latency ALERTING budget (seconds): exceeding it logs a WARNING in live
+# trading but never gates or substitutes a completed prediction.
+DEFAULT_MAX_PREDICTION_LATENCY = 0.1
+# Hard inference deadline (seconds) applied only in the LIVE inference
+# context so the trading loop cannot block on a hung model. CPU ONNX
+# inference measures ~30-400ms even under heavy load; 5s is headroom, not a
+# latency target. Backtests apply no deadline (determinism requirement).
+DEFAULT_LIVE_INFERENCE_TIMEOUT = 5.0
 # Default model registry base path (legacy flat layout). The registry also
 # auto-detects a structured subdirectory at base/models when present.
 DEFAULT_MODEL_REGISTRY_PATH = "src/ml/models"

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -74,6 +74,7 @@ from src.position_management.dynamic_risk import DynamicRiskConfig, DynamicRiskM
 from src.position_management.macro_events import MacroEventGuard
 from src.position_management.time_exits import TimeExitPolicy, TimeRestrictions
 from src.position_management.trailing_stops import TrailingStopPolicy
+from src.prediction.inference_context import InferenceContext, set_inference_context
 from src.regime.detector import RegimeDetector
 from src.risk.circuit_breaker import AccountCircuitBreaker
 from src.risk.risk_manager import RiskManager, RiskParameters
@@ -240,6 +241,11 @@ class Backtester:
             _regime_switcher_class: Optional regime switcher class for testing (internal).
             _strategy_manager: Optional strategy manager class or instance for testing (internal).
         """
+        # Backtest results must not depend on wall-clock/CPU load: pin the
+        # prediction pipeline to its deterministic policy (no inference
+        # deadline, no latency-based substitution). See #912 side-finding.
+        set_inference_context(InferenceContext.DETERMINISTIC)
+
         if initial_balance <= 0:
             raise ValueError("Initial balance must be positive")
         if annual_margin_interest_rate < 0 or not math.isfinite(annual_margin_interest_rate):

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -110,6 +110,7 @@ from src.position_management.macro_events import MacroEventGuard
 from src.position_management.partial_manager import PartialExitPolicy
 from src.position_management.time_exits import TimeExitPolicy, TimeRestrictions
 from src.position_management.trailing_stops import TrailingStopPolicy
+from src.prediction.inference_context import InferenceContext, set_inference_context
 from src.regime.detector import RegimeDetector
 from src.risk.circuit_breaker import AccountCircuitBreaker
 from src.risk.risk_manager import RiskManager, RiskParameters
@@ -252,6 +253,11 @@ class LiveTradingEngine:
             app config). The runner builds these explicitly; when omitted the
             engine resolves them itself (#486).
         """
+
+        # Live inference runs under a bounded latency budget so the trading
+        # loop cannot block indefinitely on a hung model; timeouts are
+        # accounted loudly (WARNING + counter + timed_out signal stamp).
+        set_inference_context(InferenceContext.LIVE)
 
         self._validate_inputs(
             initial_balance=initial_balance,

--- a/src/prediction/config.py
+++ b/src/prediction/config.py
@@ -17,6 +17,7 @@ from src.config.constants import (
     DEFAULT_ENABLE_SENTIMENT,
     DEFAULT_ENSEMBLE_METHOD,
     DEFAULT_FEATURE_CACHE_TTL,
+    DEFAULT_LIVE_INFERENCE_TIMEOUT,
     DEFAULT_MAX_PREDICTION_LATENCY,
     DEFAULT_MIN_CONFIDENCE_THRESHOLD,
     DEFAULT_MODEL_CACHE_TTL,
@@ -41,7 +42,10 @@ class PredictionConfig:
         default_factory=lambda: DEFAULT_PREDICTION_HORIZONS.copy()
     )
     min_confidence_threshold: float = DEFAULT_MIN_CONFIDENCE_THRESHOLD
+    # Alerting budget only — never gates a completed prediction.
     max_prediction_latency: float = DEFAULT_MAX_PREDICTION_LATENCY
+    # Hard deadline applied only in the LIVE inference context.
+    live_inference_timeout: float = DEFAULT_LIVE_INFERENCE_TIMEOUT
     model_registry_path: str = DEFAULT_MODEL_REGISTRY_PATH
     enable_sentiment: bool = DEFAULT_ENABLE_SENTIMENT
     enable_market_microstructure: bool = DEFAULT_ENABLE_MARKET_MICROSTRUCTURE
@@ -82,6 +86,9 @@ class PredictionConfig:
             ),
             max_prediction_latency=config.get_float(
                 "MAX_PREDICTION_LATENCY", default=DEFAULT_MAX_PREDICTION_LATENCY
+            ),
+            live_inference_timeout=config.get_float(
+                "LIVE_INFERENCE_TIMEOUT", default=DEFAULT_LIVE_INFERENCE_TIMEOUT
             ),
             model_registry_path=config.get(
                 "MODEL_REGISTRY_PATH", default=DEFAULT_MODEL_REGISTRY_PATH
@@ -126,6 +133,9 @@ class PredictionConfig:
         if self.max_prediction_latency <= 0.0:
             raise ValueError("max_prediction_latency must be positive")
 
+        if self.live_inference_timeout <= 0.0:
+            raise ValueError("live_inference_timeout must be positive")
+
         if self.feature_cache_ttl <= 0:
             raise ValueError("feature_cache_ttl must be positive")
 
@@ -166,6 +176,7 @@ class PredictionConfig:
             f"horizons={self.prediction_horizons}, "
             f"confidence_threshold={self.min_confidence_threshold}, "
             f"max_latency={self.max_prediction_latency}s, "
+            f"live_timeout={self.live_inference_timeout}s, "
             f"sentiment={self.enable_sentiment}, "
             f"microstructure={self.enable_market_microstructure}, "
             f"ensemble={self.enable_ensemble}/{self.ensemble_method}, "

--- a/src/prediction/engine.py
+++ b/src/prediction/engine.py
@@ -11,6 +11,7 @@ import logging
 import math
 import time
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any, cast
@@ -39,10 +40,12 @@ from .exceptions import (
     FeatureExtractionError,
     InvalidInputError,
     ModelInferenceError,
+    ModelInferenceTimeoutError,
     ModelNotFoundError,
 )
 from .features.pipeline import FeaturePipeline
 from .features.selector import FeatureSelector
+from .inference_context import InferenceContext, get_inference_context
 from .models.onnx_runner import ModelPrediction
 from .models.registry import PredictionModelRegistry, StrategyModel
 from .utils.caching import PredictionCacheManager
@@ -128,6 +131,8 @@ class PredictionEngine:
         self._cache_hits = 0
         self._cache_misses = 0
         self._feature_extraction_time = 0.0
+        # Live-context inference timeouts (deterministic contexts never time out)
+        self._inference_timeout_count = 0
         # Track per-model inference times with bounded size to prevent memory leaks
         self._model_inference_times: dict[str, deque[float]] = {}
         # Track feature extraction times for averaging
@@ -185,21 +190,11 @@ class PredictionEngine:
 
             # Make prediction (with optional ensemble)
             if self._ensemble_aggregator is None:
-                # Wrap prediction with timeout to prevent hanging on slow/hung models
-                timeout_seconds = self._get_timeout_seconds()
-                try:
-                    prediction = run_with_timeout(
-                        model.predict,
-                        args=(prepared_features,),
-                        timeout_seconds=timeout_seconds,
-                        operation_name="ML model inference",
-                    )
-                except InfraTimeoutError as timeout_err:
-                    # Prediction exceeded timeout - return error result
-                    inference_time = time.time() - start_time
-                    raise ModelInferenceError(
-                        f"Model inference timeout after {timeout_seconds}s"
-                    ) from timeout_err
+                prediction = self._run_inference(
+                    model.predict,
+                    (prepared_features,),
+                    operation_name="ML model inference",
+                )
 
                 final_price = prediction.price
                 final_conf = prediction.confidence
@@ -230,9 +225,6 @@ class PredictionEngine:
                 if not ensemble_bundles:
                     ensemble_bundles = [bundle]
 
-                # Same timeout configuration as single model
-                timeout_seconds = self._get_timeout_seconds()
-
                 for ensemble_bundle in ensemble_bundles:
                     ensemble_features = self._prepare_features_for_bundle(
                         ensemble_bundle, features, features_df
@@ -241,19 +233,13 @@ class PredictionEngine:
                         features_used = self._count_features_used(ensemble_features)
 
                     try:
-                        raw_prediction = run_with_timeout(
+                        raw_prediction = self._run_inference(
                             ensemble_bundle.runner.predict,
-                            args=(ensemble_features,),
-                            timeout_seconds=timeout_seconds,
+                            (ensemble_features,),
                             operation_name=f"Ensemble model {ensemble_bundle.key} inference",
                         )
-                    except InfraTimeoutError:
-                        # Log timeout and skip this ensemble member
-                        logger.warning(
-                            "Ensemble model %s timed out after %ss, skipping",
-                            ensemble_bundle.key,
-                            timeout_seconds,
-                        )
+                    except ModelInferenceTimeoutError:
+                        # Already counted/logged by _run_inference; skip member
                         continue
 
                     # Skip this ensemble member if denormalization fails (e.g., NaN/Inf predictions)
@@ -296,25 +282,19 @@ class PredictionEngine:
             # Calculate total inference time
             inference_time = time.time() - start_time
 
-            # Predictions that exceed max_prediction_latency should return an error result,
-            # even if the prediction completed successfully.
-            if inference_time > self.config.max_prediction_latency:
-                return PredictionResult(
-                    price=0.0,
-                    confidence=0.0,
-                    direction=0,
-                    model_name=final_model_name,
-                    timestamp=datetime.now(UTC),
-                    inference_time=inference_time,
-                    features_used=features_used,
-                    error=f"Prediction timeout after {inference_time:.3f}s (max: {self.config.max_prediction_latency}s)",
-                    metadata={
-                        "error_type": "PredictionTimeoutError",
-                        "data_length": len(data),
-                        "feature_extraction_time": feature_time,
-                        "model_inference_time": None,
-                        "config_version": self._get_config_version(),
-                    },
+            # max_prediction_latency is an ALERTING budget: a completed
+            # prediction is always returned. Only the live context raises the
+            # alert — in deterministic contexts wall-clock must not influence
+            # output or logs (backtest reproducibility).
+            if (
+                inference_time > self.config.max_prediction_latency
+                and get_inference_context() is InferenceContext.LIVE
+            ):
+                logger.warning(
+                    "Prediction latency %.3fs exceeded alert budget %.3fs (model=%s)",
+                    inference_time,
+                    self.config.max_prediction_latency,
+                    final_model_name,
                 )
 
             # Check if cache was hit (from feature pipeline)
@@ -356,17 +336,16 @@ class PredictionEngine:
             return result
 
         except Exception as e:
-            # Calculate total time for both timeout check and error result
             total_time = time.time() - start_time
 
-            # Check for timeout but preserve original error
-            error_message = str(e)
-            error_type = type(e).__name__
-
-            if total_time > self.config.max_prediction_latency:
-                # Add timeout information to the original error message.
-                error_message = f"Prediction timeout after {total_time:.3f}s (max: {self.config.max_prediction_latency}s). Original error: {error_message}"
-                error_type = f"PredictionTimeoutError+{error_type}"
+            metadata: dict[str, Any] = {
+                "error_type": type(e).__name__,
+                "data_length": len(data) if isinstance(data, pd.DataFrame) else 0,
+            }
+            # Stamp live latency-budget timeouts so downstream consumers can
+            # attribute degraded (HOLD-substituted) decisions to timeouts.
+            if isinstance(e, ModelInferenceTimeoutError):
+                metadata["timed_out"] = True
 
             # Return error result
             return PredictionResult(
@@ -377,11 +356,8 @@ class PredictionEngine:
                 timestamp=datetime.now(UTC),
                 inference_time=total_time,
                 features_used=0,
-                error=error_message,
-                metadata={
-                    "error_type": error_type,
-                    "data_length": len(data) if isinstance(data, pd.DataFrame) else 0,
-                },
+                error=str(e),
+                metadata=metadata,
             )
 
     def predict_series(
@@ -502,25 +478,15 @@ class PredictionEngine:
         num_windows = windows.shape[0]
         preds_norm = np.empty((num_windows,), dtype=np.float32)
 
-        # Configure timeout for series prediction
-        timeout_seconds = self._get_timeout_seconds()
-
         for start in range(0, num_windows, batch_size):
             end = min(start + batch_size, num_windows)
             batch = windows[start:end]
 
-            # Wrap session.run with timeout to prevent hanging on large batches
-            try:
-                output = run_with_timeout(
-                    session.run,
-                    args=(None, {input_name: batch}),
-                    timeout_seconds=timeout_seconds,
-                    operation_name=f"Series prediction batch {start}-{end}",
-                )
-            except InfraTimeoutError as timeout_err:
-                raise ModelInferenceError(
-                    f"Series prediction batch timeout after {timeout_seconds}s"
-                ) from timeout_err
+            output = self._run_inference(
+                session.run,
+                (None, {input_name: batch}),
+                operation_name=f"Series prediction batch {start}-{end}",
+            )
 
             # Validate output before accessing
             if not output or len(output) == 0:
@@ -635,19 +601,12 @@ class PredictionEngine:
                 self._total_feature_extraction_time += feature_time
                 self._feature_extraction_count += 1
 
-                # Make prediction with pre-loaded model (with timeout protection)
-                timeout_seconds = self._get_timeout_seconds()
-                try:
-                    prediction = run_with_timeout(
-                        model.predict,
-                        args=(prepared_features,),
-                        timeout_seconds=timeout_seconds,
-                        operation_name=f"Batch prediction {i+1}/{len(data_batches)}",
-                    )
-                except InfraTimeoutError as timeout_err:
-                    raise ModelInferenceError(
-                        f"Batch prediction timeout after {timeout_seconds}s"
-                    ) from timeout_err
+                # Make prediction with pre-loaded model (live latency budget only)
+                prediction = self._run_inference(
+                    model.predict,
+                    (prepared_features,),
+                    operation_name=f"Batch prediction {i+1}/{len(data_batches)}",
+                )
 
                 # Apply rolling MinMax denormalization if needed
                 denorm_price = self._apply_rolling_denormalization(prediction.price, bundle, data)
@@ -681,6 +640,14 @@ class PredictionEngine:
 
             except Exception as e:
                 # Create error result for this batch
+                batch_metadata: dict[str, Any] = {
+                    "error_type": type(e).__name__,
+                    "batch_index": i,
+                    "batch_size": len(data_batches),
+                    "data_length": len(data) if isinstance(data, pd.DataFrame) else 0,
+                }
+                if isinstance(e, ModelInferenceTimeoutError):
+                    batch_metadata["timed_out"] = True
                 error_result = PredictionResult(
                     price=0.0,
                     confidence=0.0,
@@ -690,12 +657,7 @@ class PredictionEngine:
                     inference_time=time.time() - start_time,
                     features_used=0,
                     error=str(e),
-                    metadata={
-                        "error_type": type(e).__name__,
-                        "batch_index": i,
-                        "batch_size": len(data_batches),
-                        "data_length": len(data) if isinstance(data, pd.DataFrame) else 0,
-                    },
+                    metadata=batch_metadata,
                 )
                 results.append(error_result)
 
@@ -756,6 +718,7 @@ class PredictionEngine:
             "model_inference_times": model_times,
             "cache_hits": self._cache_hits,
             "cache_misses": self._cache_misses,
+            "inference_timeouts": self._inference_timeout_count,
         }
 
     def clear_caches(self) -> None:
@@ -877,9 +840,49 @@ class PredictionEngine:
         return health
 
     # Private methods
-    def _get_timeout_seconds(self) -> float:
-        """Return the configured prediction timeout in seconds."""
-        return self.config.max_prediction_latency
+    def _get_timeout_seconds(self) -> float | None:
+        """Return the hard inference deadline for the current context.
+
+        ``None`` (deterministic contexts: backtest/research/training) means
+        inference is never aborted on wall-clock time — a load-dependent
+        timeout would silently change backtest results between identical
+        runs. Live trading keeps a bounded deadline so the trading loop
+        cannot block indefinitely on a hung model.
+        """
+        if get_inference_context() is InferenceContext.LIVE:
+            return self.config.live_inference_timeout
+        return None
+
+    def _run_inference(self, func: Callable[..., Any], args: tuple, operation_name: str) -> Any:
+        """Run one inference call under the current context's latency policy.
+
+        Raises:
+            ModelInferenceTimeoutError: Live context only — the call exceeded
+                the latency budget. Counted and logged loudly here so every
+                substitution is attributable.
+        """
+        timeout_seconds = self._get_timeout_seconds()
+        if timeout_seconds is None:
+            return func(*args)
+        try:
+            return run_with_timeout(
+                func,
+                args=args,
+                timeout_seconds=timeout_seconds,
+                operation_name=operation_name,
+            )
+        except InfraTimeoutError as timeout_err:
+            self._inference_timeout_count += 1
+            logger.warning(
+                "%s exceeded live inference timeout of %.1fs — substituting no-signal "
+                "result (total timeouts this session: %d)",
+                operation_name,
+                timeout_seconds,
+                self._inference_timeout_count,
+            )
+            raise ModelInferenceTimeoutError(
+                f"{operation_name} timeout after {timeout_seconds}s"
+            ) from timeout_err
 
     def _validate_input_data(self, data: pd.DataFrame) -> None:
         """Validate input data has required columns and sufficient length"""

--- a/src/prediction/exceptions.py
+++ b/src/prediction/exceptions.py
@@ -37,3 +37,9 @@ class ModelInferenceError(PredictionEngineError):
     """Raised when model inference fails"""
 
     pass
+
+
+class ModelInferenceTimeoutError(ModelInferenceError):
+    """Raised when model inference exceeds the live latency budget"""
+
+    pass

--- a/src/prediction/inference_context.py
+++ b/src/prediction/inference_context.py
@@ -1,0 +1,54 @@
+"""Process-wide inference execution context.
+
+Backtest results must be bit-identical run-to-run regardless of CPU load, so
+in the DETERMINISTIC context (the default) inference is never aborted on
+wall-clock time — a load-dependent timeout silently substituting a failed
+prediction changes trade sequences between identical runs (#912 side-finding).
+
+Live trading opts into the LIVE context, where inference runs under a bounded
+latency budget (``PredictionConfig.live_inference_timeout``) so the trading
+loop cannot block indefinitely on a hung model. Timeouts there are accounted
+loudly: WARNING log, engine counter, and a ``timed_out`` result stamp.
+
+The context is pinned by engine constructors (``Backtester`` -> DETERMINISTIC,
+``LiveTradingEngine`` -> LIVE); nothing else should need to set it.
+"""
+
+from __future__ import annotations
+
+import threading
+from enum import Enum
+
+
+class InferenceContext(Enum):
+    """Latency policy for model inference."""
+
+    DETERMINISTIC = "deterministic"
+    LIVE = "live"
+
+
+_lock = threading.Lock()
+_context: InferenceContext = InferenceContext.DETERMINISTIC
+
+
+def get_inference_context() -> InferenceContext:
+    """Return the current inference context."""
+    return _context
+
+
+def set_inference_context(context: InferenceContext) -> None:
+    """Set the process-wide inference context.
+
+    Raises:
+        ValueError: If ``context`` is not an :class:`InferenceContext`.
+    """
+    if not isinstance(context, InferenceContext):
+        raise ValueError(f"context must be an InferenceContext, got {context!r}")
+    global _context
+    with _lock:
+        _context = context
+
+
+def reset_inference_context() -> None:
+    """Restore the default (deterministic) context. Intended for tests."""
+    set_inference_context(InferenceContext.DETERMINISTIC)

--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -197,6 +197,9 @@ class MLSignalGenerator(SignalGenerator):
         self.prediction_engine: PredictionEngine | None = None
         self._engine_warning_emitted = False
         self.use_engine_batch = get_config().get_bool("ENGINE_BATCH_INFERENCE", default=False)
+        # True when the most recent failed prediction was a live inference
+        # timeout — stamped into the HOLD signal for attributability.
+        self._last_prediction_timed_out = False
 
         # Initialize feature pipeline
         self._setup_feature_pipeline()
@@ -292,7 +295,12 @@ class MLSignalGenerator(SignalGenerator):
                 direction=SignalDirection.HOLD,
                 strength=0.0,
                 confidence=0.0,
-                metadata={"generator": self.name, "reason": "prediction_failed", "index": index},
+                metadata={
+                    "generator": self.name,
+                    "reason": "prediction_failed",
+                    "timed_out": self._last_prediction_timed_out,
+                    "index": index,
+                },
             )
 
         current_price = df["close"].iloc[index]
@@ -399,6 +407,7 @@ class MLSignalGenerator(SignalGenerator):
         Returns:
             Predicted price or None if prediction fails
         """
+        self._last_prediction_timed_out = False
         try:
             # Feature pipeline transformation currently not used
             # (prediction engine handles raw price data directly)
@@ -412,6 +421,20 @@ class MLSignalGenerator(SignalGenerator):
                 index - self.sequence_length : index
             ]
             result = self.prediction_engine.predict(window_df, model_name=self.model_name)
+
+            # An errored result carries a placeholder price of 0.0 — treating
+            # it as real would fabricate a -100% predicted return (phantom
+            # SELL). Degrade to a failed prediction (caller emits HOLD).
+            if result.error is not None:
+                self._last_prediction_timed_out = bool(result.metadata.get("timed_out", False))
+                logger.warning(
+                    "MLSignalGenerator: prediction failed at index %d (timed_out=%s): %s",
+                    index,
+                    self._last_prediction_timed_out,
+                    result.error,
+                )
+                return None
+
             pred = float(result.price)
 
             # Prediction engine returns real prices
@@ -621,6 +644,9 @@ class MLBasicSignalGenerator(SignalGenerator):
         self._registry: PredictionModelRegistry | None = None
         self._engine_warning_emitted = False
         self.use_engine_batch = get_config().get_bool("ENGINE_BATCH_INFERENCE", default=False)
+        # True when the most recent failed prediction was a live inference
+        # timeout — stamped into the HOLD signal for attributability.
+        self._last_prediction_timed_out = False
 
         # Cross-symbol guard state: which model symbol actually scored the
         # last prediction, the pinned substitute bundle (flag opt-in only),
@@ -858,6 +884,7 @@ class MLBasicSignalGenerator(SignalGenerator):
                 metadata={
                     "generator": self.name,
                     "reason": "prediction_failed",
+                    "timed_out": self._last_prediction_timed_out,
                     "index": index,
                     **self._symbol_guard_stamps(),
                 },
@@ -965,6 +992,7 @@ class MLBasicSignalGenerator(SignalGenerator):
         Returns:
             Predicted price or None if prediction fails
         """
+        self._last_prediction_timed_out = False
         try:
             # Get prediction from prediction engine
             if self.prediction_engine is None:
@@ -1034,6 +1062,20 @@ class MLBasicSignalGenerator(SignalGenerator):
             except (KeyError, ValueError):
                 # Fall back to default registry resolution if explicit lookup fails
                 result = self.prediction_engine.predict(window_df)
+
+            # An errored result carries a placeholder price of 0.0 — treating
+            # it as real would fabricate a -100% predicted return (phantom
+            # SELL). Degrade to a failed prediction (caller emits HOLD).
+            if result.error is not None:
+                self._last_prediction_timed_out = bool(result.metadata.get("timed_out", False))
+                self._model_symbol = None
+                logger.warning(
+                    "MLBasicSignalGenerator: prediction failed at index %d (timed_out=%s): %s",
+                    index,
+                    self._last_prediction_timed_out,
+                    result.error,
+                )
+                return None
 
             # Detect which symbol's model actually scored this prediction so
             # signals can be stamped and mismatches surfaced loudly.

--- a/src/tech/adapters/row_extractors.py
+++ b/src/tech/adapters/row_extractors.py
@@ -128,6 +128,8 @@ _ML_SIGNAL_METADATA_KEYS = (
     "generator",
     "error",
     "error_type",
+    # Live inference-timeout substitutions (see PredictionEngine._run_inference)
+    "timed_out",
 )
 
 # Failure reasons only the ML generators emit. Generic reasons such as

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,6 +210,21 @@ def pytest_collection_modifyitems(config, items):  # noqa: D401
         config._has_integration_selected = has_integration
 
 
+@pytest.fixture(autouse=True)
+def _reset_inference_context():
+    """Keep the process-wide inference context from leaking across tests.
+
+    Engine constructors pin it (Backtester -> deterministic, live engine ->
+    live); without a reset, one test's engine would change timeout behavior
+    for every later test in the same worker.
+    """
+    from src.prediction.inference_context import reset_inference_context
+
+    reset_inference_context()
+    yield
+    reset_inference_context()
+
+
 @pytest.fixture
 def sample_ohlcv_data():
     """Generate realistic OHLCV data for testing"""

--- a/tests/integration/test_component_trading_workflows.py
+++ b/tests/integration/test_component_trading_workflows.py
@@ -230,6 +230,7 @@ class TestEndToEndTradingWorkflows:
             mock_result = Mock(spec=PredictionResult)
             mock_result.price = current_price * 1.05  # 5% higher = bullish
             mock_result.confidence = 0.85
+            mock_result.error = None
             mock_result.metadata = {"model": "test_model"}
             return mock_result
 

--- a/tests/unit/backtesting/test_ml_predictions_logging.py
+++ b/tests/unit/backtesting/test_ml_predictions_logging.py
@@ -83,6 +83,16 @@ class TestExtractMlPredictionsFromSignal:
         assert result["reason"] == "prediction_failed"
         assert result["generator"] == "ml_basic_signal_generator"
 
+    def test_timed_out_stamp_flows_to_logged_row(self):
+        """Live inference-timeout substitutions stay attributable in DB rows."""
+        signal = _ml_failure_signal()
+        signal.metadata["timed_out"] = True
+
+        result = extract_ml_predictions_from_signal(signal)
+
+        assert result["prediction_failed"] is True
+        assert result["timed_out"] is True
+
     def test_invalid_prediction_or_price_is_flagged_as_failure(self):
         signal = Signal(
             direction=SignalDirection.HOLD,

--- a/tests/unit/cli/test_live.py
+++ b/tests/unit/cli/test_live.py
@@ -311,10 +311,28 @@ class TestControlTrain:
 
 
 class TestControlDeployModel:
-    """Tests for the deploy-model subcommand of live-control."""
+    """Tests for the deploy-model subcommand of live-control.
+
+    The validation gate is mocked at the `_gate_and_promote` seam: its verdict
+    depends on real multi-window backtests of whatever model the repo registry
+    holds (model quality + market data), which is not a unit-test concern —
+    the gate itself is covered by the src/ml/validation tests.
+    """
+
+    @staticmethod
+    def _gate_decision(promoted: bool):
+        from src.ml.validation.gate import GateDecision
+
+        return GateDecision(
+            passed=promoted,
+            promoted=promoted,
+            reason="all windows passed" if promoted else "failed one or more validation windows",
+            report=None,
+            audit_path=None,
+        )
 
     def test_deploys_model_successfully(self):
-        """Test that model deployment executes successfully."""
+        """Test that model deployment executes successfully when the gate passes."""
         # Arrange
         with tempfile.TemporaryDirectory() as tmpdir:
             registry = Path(tmpdir)
@@ -328,11 +346,47 @@ class TestControlDeployModel:
             )
 
             # Act
-            with patch("cli.commands.live.MODEL_REGISTRY", registry):
+            with (
+                patch("cli.commands.live.MODEL_REGISTRY", registry),
+                patch(
+                    "cli.commands.live._gate_and_promote",
+                    return_value=self._gate_decision(promoted=True),
+                ) as gate,
+            ):
                 result = _control(args)
 
                 # Assert
                 assert result == 0
+                gate.assert_called_once()
+                assert gate.call_args.kwargs["symbol"] == "BTCUSDT"
+                assert gate.call_args.kwargs["model_type"] == "basic"
+
+    def test_deploy_blocked_when_gate_fails(self):
+        """Test that a failing validation gate blocks deployment with exit code 1."""
+        # Arrange
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = Path(tmpdir)
+            version_dir = registry / "BTCUSDT" / "basic" / "2024-10-01_v1"
+            version_dir.mkdir(parents=True)
+
+            args = argparse.Namespace(
+                control_cmd="deploy-model",
+                model_path=str(version_dir),
+                close_positions=False,
+            )
+
+            # Act
+            with (
+                patch("cli.commands.live.MODEL_REGISTRY", registry),
+                patch(
+                    "cli.commands.live._gate_and_promote",
+                    return_value=self._gate_decision(promoted=False),
+                ),
+            ):
+                result = _control(args)
+
+                # Assert
+                assert result == 1
 
     def test_returns_error_for_invalid_model_path(self):
         """Test that error is returned for invalid model path."""

--- a/tests/unit/predictions/test_engine_prediction.py
+++ b/tests/unit/predictions/test_engine_prediction.py
@@ -193,8 +193,13 @@ class TestPredictionEnginePredict:
 
     @patch("src.prediction.engine.PredictionModelRegistry")
     @patch("src.prediction.engine.FeaturePipeline")
-    def test_predict_timeout(self, mock_pipeline, mock_registry):
-        """Test prediction timeout logic"""
+    def test_slow_prediction_is_returned_intact(self, mock_pipeline, mock_registry):
+        """A completed prediction is never substituted because it was slow.
+
+        max_prediction_latency is a latency-ALERTING budget; exceeding it must
+        not zero out a successful prediction (that substitution made backtest
+        results depend on CPU load).
+        """
         config = PredictionConfig()
         config.max_prediction_latency = 0.001
         engine = PredictionEngine(config)
@@ -223,18 +228,15 @@ class TestPredictionEnginePredict:
         data = self.create_test_data()
         result = engine.predict(data)
 
-        assert result.error is not None
-        assert "Prediction timeout" in result.error
-        assert result.inference_time > config.max_prediction_latency
-        assert result.price == 0.0
-        assert result.confidence == 0.0
-        assert result.direction == 0
-        assert result.metadata["error_type"] == "PredictionTimeoutError"
+        assert result.error is None
+        assert result.price == 100.0
+        assert result.confidence == 0.8
+        assert result.direction == 1
 
     @patch("src.prediction.engine.PredictionModelRegistry")
     @patch("src.prediction.engine.FeaturePipeline")
-    def test_predict_timeout_with_original_error(self, mock_pipeline, mock_registry):
-        """Test timeout logic preserves original error when both timeout and exception occur"""
+    def test_slow_failing_prediction_keeps_original_error(self, mock_pipeline, mock_registry):
+        """Errors are reported as-is; latency no longer relabels them as timeouts."""
         config = PredictionConfig()
         config.max_prediction_latency = 0.001
         engine = PredictionEngine(config)
@@ -251,13 +253,196 @@ class TestPredictionEnginePredict:
         result = engine.predict(data)
 
         assert result.error is not None
-        assert "Prediction timeout" in result.error
         assert "Feature extraction failed" in result.error
-        assert result.inference_time > config.max_prediction_latency
+        assert "Prediction timeout" not in result.error
         assert result.price == 0.0
         assert result.confidence == 0.0
         assert result.direction == 0
-        assert result.metadata["error_type"] == "PredictionTimeoutError+FeatureExtractionError"
+        assert result.metadata["error_type"] == "FeatureExtractionError"
+
+
+class TestDeterministicInference:
+    """Backtest/research context: inference must never race a wall clock."""
+
+    def create_test_data(self, num_rows=120):
+        rng = np.random.default_rng(7)
+        return pd.DataFrame(
+            {
+                "open": rng.uniform(100, 110, num_rows),
+                "high": rng.uniform(110, 120, num_rows),
+                "low": rng.uniform(90, 100, num_rows),
+                "close": rng.uniform(100, 110, num_rows),
+                "volume": rng.uniform(1000, 2000, num_rows),
+            }
+        )
+
+    def _make_engine_with_slow_model(self, config: PredictionConfig, sleep_seconds: float):
+        with (
+            patch("src.prediction.engine.PredictionModelRegistry"),
+            patch("src.prediction.engine.FeaturePipeline"),
+        ):
+            engine = PredictionEngine(config)
+
+        engine.feature_pipeline.transform.return_value = np.random.random((1, 10))
+
+        mock_model = Mock()
+
+        def slow_predict(features):
+            import time
+
+            time.sleep(sleep_seconds)
+            return ModelPrediction(
+                price=105.5,
+                confidence=0.85,
+                direction=1,
+                model_name="slow_model",
+                inference_time=sleep_seconds,
+            )
+
+        mock_model.predict.side_effect = slow_predict
+        bundle = _make_bundle(mock_model)
+        engine.model_registry.list_bundles.return_value = [bundle]
+        engine.model_registry.get_default_bundle.return_value = bundle
+        return engine
+
+    def test_slow_inference_never_times_out_in_deterministic_context(self):
+        """Inference slower than every latency budget still yields the real
+        prediction — identically on repeated calls (determinism guarantee)."""
+        config = PredictionConfig()
+        config.max_prediction_latency = 0.001  # tighter than the sleep below
+        config.live_inference_timeout = 0.01  # would abort if (wrongly) applied
+        engine = self._make_engine_with_slow_model(config, sleep_seconds=0.15)
+
+        data = self.create_test_data()
+        first = engine.predict(data)
+        second = engine.predict(data)
+
+        for result in (first, second):
+            assert result.error is None
+            assert result.price == 105.5
+            assert result.direction == 1
+        assert (first.price, first.confidence, first.direction) == (
+            second.price,
+            second.confidence,
+            second.direction,
+        )
+        assert engine.get_performance_stats()["inference_timeouts"] == 0
+
+    def test_deterministic_context_does_not_log_latency_alerts(self, caplog):
+        """Wall-clock noise must not leak into backtest logs as warnings."""
+        import logging
+
+        config = PredictionConfig()
+        config.max_prediction_latency = 0.001
+        engine = self._make_engine_with_slow_model(config, sleep_seconds=0.05)
+
+        with caplog.at_level(logging.WARNING, logger="src.prediction.engine"):
+            result = engine.predict(self.create_test_data())
+
+        assert result.error is None
+        assert not [r for r in caplog.records if "latency" in r.message.lower()]
+
+
+class TestLiveInferenceTimeoutAccounting:
+    """Live context: bounded latency budget with loud, attributable accounting."""
+
+    def create_test_data(self, num_rows=120):
+        rng = np.random.default_rng(7)
+        return pd.DataFrame(
+            {
+                "open": rng.uniform(100, 110, num_rows),
+                "high": rng.uniform(110, 120, num_rows),
+                "low": rng.uniform(90, 100, num_rows),
+                "close": rng.uniform(100, 110, num_rows),
+                "volume": rng.uniform(1000, 2000, num_rows),
+            }
+        )
+
+    def _make_engine_with_slow_model(self, config: PredictionConfig, sleep_seconds: float):
+        with (
+            patch("src.prediction.engine.PredictionModelRegistry"),
+            patch("src.prediction.engine.FeaturePipeline"),
+        ):
+            engine = PredictionEngine(config)
+
+        engine.feature_pipeline.transform.return_value = np.random.random((1, 10))
+
+        mock_model = Mock()
+
+        def slow_predict(features):
+            import time
+
+            time.sleep(sleep_seconds)
+            return ModelPrediction(
+                price=105.5,
+                confidence=0.85,
+                direction=1,
+                model_name="slow_model",
+                inference_time=sleep_seconds,
+            )
+
+        mock_model.predict.side_effect = slow_predict
+        bundle = _make_bundle(mock_model)
+        engine.model_registry.list_bundles.return_value = [bundle]
+        engine.model_registry.get_default_bundle.return_value = bundle
+        return engine
+
+    def test_live_timeout_is_loud_and_stamped(self, caplog):
+        import logging
+
+        from src.prediction.inference_context import InferenceContext, set_inference_context
+
+        set_inference_context(InferenceContext.LIVE)
+        config = PredictionConfig()
+        config.live_inference_timeout = 0.05
+        engine = self._make_engine_with_slow_model(config, sleep_seconds=0.5)
+
+        with caplog.at_level(logging.WARNING, logger="src.prediction.engine"):
+            result = engine.predict(self.create_test_data())
+
+        assert result.error is not None
+        assert "timeout" in result.error.lower()
+        assert result.metadata["timed_out"] is True
+        assert result.price == 0.0
+        assert result.confidence == 0.0
+        assert result.direction == 0
+        assert engine.get_performance_stats()["inference_timeouts"] == 1
+        warning_messages = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("timeout" in m.lower() for m in warning_messages)
+
+    def test_live_fast_prediction_within_budget_succeeds(self):
+        from src.prediction.inference_context import InferenceContext, set_inference_context
+
+        set_inference_context(InferenceContext.LIVE)
+        config = PredictionConfig()
+        config.live_inference_timeout = 5.0
+        engine = self._make_engine_with_slow_model(config, sleep_seconds=0.0)
+
+        result = engine.predict(self.create_test_data())
+
+        assert result.error is None
+        assert result.price == 105.5
+        assert engine.get_performance_stats()["inference_timeouts"] == 0
+
+    def test_live_latency_alert_warns_without_substitution(self, caplog):
+        """Exceeding the alerting budget logs a WARNING but returns the result."""
+        import logging
+
+        from src.prediction.inference_context import InferenceContext, set_inference_context
+
+        set_inference_context(InferenceContext.LIVE)
+        config = PredictionConfig()
+        config.max_prediction_latency = 0.001
+        config.live_inference_timeout = 5.0
+        engine = self._make_engine_with_slow_model(config, sleep_seconds=0.05)
+
+        with caplog.at_level(logging.WARNING, logger="src.prediction.engine"):
+            result = engine.predict(self.create_test_data())
+
+        assert result.error is None
+        assert result.price == 105.5
+        warning_messages = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any("latency" in m.lower() for m in warning_messages)
 
 
 class TestApplyRollingDenormalization:

--- a/tests/unit/predictions/test_inference_context.py
+++ b/tests/unit/predictions/test_inference_context.py
@@ -1,0 +1,144 @@
+"""Tests for the inference execution context (deterministic vs live).
+
+Backtest results must be identical run-to-run regardless of CPU load, so the
+deterministic context never imposes a wall-clock deadline on inference. Live
+trading opts into a bounded latency budget so the trading loop cannot block
+indefinitely on a hung model.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.config.constants import DEFAULT_LIVE_INFERENCE_TIMEOUT
+from src.prediction.config import PredictionConfig
+from src.prediction.engine import PredictionEngine
+from src.prediction.inference_context import (
+    InferenceContext,
+    get_inference_context,
+    set_inference_context,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class TestInferenceContextModule:
+    """Process-wide context switch semantics."""
+
+    def test_default_context_is_deterministic(self):
+        assert get_inference_context() is InferenceContext.DETERMINISTIC
+
+    def test_set_and_get_live_context(self):
+        set_inference_context(InferenceContext.LIVE)
+        assert get_inference_context() is InferenceContext.LIVE
+
+    def test_reset_restores_deterministic(self):
+        from src.prediction.inference_context import reset_inference_context
+
+        set_inference_context(InferenceContext.LIVE)
+        reset_inference_context()
+        assert get_inference_context() is InferenceContext.DETERMINISTIC
+
+    def test_set_rejects_invalid_context(self):
+        with pytest.raises(ValueError):
+            set_inference_context("yolo")  # type: ignore[arg-type]
+
+
+class TestDefaults:
+    """Default values are safe without any configuration."""
+
+    def test_live_inference_timeout_default_is_seconds_scale(self):
+        # 0.1s was a latency-alerting budget mistakenly used as an inference
+        # deadline; the live hard deadline must be orders of magnitude above
+        # typical CPU ONNX inference (~30-400ms under load).
+        assert DEFAULT_LIVE_INFERENCE_TIMEOUT == 5.0
+
+    def test_prediction_config_default_live_timeout(self):
+        config = PredictionConfig()
+        assert config.live_inference_timeout == DEFAULT_LIVE_INFERENCE_TIMEOUT
+
+    def test_prediction_config_validates_live_timeout(self):
+        config = PredictionConfig(live_inference_timeout=0.0)
+        with pytest.raises(ValueError, match="live_inference_timeout"):
+            config.validate()
+
+    def test_max_prediction_latency_still_validated(self):
+        config = PredictionConfig(max_prediction_latency=-0.1)
+        with pytest.raises(ValueError, match="max_prediction_latency"):
+            config.validate()
+
+
+class TestEngineTimeoutResolution:
+    """PredictionEngine derives its inference deadline from the context."""
+
+    def _make_engine(self) -> PredictionEngine:
+        with (
+            patch("src.prediction.engine.PredictionModelRegistry"),
+            patch("src.prediction.engine.FeaturePipeline"),
+        ):
+            return PredictionEngine(PredictionConfig())
+
+    def test_deterministic_context_has_no_deadline(self):
+        engine = self._make_engine()
+        assert engine._get_timeout_seconds() is None
+
+    def test_live_context_uses_config_live_timeout(self):
+        engine = self._make_engine()
+        set_inference_context(InferenceContext.LIVE)
+        assert engine._get_timeout_seconds() == engine.config.live_inference_timeout
+
+
+class TestEnginesPinContext:
+    """Both engines select the context-appropriate policy at construction."""
+
+    def test_backtester_pins_deterministic_context(self, mock_data_provider):
+        set_inference_context(InferenceContext.LIVE)
+
+        from src.engines.backtest.engine import Backtester
+
+        mock_strategy = MagicMock()
+        mock_strategy.get_risk_overrides.return_value = None
+        mock_strategy.name = "MockStrategy"
+
+        Backtester(
+            strategy=mock_strategy,
+            data_provider=mock_data_provider,
+            initial_balance=10_000,
+            log_to_database=False,
+        )
+
+        assert get_inference_context() is InferenceContext.DETERMINISTIC
+
+    def test_live_engine_pins_live_context(self):
+        with patch("src.engines.live.trading_engine.DatabaseManager"):
+            from src.engines.live.trading_engine import LiveTradingEngine
+
+            mock_strategy = MagicMock()
+            mock_strategy.get_risk_overrides.return_value = {}
+            mock_strategy.__class__.__name__ = "MockStrategy"
+            mock_strategy.config = {}
+
+            mock_dp = MagicMock()
+            mock_dp.get_current_price.return_value = 50000.0
+            mock_dp.get_live_data.return_value = pd.DataFrame(
+                {
+                    "open": [50000.0] * 5,
+                    "high": [51000.0] * 5,
+                    "low": [49000.0] * 5,
+                    "close": [50500.0] * 5,
+                    "volume": [100.0] * 5,
+                },
+                index=pd.date_range("2024-01-01", periods=5, freq="1h", tz="UTC"),
+            )
+
+            LiveTradingEngine(
+                strategy=mock_strategy,
+                data_provider=mock_dp,
+                enable_live_trading=False,
+                initial_balance=1000.0,
+                enable_dynamic_risk=False,
+                enable_hot_swapping=False,
+            )
+
+        assert get_inference_context() is InferenceContext.LIVE

--- a/tests/unit/strategies/components/test_ml_signal_generator.py
+++ b/tests/unit/strategies/components/test_ml_signal_generator.py
@@ -102,6 +102,8 @@ class TestMLSignalGenerator:
 
         # Mock prediction result
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 51000.0
         mock_engine.predict.return_value = mock_result
 
@@ -137,6 +139,8 @@ class TestMLSignalGenerator:
         # Mock prediction engine
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 51000.0  # Predicted price higher than current
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -160,6 +164,8 @@ class TestMLSignalGenerator:
         # Mock prediction engine to return lower prediction (potential short signal)
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 49500.0  # Prediction lower than current price
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -256,6 +262,8 @@ class TestMLSignalGenerator:
         # Mock prediction engine
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         real_price = 50000.0  # Real price from prediction engine
         mock_result.price = real_price
         mock_engine.predict.return_value = mock_result
@@ -305,6 +313,8 @@ class TestMLSignalGenerator:
         """Test get_confidence method"""
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 50500.0  # Slight price increase
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -438,6 +448,8 @@ class TestMLBasicSignalGenerator:
         # Mock prediction engine
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 51000.0  # Predicted price higher than current
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -473,6 +485,8 @@ class TestMLBasicSignalGenerator:
         # Mock prediction engine to return higher prediction than current price
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 55000.0  # Very high predicted price
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -500,6 +514,8 @@ class TestMLBasicSignalGenerator:
         def mock_predict(window_df, model_name=None):
             # Return a price 1% below the actual current price (well below -0.05% threshold)
             mock_result = Mock(spec=PredictionResult)
+            mock_result.error = None
+            mock_result.metadata = {}
             mock_result.price = current_price * 0.99  # 1% below current
             return mock_result
 
@@ -524,6 +540,8 @@ class TestMLBasicSignalGenerator:
         # Mock prediction engine to return prediction close to current price
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 50000.0  # Neutral prediction (close to current price)
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -562,6 +580,8 @@ class TestMLBasicSignalGenerator:
         """Test get_confidence method for basic generator"""
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 51500.0  # Price prediction showing positive return
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -599,6 +619,8 @@ class TestMLBasicSignalGenerator:
         """Test prediction engine metadata inclusion"""
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 51000.0
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -623,6 +645,8 @@ class TestMLBasicSignalGenerator:
         # Mock prediction engine
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         real_price = 45000.0  # Real price from prediction engine
         mock_result.price = real_price
         mock_engine.predict.return_value = mock_result
@@ -701,6 +725,8 @@ class TestMLBasicSignalGenerator:
         mock_engine.model_registry = mock_registry
 
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 3000.0
         mock_engine.predict.return_value = mock_result
         mock_engine_class.return_value = mock_engine
@@ -813,6 +839,8 @@ class TestMLSignalGeneratorEdgeCases:
         """Test handling of zero prices"""
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
         mock_result.price = 50000.0
         mock_engine.predict.return_value = mock_result
         mock_engine.health_check.return_value = {"status": "healthy"}
@@ -835,3 +863,115 @@ class TestMLSignalGeneratorEdgeCases:
         # Should handle zero prices gracefully
         assert isinstance(signal, Signal)
         assert signal.metadata["predicted_return"] == 0  # Should be 0 when current_price is 0
+
+
+class TestErroredPredictionResultHandling:
+    """Errored engine results must degrade to HOLD, never a phantom signal.
+
+    The engine reports failures (including live inference timeouts) as
+    PredictionResult(price=0.0, error=...). Treating that price as real
+    produced a predicted_return of -100% — a full-strength phantom SELL.
+    """
+
+    def create_test_dataframe(self, length=150):
+        np.random.seed(42)
+        base_price = 50000
+        prices = [base_price]
+        for change in np.random.normal(0, 0.02, length - 1):
+            prices.append(max(prices[-1] * (1 + change), 1000))
+        return pd.DataFrame(
+            {
+                "open": prices,
+                "high": [p * 1.01 for p in prices],
+                "low": [p * 0.99 for p in prices],
+                "close": prices,
+                "volume": np.random.uniform(1000, 10000, length),
+            },
+            index=pd.date_range("2023-01-01", periods=length, freq="1h"),
+        )
+
+    def _errored_result(self, timed_out: bool):
+        result = Mock(spec=PredictionResult)
+        result.price = 0.0
+        result.confidence = 0.0
+        result.direction = 0
+        result.model_name = "BTCUSDT:1h:basic:v1"
+        result.error = "Model inference timeout after 5.0s"
+        result.metadata = {"timed_out": True} if timed_out else {"error_type": "SomeError"}
+        return result
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_basic_generator_holds_on_errored_result(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine.predict.return_value = self._errored_result(timed_out=False)
+        mock_engine_class.return_value = mock_engine
+
+        generator = MLBasicSignalGenerator(sequence_length=120)
+        signal = generator.generate_signal(self.create_test_dataframe(150), 130)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.strength == 0.0
+        assert signal.confidence == 0.0
+        assert signal.metadata["reason"] == "prediction_failed"
+        assert signal.metadata["timed_out"] is False
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_basic_generator_stamps_timed_out_on_timeout(
+        self, mock_config_class, mock_engine_class
+    ):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine.predict.return_value = self._errored_result(timed_out=True)
+        mock_engine_class.return_value = mock_engine
+
+        generator = MLBasicSignalGenerator(sequence_length=120)
+        signal = generator.generate_signal(self.create_test_dataframe(150), 130)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.metadata["reason"] == "prediction_failed"
+        assert signal.metadata["timed_out"] is True
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_adaptive_generator_holds_on_errored_result(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine.predict.return_value = self._errored_result(timed_out=True)
+        mock_engine_class.return_value = mock_engine
+
+        generator = MLSignalGenerator(sequence_length=120)
+        signal = generator.generate_signal(self.create_test_dataframe(150), 130)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.strength == 0.0
+        assert signal.confidence == 0.0
+        assert signal.metadata["reason"] == "prediction_failed"
+        assert signal.metadata["timed_out"] is True
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_timed_out_stamp_resets_on_next_successful_prediction(
+        self, mock_config_class, mock_engine_class
+    ):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        ok_result = Mock(spec=PredictionResult)
+        ok_result.price = 51000.0
+        ok_result.error = None
+        ok_result.metadata = {}
+        ok_result.model_name = "BTCUSDT:1h:basic:v1"
+        mock_engine.predict.side_effect = [self._errored_result(timed_out=True), ok_result]
+        mock_engine_class.return_value = mock_engine
+
+        generator = MLBasicSignalGenerator(sequence_length=120)
+        df = self.create_test_dataframe(150)
+
+        failed = generator.generate_signal(df, 130)
+        assert failed.metadata["timed_out"] is True
+
+        ok = generator.generate_signal(df, 131)
+        assert ok.metadata.get("reason") != "prediction_failed"
+        assert "timed_out" not in ok.metadata

--- a/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
+++ b/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
@@ -39,6 +39,8 @@ def _make_engine(registry=None, predicted_price=51000.0):
     result = Mock()
     result.price = predicted_price
     result.model_name = "BTCUSDT:1h:basic:v1"
+    result.error = None
+    result.metadata = {}
     engine.predict.return_value = result
     if registry is not None:
         engine.model_registry = registry


### PR DESCRIPTION
# fix(prediction): deterministic backtest inference; loud live timeout accounting

## Summary

Fixes the P1 backtest non-determinism root-caused in **experiment #912's side-finding**
(`docs/research/experiments/2026-07-05_confidence-calibration.md`): identical backtests
(same model, same window, same code) produced different results under CPU contention —
measured 46 vs 55 trades, −11.36% vs −10.33% return. This broke the frozen-exam
evaluation system's core comparability guarantee
(`docs/architecture/model_evaluation_system.md`).

## Root cause (traced)

1. **`src/config/constants.py:10`** — `DEFAULT_MAX_PREDICTION_LATENCY = 0.1`, documented
   as a latency-**alerting** budget, flowed into `PredictionConfig.max_prediction_latency`
   (`src/prediction/config.py:44`, env `MAX_PREDICTION_LATENCY`).
2. **`src/prediction/engine.py`** (`_get_timeout_seconds`, old line 880-882) returned that
   alerting budget as a **hard abort deadline** for `run_with_timeout(model.predict, ...)`
   (old lines 189-196) — thread-based **wall-clock** timing, so purely load-dependent.
   Measured on this machine: CPU ONNX `predict()` takes 33ms min / 113ms median /
   4.0s max under load — the majority of bars can blow a 0.1s gate on a busy box.
3. Same engine, old lines 299-318: even a **successfully completed** prediction was
   replaced with a zeroed error result if total wall time exceeded 0.1s. Both mechanisms
   made results a function of OS scheduling.
4. **Worse than HOLD**: errored results carry placeholder `price=0.0`, and neither
   `MLSignalGenerator` nor `MLBasicSignalGenerator` checked `PredictionResult.error` —
   `predicted_return = (0 − price)/price = −100%` → a **full-strength phantom SELL**
   (confidence 1.0, `enter_short=True`), silently, on any slow or errored bar, in both
   engines.

No other code sets or consumes the 0.1s gate (verified: only `config.py` + `engine.py`
reference `MAX_PREDICTION_LATENCY`; experiment runners reach it via the same
`PredictionConfig.from_config_manager()` path).

## Design

**Process-wide `InferenceContext`** (`src/prediction/inference_context.py`), pinned by
engine constructors — no configuration needed for the safe behavior:

| Context | Who pins it | Inference deadline | Latency alerting |
|---|---|---|---|
| `DETERMINISTIC` (**default**) | `Backtester.__init__` (also default for research scripts / training) | **None** — inference always runs to completion | none (wall clock must not influence backtest output or logs) |
| `LIVE` | `LiveTradingEngine.__init__` | `PredictionConfig.live_inference_timeout` — **5s default** (env `LIVE_INFERENCE_TIMEOUT`) | WARNING when `max_prediction_latency` (0.1s) exceeded; result returned intact |

**Live timeout accounting (loud, attributable):**
- WARNING log at the engine (`_run_inference`), with running count
- `inference_timeouts` counter exposed in `get_performance_stats()`
- `timed_out: true` stamped in the error `PredictionResult.metadata`
  (`ModelInferenceTimeoutError`, new exception)
- signal generators degrade to an explicit HOLD (`reason: prediction_failed`) with
  `timed_out` stamped in `Signal.metadata` — live decisions degraded by timeouts are
  now attributable end-to-end

**Phantom-SELL fix:** both ML signal generators now treat any errored
`PredictionResult` as a failed prediction (HOLD) instead of consuming `price=0.0`.

**`max_prediction_latency` is alert-only** (its documented purpose): never gates or
substitutes a completed prediction; error results keep their original error type (no
more load-dependent `PredictionTimeoutError+X` relabeling).

A test-suite autouse fixture (`tests/conftest.py`) resets the context between tests so
engine constructions can't leak policy across tests.

## Determinism proof

All runs: `atb backtest ml_basic`, fixed window `--start 2026-02-01 --end 2026-03-03`
(30d), 1h, real ONNX models from the repo registry, cached market data (identical inputs),
**under artificial CPU load** (6 busy-loop workers) on top of heavy ambient load
(load average 74–98 on 8 cores; per-bar prediction wall time observed at 0.8–1.7s —
8–17x over the old 0.1s gate, i.e. under the old code virtually every bar was substituted).

**This branch — ETHUSDT, two back-to-back runs:**

| Run | Trades | Win rate | Return | MaxDD | Final balance |
|---|---|---|---|---|---|
| 1 | 8 | 50.00% | −0.01% | 0.06% | $999.94 |
| 2 | 8 | 50.00% | −0.01% | 0.06% | $999.94 |

**IDENTICAL** — including all **601 per-bar strategy decisions** (direction, size,
confidence, strength), verified by diffing the decision logs line-by-line.
A second pair (BTCUSDT, June window, 1 trade) was also identical.

**Control — `origin/develop` (adefd339), same window/model/data/load:**

| Run | Trades | Win rate | Return | MaxDD | Final balance | timeout substitutions logged |
|---|---|---|---|---|---|---|
| 1 | 86 | 43.02% | −1.90% | 1.92% | $980.91 | 63 |
| 2 | 89 | 38.20% | −2.22% | 2.24% | $977.76 | 179 |

**DIVERGED** — and both runs are corrupted: ~80 of those trades are phantom shorts
fabricated from timeout-substituted `price=0.0` predictions (the honest count on the
same inputs is 8). This reproduces #912's side-finding and #913's forensics exactly.

## Testing

- TDD: all new tests written first and failing (old behavior asserted the defect —
  e.g. `test_predict_timeout` required a completed prediction to be zeroed).
- New: `tests/unit/predictions/test_inference_context.py` (context semantics, defaults,
  engine pinning by both `Backtester` and `LiveTradingEngine`);
  `TestDeterministicInference` + `TestLiveInferenceTimeoutAccounting` in
  `tests/unit/predictions/test_engine_prediction.py`;
  `TestErroredPredictionResultHandling` in
  `tests/unit/strategies/components/test_ml_signal_generator.py` (phantom-SELL regression).
- Updated: success-path mocks now model the real contract (`error=None`);
  latency-substitution tests replaced with intact-result assertions.
- Full unit suite (`tests/run_tests.py unit`, 4 workers): **4624 passed, 4 failed** — all 4 are pre-existing load-contention flakes, not regressions: `test_indicators_performance` (asserts <3s wall clock; 11.8s under load-60), `test_inference_speed_benchmark` (300s cap), `test_one_minute_timeframe` (300s cap; its sibling `test_one_day_timeframe` **fails on origin/develop at 190s while passing on this branch at 111s** under the same load), and `test_deploys_model_successfully` (runs a real validation-gate backtest; on origin/develop it can't finish within 7 minutes under the same load). CI runners are uncontended.
- `atb dev quality --changed`: black, ruff, mypy all green.

## CI triage (first push)

Two CI failures on the first push, both downstream consequences of killing the defect,
both fixed in follow-up commits:

- `test_ml_signal_generation_integration`: its mocked `PredictionResult` never set
  `error=None`; a spec'd Mock attribute is truthy, tripping the new errored-result
  guard. Mock now models the real contract.
- `test_deploys_model_successfully`: this "unit" test ran the **real #801 validation
  gate** — three multi-window backtests of the repo's live model — and **only passed
  because the 0.1s abort defect fabricated phantom trades that satisfied the gate's
  per-window `min_trades` floors**. Now mocked at the `_gate_and_promote` seam (with a
  new blocked-path case); the gate itself stays covered by `src/ml/validation` tests.

**Policy note for reviewers / PM**: with honest inference, the #801 gate's per-window
`min_trades` floors (`config/validation_windows.json`) may now honestly block
deployments that previously passed on phantom trades. That is the gate working as
designed on truthful data, but the thresholds were implicitly calibrated against
corrupted backtests — worth a follow-up review of the floors against honest
`ml_basic` 1d trade counts.

## Impact / parity notes

- Backtest: deterministic under any load; also slightly faster (no per-inference
  thread spawn).
- Live: keeps a real hang guard (5s vs typical 30-400ms inference) instead of a budget
  that silently degraded most bars under load; slow-but-complete predictions are now
  used instead of discarded.
- Both engines make the context-appropriate choice by default; no config required.

Closes #913. Refs #912 (side-finding); corroborated by the #916 forensics notes (latency-abort defect, no prod impact to date). Builds on #917: the `timed_out` stamp flows through its `extract_ml_predictions_from_signal` into `strategy_executions.ml_predictions` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
