### PR TITLE
feat(ml): cloud-first tournaments — cache-tier ingestion + architecture selection on atb train cloud (#918)

### DIFF
--- a/cli/commands/train_cloud.py
+++ b/cli/commands/train_cloud.py
@@ -142,6 +142,20 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         help="Force price-only model (no sentiment)",
     )
     parser.add_argument(
+        "--model-type",
+        type=str,
+        default="cnn_lstm",
+        choices=["lstm", "cnn_lstm", "attention_lstm", "tcn", "tcn_attention", "tft"],
+        help="Model architecture (default: cnn_lstm)",
+    )
+    parser.add_argument(
+        "--model-variant",
+        type=str,
+        default="default",
+        choices=["default", "lightweight", "deep"],
+        help="Architecture variant (default: default)",
+    )
+    parser.add_argument(
         "--instance-type",
         type=str,
         default="ml.g4dn.xlarge",
@@ -226,6 +240,8 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         sequence_length=args.sequence_length,
         force_sentiment=args.force_sentiment,
         force_price_only=args.force_price_only,
+        model_type=args.model_type,
+        model_variant=args.model_variant,
         diagnostics=DiagnosticsOptions(
             generate_plots=False,  # Skip plots in cloud (no display)
             evaluate_robustness=True,
@@ -258,6 +274,7 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
     print(f"  Epochs:          {args.epochs}")
     print(f"  Batch Size:      {args.batch_size}")
     print(f"  Sequence Length: {args.sequence_length}")
+    print(f"  Architecture:    {args.model_type} ({args.model_variant})")
     print()
     print(f"  Provider:        {provider.provider_name}")
     print(f"  Instance:        {args.instance_type}")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Cloud-first model tournaments (#918, #909)**: `atb train cloud` gains
+  `--model-type {lstm,cnn_lstm,attention_lstm,tcn,tcn_attention,tft}` and
+  `--model-variant {default,lightweight,deep}`, threaded end-to-end through
+  `TrainingConfig` → SageMaker job hyperparameters → the training container
+  entrypoint (defaults preserve current behavior: `cnn_lstm`/`default`).
+  Training-corpus ingestion now consults the year-based parquet cache
+  (`atb data prefill-cache`) before any network fetch, fetches missing ranges
+  from Binance only, and validates coverage (open-time boundary slack,
+  calendar-day start check, ≥99% expected-bar ratio). **Training corpora no
+  longer fall back to a third-party provider** — a range Binance/cache cannot
+  cover fails loudly with remediation guidance instead of silently switching
+  sources mid-corpus (#909). Archive CSV timestamp parsing hardened with
+  `format="mixed", utc=True` (Binance's earliest kline archives mix on-the-hour
+  and sub-second timestamps in one file). Tournaments run cloud-first from now
+  on; see `docs/prediction.md`.
+  **⚠️ Deploy note: the ECR training image must be rebuilt and pushed
+  (`./src/ml/cloud/build-and-push.sh`) after this merge and before any cloud
+  training run uses these fixes — the container bakes in
+  `src/ml/training_pipeline/`, and the weekly training routine's image-freshness
+  precondition will refuse to run against a stale image.**
+
 - **Cloud training hardening (#890)**: `atb train cloud` accepts `--start-date`/`--end-date`
   (UTC, mutually exclusive with `--days`) for fixed-cutoff experiments; `--no-wait` now uploads
   the S3 data channel before submitting (previously the async path always failed in-container);
@@ -23,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (falls back to a `-N` suffixed sibling). Cloud workflow documented in `docs/prediction.md`.
 
 ### Changed
+- **`--force-price-only` behavior change (#918)**: `atb train model
+  --force-price-only` now routes through `PriceOnlyFeatureExtractor` (the 5
+  causally-normalized OHLCV features used by `atb train price` and live
+  inference) and regresses `close_normalized` instead of the raw dollar close.
+  Previously the flag only skipped the sentiment download while still building
+  the 9-feature globally-scaled pipeline and predicting raw prices — metrics
+  were incomparable with price-only baselines. Bundles still land in the
+  `price/` registry namespace (never implicitly in `basic/`), and
+  `atb train price` itself is untouched. Pinned by unit tests.
 - **#486 live-engine modularization complete**: `LiveTradingEngine._init_modular_handlers`
   (the last open item from `docs/refactor/live_engine_modularization.md`) is now a
   thin orchestrator over four construction-phase helpers — `_init_core_handlers`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -66,6 +66,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backtest determinism fingerprint byte-identical.
 
 ### Fixed
+- **#928 `create_model` TypeError for non-CNN architectures**: the trainer always
+  forwards `has_sentiment` to `create_model`, but only the CNN-LSTM baseline
+  accepts it — `tft`, `tcn_attention`, and the default variants of
+  `attention_lstm`/`tcn` crashed at model construction with
+  `TypeError: ... unexpected keyword argument 'has_sentiment'`. `create_model`
+  now pops `has_sentiment` before the architecture dispatch, so CNN-LSTM still
+  receives the real flag and no other factory sees it. A parametrized smoke test
+  now constructs every CLI-selectable `(model_type, variant)` pair with the
+  trainer's exact kwargs.
 - **#914 `strategy_executions.ml_predictions` no longer always null**: every row
   ever written (151k+ in prod) carried JSON `null` because the logging call sites
   extracted prediction data from dataframe columns (`onnx_pred`, `ml_prediction`)

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -1,6 +1,6 @@
 # Prediction & models
 
-> **Last Updated**: 2026-01-12  
+> **Last Updated**: 2026-07-07  
 > **Related Documentation**: [Backtesting](backtesting.md), [Live trading](live_trading.md)
 
 Machine-learning inference and model lifecycle management live under `src/prediction` and `src/ml`. The goal is to keep training
@@ -99,13 +99,25 @@ Use the following knobs when running `atb train model` locally:
 - `--epochs`, `--batch-size`, and `--sequence-length` adjust hyperparameters without editing code.
 - `--skip-plots`, `--skip-robustness`, and `--skip-onnx` let you bypass the slowest diagnostics when you only need a quick experiment. Leave them off for production artifacts so the metadata and ONNX bundle stay in sync.
 - `--disable-mixed-precision` falls back to float32 math if you encounter GPU/MPS precision glitches. Mixed precision remains enabled by default when a GPU is present to speed up long jobs.
+- `--force-price-only` trains against the production price-only contract: the 5 `PriceOnlyFeatureExtractor` features (rolling causal min-max normalization) with `close_normalized` as the regression target — the same contract `atb train price` and live inference use. Bundles still land in the `price/` namespace; promotion into `basic/` stays an explicit step.
 
 The defaults remain equivalent to the legacy behavior (300 epochs, batch size 32, sequence length 120, diagnostics on, ONNX on), so unattended jobs continue to produce identical artifacts unless you override the flags explicitly.
+
+### Training data sourcing (single-source, fail-loud)
+
+Training corpora are loaded through the year-based parquet cache (`atb data prefill-cache`)
+before any network fetch; ranges missing from the cache are fetched from Binance and cached, so
+repeated runs — e.g. multi-entrant tournaments — train on identical rows without re-downloading.
+There is **no third-party fallback at training time**: if Binance/cache cannot fully cover the
+requested window (open-time boundary slack, calendar-day start check, ≥99% expected-bar
+coverage), training fails loudly instead of silently switching data sources mid-corpus (#909).
+Fix a failure by prefilling the cache, passing `--input-data-s3`, or adjusting the date range.
 
 ## Cloud training (AWS SageMaker)
 
 `atb train cloud` runs the same training pipeline on SageMaker spot GPU instances (`src/ml/cloud/`). Because Binance blocks
-AWS IPs, the CLI always downloads candles locally, uploads them to S3 as the job's data channel, and the container trains
+AWS IPs, the CLI always assembles the corpus locally (parquet cache first, Binance for gaps — see
+"Training data sourcing" above), uploads it to S3 as the job's data channel, and the container trains
 from that channel — both in blocking mode and with `--no-wait`.
 
 ```bash
@@ -115,12 +127,26 @@ atb train cloud BTCUSDT --start-date 2026-05-01 --end-date 2026-06-01 --epochs 5
 # Production-style retrain: last 365 days ending now
 atb train cloud BTCUSDT --days 365 --epochs 300
 
+# Architecture selection (tournament entrants): lstm, cnn_lstm, attention_lstm,
+# tcn, tcn_attention, tft x {default, lightweight, deep}
+atb train cloud ETHUSDT --model-type tcn_attention --model-variant deep --force-price-only
+
 # Async round trip
 atb train cloud BTCUSDT --no-wait            # uploads data, submits, prints job id
 atb train cloud-status <JOB_NAME>            # poll status
 atb train cloud-status <JOB_NAME> --sync     # download + sync bundle into the registry
 atb train cloud-list [BTCUSDT]               # list job outputs in S3 (newest first)
 ```
+
+### Model tournaments run cloud-first
+
+Architecture/model tournaments are run as **parallel SageMaker jobs, not sequential local
+training** (Board decision 2026-07-06, #918): a 5-entrant sweep costs roughly $0.10–0.50 total
+and finishes in under an hour of wall-clock time. Submit one `atb train cloud … --no-wait
+--model-type <entrant>` job per entrant with an identical fixed `--start-date`/`--end-date`
+window, then sync and evaluate the bundles. Local training remains the fallback only for
+protocol-experimental runs that need unpushed pipeline patches. Before a tournament, confirm the
+ECR image is fresh (see the rebuild note below) — the container bakes in `src/ml/training_pipeline/`.
 
 ### Namespace and promotion flow
 

--- a/src/ml/cloud/entrypoint.py
+++ b/src/ml/cloud/entrypoint.py
@@ -72,6 +72,10 @@ def parse_hyperparameters(params: dict) -> dict:
         "force_sentiment": params.get("force_sentiment", "false").lower() == "true",
         "force_price_only": params.get("force_price_only", "false").lower() == "true",
         "mixed_precision": params.get("mixed_precision", "true").lower() == "true",
+        # Architecture selection; defaults match TrainingConfig so jobs submitted by
+        # older CLIs keep training the incumbent cnn_lstm architecture.
+        "model_type": params.get("model_type", "cnn_lstm"),
+        "model_variant": params.get("model_variant", "default"),
     }
 
 
@@ -116,6 +120,8 @@ def run_training(parsed_params: dict) -> int:
             force_sentiment=parsed_params["force_sentiment"],
             force_price_only=parsed_params["force_price_only"],
             mixed_precision=parsed_params["mixed_precision"],
+            model_type=parsed_params["model_type"],
+            model_variant=parsed_params["model_variant"],
             diagnostics=DiagnosticsOptions(
                 generate_plots=False,  # No display in container
                 evaluate_robustness=True,
@@ -135,6 +141,7 @@ def run_training(parsed_params: dict) -> int:
         logger.info(f"Starting training for {config.symbol}")
         logger.info(f"Data range: {start_date} to {end_date}")
         logger.info(f"Epochs: {config.epochs}, Batch size: {config.batch_size}")
+        logger.info(f"Architecture: {config.model_type} (variant: {config.model_variant})")
 
         # Run training
         result = run_training_pipeline(ctx)

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -6,7 +6,6 @@ upload data → submit job → wait → download artifacts → sync to registry.
 
 from __future__ import annotations
 
-import argparse
 import itertools
 import json
 import logging
@@ -133,59 +132,48 @@ class CloudTrainingOrchestrator:
         )
 
     def _prepare_training_data(self) -> str | None:
-        """Download training data locally and upload to S3.
+        """Assemble the training corpus locally and upload it to S3.
 
-        This step is required because Binance API blocks requests from AWS IP addresses.
-        Data is downloaded fresh from Binance (no cache) and uploaded to S3
-        for SageMaker to use as input channel.
+        This step is required because the Binance API blocks requests from AWS IP
+        addresses. The corpus comes from the training pipeline's single-source
+        loader: prefilled parquet cache first, Binance for missing ranges, and a
+        loud failure instead of any third-party fallback (#909) — so cloud jobs
+        train on exactly the rows a local run would see.
 
         Returns:
             S3 URI of uploaded data, or None if input_data_s3_uri was already set
 
         Raises:
-            RuntimeError: If data download or upload fails
+            RuntimeError: If the corpus cannot be assembled or fails coverage checks
         """
         # Skip if S3 URI already provided by user
         if self.config.input_data_s3_uri:
             logger.info(f"Using provided S3 data URI: {self.config.input_data_s3_uri}")
             return None
 
-        from cli.commands.data import _download
+        from src.ml.training_pipeline.config import TrainingContext
+        from src.ml.training_pipeline.ingestion import load_training_corpus
 
         tc = self.config.training_config
 
-        logger.info(f"Downloading {tc.symbol} data from Binance (fresh, no cache)...")
+        logger.info(f"Loading {tc.symbol} training corpus (cache first, Binance for gaps)...")
+        corpus = load_training_corpus(TrainingContext(config=tc))
 
-        # Create temp directory for downloads
         with tempfile.TemporaryDirectory() as tmpdir:
-            # Download data from Binance using existing CLI function
-            args = argparse.Namespace(
-                symbol=tc.symbol,
-                timeframe=tc.timeframe,
-                start_date=tc.start_date.strftime("%Y-%m-%d"),
-                end_date=tc.end_date.strftime("%Y-%m-%d"),
-                output_dir=tmpdir,
-                format="csv",
+            csv_path = (
+                Path(tmpdir)
+                / f"{tc.symbol}_{tc.timeframe}_{tc.start_date:%Y-%m-%d}_{tc.end_date:%Y-%m-%d}.csv"
             )
+            # The container's loader looks up a "timestamp" column by name
+            corpus.rename_axis("timestamp").to_csv(csv_path, index=True)
 
-            if _download(args) != 0:
-                raise RuntimeError("Failed to download training data from Binance")
-
-            # Find downloaded file
-            data_files = list(Path(tmpdir).glob("*.csv"))
-            if not data_files:
-                raise RuntimeError("No data files found after download")
-
-            logger.info(f"Downloaded {len(data_files)} file(s)")
-
-            # Upload to S3 using existing artifact manager
             logger.info(
                 f"Uploading training data to S3 bucket {self.config.storage_config.s3_bucket}..."
             )
             s3_uri = self.s3_manager.upload_training_data(
                 symbol=tc.symbol,
                 timeframe=tc.timeframe,
-                data_files=data_files,
+                data_files=[csv_path],
             )
 
             logger.info(f"Training data uploaded to {s3_uri}")
@@ -356,6 +344,8 @@ class CloudTrainingOrchestrator:
                 "force_sentiment": str(tc.force_sentiment).lower(),
                 "force_price_only": str(tc.force_price_only).lower(),
                 "mixed_precision": str(tc.mixed_precision).lower(),
+                "model_type": tc.model_type,
+                "model_variant": tc.model_variant,
             },
         )
 

--- a/src/ml/training_pipeline/config.py
+++ b/src/ml/training_pipeline/config.py
@@ -64,7 +64,7 @@ class TrainingConfig:
 
     # Valid model types and variants for validation
     _VALID_MODEL_TYPES = frozenset(
-        {"cnn_lstm", "adaptive", "default", "attention_lstm", "tcn", "tcn_attention", "lstm"}
+        {"cnn_lstm", "adaptive", "default", "attention_lstm", "tcn", "tcn_attention", "tft", "lstm"}
     )
     _VALID_MODEL_VARIANTS = frozenset({"default", "lightweight", "deep"})
 
@@ -142,12 +142,3 @@ class TrainingContext:
             End date as ISO 8601 string (YYYY-MM-DD)
         """
         return self.config.end_date.strftime("%Y-%m-%dT23:59:59Z")
-
-    @property
-    def price_data_glob(self) -> str:
-        """Generate glob pattern for finding downloaded price data files.
-
-        Returns:
-            Glob pattern matching price data files (e.g., 'BTCUSDT_1h_*.csv')
-        """
-        return f"{self.symbol_exchange}_{self.config.timeframe}_{self.start_iso}_{self.end_iso}.*"

--- a/src/ml/training_pipeline/ingestion.py
+++ b/src/ml/training_pipeline/ingestion.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import logging
 import os
-from argparse import Namespace
+from datetime import UTC, timedelta
 from pathlib import Path
 
 import pandas as pd
 
-from cli.commands import data as data_commands
 from src.data_providers.feargreed_provider import FearGreedProvider
 from src.ml.training_pipeline.config import TrainingContext
 
@@ -17,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 # SageMaker S3 data channel path
 SAGEMAKER_INPUT_DATA_PATH = Path("/opt/ml/input/data/training")
+
+# Minimum fraction of expected fixed-frequency bars a corpus must contain.
+# Below this the range has real holes (missing rows), not just a late listing date.
+MIN_CORPUS_COVERAGE_RATIO = 0.99
 
 
 def _download_from_s3(s3_uri: str, local_path: Path) -> Path:
@@ -68,13 +71,6 @@ def _download_from_s3(s3_uri: str, local_path: Path) -> Path:
     return local_file
 
 
-def _resolve_latest_file(pattern: str, directory: Path) -> Path:
-    matches = sorted(directory.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
-    if not matches:
-        raise FileNotFoundError(f"No files matched pattern {pattern} in {directory}")
-    return matches[0]
-
-
 def _validate_data_coverage(df: pd.DataFrame, ctx: TrainingContext, file_path: Path) -> None:
     """Validate that loaded data covers the expected date range.
 
@@ -123,6 +119,135 @@ def _validate_data_coverage(df: pd.DataFrame, ctx: TrainingContext, file_path: P
     )
 
 
+def _timeframe_delta(timeframe: str) -> timedelta:
+    """Convert a timeframe string (e.g. ``1h``) to its candle interval.
+
+    Raises:
+        RuntimeError: If the timeframe cannot be parsed (coverage validation
+            would be meaningless with an unknown bar interval).
+    """
+    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+    try:
+        unit = timeframe[-1].lower()
+        value = int(timeframe[:-1]) if len(timeframe) > 1 else 1
+        if unit in units and value > 0:
+            return timedelta(**{units[unit]: value})
+    except (ValueError, TypeError, IndexError):
+        pass
+    raise RuntimeError(f"Cannot validate corpus coverage for unknown timeframe: {timeframe!r}")
+
+
+def _corpus_failure(ctx: TrainingContext, reason: str) -> RuntimeError:
+    """Build the loud, actionable error raised when a training corpus is unusable."""
+    return RuntimeError(
+        f"Training corpus for {ctx.config.symbol} {ctx.config.timeframe} "
+        f"({ctx.config.start_date.date()} to {ctx.config.end_date.date()}) "
+        f"could not be loaded: {reason}. Training never falls back to a third-party "
+        "data source (silent source-switching mid-corpus is a data-integrity hazard, "
+        "see #909). Prefill the local cache with "
+        f"`atb data prefill-cache --symbols {ctx.config.symbol} "
+        f"--timeframes {ctx.config.timeframe}`, provide the data explicitly via "
+        "--input-data-s3, or adjust the training date range."
+    )
+
+
+def _validate_corpus_coverage(
+    df: pd.DataFrame,
+    ctx: TrainingContext,
+    query_start: pd.Timestamp,
+    query_end: pd.Timestamp,
+) -> None:
+    """Validate that a corpus covers the requested window without internal gaps.
+
+    Raises:
+        RuntimeError: If the corpus misses the window boundaries or has holes.
+    """
+    if df is None or df.empty:
+        raise _corpus_failure(ctx, "no candles were returned")
+
+    bar = _timeframe_delta(ctx.config.timeframe)
+    data_start = pd.Timestamp(df.index.min())
+    data_end = pd.Timestamp(df.index.max())
+
+    # A candle's index is its *open* time, so the last bar of the window opens up to one
+    # interval before the end boundary. Windows that extend to now (or the future) can
+    # only contain bars up to the most recent closed candle, so clamp before comparing.
+    effective_end = min(query_end, pd.Timestamp.now(tz="UTC"))
+    # The start side only requires the same calendar day: a symbol's first-ever candle can
+    # open hours after midnight on its listing day (e.g. ETHUSDT opens 04:00 on 2017-08-17).
+    # That is market history, not a cache gap; real holes are caught by the ratio check
+    # below, which is computed from the corpus's own span rather than the query window.
+    if data_start.normalize() > query_start.normalize() or data_end < (effective_end - bar):
+        raise _corpus_failure(
+            ctx,
+            f"available data ({data_start} to {data_end}) does not cover "
+            f"the requested window ({query_start} to {query_end})",
+        )
+
+    expected_bars = int((data_end - data_start) / bar) + 1
+    coverage_ratio = len(df) / expected_bars if expected_bars > 0 else 0.0
+    if coverage_ratio < MIN_CORPUS_COVERAGE_RATIO:
+        raise _corpus_failure(
+            ctx,
+            f"only {len(df)} of {expected_bars} expected bars are present "
+            f"({coverage_ratio:.1%} coverage) between {data_start} and {data_end}",
+        )
+
+
+def load_training_corpus(ctx: TrainingContext) -> pd.DataFrame:
+    """Load the OHLCV training corpus via the parquet cache backed by Binance.
+
+    Consults the year-based parquet cache (populated by ``atb data prefill-cache``)
+    before any network fetch; missing years are fetched from Binance and cached, so
+    repeated runs (e.g. multi-entrant model tournaments) see identical rows without
+    re-downloading. There is deliberately no third-party fallback: a training corpus
+    must come from a single source, so failures and coverage gaps raise loudly
+    instead of silently switching providers mid-corpus (#909).
+
+    Args:
+        ctx: Training context with config and paths
+
+    Returns:
+        DataFrame with OHLCV data covering [start_date, end_date], indexed by
+        UTC timestamp
+
+    Raises:
+        RuntimeError: If the corpus cannot be fetched or fails coverage validation
+    """
+    from src.config.paths import get_cache_dir
+    from src.data_providers.binance_provider import BinanceProvider
+    from src.data_providers.cached_data_provider import CachedDataProvider
+
+    provider = CachedDataProvider(BinanceProvider(), cache_dir=str(get_cache_dir()))
+    # End-of-day boundaries (ctx.start_iso/end_iso) so the corpus covers the full
+    # requested last day instead of truncating it at midnight.
+    query_start = pd.Timestamp(ctx.start_iso)
+    query_end = pd.Timestamp(ctx.end_iso)
+    try:
+        df = provider.get_historical_data(
+            ctx.symbol_exchange,
+            ctx.config.timeframe,
+            query_start.to_pydatetime(),
+            query_end.to_pydatetime(),
+        )
+    except (ConnectionError, TimeoutError, ValueError, OSError) as exc:
+        raise _corpus_failure(ctx, f"provider error: {exc}") from exc
+
+    if df is not None and not df.empty and df.index.tz is None:
+        df = df.tz_localize(UTC)
+
+    _validate_corpus_coverage(df, ctx, query_start, query_end)
+    logger.info(
+        "Training corpus for %s %s: %d candles (%s to %s)",
+        ctx.config.symbol,
+        ctx.config.timeframe,
+        len(df),
+        df.index.min(),
+        df.index.max(),
+    )
+    return df[(df.index >= query_start) & (df.index <= query_end)]
+
+
 def download_price_data(ctx: TrainingContext, s3_data_uri: str | None = None) -> pd.DataFrame:
     """Download OHLCV data for the requested symbol and date range.
 
@@ -153,31 +278,8 @@ def download_price_data(ctx: TrainingContext, s3_data_uri: str | None = None) ->
         downloaded_file = _download_from_s3(s3_data_uri, ctx.paths.data_dir)
         return _load_price_data_file(downloaded_file)
 
-    # Priority 3: Download from exchange API
-    ns = Namespace(
-        symbol=ctx.symbol_exchange,
-        timeframe=ctx.config.timeframe,
-        start_date=ctx.start_iso,
-        end_date=ctx.end_iso,
-        output_dir=str(ctx.paths.data_dir),
-        format="csv",
-    )
-    logger.info(
-        "Downloading price data for %s (%s %s-%s)",
-        ctx.config.symbol,
-        ctx.config.timeframe,
-        ctx.config.start_date.date(),
-        ctx.config.end_date.date(),
-    )
-    # Note: Uses internal CLI command directly to avoid subprocess overhead
-    # This is intentional coupling as training pipeline needs programmatic access
-    status = data_commands._download(ns)
-    if status != 0:
-        raise RuntimeError("Price data download failed")
-
-    latest_file = _resolve_latest_file(ctx.price_data_glob, ctx.paths.data_dir)
-    logger.debug("Using price data file %s", latest_file)
-    return _load_price_data_file(latest_file)
+    # Priority 3: prefilled parquet cache backed by Binance (single-source, fail-loud)
+    return load_training_corpus(ctx)
 
 
 def _load_price_data_file(file_path: Path) -> pd.DataFrame:
@@ -194,7 +296,11 @@ def _load_price_data_file(file_path: Path) -> pd.DataFrame:
         df = pd.read_feather(file_path)
     else:
         df = pd.read_csv(file_path, encoding="utf-8")
-    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    # format="mixed": Binance's earliest kline archives mix on-the-hour and sub-second
+    # timestamps within one file (e.g. ETHUSDT 2018-02 has a run offset by ":28:14.8").
+    # A plain pd.to_datetime() infers one fixed format from the first rows and raises
+    # ValueError the moment a later row's format differs.
+    df["timestamp"] = pd.to_datetime(df["timestamp"], format="mixed", utc=True)
     df = df.set_index("timestamp")
     return df.sort_index()
 

--- a/src/ml/training_pipeline/models.py
+++ b/src/ml/training_pipeline/models.py
@@ -191,9 +191,13 @@ def create_model(
     """
     model_type_lower = model_type.lower()
 
+    # Only the CNN-LSTM baseline consumes has_sentiment. Pop it here so the other
+    # architecture factories — which don't accept it — never receive it via the
+    # **kwargs forwarding below (the trainer always passes it; see #928).
+    has_sentiment = kwargs.pop("has_sentiment", True)
+
     # CNN-LSTM (original/baseline) - use optimized adaptive model
     if model_type_lower in ["cnn_lstm", "adaptive", "default"]:
-        has_sentiment = kwargs.get("has_sentiment", True)
         return create_adaptive_model(input_shape, has_sentiment)
 
     # Attention-LSTM

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -12,6 +12,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
+if TYPE_CHECKING:
+    from sklearn.preprocessing import MinMaxScaler
+
 try:
     import tensorflow as tf
 
@@ -38,6 +41,7 @@ from src.ml.training_pipeline.features import (
 from src.ml.training_pipeline.gpu_config import configure_gpu
 from src.ml.training_pipeline.ingestion import download_price_data, load_sentiment_data
 from src.ml.training_pipeline.models import create_model, get_model_callbacks
+from src.prediction.features.price_only import PriceOnlyFeatureExtractor
 
 logger = logging.getLogger(__name__)
 
@@ -171,11 +175,28 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
                 "Check data availability and timeframe alignment."
             )
 
-        feature_data, scalers, feature_names = create_robust_features(
-            merged_df.copy(), sentiment_assessment, ctx.config.sequence_length
-        )
+        if ctx.config.force_price_only:
+            # Route through the same 5-feature, causally-normalized extractor that
+            # `atb train price` and production inference use. Historically this flag
+            # only skipped the sentiment download while still building
+            # create_robust_features' 9-feature globally-scaled pipeline, silently
+            # diverging from the price-only contract.
+            extractor = PriceOnlyFeatureExtractor(normalization_window=ctx.config.sequence_length)
+            feature_data = extractor.extract(merged_df.copy())
+            feature_names = extractor.get_feature_names()
+            feature_data = feature_data.dropna(subset=feature_names)
+            scalers: dict[str, MinMaxScaler] = {}
+            # Predict the rolling-normalized close, matching `atb train price`. The raw
+            # close would regress dollar magnitudes with no denormalization step
+            # (scalers is empty), making RMSE/MAPE incomparable with existing
+            # price-only baselines.
+            target_array = feature_data["close_normalized"].to_numpy(dtype=np.float32)
+        else:
+            feature_data, scalers, feature_names = create_robust_features(
+                merged_df.copy(), sentiment_assessment, ctx.config.sequence_length
+            )
+            target_array = feature_data["close"].to_numpy(dtype=np.float32)
         feature_array = feature_data[feature_names].to_numpy(dtype=np.float32)
-        target_array = feature_data["close"].to_numpy(dtype=np.float32)
         sequences, targets = create_sequences(
             feature_array,
             target_array,
@@ -230,6 +251,10 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
             scalers.get("close"),
         )
 
+        # force_price_only bundles stay in price/ even though they share `atb train
+        # price`'s basic/ contract: writing to basic/ here would implicitly repoint
+        # basic/latest — the symlink live strategies load. Promotion into basic/ is
+        # always an explicit step (atb train cloud-promote / atb models promote).
         metadata = {
             "symbol": ctx.config.symbol,
             "model_type": "sentiment" if has_sentiment else "price",

--- a/tests/unit/cloud/test_entrypoint.py
+++ b/tests/unit/cloud/test_entrypoint.py
@@ -1,0 +1,114 @@
+"""Unit tests for the SageMaker training container entrypoint."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.ml.cloud.entrypoint import parse_hyperparameters, run_training
+
+
+@pytest.mark.fast
+class TestParseHyperparameters:
+    """Tests for hyperparameter parsing (SageMaker passes all values as strings)."""
+
+    def test_defaults_preserve_current_behavior(self) -> None:
+        # Act
+        parsed = parse_hyperparameters({})
+
+        # Assert
+        assert parsed["symbol"] == "BTCUSDT"
+        assert parsed["timeframe"] == "1h"
+        assert parsed["epochs"] == 300
+        assert parsed["batch_size"] == 32
+        assert parsed["sequence_length"] == 120
+        assert parsed["force_sentiment"] is False
+        assert parsed["force_price_only"] is False
+        assert parsed["mixed_precision"] is True
+        assert parsed["model_type"] == "cnn_lstm"
+        assert parsed["model_variant"] == "default"
+
+    def test_model_type_and_variant_are_parsed(self) -> None:
+        # Act
+        parsed = parse_hyperparameters({"model_type": "tcn", "model_variant": "lightweight"})
+
+        # Assert
+        assert parsed["model_type"] == "tcn"
+        assert parsed["model_variant"] == "lightweight"
+
+    def test_numeric_strings_converted(self) -> None:
+        # Act
+        parsed = parse_hyperparameters({"epochs": "50", "batch_size": "64"})
+
+        # Assert
+        assert parsed["epochs"] == 50
+        assert parsed["batch_size"] == 64
+
+
+@pytest.mark.fast
+class TestRunTrainingThreading:
+    """Tests that parsed hyperparameters reach TrainingConfig."""
+
+    def _base_params(self, **overrides) -> dict:
+        params = parse_hyperparameters(
+            {"start_date": "2026-05-01T00:00:00", "end_date": "2026-06-01T00:00:00"}
+        )
+        params.update(overrides)
+        return params
+
+    def _run_with_stub_pipeline(self, params: dict) -> tuple[int, MagicMock]:
+        """Run entrypoint.run_training against a stubbed pipeline module.
+
+        The pipeline module imports TensorFlow at import time; stubbing it in
+        sys.modules keeps these tests fast and isolated from TF.
+        """
+        fake_pipeline = MagicMock()
+        fake_pipeline.run_training_pipeline.return_value = MagicMock(
+            success=True, duration_seconds=1.0, artifact_paths=None
+        )
+        with patch.dict(sys.modules, {"src.ml.training_pipeline.pipeline": fake_pipeline}):
+            rc = run_training(params)
+        return rc, fake_pipeline.run_training_pipeline
+
+    def test_model_type_and_variant_reach_training_config(self) -> None:
+        # Arrange
+        params = self._base_params(model_type="tcn_attention", model_variant="deep")
+
+        # Act
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        # Assert
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.model_type == "tcn_attention"
+        assert ctx.config.model_variant == "deep"
+
+    def test_defaults_reach_training_config(self) -> None:
+        # Arrange
+        params = self._base_params()
+
+        # Act
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        # Assert
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.model_type == "cnn_lstm"
+        assert ctx.config.model_variant == "default"
+
+    def test_invalid_model_type_fails_before_training(self) -> None:
+        # Arrange - TrainingConfig validation must reject unknown architectures
+        params = self._base_params(model_type="transformer")
+        fake_pipeline = MagicMock()
+
+        # Act
+        with (
+            patch.dict(sys.modules, {"src.ml.training_pipeline.pipeline": fake_pipeline}),
+            patch("src.ml.cloud.entrypoint.write_failure_file") as mock_failure,
+        ):
+            rc = run_training(params)
+
+        # Assert
+        assert rc == 1
+        fake_pipeline.run_training_pipeline.assert_not_called()
+        mock_failure.assert_called_once()

--- a/tests/unit/cloud/test_orchestrator.py
+++ b/tests/unit/cloud/test_orchestrator.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from src.ml.cloud.config import CloudInstanceConfig, CloudStorageConfig, CloudTrainingConfig
@@ -126,6 +127,38 @@ class TestBuildJobSpec:
         spec = orchestrator._build_job_spec()
         assert spec.use_spot_instances is True
 
+    def test_build_job_spec_default_architecture_hyperparameters(
+        self, orchestrator: CloudTrainingOrchestrator
+    ) -> None:
+        """Verify default architecture selection reaches the job hyperparameters."""
+        spec = orchestrator._build_job_spec()
+        assert spec.hyperparameters["model_type"] == "cnn_lstm"
+        assert spec.hyperparameters["model_variant"] == "default"
+
+    def test_build_job_spec_custom_architecture_hyperparameters(self) -> None:
+        """Verify --model-type/--model-variant selections reach the job hyperparameters."""
+        training_config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 1),
+            model_type="tcn_attention",
+            model_variant="deep",
+        )
+        cloud_config = CloudTrainingConfig(
+            training_config=training_config,
+            storage_config=CloudStorageConfig(s3_bucket="test-bucket"),
+        )
+        orchestrator = CloudTrainingOrchestrator(cloud_config, MagicMock())
+
+        spec = orchestrator._build_job_spec()
+
+        assert spec.hyperparameters["model_type"] == "tcn_attention"
+        assert spec.hyperparameters["model_variant"] == "deep"
+        # SageMaker requires string hyperparameter values end-to-end
+        assert spec.to_hyperparameters()["model_type"] == "tcn_attention"
+        assert spec.to_hyperparameters()["model_variant"] == "deep"
+
 
 class TestSubmitJob:
     """Tests for submit_job method."""
@@ -174,12 +207,11 @@ class TestSubmitJob:
             cloud_config, mock_provider, s3_manager=mock_s3_manager
         )
 
-        def mock_download_func(args: MagicMock) -> int:
-            csv_path = Path(args.output_dir) / "BTCUSDT_1h_2024.csv"
-            csv_path.write_text("timestamp,open,high,low,close,volume\n2024-01-01,1,1,1,1,1")
-            return 0
-
-        with patch("cli.commands.data._download", side_effect=mock_download_func):
+        corpus = pd.DataFrame(
+            {"open": 1.0, "high": 1.0, "low": 1.0, "close": 1.0, "volume": 1.0},
+            index=pd.date_range("2024-01-01", periods=24, freq="1h", tz="UTC"),
+        )
+        with patch("src.ml.training_pipeline.ingestion.load_training_corpus", return_value=corpus):
             job_id = orchestrator.submit_job()
 
         assert job_id == "job-async"
@@ -415,6 +447,15 @@ class TestPrepareTrainingData:
             storage_config=CloudStorageConfig(s3_bucket="test-bucket"),
         )
 
+    @staticmethod
+    def _corpus_frame() -> "pd.DataFrame":
+        """Small OHLCV corpus as returned by load_training_corpus."""
+        index = pd.date_range("2024-01-01", periods=24, freq="1h", tz="UTC")
+        return pd.DataFrame(
+            {"open": 100.0, "high": 101.0, "low": 99.0, "close": 100.5, "volume": 1000.0},
+            index=index,
+        )
+
     def test_skips_when_s3_uri_already_set(self, cloud_config: CloudTrainingConfig) -> None:
         """Verify _prepare_training_data returns None when input_data_s3_uri is set."""
         cloud_config.input_data_s3_uri = "s3://existing-bucket/data"
@@ -426,10 +467,8 @@ class TestPrepareTrainingData:
 
         assert result is None
 
-    def test_successful_download_and_upload(
-        self, cloud_config: CloudTrainingConfig, tmp_path: Path
-    ) -> None:
-        """Verify successful download from Binance and upload to S3."""
+    def test_successful_corpus_load_and_upload(self, cloud_config: CloudTrainingConfig) -> None:
+        """Verify the single-source corpus loader feeds the S3 upload."""
         mock_provider = MagicMock()
         mock_provider.provider_name = "local"
         mock_s3_manager = MagicMock()
@@ -439,47 +478,64 @@ class TestPrepareTrainingData:
             cloud_config, mock_provider, s3_manager=mock_s3_manager
         )
 
-        # Create a mock download function that creates a CSV file in the temp dir
-        def mock_download_func(args: MagicMock) -> int:
-            # Create a CSV file in the output directory
-            csv_path = Path(args.output_dir) / "BTCUSDT_1h_2024.csv"
-            csv_path.write_text(
-                "timestamp,open,high,low,close,volume\n2024-01-01,100,101,99,100,1000"
-            )
-            return 0
-
-        with patch("cli.commands.data._download", side_effect=mock_download_func):
+        with patch(
+            "src.ml.training_pipeline.ingestion.load_training_corpus",
+            return_value=self._corpus_frame(),
+        ) as mock_corpus:
             result = orchestrator._prepare_training_data()
 
         assert result == "s3://test-bucket/data/BTCUSDT"
+        mock_corpus.assert_called_once()
+        ctx = mock_corpus.call_args.args[0]
+        assert ctx.config is cloud_config.training_config
         mock_s3_manager.upload_training_data.assert_called_once()
-        # Verify the upload was called with correct symbol and timeframe
         call_kwargs = mock_s3_manager.upload_training_data.call_args
         assert call_kwargs.kwargs["symbol"] == "BTCUSDT"
         assert call_kwargs.kwargs["timeframe"] == "1h"
 
-    def test_raises_error_when_download_fails(self, cloud_config: CloudTrainingConfig) -> None:
-        """Verify RuntimeError raised when Binance download fails."""
+    def test_uploaded_csv_has_timestamp_column(self, cloud_config: CloudTrainingConfig) -> None:
+        """The container's loader requires a 'timestamp' column in the uploaded CSV."""
+        mock_provider = MagicMock()
+        mock_provider.provider_name = "local"
+        mock_s3_manager = MagicMock()
+        uploaded: dict[str, str] = {}
+
+        def capture_upload(symbol: str, timeframe: str, data_files: list[Path]) -> str:
+            # Read inside the call: the temp dir is deleted once _prepare returns
+            uploaded["name"] = data_files[0].name
+            uploaded["header"] = data_files[0].read_text().splitlines()[0]
+            uploaded["rows"] = str(len(data_files[0].read_text().splitlines()) - 1)
+            return "s3://test-bucket/data/BTCUSDT"
+
+        mock_s3_manager.upload_training_data.side_effect = capture_upload
+
+        orchestrator = CloudTrainingOrchestrator(
+            cloud_config, mock_provider, s3_manager=mock_s3_manager
+        )
+
+        with patch(
+            "src.ml.training_pipeline.ingestion.load_training_corpus",
+            return_value=self._corpus_frame(),
+        ):
+            orchestrator._prepare_training_data()
+
+        assert uploaded["header"].startswith("timestamp,")
+        assert uploaded["rows"] == "24"
+        assert uploaded["name"] == "BTCUSDT_1h_2024-01-01_2024-12-01.csv"
+
+    def test_raises_error_when_corpus_load_fails(self, cloud_config: CloudTrainingConfig) -> None:
+        """Corpus failures propagate loudly - there is no silent fallback source."""
         mock_provider = MagicMock()
         mock_provider.provider_name = "local"
 
         orchestrator = CloudTrainingOrchestrator(cloud_config, mock_provider)
 
-        with patch("cli.commands.data._download", return_value=1):
-            with pytest.raises(RuntimeError, match="Failed to download training data"):
+        with patch(
+            "src.ml.training_pipeline.ingestion.load_training_corpus",
+            side_effect=RuntimeError("Training corpus for BTCUSDT 1h could not be loaded"),
+        ):
+            with pytest.raises(RuntimeError, match="could not be loaded"):
                 orchestrator._prepare_training_data()
-
-    def test_raises_error_when_no_data_files_found(self, cloud_config: CloudTrainingConfig) -> None:
-        """Verify RuntimeError raised when no CSV files found after download."""
-        mock_provider = MagicMock()
-        mock_provider.provider_name = "local"
-
-        orchestrator = CloudTrainingOrchestrator(cloud_config, mock_provider)
-
-        with patch("cli.commands.data._download", return_value=0):
-            with patch("pathlib.Path.glob", return_value=[]):
-                with pytest.raises(RuntimeError, match="No data files found"):
-                    orchestrator._prepare_training_data()
 
 
 class TestFindArtifactsRoot:

--- a/tests/unit/cloud/test_train_cloud_cli.py
+++ b/tests/unit/cloud/test_train_cloud_cli.py
@@ -9,6 +9,7 @@ import pytest
 
 from cli.commands.train_cloud import (
     DEFAULT_TRAINING_DAYS,
+    _handle_cloud,
     _handle_cloud_list,
     _handle_cloud_promote,
     _handle_cloud_status,
@@ -113,6 +114,62 @@ class TestParseJobName:
 def _ns(args: list[str]) -> argparse.Namespace:
     """Build the REMAINDER-style namespace the handlers receive."""
     return argparse.Namespace(args=args)
+
+
+@pytest.mark.fast
+class TestHandleCloudArchitectureSelection:
+    """Tests for --model-type/--model-variant threading on `atb train cloud`."""
+
+    def _submit(self, cli_args: list[str]) -> MagicMock:
+        """Run _handle_cloud with mocked provider/orchestrator; return orchestrator cls mock."""
+        provider = MagicMock()
+        provider.is_available.return_value = True
+        provider.provider_name = "sagemaker"
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.submit_job.return_value = "job-1"
+
+        with (
+            patch.dict("os.environ", {"SAGEMAKER_S3_BUCKET": "test-bucket"}),
+            patch("src.ml.cloud.providers.get_provider", return_value=provider),
+            patch(
+                "src.ml.cloud.orchestrator.CloudTrainingOrchestrator",
+                return_value=mock_orchestrator,
+            ) as mock_cls,
+        ):
+            rc = _handle_cloud(_ns(cli_args))
+
+        assert rc == 0
+        return mock_cls
+
+    def test_model_type_and_variant_reach_training_config(self) -> None:
+        mock_cls = self._submit(
+            ["BTCUSDT", "--no-wait", "--model-type", "tcn", "--model-variant", "deep"]
+        )
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.model_type == "tcn"
+        assert training_config.model_variant == "deep"
+
+    def test_defaults_preserve_current_behavior(self) -> None:
+        mock_cls = self._submit(["BTCUSDT", "--no-wait"])
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.model_type == "cnn_lstm"
+        assert training_config.model_variant == "default"
+
+    def test_tft_is_accepted(self) -> None:
+        mock_cls = self._submit(["BTCUSDT", "--no-wait", "--model-type", "tft"])
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.model_type == "tft"
+
+    def test_unknown_model_type_rejected_by_argparse(self) -> None:
+        with pytest.raises(SystemExit):
+            _handle_cloud(_ns(["BTCUSDT", "--no-wait", "--model-type", "transformer"]))
+
+    def test_unknown_model_variant_rejected_by_argparse(self) -> None:
+        with pytest.raises(SystemExit):
+            _handle_cloud(_ns(["BTCUSDT", "--no-wait", "--model-variant", "huge"]))
 
 
 @pytest.mark.fast

--- a/tests/unit/training_pipeline/test_ml_training_config.py
+++ b/tests/unit/training_pipeline/test_ml_training_config.py
@@ -139,6 +139,41 @@ class TestTrainingConfig:
         assert config.mixed_precision is False
         assert config.diagnostics.generate_plots is False
 
+    def test_accepts_tft_model_type(self):
+        # Arrange & Act
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+            model_type="tft",
+        )
+
+        # Assert
+        assert config.model_type == "tft"
+
+    def test_rejects_unknown_model_type(self):
+        # Act & Assert
+        with pytest.raises(ValueError, match="model_type"):
+            TrainingConfig(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 12, 31),
+                model_type="transformer",
+            )
+
+    def test_rejects_unknown_model_variant(self):
+        # Act & Assert
+        with pytest.raises(ValueError, match="model_variant"):
+            TrainingConfig(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 12, 31),
+                model_variant="huge",
+            )
+
     def test_days_requested(self):
         # Arrange
         start = datetime(2024, 1, 1)
@@ -260,23 +295,3 @@ class TestTrainingContext:
 
         # Assert
         assert end_iso == "2024-12-31T23:59:59Z"
-
-    @patch("src.trading.symbols.factory.SymbolFactory.to_exchange_symbol")
-    def test_price_data_glob_property(self, mock_factory):
-        # Arrange
-        mock_factory.return_value = "BTCUSDT"
-        start = datetime(2024, 1, 1)
-        end = datetime(2024, 1, 31)
-        config = TrainingConfig(
-            symbol="BTCUSDT",
-            timeframe="1h",
-            start_date=start,
-            end_date=end,
-        )
-        ctx = TrainingContext(config=config)
-
-        # Act
-        glob_pattern = ctx.price_data_glob
-
-        # Assert
-        assert glob_pattern == "BTCUSDT_1h_2024-01-01T00:00:00Z_2024-01-31T23:59:59Z.*"

--- a/tests/unit/training_pipeline/test_ml_training_ingestion.py
+++ b/tests/unit/training_pipeline/test_ml_training_ingestion.py
@@ -1,6 +1,6 @@
 """Unit tests for ML training pipeline data ingestion module."""
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -8,220 +8,326 @@ import pytest
 
 from src.ml.training_pipeline.config import TrainingConfig, TrainingContext, TrainingPaths
 from src.ml.training_pipeline.ingestion import (
-    _resolve_latest_file,
+    _load_price_data_file,
     download_price_data,
     load_sentiment_data,
+    load_training_corpus,
 )
 
 
+def _make_ctx(tmp_path, start=None, end=None, timeframe="1h", symbol="BTCUSDT"):
+    """Build a TrainingContext rooted in tmp_path."""
+    config = TrainingConfig(
+        symbol=symbol,
+        timeframe=timeframe,
+        start_date=start or datetime(2024, 1, 1),
+        end_date=end or datetime(2024, 1, 31),
+    )
+    paths = TrainingPaths(
+        project_root=tmp_path,
+        data_dir=tmp_path / "data",
+        models_dir=tmp_path / "models",
+    )
+    return TrainingContext(config=config, paths=paths)
+
+
+def _hourly_frame(start: str, end: str) -> pd.DataFrame:
+    """Build an OHLCV frame with one row per hour over [start, end] (UTC)."""
+    index = pd.date_range(start, end, freq="1h", tz="UTC")
+    return pd.DataFrame(
+        {
+            "open": 100.0,
+            "high": 105.0,
+            "low": 99.0,
+            "close": 103.0,
+            "volume": 1000.0,
+        },
+        index=index,
+    )
+
+
+def _patch_cache_provider(df_or_exc):
+    """Patch the corpus loader's provider stack; returns the CachedDataProvider mock."""
+    provider = MagicMock()
+    if isinstance(df_or_exc, Exception):
+        provider.get_historical_data.side_effect = df_or_exc
+    else:
+        provider.get_historical_data.return_value = df_or_exc
+    return provider
+
+
 @pytest.mark.fast
-class TestResolveLatestFile:
-    """Test _resolve_latest_file helper function."""
+class TestLoadTrainingCorpus:
+    """Tests for load_training_corpus (cache tier + single-source contract)."""
 
-    def test_resolve_latest_file_single_match(self, tmp_path):
+    def _run(self, ctx, df_or_exc):
+        provider = _patch_cache_provider(df_or_exc)
+        with (
+            patch(
+                "src.data_providers.cached_data_provider.CachedDataProvider",
+                return_value=provider,
+            ) as provider_cls,
+            patch("src.data_providers.binance_provider.BinanceProvider") as binance_cls,
+        ):
+            result = load_training_corpus(ctx)
+        return result, provider, provider_cls, binance_cls
+
+    def test_full_coverage_returns_corpus(self, tmp_path):
         # Arrange
-        file1 = tmp_path / "data_2024-01-01.csv"
-        file1.touch()
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00")
 
         # Act
-        result = _resolve_latest_file("data_*.csv", tmp_path)
+        result, provider, _, _ = self._run(ctx, df)
 
         # Assert
-        assert result == file1
+        assert len(result) == len(df)
+        assert result.index.min() == pd.Timestamp("2024-01-01 00:00", tz="UTC")
+        assert result.index.max() == pd.Timestamp("2024-01-31 23:00", tz="UTC")
+        provider.get_historical_data.assert_called_once()
 
-    def test_resolve_latest_file_multiple_matches_returns_newest(self, tmp_path):
+    def test_wraps_binance_without_third_party_fallback(self, tmp_path):
         # Arrange
-        file1 = tmp_path / "data_2024-01-01.csv"
-        file2 = tmp_path / "data_2024-01-02.csv"
-        file1.touch()
-        file2.touch()
-
-        # Ensure file2 has newer modification time
-        import time
-
-        time.sleep(0.01)
-        file2.touch()
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00")
 
         # Act
-        result = _resolve_latest_file("data_*.csv", tmp_path)
+        _, _, provider_cls, binance_cls = self._run(ctx, df)
+
+        # Assert - cache wraps BinanceProvider directly (no FallbackProvider)
+        binance_cls.assert_called_once_with()
+        assert provider_cls.call_args.args[0] is binance_cls.return_value
+
+    def test_queries_full_end_day(self, tmp_path):
+        # Arrange
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00")
+
+        # Act
+        _, provider, _, _ = self._run(ctx, df)
+
+        # Assert - end boundary is end-of-day, not midnight (matches ctx.end_iso)
+        call = provider.get_historical_data.call_args
+        assert call.args[2] == datetime(2024, 1, 1, tzinfo=UTC)
+        assert call.args[3] == datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC)
+
+    def test_intraday_listing_offset_on_start_day_accepted(self, tmp_path):
+        # Arrange - ETHUSDT-style listing: first candle opens 04:00, not midnight
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 04:00", "2024-01-31 23:00")
+
+        # Act
+        result, _, _, _ = self._run(ctx, df)
 
         # Assert
-        assert result == file2
+        assert result.index.min() == pd.Timestamp("2024-01-01 04:00", tz="UTC")
 
-    def test_resolve_latest_file_no_matches_raises_error(self, tmp_path):
-        # Arrange - no files created
+    def test_start_a_calendar_day_late_rejected(self, tmp_path):
+        # Arrange
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-02 00:00", "2024-01-31 23:00")
 
         # Act & Assert
-        with pytest.raises(FileNotFoundError, match="No files matched pattern"):
-            _resolve_latest_file("data_*.csv", tmp_path)
+        with pytest.raises(RuntimeError, match="does not cover"):
+            self._run(ctx, df)
+
+    def test_end_one_bar_short_accepted(self, tmp_path):
+        # Arrange - candle index is open time: last bar of the day opens at 23:00
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00")
+
+        # Act
+        result, _, _, _ = self._run(ctx, df)
+
+        # Assert
+        assert result.index.max() == pd.Timestamp("2024-01-31 23:00", tz="UTC")
+
+    def test_end_more_than_one_bar_short_rejected(self, tmp_path):
+        # Arrange
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 21:00")
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="does not cover"):
+            self._run(ctx, df)
+
+    def test_gap_in_middle_rejected(self, tmp_path):
+        # Arrange - drop a full day of bars inside the range (real cache gap)
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00")
+        gap_mask = (df.index < "2024-01-10") | (df.index >= "2024-01-12")
+        df = df[gap_mask]
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="expected bars"):
+            self._run(ctx, df)
+
+    def test_empty_result_fails_loudly_with_guidance(self, tmp_path):
+        # Arrange
+        ctx = _make_ctx(tmp_path)
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="prefill-cache"):
+            self._run(ctx, pd.DataFrame())
+
+    def test_provider_error_fails_loudly_instead_of_fallback(self, tmp_path):
+        # Arrange
+        ctx = _make_ctx(tmp_path)
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="prefill-cache"):
+            self._run(ctx, ConnectionError("Binance unreachable"))
+
+    def test_window_extending_to_now_clamps_end_boundary(self, tmp_path):
+        # Arrange - end date is today: only bars up to the last closed candle exist
+        now = datetime.now(UTC)
+        start = (now - timedelta(days=3)).replace(hour=0, minute=0, second=0, microsecond=0)
+        ctx = _make_ctx(tmp_path, start=start, end=now)
+        last_closed = pd.Timestamp(now).floor("1h")
+        df = _hourly_frame(
+            start.strftime("%Y-%m-%d %H:%M"),
+            last_closed.tz_localize(None).strftime("%Y-%m-%d %H:%M"),
+        )
+
+        # Act
+        result, _, _, _ = self._run(ctx, df)
+
+        # Assert
+        assert result.index.max() == last_closed
+
+    def test_naive_index_from_provider_normalized_to_utc(self, tmp_path):
+        # Arrange
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00").tz_localize(None)
+
+        # Act
+        result, _, _, _ = self._run(ctx, df)
+
+        # Assert
+        assert result.index.tz is not None
+        assert len(result) == len(df)
 
 
 @pytest.mark.fast
 class TestDownloadPriceData:
-    """Test download_price_data function."""
+    """Tests for download_price_data tier ordering."""
 
-    @patch("src.ml.training_pipeline.ingestion.data_commands._download")
-    @patch("src.ml.training_pipeline.ingestion._resolve_latest_file")
-    def test_download_price_data_csv_format(self, mock_resolve, mock_download, tmp_path):
+    @patch("src.ml.training_pipeline.ingestion.load_training_corpus")
+    def test_uses_training_corpus_tier(self, mock_corpus, tmp_path):
         # Arrange
-        start = datetime(2024, 1, 1)
-        end = datetime(2024, 1, 31)
-        config = TrainingConfig(
-            symbol="BTCUSDT",
-            timeframe="1h",
-            start_date=start,
-            end_date=end,
-        )
-        paths = TrainingPaths(
-            project_root=tmp_path,
-            data_dir=tmp_path / "data",
-            models_dir=tmp_path / "models",
-        )
-        ctx = TrainingContext(config=config, paths=paths)
-
-        csv_file = tmp_path / "data" / "test.csv"
-        csv_file.parent.mkdir(parents=True, exist_ok=True)
-        df = pd.DataFrame(
-            {
-                "timestamp": pd.date_range("2024-01-01", periods=3, freq="1h"),
-                "open": [100.0, 101.0, 102.0],
-                "high": [105.0, 106.0, 107.0],
-                "low": [99.0, 100.0, 101.0],
-                "close": [103.0, 104.0, 105.0],
-                "volume": [1000.0, 1100.0, 1200.0],
-            }
-        )
-        df.to_csv(csv_file, index=False)
-
-        mock_download.return_value = 0
-        mock_resolve.return_value = csv_file
+        ctx = _make_ctx(tmp_path)
+        df = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00")
+        mock_corpus.return_value = df
 
         # Act
         result = download_price_data(ctx)
 
         # Assert
-        assert isinstance(result, pd.DataFrame)
-        assert len(result) == 3
-        assert "open" in result.columns
-        assert result.index.name == "timestamp"
-        assert isinstance(result.index[0], pd.Timestamp)
-        mock_download.assert_called_once()
+        assert result is df
+        mock_corpus.assert_called_once_with(ctx)
 
-    @patch("src.ml.training_pipeline.ingestion.data_commands._download")
-    @patch("src.ml.training_pipeline.ingestion._resolve_latest_file")
-    def test_download_price_data_feather_format(self, mock_resolve, mock_download, tmp_path):
+    @patch("src.ml.training_pipeline.ingestion.load_training_corpus")
+    @patch("src.ml.training_pipeline.ingestion._load_price_data_file")
+    @patch("src.ml.training_pipeline.ingestion._download_from_s3")
+    def test_s3_uri_takes_priority_over_corpus_tier(
+        self, mock_s3, mock_load, mock_corpus, tmp_path
+    ):
         # Arrange
-        start = datetime(2024, 1, 1)
-        end = datetime(2024, 1, 31)
-        config = TrainingConfig(
-            symbol="BTCUSDT",
-            timeframe="1h",
-            start_date=start,
-            end_date=end,
-        )
-        paths = TrainingPaths(
-            project_root=tmp_path,
-            data_dir=tmp_path / "data",
-            models_dir=tmp_path / "models",
-        )
-        ctx = TrainingContext(config=config, paths=paths)
+        ctx = _make_ctx(tmp_path)
+        mock_s3.return_value = tmp_path / "data.csv"
+        expected = _hourly_frame("2024-01-01 00:00", "2024-01-31 23:00")
+        mock_load.return_value = expected
 
-        feather_file = tmp_path / "data" / "test.feather"
-        feather_file.parent.mkdir(parents=True, exist_ok=True)
+        # Act
+        result = download_price_data(ctx, s3_data_uri="s3://bucket/data.csv")
+
+        # Assert
+        assert result is expected
+        mock_corpus.assert_not_called()
+
+    @patch("src.ml.training_pipeline.ingestion.load_training_corpus")
+    def test_corpus_failure_propagates(self, mock_corpus, tmp_path):
+        # Arrange
+        ctx = _make_ctx(tmp_path)
+        mock_corpus.side_effect = RuntimeError("Training corpus for BTCUSDT could not be loaded")
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="could not be loaded"):
+            download_price_data(ctx)
+
+
+@pytest.mark.fast
+class TestLoadPriceDataFile:
+    """Tests for _load_price_data_file parsing behavior."""
+
+    def test_parses_mixed_timestamp_formats(self, tmp_path):
+        # Arrange - Binance's earliest kline archives mix on-the-hour and
+        # sub-second-offset timestamps within one file (e.g. ETHUSDT 2018-02)
+        csv_file = tmp_path / "mixed.csv"
+        csv_file.write_text(
+            "timestamp,open,high,low,close,volume\n"
+            "2018-02-04 00:00:00,100,101,99,100,1000\n"
+            "2018-02-04 01:28:14.8,100,101,99,100,1000\n"
+            "2018-02-04 02:00:00,100,101,99,100,1000\n"
+        )
+
+        # Act
+        result = _load_price_data_file(csv_file)
+
+        # Assert
+        assert len(result) == 3
+        assert result.index[1] == pd.Timestamp("2018-02-04 01:28:14.8", tz="UTC")
+
+    def test_naive_timestamps_become_utc(self, tmp_path):
+        # Arrange
+        csv_file = tmp_path / "naive.csv"
+        csv_file.write_text(
+            "timestamp,open,high,low,close,volume\n2024-01-01 00:00:00,100,101,99,100,1000\n"
+        )
+
+        # Act
+        result = _load_price_data_file(csv_file)
+
+        # Assert
+        assert result.index.tz is not None
+        assert result.index[0] == pd.Timestamp("2024-01-01 00:00:00", tz="UTC")
+
+    def test_sorts_by_index(self, tmp_path):
+        # Arrange
+        csv_file = tmp_path / "unsorted.csv"
+        csv_file.write_text(
+            "timestamp,open,close\n"
+            "2024-01-01 02:00:00,102,105\n"
+            "2024-01-01 00:00:00,100,103\n"
+            "2024-01-01 01:00:00,101,104\n"
+        )
+
+        # Act
+        result = _load_price_data_file(csv_file)
+
+        # Assert
+        assert result.index[0] == pd.Timestamp("2024-01-01 00:00:00", tz="UTC")
+        assert result.index[1] == pd.Timestamp("2024-01-01 01:00:00", tz="UTC")
+        assert result.index[2] == pd.Timestamp("2024-01-01 02:00:00", tz="UTC")
+
+    def test_loads_feather_file(self, tmp_path):
+        # Arrange
+        feather_file = tmp_path / "data.feather"
         df = pd.DataFrame(
             {
                 "timestamp": pd.date_range("2024-01-01", periods=3, freq="1h"),
                 "open": [100.0, 101.0, 102.0],
-                "high": [105.0, 106.0, 107.0],
-                "low": [99.0, 100.0, 101.0],
                 "close": [103.0, 104.0, 105.0],
-                "volume": [1000.0, 1100.0, 1200.0],
             }
         )
         df.to_feather(feather_file)
 
-        mock_download.return_value = 0
-        mock_resolve.return_value = feather_file
-
         # Act
-        result = download_price_data(ctx)
+        result = _load_price_data_file(feather_file)
 
         # Assert
-        assert isinstance(result, pd.DataFrame)
         assert len(result) == 3
-        assert "open" in result.columns
         assert result.index.name == "timestamp"
-        mock_download.assert_called_once()
-
-    @patch("src.ml.training_pipeline.ingestion.data_commands._download")
-    def test_download_price_data_download_failure(self, mock_download, tmp_path):
-        # Arrange
-        start = datetime(2024, 1, 1)
-        end = datetime(2024, 1, 31)
-        config = TrainingConfig(
-            symbol="BTCUSDT",
-            timeframe="1h",
-            start_date=start,
-            end_date=end,
-        )
-        paths = TrainingPaths(
-            project_root=tmp_path,
-            data_dir=tmp_path / "data",
-            models_dir=tmp_path / "models",
-        )
-        ctx = TrainingContext(config=config, paths=paths)
-
-        mock_download.return_value = 1  # Failure status
-
-        # Act & Assert
-        with pytest.raises(RuntimeError, match="Price data download failed"):
-            download_price_data(ctx)
-
-    @patch("src.ml.training_pipeline.ingestion.data_commands._download")
-    @patch("src.ml.training_pipeline.ingestion._resolve_latest_file")
-    def test_download_price_data_sorts_by_index(self, mock_resolve, mock_download, tmp_path):
-        # Arrange
-        start = datetime(2024, 1, 1)
-        end = datetime(2024, 1, 31)
-        config = TrainingConfig(
-            symbol="BTCUSDT",
-            timeframe="1h",
-            start_date=start,
-            end_date=end,
-        )
-        paths = TrainingPaths(
-            project_root=tmp_path,
-            data_dir=tmp_path / "data",
-            models_dir=tmp_path / "models",
-        )
-        ctx = TrainingContext(config=config, paths=paths)
-
-        csv_file = tmp_path / "data" / "test.csv"
-        csv_file.parent.mkdir(parents=True, exist_ok=True)
-        # Create unsorted data
-        df = pd.DataFrame(
-            {
-                "timestamp": [
-                    pd.Timestamp("2024-01-01 02:00:00"),
-                    pd.Timestamp("2024-01-01 00:00:00"),
-                    pd.Timestamp("2024-01-01 01:00:00"),
-                ],
-                "open": [102.0, 100.0, 101.0],
-                "close": [105.0, 103.0, 104.0],
-            }
-        )
-        df.to_csv(csv_file, index=False)
-
-        mock_download.return_value = 0
-        mock_resolve.return_value = csv_file
-
-        # Act
-        result = download_price_data(ctx)
-
-        # Assert
-        assert result.index[0] == pd.Timestamp("2024-01-01 00:00:00")
-        assert result.index[1] == pd.Timestamp("2024-01-01 01:00:00")
-        assert result.index[2] == pd.Timestamp("2024-01-01 02:00:00")
 
 
 @pytest.mark.fast

--- a/tests/unit/training_pipeline/test_ml_training_models.py
+++ b/tests/unit/training_pipeline/test_ml_training_models.py
@@ -367,3 +367,41 @@ class TestDefaultCallbacks:
         reduce_lr = next(cb for cb in result if isinstance(cb, callbacks.ReduceLROnPlateau))
         # patience // 3 = 1, but minimum is 3
         assert reduce_lr.patience == 3
+
+
+# Every architecture selectable from the train CLIs, crossed with every variant.
+# Mirrors the choices exposed by `atb train cloud --model-type/--model-variant`.
+TRAINER_MODEL_MATRIX = [
+    (model_type, variant)
+    for model_type in ["lstm", "cnn_lstm", "attention_lstm", "tcn", "tcn_attention", "tft"]
+    for variant in ["default", "lightweight", "deep"]
+]
+
+
+@pytest.mark.fast
+@pytest.mark.skipif(not _TENSORFLOW_AVAILABLE, reason="TensorFlow not installed")
+class TestCreateModelTrainerContract:
+    """Regression guard for #928: every CLI-selectable (model_type, variant) pair
+    must construct with the exact kwargs run_training_pipeline passes.
+
+    The trainer always forwards has_sentiment; factories that don't accept it
+    must never see it (create_model pops it before dispatch).
+    """
+
+    @pytest.mark.parametrize(("model_type", "variant"), TRAINER_MODEL_MATRIX)
+    def test_constructs_with_trainer_kwargs(self, model_type, variant):
+        # Arrange - mirror run_training_pipeline's call exactly (price-only shape)
+        input_shape = (120, 5)
+
+        # Act
+        model = create_model(
+            model_type=model_type,
+            input_shape=input_shape,
+            variant=variant,
+            has_sentiment=False,
+        )
+
+        # Assert
+        assert isinstance(model, tf.keras.Model)
+        assert model.input_shape == (None, 120, 5)
+        assert model.output_shape == (None, 1)

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -322,6 +322,181 @@ class TestRunTrainingPipeline:
         assert "symbol" in result.metadata
         assert result.metadata["symbol"] == "BTCUSDT"
 
+    def _make_price_df(self, periods=200):
+        """Build a deterministic OHLCV frame with varying prices."""
+        rng = np.random.default_rng(42)
+        closes = 100.0 + np.cumsum(rng.normal(0, 1, periods))
+        return pd.DataFrame(
+            {
+                "open": closes - 0.5,
+                "high": closes + 1.0,
+                "low": closes - 1.0,
+                "close": closes,
+                "volume": 1000.0 + rng.uniform(0, 100, periods),
+            },
+            index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+        )
+
+    def _run_pipeline_with_mocks(self, ctx, price_df, mocks):
+        """Run the pipeline with the standard post-feature stages mocked out."""
+        sequences = np.random.rand(50, ctx.config.sequence_length, 5).astype(np.float32)
+        targets = np.random.rand(50).astype(np.float32)
+        mocks["create_sequences"].return_value = (sequences, targets)
+        mocks["split_sequences"].return_value = (
+            sequences[:40],
+            targets[:40],
+            sequences[40:],
+            targets[40:],
+        )
+        mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
+        model = MagicMock()
+        model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
+        mocks["create_model"].return_value = model
+        mocks["validate_model_robustness"].return_value = {}
+        mocks["evaluate_model_performance"].return_value = {"test_rmse": 0.1}
+        artifact_paths = MagicMock()
+        artifact_paths.directory = ctx.paths.models_dir
+        mocks["save_artifacts"].return_value = artifact_paths
+        mocks["create_training_plots"].return_value = None
+        return run_training_pipeline(ctx)
+
+    def _pipeline_mocks(self):
+        """Context-manage patches for the post-feature pipeline stages."""
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        names = [
+            "configure_gpu",
+            "download_price_data",
+            "load_sentiment_data",
+            "create_robust_features",
+            "create_sequences",
+            "split_sequences",
+            "build_tf_datasets",
+            "create_model",
+            "validate_model_robustness",
+            "evaluate_model_performance",
+            "save_artifacts",
+            "create_training_plots",
+            "enable_mixed_precision",
+        ]
+        mocks = {
+            name: stack.enter_context(patch(f"src.ml.training_pipeline.pipeline.{name}"))
+            for name in names
+        }
+        mocks["configure_gpu"].return_value = None
+        return stack, mocks
+
+    def test_force_price_only_routes_through_price_only_extractor(self, tmp_path):
+        """force_price_only must produce the production 5-feature price-only contract.
+
+        Pins the contract: PriceOnlyFeatureExtractor features (not
+        create_robust_features' 9-feature pipeline), target = close_normalized
+        (not raw close). The bundle stays in the price/ namespace so basic/latest
+        (loaded by live strategies) is never repointed implicitly.
+        """
+        from src.prediction.features.price_only import PriceOnlyFeatureExtractor
+
+        # Arrange
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+            force_price_only=True,
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+        price_df = self._make_price_df()
+
+        stack, mocks = self._pipeline_mocks()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+
+            # Act
+            result = self._run_pipeline_with_mocks(ctx, price_df, mocks)
+
+        # Assert
+        assert result.success is True, result.metadata
+        mocks["create_robust_features"].assert_not_called()
+
+        expected = PriceOnlyFeatureExtractor(normalization_window=10).extract(price_df.copy())
+        expected_names = [
+            "close_normalized",
+            "volume_normalized",
+            "high_normalized",
+            "low_normalized",
+            "open_normalized",
+        ]
+        feature_array, target_array, seq_len = mocks["create_sequences"].call_args.args
+        assert feature_array.shape[1] == 5
+        assert seq_len == 10
+        np.testing.assert_allclose(
+            target_array,
+            expected["close_normalized"].to_numpy(dtype=np.float32),
+            rtol=1e-6,
+        )
+
+        assert result.metadata["model_type"] == "price"
+        assert result.metadata["feature_names"] == expected_names
+        assert mocks["create_model"].call_args.kwargs["input_shape"] == (10, 5)
+        # Bundle must be saved under price/, never basic/ (which would flip the
+        # live-loaded basic/latest symlink as a training side effect)
+        assert mocks["save_artifacts"].call_args.args[2] == "price"
+
+    def test_default_path_regresses_raw_close(self, tmp_path):
+        """Without force_price_only the existing contract is unchanged.
+
+        create_robust_features supplies the features and the raw close is the
+        regression target; registry model_type stays price/sentiment.
+        """
+        # Arrange
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+        price_df = self._make_price_df()
+
+        feature_df = price_df.copy()
+        feature_df["close_scaled"] = 0.5
+
+        stack, mocks = self._pipeline_mocks()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+
+            # Act
+            result = self._run_pipeline_with_mocks(ctx, price_df, mocks)
+
+        # Assert
+        assert result.success is True, result.metadata
+        mocks["create_robust_features"].assert_called_once()
+        _, target_array, _ = mocks["create_sequences"].call_args.args
+        np.testing.assert_allclose(target_array, feature_df["close"].to_numpy(dtype=np.float32))
+        assert result.metadata["model_type"] == "price"
+
     @patch("src.ml.training_pipeline.pipeline.download_price_data")
     def test_handles_download_failure(self, mock_download, tmp_path):
         # Arrange


### PR DESCRIPTION
# Cloud-first model tournaments: upstream tournament pipeline fixes + architecture selection on `atb train cloud`

Closes #918. Closes #928. Refs #909.

> **⚠️ Deploy note — image rebuild required**: the ECR training image bakes in `src/ml/training_pipeline/`. After this merge, rebuild and push (`./src/ml/cloud/build-and-push.sh`) **before any cloud training run uses these fixes**. This is intentionally not done in this PR (a tournament is consuming local compute and the push saturates uplink). The weekly training routine's image-freshness precondition will refuse to run against a stale image, which enforces the rebuild.

## What this does

Board decision (2026-07-06): tournaments run **cloud-first** from now on — parallel SageMaker jobs instead of sequential local training. This PR upstreams the tournament's worktree-local pipeline fixes (production-adapted) and adds architecture selection to the cloud CLI so the next tournament can run entirely in the cloud.

### 1. Ingestion cache tier + single-source training corpora (`src/ml/training_pipeline/ingestion.py`)

- New `load_training_corpus()`: consults the year-based parquet cache (`atb data prefill-cache`) **before any network fetch**; missing years are fetched from Binance only and cached, so repeated/multi-entrant runs see identical rows.
- Coverage validation per the tournament's design: open-time boundary slack (a candle's index is its open time), calendar-day start check (intraday listing times like ETHUSDT's 04:00 first candle are market history, not gaps), and a ≥0.99 expected-bar ratio computed from the corpus's own span.
- **No silent third-party fallback for training corpora**: the old tier delegated to `cli.commands.data._download` (FallbackProvider, Binance → CoinGecko). Per the #909 discussion, the fallback serves genuine Binance archive data, but silent source-switching mid-corpus is still unacceptable for training — it now fails loudly with remediation guidance (prefill the cache / `--input-data-s3` / adjust the window).
- `CloudTrainingOrchestrator._prepare_training_data` now routes through the same corpus loader, so the S3 data channel a cloud job trains on carries exactly the rows a local run would see (and repeated tournament submissions stop re-downloading years of candles).

### 2. `--force-price-only` behavior change (`src/ml/training_pipeline/pipeline.py`) — pinned by tests + changelog

- Routes through `PriceOnlyFeatureExtractor` (5 causally-normalized OHLCV features) instead of only skipping the sentiment download while still building the 9-feature globally-scaled pipeline.
- Target is `close_normalized`, not the raw dollar close (raw close regressed dollar magnitudes with no denormalization step — RMSE/MAPE incomparable with price-only baselines).
- `atb train price`'s separate path is **byte-identical**: `git diff origin/develop -- cli/commands/train_commands.py cli/commands/train.py` is empty.

### 3. Datetime parse hardening

`_load_price_data_file` uses `pd.to_datetime(..., format="mixed", utc=True)` — Binance's earliest kline archives mix on-the-hour and sub-second timestamps in one file (ETHUSDT 2018-02, crash at row 4189 with the old fixed-format inference).

### 4. Architecture selection on the cloud CLI

`atb train cloud SYMBOL --model-type {lstm,cnn_lstm,attention_lstm,tcn,tcn_attention,tft} --model-variant {default,lightweight,deep}` threaded end-to-end: CLI → `TrainingConfig` → SageMaker job hyperparameters (`TrainingJobSpec.hyperparameters`) → container entrypoint (`parse_hyperparameters` → `TrainingConfig`). Defaults (`cnn_lstm`/`default`) preserve current behavior, including for jobs submitted by older CLIs. `TrainingConfig._VALID_MODEL_TYPES` now accepts `tft`.

**Model-factory kwargs fix (#928, found in review)**: `create_model` now pops `has_sentiment` out of `**kwargs` before the architecture dispatch. The trainer always forwards `has_sentiment`, but only the CNN-LSTM baseline accepts it — `tft` (newly enabled here) and the pre-existing `attention_lstm`/`tcn` default variants and `tcn_attention` crashed with `TypeError` at model construction (i.e. in-container, after the spot instance and data upload were paid for). CNN-LSTM still receives the real flag; no other factory ever sees it. Regression guard added: a parametrized smoke test constructs **every** CLI-selectable `(model_type, variant)` pair — all 18, including `tft` — with the trainer's exact kwargs (`input_shape=(120, 5)`, `variant`, `has_sentiment=False`); it reproduced all five TypeErrors before the fix and passes after. (An earlier revision of this description claimed `tft` was "already supported by `create_model`" — that was wrong; the review caught it.)

### 5. Docs

`docs/prediction.md`: cloud-first tournament note (parallel SageMaker jobs, ~$0.10–0.50 per 5-entrant sweep, local only for protocol-experimental runs needing unpushed patches), single-source data sourcing section, architecture-selection examples. Changelog updated with the behavior-change pin and the image-rebuild deploy note.

## Lifted vs adapted (vs the arch-tournament worktree patch)

| Tournament patch | Upstreamed as |
|---|---|
| Cache tier fell **back** to the FallbackProvider download on miss | **Fails loudly** — no third-party fallback for training corpora (per #918/#909) |
| Hardcoded `{"1h","4h","1d"}` offset map, silent `1h` default | General timeframe parser; unknown timeframe raises |
| No handling for windows extending to now | End boundary clamped to the last closed candle |
| `cache_dir` hand-built from `project_root` | `src.config.paths.get_cache_dir()` (same dir `prefill-cache` writes) |
| Forced registry namespace `basic/` for force_price_only bundles | **Not lifted**: kept `price/` — writing to `basic/` would implicitly repoint `basic/latest` (the symlink live strategies load) as a training side effect, violating the explicit-promotion rail (`atb train cloud-promote`). A test now pins this. |
| `_generate_version_id` hunk (stale-base artifact of the worktree predating #891) | **Not lifted** — would have reverted #891's collision fix |
| Feature routing, `close_normalized` target, datetime hardening, coverage-validation design | Lifted as-is (comments trimmed) |

## Testing

- TDD: new/updated unit tests for the corpus loader (coverage boundaries, gap ratio, clamping, fail-loud messages, no-fallback wiring), mixed-format timestamp parsing, force-price-only contract (extractor routing, `close_normalized` target, `price/` namespace pin), default-path regression pin (raw close, `create_robust_features`), `TrainingConfig` tft acceptance, job-spec hyperparameters, entrypoint parsing/threading, CLI flag threading + argparse rejection.
- `atb dev quality --changed --branch origin/develop`: black ✅ ruff ✅ mypy ✅; bandit run directly on changed source files ✅.
- Full local `atb test unit`: **3821 passed, 7 failed** — all 7 failures are in files this PR does not touch (`test_engine_prediction`, `test_indicators` perf, `test_live` deploy, `test_models_tft` forward pass, two backtesting timeframe edge cases, inference benchmark) and are load artifacts: the box was at **load average 131** with the architecture tournament training concurrently, so 5 failures are hard `Timeout >300s` and 2 are wall-clock assertions (`<3.0s` taking 31s). Re-run in isolation, the non-TF-heavy ones pass; the TF-heavy ones remain starved. None import the modules changed here; develop CI is green on the same tests. PR CI on clean runners is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
