### PR TITLE
feat(live-ops): real manual kill-switch — atb live-control halt/resume (#922)

### DIFF
--- a/.claude/LESSONS.md
+++ b/.claude/LESSONS.md
@@ -210,6 +210,11 @@ keep the skill generic and let the specifics live here.
 - `code=-1111` (price precision) / `code=51077` (qty precision) — order precision rejection (should
   be fixed; recurrence = regression, see §1.1).
 - `-2010` / "insufficient balance" on a stop-loss → unprotected position.
+- `MANUAL SYSTEM HALT ENFORCED` / `error_code=SYSTEM_HALT` (#922) — the manual kill-switch
+  (`atb live-control halt`) is in force: entries + scale-ins blocked, exits/stops continue.
+  Expected if an operator just pulled it (a `SYSTEM_HALT_COMMAND` event precedes it); if nobody
+  did, investigate WHO wrote the `system_control_flags.system_halt` row. `SYSTEM_HALT_CLEARED`
+  = resumed.
 - "No active trading session for balance update" — balance updates silently failing (§1.3, #693).
 - `Margin position check failed` — reconciler erroring every cycle (§1.2, #674).
 - A **new** position opened while an **untracked**/orphaned position may be live → double-exposure.

--- a/cli/commands/live.py
+++ b/cli/commands/live.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
+from cli.commands.live_halt import ENV_DB_URL_VARS, halt_main, resume_main
 from cli.core.forward import forward_to_module_main
 from src.infrastructure.runtime.paths import get_project_root
 
@@ -370,9 +371,11 @@ def _control(ns: argparse.Namespace) -> int:
         print(json.dumps(status, indent=2))
         return 0
 
-    if ns.control_cmd == "emergency-stop":
-        print("🚨 EMERGENCY STOP INITIATED (simulated)")
-        return 0
+    if ns.control_cmd == "halt":
+        return halt_main(ns)
+
+    if ns.control_cmd == "resume":
+        return resume_main(ns)
 
     if ns.control_cmd == "swap-strategy":
         print(
@@ -435,8 +438,27 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     p_status = sub.add_parser("status", help="Show engine status")
     p_status.set_defaults(func=_control)
 
-    p_stop = sub.add_parser("emergency-stop", help="Emergency stop trading")
-    p_stop.set_defaults(func=_control)
+    halt_env_help = (
+        "Target environment; resolves the database via RAILWAY_PRODUCTION_DATABASE_URL / "
+        "RAILWAY_STAGING_DATABASE_URL / DATABASE_URL"
+    )
+    p_halt = sub.add_parser(
+        "halt",
+        help=(
+            "Manual kill-switch: durably block new entries + scale-ins in the target "
+            "environment (exits, stop-losses and reconciliation keep running)"
+        ),
+    )
+    p_halt.add_argument("--env", required=True, choices=tuple(ENV_DB_URL_VARS), help=halt_env_help)
+    p_halt.add_argument("--reason", default=None, help="Why the switch is being pulled (logged)")
+    p_halt.set_defaults(func=_control)
+
+    p_resume = sub.add_parser("resume", help="Clear the manual kill-switch (explicit, logged)")
+    p_resume.add_argument(
+        "--env", required=True, choices=tuple(ENV_DB_URL_VARS), help=halt_env_help
+    )
+    p_resume.add_argument("--reason", default=None, help="Why trading is resuming (logged)")
+    p_resume.set_defaults(func=_control)
 
     p_swap = sub.add_parser("swap-strategy", help="Hot-swap strategy (simulated)")
     p_swap.add_argument("--strategy", required=True)

--- a/cli/commands/live_halt.py
+++ b/cli/commands/live_halt.py
@@ -23,6 +23,7 @@ import argparse
 import getpass
 import os
 from datetime import UTC, datetime
+from urllib.parse import urlsplit
 
 from src.database.manager import DatabaseManager, SystemHaltStatus
 from src.database.models import EventType
@@ -47,6 +48,31 @@ def resume_main(ns: argparse.Namespace) -> int:
     return _apply(ns, halt=False)
 
 
+def _operator_source() -> str:
+    """Best-effort operator attribution — must NEVER block the flag write.
+
+    ``getpass.getuser()`` raises on hardened containers with no passwd entry
+    for the UID (OSError, or KeyError from the pwd lookup on older Pythons).
+    """
+    try:
+        user = getpass.getuser()
+    except (OSError, KeyError):
+        user = os.environ.get("USER", "unknown")
+    return f"cli:{user}"
+
+
+def _masked_target(url: str) -> str:
+    """The DB target as ``host:port/dbname`` with credentials stripped."""
+    try:
+        parts = urlsplit(url)
+        host = parts.hostname or "unknown-host"
+        port = f":{parts.port}" if parts.port else ""
+        dbname = parts.path.lstrip("/") or "unknown-db"
+        return f"{host}{port}/{dbname}"
+    except ValueError:
+        return "unparseable-url"
+
+
 def _apply(ns: argparse.Namespace, *, halt: bool) -> int:
     """Shared halt/resume flow: resolve env -> flip flag -> announce -> print state."""
     action = "HALT" if halt else "RESUME"
@@ -59,6 +85,10 @@ def _apply(ns: argparse.Namespace, *, halt: bool) -> int:
             f"{ns.env} Railway service (`railway variables --set FEATURE_ENTRY_PAUSE=true`)."
         )
         return 1
+
+    # Echo the resolved target BEFORE any mutation: a mis-set RAILWAY_* var
+    # silently pointing at the wrong database must be visible to the operator.
+    _line(f"target: env={ns.env} db={_masked_target(url)} (from ${url_var})")
 
     try:
         db = DatabaseManager(url)
@@ -75,7 +105,7 @@ def _apply(ns: argparse.Namespace, *, halt: bool) -> int:
             f"reason={current.reason or 'none'}, by={current.source or 'unknown'}) — no change"
         )
     else:
-        source = f"cli:{getpass.getuser()}"
+        source = _operator_source()
         status = db.set_system_halt(halt, reason=ns.reason, source=source)
         _line(
             f"system_halt {action} set (env={ns.env}, by={source}, "

--- a/cli/commands/live_halt.py
+++ b/cli/commands/live_halt.py
@@ -1,0 +1,201 @@
+"""Manual kill-switch commands: `atb live-control halt` / `resume` (#922).
+
+Writes the durable ``system_halt`` control flag in the TARGET environment's
+database. The running engine polls the flag at the top of every trading-loop
+iteration, so a halt takes effect within one iteration (typically seconds to a
+few minutes, bounded by the engine's adaptive check interval) — no restart or
+redeploy required. Semantics match FEATURE_ENTRY_PAUSE: new entries and
+scale-ins are blocked; exits, stop-losses and reconciliation continue.
+
+Fallback path (if the database write is impossible): flip
+``FEATURE_ENTRY_PAUSE=true`` on the Railway service — note that a Railway
+variable change triggers a redeploy, so that path has ~3 minutes of latency.
+
+Both commands emit a ``system_events`` row (+ webhook alert when
+``ALERT_WEBHOOK_URL`` is set) and print the resulting account state — open
+positions and their protective stops — via read-only queries, in an
+append-friendly one-line-per-fact format.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import os
+from datetime import UTC, datetime
+
+from src.database.manager import DatabaseManager, SystemHaltStatus
+from src.database.models import EventType
+
+# Target environment -> env var holding its database URL. The RAILWAY_* vars
+# are the same ones the heartbeat monitor uses (scripts/check_heartbeat.py);
+# `development` targets the local DATABASE_URL for drills and tests.
+ENV_DB_URL_VARS = {
+    "production": "RAILWAY_PRODUCTION_DATABASE_URL",
+    "staging": "RAILWAY_STAGING_DATABASE_URL",
+    "development": "DATABASE_URL",
+}
+
+
+def halt_main(ns: argparse.Namespace) -> int:
+    """Durably halt new risk in the target environment (entries + scale-ins)."""
+    return _apply(ns, halt=True)
+
+
+def resume_main(ns: argparse.Namespace) -> int:
+    """Explicitly clear the manual halt in the target environment."""
+    return _apply(ns, halt=False)
+
+
+def _apply(ns: argparse.Namespace, *, halt: bool) -> int:
+    """Shared halt/resume flow: resolve env -> flip flag -> announce -> print state."""
+    action = "HALT" if halt else "RESUME"
+    url_var = ENV_DB_URL_VARS[ns.env]
+    url = os.environ.get(url_var)
+    if not url:
+        _line(f"ERROR: {url_var} is not set — cannot reach the {ns.env} database.")
+        _line(
+            "Fallback (requires restart, ~3 min): set FEATURE_ENTRY_PAUSE=true on the "
+            f"{ns.env} Railway service (`railway variables --set FEATURE_ENTRY_PAUSE=true`)."
+        )
+        return 1
+
+    try:
+        db = DatabaseManager(url)
+    except Exception as e:
+        _line(f"ERROR: could not connect to the {ns.env} database: {e}")
+        return 1
+
+    current = db.get_system_halt()
+    if current.active == halt:
+        since = current.updated_at.isoformat() if current.updated_at else "unknown"
+        state_word = "ACTIVE" if halt else "CLEAR"
+        _line(
+            f"system_halt already {state_word} (env={ns.env}, since={since}, "
+            f"reason={current.reason or 'none'}, by={current.source or 'unknown'}) — no change"
+        )
+    else:
+        source = f"cli:{getpass.getuser()}"
+        status = db.set_system_halt(halt, reason=ns.reason, source=source)
+        _line(
+            f"system_halt {action} set (env={ns.env}, by={source}, "
+            f"reason={ns.reason or 'none'})"
+        )
+        if halt:
+            _line(
+                "engine effect: entries + scale-ins BLOCKED within one trading-loop "
+                "iteration; exits/stops/reconciliation UNAFFECTED"
+            )
+        else:
+            _line("engine effect: entries + scale-ins re-enabled within one loop iteration")
+        _announce(db, ns.env, halt=halt, status=status, source=source)
+
+    _print_account_state(db, ns.env)
+    _line(
+        "verify enforcement: system_events error_code="
+        + ("SYSTEM_HALT" if halt else "SYSTEM_HALT_CLEARED")
+        + " (emitted by the engine when it honors the flag)"
+    )
+    return 0
+
+
+def _announce(
+    db: DatabaseManager,
+    env: str,
+    *,
+    halt: bool,
+    status: SystemHaltStatus,
+    source: str,
+) -> None:
+    """Emit the CRITICAL system_event + webhook page for the command itself.
+
+    The flag write above is the protective action; announcement failures are
+    reported but never fail the command.
+    """
+    action = "HALT" if halt else "RESUME"
+    message = (
+        f"MANUAL {action} ISSUED for {env} by {source} "
+        f"(reason: {status.reason or 'none'}). "
+        + (
+            "Entries and scale-ins will stop within one trading-loop iteration; "
+            "exits and stop-losses remain active."
+            if halt
+            else "Entries and scale-ins will resume within one trading-loop iteration."
+        )
+    )
+    delivered = _send_webhook_alert(message)
+    if not delivered:
+        _line(
+            "WARNING: no alert webhook delivery (ALERT_WEBHOOK_URL unset or POST failed) "
+            "— page the operator manually"
+        )
+    try:
+        db.log_event(
+            event_type=EventType.ALERT,
+            message=message,
+            severity="critical" if halt else "warning",
+            component="ops",
+            error_code="SYSTEM_HALT_COMMAND" if halt else "SYSTEM_RESUME_COMMAND",
+            alert_sent=delivered,
+            alert_method="webhook" if delivered else None,
+        )
+    except Exception as e:
+        _line(f"WARNING: system_events write failed ({e}) — halt flag itself IS set")
+
+
+def _send_webhook_alert(message: str) -> bool:
+    """POST the operator page; same payload shape as the engine's _send_alert.
+
+    Returns True only on a delivered (2xx) page so `alert_sent` reflects
+    reality.
+    """
+    url = os.environ.get("ALERT_WEBHOOK_URL")
+    if not url:
+        return False
+    try:
+        import requests  # type: ignore[import-untyped]  # types-requests not installed
+
+        payload = {
+            "text": f"🤖 Trading Bot: {message}",
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+        resp = requests.post(url, json=payload, timeout=10)
+        resp.raise_for_status()
+        return True
+    except Exception as e:
+        _line(f"WARNING: alert webhook POST failed: {e}")
+        return False
+
+
+def _print_account_state(db: DatabaseManager, env: str) -> None:
+    """Read-only snapshot of what the account holds and how it is protected."""
+    try:
+        session_id = db.get_active_session_id()
+        _line(f"active session: {session_id if session_id is not None else 'none'} (env={env})")
+        positions = db.get_active_positions()
+    except Exception as e:
+        _line(f"WARNING: could not read account state: {e}")
+        return
+
+    _line(f"open positions: {len(positions)}")
+    for p in positions:
+        stop_price = p.get("stop_loss")
+        stop_order = p.get("stop_loss_order_id")
+        if stop_price is None and not stop_order:
+            protection = "NO STOP — position is UNPROTECTED, review immediately"
+        else:
+            protection = (
+                f"sl={stop_price if stop_price is not None else 'unknown'}"
+                f" (order {stop_order or 'not placed'})"
+            )
+        _line(
+            f"  {p.get('symbol')} {p.get('side')} qty={p.get('quantity')} "
+            f"entry={p.get('entry_price')} {protection} "
+            f"tp={p.get('take_profit')} upnl={p.get('unrealized_pnl')}"
+        )
+
+
+def _line(text: str) -> None:
+    """Append-friendly output: one UTC-timestamped fact per line."""
+    stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"[{stamp}] {text}")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -48,7 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SYSTEM_HALT`/`SYSTEM_HALT_CLEARED` from the engine when it honors the flag), page the alert
   webhook, and print the account state (open positions + protective stops, `NO STOP` flagged).
   Fail-safe: a DB outage never releases an active halt; halt/resume are idempotent; the halt is
-  independent of close-only mode so `resume` cannot clear a drawdown/circuit-breaker trip. The
+  independent of close-only mode so `resume` cannot clear a drawdown/circuit-breaker trip.
+  Fail-CLOSED startup: until the flag has been successfully read once (priming read at engine
+  construction, retried each loop iteration) the entry gates refuse new risk, so a reboot behind
+  a dead database cannot trade past an operator halt (`SYSTEM_HALT_UNVERIFIED` pages the operator);
+  exits/stops/reconciliation are never gated. The CLI echoes the masked resolved DB host before
+  mutating. Table also covered by Alembic migration `0012_add_system_control_flags`. The
   simulated `emergency-stop` subcommand was REMOVED — no fake safety commands.
 - **Cloud-first model tournaments (#918, #909)**: `atb train cloud` gains
   `--model-type {lstm,cnn_lstm,attention_lstm,tcn,tcn_attention,tft}` and

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so degraded live decisions are attributable in the database. Closes #913.
 
 ### Added
+- **Real manual kill-switch (#922)**: `atb live-control halt --env production|staging|development
+  [--reason "..."]` and `atb live-control resume` now exist and are REAL. Halt durably upserts a
+  `system_halt` row in the target environment's new `system_control_flags` table; the running
+  engine's `SystemHaltEnforcer` polls it at the top of every trading-loop iteration and mirrors
+  it into the entry-pause gate, so entries + scale-ins stop within ONE iteration (no restart) while
+  exits, stop-losses and reconciliation continue — FEATURE_ENTRY_PAUSE semantics. Both commands
+  emit `system_events` rows (`SYSTEM_HALT_COMMAND`/`SYSTEM_RESUME_COMMAND` from the CLI;
+  `SYSTEM_HALT`/`SYSTEM_HALT_CLEARED` from the engine when it honors the flag), page the alert
+  webhook, and print the account state (open positions + protective stops, `NO STOP` flagged).
+  Fail-safe: a DB outage never releases an active halt; halt/resume are idempotent; the halt is
+  independent of close-only mode so `resume` cannot clear a drawdown/circuit-breaker trip. The
+  simulated `emergency-stop` subcommand was REMOVED — no fake safety commands.
 - **Cloud-first model tournaments (#918, #909)**: `atb train cloud` gains
   `--model-type {lstm,cnn_lstm,attention_lstm,tcn,tcn_attention,tft}` and
   `--model-variant {default,lightweight,deep}`, threaded end-to-end through

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -104,6 +104,44 @@ numbers `account_history.drawdown` is derived from.
   current balance (the guard stays armed from the new baseline). **Remove the flag after the
   restart** — leaving it set re-baselines the peak on every future restart, weakening the cap.
 
+## Manual kill-switch (`atb live-control halt` / `resume`)
+
+The human/PM manual halt required by `risk-limits.json` `kill_switch.manual_trigger_command`
+(#922). One command durably puts the TARGET environment's engine into a no-new-risk state
+with **FEATURE_ENTRY_PAUSE semantics**: new entries and scale-ins are blocked; exits,
+partial exits, stop-loss management, and reconciliation keep running. Nothing is liquidated.
+
+```bash
+atb live-control halt --env production --reason "duplicate order storm"
+atb live-control resume --env production --reason "root cause fixed"
+```
+
+- **Mechanism (restartless)**: the command upserts the `system_halt` row in the target
+  environment's `system_control_flags` table (resolved from
+  `RAILWAY_PRODUCTION_DATABASE_URL` / `RAILWAY_STAGING_DATABASE_URL` / `DATABASE_URL`).
+  The running engine's `SystemHaltEnforcer`
+  (`src/engines/live/monitoring/system_halt_enforcer.py`) polls the flag at the **top of
+  every trading-loop iteration** and mirrors it into the shared gate consulted by entry
+  evaluation, the `execute_entry_locked` chokepoint, the legacy short path, and scale-ins.
+- **Latency**: command → effect is at most one loop iteration (the adaptive check interval,
+  seconds up to `DEFAULT_MAX_CHECK_INTERVAL`; ~2 min at prod cadence). No restart/redeploy.
+- **Fallback (requires restart)**: `railway variables --set FEATURE_ENTRY_PAUSE=true` on the
+  target service — a Railway variable change triggers a redeploy, so expect ~3 minutes of
+  latency; use it only if the database write path is unavailable.
+- **Observability**: the command emits a CRITICAL `system_events` row
+  (`error_code=SYSTEM_HALT_COMMAND`) plus a webhook page (when `ALERT_WEBHOOK_URL` is set),
+  and prints the resulting account state — active session, open positions and their
+  protective stops (positions without a stop are flagged `NO STOP`). The engine emits its
+  own row when it honors the flag (`error_code=SYSTEM_HALT`; `SYSTEM_HALT_CLEARED` on
+  resume) — that second event is the proof of enforcement.
+- **Fail-safe**: a DB outage never releases an active halt (the engine keeps its last-known
+  state); halting twice is idempotent. The halt is independent of close-only mode, so
+  `resume` cannot accidentally clear a drawdown/circuit-breaker trip.
+- The former `emergency-stop` subcommand printed "(simulated)" and did nothing; it has been
+  removed — `halt` is the real safety command. Cancelling in-flight entry orders from an
+  out-of-process CLI would race the running engine's order tracking, so unfilled entries are
+  left to the engine's own timeout/cancel logic while the halt guarantees no new ones start.
+
 ## Position management features
 
 - Dynamic risk adjustment (`DynamicRiskManager`) tapers exposure after drawdowns and relaxes limits during recoveries. Configure
@@ -245,7 +283,9 @@ The control surface lives under `atb live-control`:
   registry’s `latest` symlink automatically so the live engine picks up the new model.
 - `atb live-control deploy-model --model-path <staging-dir> --close-positions` – promote a staged bundle into the live strategy
   directory.
-- `atb live-control list-models` / `status` / `emergency-stop` – quick operational actions when supervising a running engine.
+- `atb live-control list-models` / `status` – quick operational reads when supervising a running engine.
+- `atb live-control halt --env <production|staging|development> [--reason "..."]` / `resume` – the manual kill-switch
+  (see "Manual kill-switch" below): durably blocks new entries + scale-ins in the target environment without a restart.
 
 ## Programmatic usage
 

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -124,7 +124,9 @@ atb live-control resume --env production --reason "root cause fixed"
   every trading-loop iteration** and mirrors it into the shared gate consulted by entry
   evaluation, the `execute_entry_locked` chokepoint, the legacy short path, and scale-ins.
 - **Latency**: command → effect is at most one loop iteration (the adaptive check interval,
-  seconds up to `DEFAULT_MAX_CHECK_INTERVAL`; ~2 min at prod cadence). No restart/redeploy.
+  30–300 s per `DEFAULT_MIN_CHECK_INTERVAL`/`DEFAULT_MAX_CHECK_INTERVAL`; ~2 min at prod
+  cadence). No restart/redeploy. The CLI echoes the masked resolved DB host
+  (`target: env=... db=host:port/dbname`) before mutating anything.
 - **Fallback (requires restart)**: `railway variables --set FEATURE_ENTRY_PAUSE=true` on the
   target service — a Railway variable change triggers a redeploy, so expect ~3 minutes of
   latency; use it only if the database write path is unavailable.
@@ -137,6 +139,12 @@ atb live-control resume --env production --reason "root cause fixed"
 - **Fail-safe**: a DB outage never releases an active halt (the engine keeps its last-known
   state); halting twice is idempotent. The halt is independent of close-only mode, so
   `resume` cannot accidentally clear a drawdown/circuit-breaker trip.
+- **Fail-closed startup**: until the engine has successfully read the flag ONCE (a priming
+  read at construction, retried every loop iteration), the entry gates treat the state as
+  halted — a reboot behind an unreachable database cannot trade past an operator halt it
+  never managed to read. A boot that cannot verify the flag pages the operator
+  (`error_code=SYSTEM_HALT_UNVERIFIED`); a healthy boot establishes the state at
+  construction and starts trading immediately. Exits/stops/reconciliation are never gated.
 - The former `emergency-stop` subcommand printed "(simulated)" and did nothing; it has been
   removed — `halt` is the real safety command. Cancelling in-flight entry orders from an
   out-of-process CLI would race the running engine's order tracking, so unfilled entries are

--- a/migrations/versions/0012_add_system_control_flags.py
+++ b/migrations/versions/0012_add_system_control_flags.py
@@ -1,0 +1,56 @@
+"""Add system_control_flags table (manual kill-switch, #922)
+
+Revision ID: 0012_add_system_control_flags
+Revises: 0011_drop_optimization_cycles
+Create Date: 2026-07-07 12:00:00.000000
+
+Durable operator-set control flags the live engine polls at runtime — one row
+per flag name, upserted. The ``system_halt`` row is the manual kill-switch
+written by ``atb live-control halt`` / ``resume``.
+
+Guarded: the app's runtime ``Base.metadata.create_all`` may already have
+created the table on environments that booted the new code (or ran the halt
+CLI) before this migration, so upgrade is a no-op when the table exists.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0012_add_system_control_flags"
+down_revision = "0011_drop_optimization_cycles"
+branch_labels = None
+depends_on = None
+
+TABLE = "system_control_flags"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if TABLE in inspector.get_table_names():
+        return
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("active", sa.Boolean(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("source", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # Matches the model's `unique=True, index=True` (create_all emits a single
+    # unique index named ix_<table>_name, not a separate unique constraint).
+    op.create_index(f"ix_{TABLE}_name", TABLE, ["name"], unique=True)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if TABLE not in inspector.get_table_names():
+        return
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes(TABLE)}
+    if f"ix_{TABLE}_name" in existing_indexes:
+        op.drop_index(f"ix_{TABLE}_name", table_name=TABLE)
+    op.drop_table(TABLE)

--- a/src/database/manager.py
+++ b/src/database/manager.py
@@ -9,6 +9,7 @@ import math
 import os
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from enum import Enum
@@ -23,6 +24,7 @@ from sqlalchemy.pool import QueuePool
 from src.config.config_manager import get_config
 
 from .models import (
+    SYSTEM_HALT_FLAG_NAME,
     AccountBalance,
     AccountHistory,
     Base,
@@ -40,6 +42,7 @@ from .models import (
     ReconciliationAuditEvent,
     RiskAdjustment,
     StrategyExecution,
+    SystemControlFlag,
     SystemEvent,
     Trade,
     TradeSource,
@@ -66,6 +69,20 @@ class QueryTimeout:
 # When gross_loss is 0 but gross_profit > 0, profit factor would be infinite.
 # This cap indicates "extremely profitable" while remaining storable in Numeric(18, 8).
 MAX_PROFIT_FACTOR = 999999.99
+
+
+@dataclass(frozen=True)
+class SystemHaltStatus:
+    """Detached snapshot of the ``system_halt`` control flag (#922).
+
+    Returned instead of the ORM row so callers (trading loop, CLI) never touch
+    a session-bound object outside its transaction.
+    """
+
+    active: bool
+    reason: str | None
+    source: str | None
+    updated_at: datetime | None
 
 
 def _trade_net_pnl(trade: Any) -> float:
@@ -1627,6 +1644,90 @@ class DatabaseManager:
                 raise
 
             return event.id
+
+    def get_system_halt(self) -> SystemHaltStatus:
+        """Read the manual kill-switch flag (#922).
+
+        A missing row reads as not-halted so normal boot on a fresh database is
+        unaffected. Polled by the live trading loop each iteration — uses the
+        CRITICAL_READ timeout so a slow query cannot stall the loop.
+        """
+        with self.get_session_with_timeout(QueryTimeout.CRITICAL_READ) as session:
+            flag = (
+                session.query(SystemControlFlag)
+                .filter(SystemControlFlag.name == SYSTEM_HALT_FLAG_NAME)
+                .one_or_none()
+            )
+            if flag is None:
+                return SystemHaltStatus(active=False, reason=None, source=None, updated_at=None)
+            return SystemHaltStatus(
+                active=bool(flag.active),
+                reason=flag.reason,
+                source=flag.source,
+                updated_at=flag.updated_at,
+            )
+
+    def set_system_halt(
+        self,
+        active: bool,
+        *,
+        reason: str | None = None,
+        source: str | None = None,
+    ) -> SystemHaltStatus:
+        """Durably set/clear the manual kill-switch flag (#922); returns the new state.
+
+        Upserts the single ``system_halt`` row under a row lock so concurrent
+        operators cannot interleave a halt and a resume into a torn state. A
+        lost INSERT race on the unique name (first-ever halt issued twice at
+        once) retries once as an UPDATE — a kill-switch must not fail on a
+        duplicate pull.
+        """
+        try:
+            return self._upsert_system_halt(active, reason=reason, source=source)
+        except IntegrityError:
+            logger.warning("system_halt insert raced another writer — retrying as update")
+            return self._upsert_system_halt(active, reason=reason, source=source)
+
+    def _upsert_system_halt(
+        self,
+        active: bool,
+        *,
+        reason: str | None,
+        source: str | None,
+    ) -> SystemHaltStatus:
+        """Single upsert attempt for the ``system_halt`` row."""
+        with self.get_session() as session:
+            flag = (
+                session.query(SystemControlFlag)
+                .filter(SystemControlFlag.name == SYSTEM_HALT_FLAG_NAME)
+                .with_for_update()
+                .one_or_none()
+            )
+            if flag is None:
+                flag = SystemControlFlag(
+                    name=SYSTEM_HALT_FLAG_NAME, active=active, reason=reason, source=source
+                )
+                session.add(flag)
+            else:
+                flag.active = active
+                flag.reason = reason
+                flag.source = source
+                flag.updated_at = datetime.now(UTC)
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                raise
+            except Exception as e:
+                session.rollback()
+                logger.error("Failed to set system_halt=%s: %s", active, e, exc_info=True)
+                raise
+            return SystemHaltStatus(
+                active=bool(flag.active),
+                reason=flag.reason,
+                source=flag.source,
+                updated_at=flag.updated_at,
+            )
 
     def log_strategy_execution(
         self,

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -632,6 +632,35 @@ class SystemEvent(Base):
     created_at = Column(DateTime, default=utc_now)
 
 
+# Name of the manual kill-switch flag row (#922). Written by
+# `atb live-control halt` / `resume`; polled by the live trading loop.
+SYSTEM_HALT_FLAG_NAME = "system_halt"
+
+
+class SystemControlFlag(Base):
+    """Operator-set control flags the live engine polls at runtime.
+
+    One row per flag name (upserted, never appended) — the durable channel for
+    out-of-process operator commands such as the manual kill-switch
+    (``system_halt``). The audit trail of WHO flipped WHAT and WHEN lives in
+    ``system_events``; this table only holds the current state.
+    """
+
+    __tablename__ = "system_control_flags"
+
+    id: Mapped[int] = cast(Mapped[int], Column(Integer, primary_key=True))
+    name = Column(String(50), nullable=False, unique=True, index=True)
+    active: Mapped[bool] = cast(Mapped[bool], Column(Boolean, nullable=False, default=False))
+    reason: Mapped[str | None] = cast(Mapped[str | None], Column(Text))
+    # Who set it, e.g. 'cli:alex'
+    source: Mapped[str | None] = cast(Mapped[str | None], Column(String(100)))
+
+    created_at = Column(DateTime, default=utc_now)
+    updated_at: Mapped[datetime | None] = cast(
+        Mapped[datetime | None], Column(DateTime, default=utc_now, onupdate=utc_now)
+    )
+
+
 class ReconciliationAuditEvent(Base):
     """Immutable audit trail for reconciliation corrections.
 

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -33,6 +33,7 @@ from src.data_providers.exchange_interface import OrderSide, OrderType, SideEffe
 from src.database.models import EventType
 from src.engines.live.execution.entry_handler import LiveEntrySignal
 from src.engines.live.execution.entry_pause import EntryPauseGate
+from src.engines.live.system_halt import SystemHaltState
 from src.engines.shared.models import PositionSide
 from src.infrastructure.logging.events import log_order_event
 from src.strategies.components import Signal, SignalDirection
@@ -147,15 +148,23 @@ class LiveEntryEngineState(Protocol):
 class LiveEntryCoordinator:
     """Owns the live engine's entry decision + execution pipeline."""
 
-    def __init__(self, engine_state: LiveEntryEngineState) -> None:
-        """Bind to the engine's live state (see protocol for the surface)."""
+    def __init__(
+        self,
+        engine_state: LiveEntryEngineState,
+        system_halt: SystemHaltState | None = None,
+    ) -> None:
+        """Bind to the engine's live state (see protocol for the surface).
+
+        ``system_halt`` is the engine's shared manual kill-switch state (#922);
+        None (tests, standalone use) leaves only the feature-flag pause active.
+        """
         self._state = engine_state
-        # FEATURE_ENTRY_PAUSE gate for new entries (scale-ins are gated by the
-        # exit handler's own instance — see EntryPauseGate).
-        self._entry_pause = EntryPauseGate()
+        # Entry-pause gate (FEATURE_ENTRY_PAUSE + manual system halt) for new
+        # entries; scale-ins are gated by the exit handler's own instance.
+        self._entry_pause = EntryPauseGate(halt_state=system_halt)
 
     def _entry_paused(self, context: str) -> bool:
-        """True when FEATURE_ENTRY_PAUSE suppresses new entries (rate-limit logged)."""
+        """True when a pause source suppresses new entries (rate-limit logged)."""
         return self._entry_pause.paused(context)
 
     def check_entry_conditions(

--- a/src/engines/live/execution/entry_pause.py
+++ b/src/engines/live/execution/entry_pause.py
@@ -8,6 +8,8 @@ continue):
 - ``FEATURE_ENTRY_PAUSE`` — env-var flag; requires a restart/redeploy to flip.
 - The manual kill-switch (#922) — the DB ``system_halt`` flag mirrored into a
   ``SystemHaltState`` by the loop enforcer; takes effect without a restart.
+  A halt state that was never successfully read (``established=False``) gates
+  as if halted — fail closed until the database confirms otherwise.
 """
 
 from __future__ import annotations
@@ -62,11 +64,20 @@ class EntryPauseGate:
 
     def _active_cause(self) -> str | None:
         """The active pause source's log prefix, or None when not paused."""
-        if self._halt_state is not None and self._halt_state.active:
-            return (
-                "MANUAL SYSTEM HALT active "
-                f"(reason: {self._halt_state.reason or 'no reason recorded'})"
-            )
+        if self._halt_state is not None:
+            if not self._halt_state.established:
+                # Fail closed: the halt flag has never been successfully read
+                # (e.g. DB unreachable at boot) — do not add risk on the
+                # optimistic default.
+                return (
+                    "MANUAL SYSTEM HALT state UNVERIFIED "
+                    "(system_halt flag not successfully read yet — failing closed)"
+                )
+            if self._halt_state.active:
+                return (
+                    "MANUAL SYSTEM HALT active "
+                    f"(reason: {self._halt_state.reason or 'no reason recorded'})"
+                )
         if is_enabled("entry_pause", default=False):
             return "FEATURE_ENTRY_PAUSE active"
         return None

--- a/src/engines/live/execution/entry_pause.py
+++ b/src/engines/live/execution/entry_pause.py
@@ -1,4 +1,14 @@
-"""FEATURE_ENTRY_PAUSE gate shared by the live entry and scale-in paths."""
+"""Entry/scale-in gate shared by the live entry and scale-in paths.
+
+Two operator levers converge here, both with identical no-new-risk semantics
+(exposure must not INCREASE: new entries and scale-ins are skipped, while
+exits, partial exits, stop-loss management, reconciliation and monitoring
+continue):
+
+- ``FEATURE_ENTRY_PAUSE`` — env-var flag; requires a restart/redeploy to flip.
+- The manual kill-switch (#922) — the DB ``system_halt`` flag mirrored into a
+  ``SystemHaltState`` by the loop enforcer; takes effect without a restart.
+"""
 
 from __future__ import annotations
 
@@ -7,35 +17,32 @@ import time
 
 from src.config.constants import ENTRY_PAUSE_WARNING_INTERVAL_SECONDS
 from src.config.feature_flags import is_enabled
+from src.engines.live.system_halt import SystemHaltState
 
 logger = logging.getLogger(__name__)
 
 
 class EntryPauseGate:
-    """Rate-limit-logging gate for the ``entry_pause`` feature flag.
-
-    When FEATURE_ENTRY_PAUSE is truthy the live engine must not INCREASE
-    exposure: new entries and scale-ins are skipped, while exits, partial
-    exits, stop-loss management, reconciliation and monitoring continue.
-    The flag lets a human flatten risk ahead of macro events (FOMC/CPI)
-    with a single env var.
+    """Rate-limit-logging gate for the ``entry_pause`` flag and manual halt.
 
     Each consumer holds its own gate instance so warnings rate-limit per
     path. State is written only from the trading-loop thread; a benign
     race would at worst duplicate a log line.
     """
 
-    def __init__(self) -> None:
-        """Initialize with no warning emitted yet (first skip always warns)."""
+    def __init__(self, halt_state: SystemHaltState | None = None) -> None:
+        """Bind the optional manual-halt state; first skip always warns."""
+        self._halt_state = halt_state
         self._last_warning: float | None = None
 
     def paused(self, context: str) -> bool:
-        """True when the flag suppresses the given action; logs rate-limited.
+        """True when a pause source suppresses the given action; logs rate-limited.
 
         Warns at most once per ENTRY_PAUSE_WARNING_INTERVAL_SECONDS to avoid
         log spam from the trading loop.
         """
-        if not is_enabled("entry_pause", default=False):
+        cause = self._active_cause()
+        if cause is None:
             return False
         now = time.monotonic()
         if (
@@ -44,10 +51,22 @@ class EntryPauseGate:
         ):
             self._last_warning = now
             logger.warning(
-                "FEATURE_ENTRY_PAUSE active — skipping %s "
+                "%s — skipping %s "
                 "(exits, partial exits, stop-loss management and reconciliation continue)",
+                cause,
                 context,
             )
         else:
-            logger.debug("FEATURE_ENTRY_PAUSE active — skipping %s", context)
+            logger.debug("%s — skipping %s", cause, context)
         return True
+
+    def _active_cause(self) -> str | None:
+        """The active pause source's log prefix, or None when not paused."""
+        if self._halt_state is not None and self._halt_state.active:
+            return (
+                "MANUAL SYSTEM HALT active "
+                f"(reason: {self._halt_state.reason or 'no reason recorded'})"
+            )
+        if is_enabled("entry_pause", default=False):
+            return "FEATURE_ENTRY_PAUSE active"
+        return None

--- a/src/engines/live/execution/exit_handler.py
+++ b/src/engines/live/execution/exit_handler.py
@@ -158,6 +158,16 @@ class LiveExitHandler:
         """Wire the #802 exposure governor so scale-ins respect the gross cap."""
         self._exposure_governor = exposure_governor
 
+    def bind_system_halt(self, system_halt: SystemHaltState | None) -> None:
+        """Rebind the scale-in gate to the engine's shared manual-halt state (#922).
+
+        A DI-injected handler is constructed before the engine (and its halt
+        state) exists, so the engine rebinds it here; scale-ins must never
+        bypass the kill-switch. Rebinding resets the gate's log rate-limit
+        only — no behavioral state is lost.
+        """
+        self._entry_pause = EntryPauseGate(halt_state=system_halt)
+
     def _build_snapshot(
         self,
         symbol: str,

--- a/src/engines/live/execution/exit_handler.py
+++ b/src/engines/live/execution/exit_handler.py
@@ -28,6 +28,7 @@ from src.engines.live.execution.position_tracker import (
     LivePositionTracker,
     PositionSide,
 )
+from src.engines.live.system_halt import SystemHaltState
 from src.engines.shared.execution.execution_model import ExecutionModel
 from src.engines.shared.execution.market_snapshot import MarketSnapshot
 from src.engines.shared.execution.order_intent import OrderIntent
@@ -109,6 +110,7 @@ class LiveExitHandler:
         max_position_size: float = DEFAULT_MAX_POSITION_SIZE,
         max_filled_price_deviation: float = DEFAULT_MAX_FILLED_PRICE_DEVIATION,
         close_only_provider: Callable[[], bool] | None = None,
+        system_halt: SystemHaltState | None = None,
     ) -> None:
         """Initialize exit handler.
 
@@ -126,6 +128,9 @@ class LiveExitHandler:
             close_only_provider: Reads the engine's close-only flag at call
                 time; scale-ins (exposure increases) are suppressed while it
                 returns True. Exits and partial exits are never gated.
+            system_halt: The engine's shared manual kill-switch state (#922);
+                scale-ins are suppressed while it is active. None (tests,
+                standalone use) leaves only the feature-flag pause active.
         """
         self.execution_engine = execution_engine
         self.position_tracker = position_tracker
@@ -141,9 +146,10 @@ class LiveExitHandler:
         # Use shared managers for consistent logic across engines
         self._trailing_stop_manager = TrailingStopManager(trailing_stop_policy)
         self._strategy_exit_checker = StrategyExitChecker()
-        # FEATURE_ENTRY_PAUSE also suppresses scale-ins (exposure increases);
-        # own instance so warnings rate-limit independently of the entry path.
-        self._entry_pause = EntryPauseGate()
+        # The entry-pause gate (FEATURE_ENTRY_PAUSE + manual system halt) also
+        # suppresses scale-ins (exposure increases); own instance so warnings
+        # rate-limit independently of the entry path.
+        self._entry_pause = EntryPauseGate(halt_state=system_halt)
         # #802 follow-up P3: optional exposure governor to cap scale-in exposure
         # (set by the engine; None => inert). Mirrors the entry handler's gate.
         self._exposure_governor: ExposureGovernor | None = None

--- a/src/engines/live/monitoring/system_halt_enforcer.py
+++ b/src/engines/live/monitoring/system_halt_enforcer.py
@@ -11,7 +11,11 @@ stop-loss management and reconciliation continue. Nothing is liquidated.
 Transitions are announced once (CRITICAL system_event + alert on halt, WARNING
 on clear). Fail-safe: a failed poll keeps the last-known state, so a database
 outage can never silently release an active halt — and never trips one either
-(the existing DB-outage close-only guard covers prolonged outages).
+(the existing DB-outage close-only guard covers prolonged outages). Startup is
+fail-CLOSED: until the FIRST successful poll (a priming read at engine
+construction, retried every loop iteration) the shared state is unestablished
+and the entry gates refuse new risk — a reboot behind a dead database cannot
+trade past an operator halt it never managed to read.
 
 Fault-isolated: a failing check never crashes the trading loop, and the
 protective action (mirroring the halt) is taken before observability so an
@@ -58,28 +62,67 @@ class SystemHaltEnforcer:
         self._state = engine_state
         self._halt = halt_state
 
+    def prime(self) -> None:
+        """One authoritative startup read; loudly fail-closed if unverifiable.
+
+        Called at engine construction so a healthy boot establishes the halt
+        state BEFORE the trading loop starts. If the read fails, the state
+        stays unestablished — the entry gates refuse new risk until the first
+        successful in-loop poll — and the operator is paged.
+        """
+        self.check()
+        if self._halt.established:
+            return
+        message = (
+            "System-halt state UNVERIFIED at startup (the system_halt flag could not "
+            "be read) — failing CLOSED: new entries and scale-ins stay blocked until "
+            "the flag is successfully polled. Exits, stop-losses and reconciliation "
+            "run normally."
+        )
+        logger.critical("🛑 %s", message)
+        try:
+            self._state._record_event(
+                EventType.ALERT,
+                message,
+                severity="critical",
+                component="ops",
+                error_code="SYSTEM_HALT_UNVERIFIED",
+                alert=True,
+            )
+        except Exception as e:
+            logger.warning("Unverified-halt boot announcement failed: %s", e)
+
     def check(self) -> None:
         """Mirror the DB flag into the loop-owned halt state; announce transitions."""
         try:
             status = self._state.db_manager.get_system_halt()
         except Exception as e:
             # Fail-safe: keep the last-known state. An active halt stays
-            # latched through a DB outage; an inactive one is not tripped.
+            # latched through a DB outage; an inactive one is not tripped —
+            # and an UNESTABLISHED state stays fail-closed at the gates.
             logger.warning(
-                "system_halt flag poll failed: %s — keeping last state (halted=%s)",
+                "system_halt flag poll failed: %s — keeping last state "
+                "(halted=%s, established=%s)",
                 e,
                 self._halt.active,
+                self._halt.established,
             )
             return
 
-        if status.active == self._halt.active:
-            if status.active:
+        # Only an explicit boolean True halts. The real read coerces the DB
+        # column to bool; this guards test doubles/garbage from phantom-halting
+        # a live engine.
+        active = status.active is True
+        self._halt.established = True
+
+        if active == self._halt.active:
+            if active:
                 # Reason may be amended while halted; keep the mirror fresh
                 # without re-announcing.
                 self._halt.reason = status.reason
             return
 
-        if status.active:
+        if active:
             self._activate(status.reason, status.source)
         else:
             self._deactivate()

--- a/src/engines/live/monitoring/system_halt_enforcer.py
+++ b/src/engines/live/monitoring/system_halt_enforcer.py
@@ -1,0 +1,126 @@
+"""Manual kill-switch enforcement on the live trading loop (#922).
+
+``atb live-control halt`` durably sets the ``system_halt`` control flag in the
+target environment's database. This enforcer polls that flag once per
+trading-loop iteration (before entry evaluation, so a halt takes effect within
+the SAME iteration) and mirrors it into the loop-owned ``SystemHaltState``
+consumed by the entry/scale-in gates. Semantics match FEATURE_ENTRY_PAUSE: no
+exposure increases — new entries and scale-ins stop; exits, partial exits,
+stop-loss management and reconciliation continue. Nothing is liquidated.
+
+Transitions are announced once (CRITICAL system_event + alert on halt, WARNING
+on clear). Fail-safe: a failed poll keeps the last-known state, so a database
+outage can never silently release an active halt — and never trips one either
+(the existing DB-outage close-only guard covers prolonged outages).
+
+Fault-isolated: a failing check never crashes the trading loop, and the
+protective action (mirroring the halt) is taken before observability so an
+event failure cannot leave entries running.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Protocol
+
+from src.database.models import EventType
+from src.engines.live.system_halt import SystemHaltState
+
+if TYPE_CHECKING:
+    from src.database.manager import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+
+class SystemHaltEngineState(Protocol):
+    """Live engine state the system-halt enforcer reads and acts through."""
+
+    db_manager: DatabaseManager
+
+    def _record_event(
+        self,
+        event_type: EventType,
+        message: str,
+        *,
+        severity: str = ...,
+        component: str | None = ...,
+        error_code: str | None = ...,
+        exc: BaseException | None = ...,
+        alert: bool = ...,
+    ) -> None: ...
+
+
+class SystemHaltEnforcer:
+    """Polls the DB ``system_halt`` flag and drives the shared halt state."""
+
+    def __init__(self, engine_state: SystemHaltEngineState, halt_state: SystemHaltState) -> None:
+        """Bind to the engine's live state and the shared halt-state holder."""
+        self._state = engine_state
+        self._halt = halt_state
+
+    def check(self) -> None:
+        """Mirror the DB flag into the loop-owned halt state; announce transitions."""
+        try:
+            status = self._state.db_manager.get_system_halt()
+        except Exception as e:
+            # Fail-safe: keep the last-known state. An active halt stays
+            # latched through a DB outage; an inactive one is not tripped.
+            logger.warning(
+                "system_halt flag poll failed: %s — keeping last state (halted=%s)",
+                e,
+                self._halt.active,
+            )
+            return
+
+        if status.active == self._halt.active:
+            if status.active:
+                # Reason may be amended while halted; keep the mirror fresh
+                # without re-announcing.
+                self._halt.reason = status.reason
+            return
+
+        if status.active:
+            self._activate(status.reason, status.source)
+        else:
+            self._deactivate()
+
+    def _activate(self, reason: str | None, source: str | None) -> None:
+        """Enforce the halt (protective action first), then page the operator."""
+        self._halt.active = True
+        self._halt.reason = reason
+        try:
+            message = (
+                f"MANUAL SYSTEM HALT ENFORCED (set by {source or 'unknown'}, "
+                f"reason: {reason or 'no reason recorded'}). New entries and scale-ins "
+                "are blocked; exits, stop-losses and reconciliation continue. "
+                "Clear with 'atb live-control resume'."
+            )
+            logger.critical("🛑 %s", message)
+            self._state._record_event(
+                EventType.ALERT,
+                message,
+                severity="critical",
+                component="ops",
+                error_code="SYSTEM_HALT",
+                alert=True,
+            )
+        except Exception as e:
+            logger.critical("System-halt announcement failed after enforcement: %s", e)
+
+    def _deactivate(self) -> None:
+        """Release the halt and announce that entries are live again."""
+        self._halt.active = False
+        self._halt.reason = None
+        try:
+            message = "Manual system halt cleared — new entries and scale-ins are enabled again."
+            logger.warning("✅ %s", message)
+            self._state._record_event(
+                EventType.ALERT,
+                message,
+                severity="warning",
+                component="ops",
+                error_code="SYSTEM_HALT_CLEARED",
+                alert=True,
+            )
+        except Exception as e:
+            logger.warning("System-halt clear announcement failed: %s", e)

--- a/src/engines/live/system_halt.py
+++ b/src/engines/live/system_halt.py
@@ -9,13 +9,19 @@ from dataclasses import dataclass
 class SystemHaltState:
     """In-memory halt state shared by the loop enforcer and the entry gates.
 
-    ``SystemHaltEnforcer`` writes it after polling the database each
-    trading-loop iteration; the ``EntryPauseGate`` instances in the entry
-    coordinator and exit handler read it to suppress exposure increases
-    (entries + scale-ins) while exits, stops and reconciliation continue.
-    Written and read on the trading-loop thread only, matching the loop-owned
-    close-only flag.
+    ``SystemHaltEnforcer`` writes it after polling the database (a priming
+    read at engine construction, then once per trading-loop iteration); the
+    ``EntryPauseGate`` instances in the entry coordinator and exit handler
+    read it to suppress exposure increases (entries + scale-ins) while exits,
+    stops and reconciliation continue. Written and read on the trading-loop
+    thread only, matching the loop-owned close-only flag.
+
+    ``established`` is False until the FIRST successful poll. The gates treat
+    an unestablished state as halted (fail closed): a boot that cannot verify
+    the flag — e.g. an active halt row behind an unreachable database — must
+    not trade on the optimistic default.
     """
 
     active: bool = False
     reason: str | None = None
+    established: bool = False

--- a/src/engines/live/system_halt.py
+++ b/src/engines/live/system_halt.py
@@ -1,0 +1,21 @@
+"""Loop-owned mirror of the DB ``system_halt`` manual kill-switch flag (#922)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SystemHaltState:
+    """In-memory halt state shared by the loop enforcer and the entry gates.
+
+    ``SystemHaltEnforcer`` writes it after polling the database each
+    trading-loop iteration; the ``EntryPauseGate`` instances in the entry
+    coordinator and exit handler read it to suppress exposure increases
+    (entries + scale-ins) while exits, stops and reconciliation continue.
+    Written and read on the trading-loop thread only, matching the loop-owned
+    close-only flag.
+    """
+
+    active: bool = False
+    reason: str | None = None

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -998,6 +998,10 @@ class LiveTradingEngine:
             # Manual kill-switch (#922): scale-ins share the engine's halt state.
             system_halt=self._system_halt,
         )
+        # A DI-injected handler was built without the engine's halt state —
+        # rebind so its scale-ins cannot bypass the kill-switch. Idempotent
+        # for the default handler constructed above.
+        self.live_exit_handler.bind_system_halt(self._system_halt)
         # #802 follow-up P3: scale-ins respect the same gross exposure cap as
         # entries (share the governor instance; inert unless the flag is on).
         self.live_exit_handler.configure_exposure_gate(exposure_governor)
@@ -1030,11 +1034,16 @@ class LiveTradingEngine:
         )
         # Manual kill-switch (#922): polls the DB `system_halt` flag at the top
         # of every loop iteration so `atb live-control halt` takes effect
-        # within one iteration — no restart needed.
+        # within one iteration — no restart needed. The priming read makes a
+        # boot fail-CLOSED: until the flag is successfully read once, the
+        # entry gates refuse new risk (an active halt row behind a dead DB
+        # cannot be traded past), while a healthy boot establishes the state
+        # here and starts trading immediately.
         self._system_halt_enforcer = SystemHaltEnforcer(
             engine_state=self,
             halt_state=self._system_halt,
         )
+        self._system_halt_enforcer.prime()
 
         # Startup recovery — session balance, persisted positions, exchange
         # reconciliation. Reads/writes engine state at call time (#486).

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -72,11 +72,13 @@ from src.engines.live.monitoring import (
 )
 from src.engines.live.monitoring.circuit_breaker_enforcer import CircuitBreakerEnforcer
 from src.engines.live.monitoring.drawdown_guard import MaxDrawdownEnforcer, MaxDrawdownGuard
+from src.engines.live.monitoring.system_halt_enforcer import SystemHaltEnforcer
 from src.engines.live.recovery import LiveSessionRecoverer
 from src.engines.live.startup import LiveStartupSequencer
 from src.engines.live.strategy_hot_swap import StrategyHotSwapCoordinator
 from src.engines.live.strategy_manager import StrategyManager
 from src.engines.live.strategy_runtime import StrategyRuntimeCoordinator
+from src.engines.live.system_halt import SystemHaltState
 
 # Re-exported close-accounting helpers: the exit path (now LiveExitCoordinator)
 # uses them directly, and tests import them from this module, so keep the
@@ -420,6 +422,11 @@ class LiveTradingEngine:
         """Construct the coordinator family that owns extracted engine behaviors."""
         self._runtime_dataset = None
         self._runtime_warmup = 0
+        # Manual kill-switch (#922): one shared holder — the loop enforcer
+        # mirrors the DB `system_halt` flag into it, and the entry/scale-in
+        # gates (entry coordinator + exit handler) read it. Created first so
+        # every consumer below can bind the same instance.
+        self._system_halt = SystemHaltState()
         # Strategy-runtime state, owned by StrategyRuntimeCoordinator and assigned
         # via configure_strategy below. Declared here so the type-checker tracks
         # the attributes now that the coordinator — not an engine method — writes
@@ -443,7 +450,9 @@ class LiveTradingEngine:
         # writes engine state (balance, trackers, risk manager, session) through
         # the engine backref at call time, preserving the base-asset locking and
         # ordering of the real-money entry path (#486).
-        self.entry_coordinator = LiveEntryCoordinator(engine_state=self)
+        self.entry_coordinator = LiveEntryCoordinator(
+            engine_state=self, system_halt=self._system_halt
+        )
         self.exit_coordinator = LiveExitCoordinator(engine_state=self)
         self.dynamic_risk_coordinator = LiveDynamicRiskCoordinator(engine_state=self)
         self.loop_timing_coordinator = LiveLoopTimingCoordinator(engine_state=self)
@@ -986,6 +995,8 @@ class LiveTradingEngine:
             # Close-only mode must block ALL exposure increases, including
             # scale-ins; read at call time so mid-session trips take effect.
             close_only_provider=lambda: self._close_only_mode,
+            # Manual kill-switch (#922): scale-ins share the engine's halt state.
+            system_halt=self._system_halt,
         )
         # #802 follow-up P3: scale-ins respect the same gross exposure cap as
         # entries (share the governor instance; inert unless the flag is on).
@@ -1016,6 +1027,13 @@ class LiveTradingEngine:
         self._circuit_breaker_enforcer = CircuitBreakerEnforcer(
             engine_state=self,
             breaker=self._circuit_breaker,
+        )
+        # Manual kill-switch (#922): polls the DB `system_halt` flag at the top
+        # of every loop iteration so `atb live-control halt` takes effect
+        # within one iteration — no restart needed.
+        self._system_halt_enforcer = SystemHaltEnforcer(
+            engine_state=self,
+            halt_state=self._system_halt,
         )
 
         # Startup recovery — session balance, persisted positions, exchange
@@ -1471,6 +1489,11 @@ class LiveTradingEngine:
                 # would `continue` below before reaching them (#631).
                 self._ensure_ws_health_monitor_alive()
                 self._drain_pending_fill_exits()
+                # Manual kill-switch (#922): mirror the DB `system_halt` flag
+                # BEFORE any entry/scale-in evaluation so a halt issued via
+                # `atb live-control halt` blocks new risk in this very
+                # iteration (and on every data-outage `continue` path below).
+                self._system_halt_enforcer.check()
                 # For mock and real providers, update live data if supported.
                 # Skip when WS kline cache is active (no REST needed).
                 if not self._ws_kline_active and hasattr(self.data_provider, "update_live_data"):

--- a/tests/integration/contracts/test_engine_database_contracts.py
+++ b/tests/integration/contracts/test_engine_database_contracts.py
@@ -51,6 +51,10 @@ def _is_signature_compatible(real_sig: inspect.Signature, mock_sig: inspect.Sign
         "log_position",
         "log_event",
         "log_account_snapshot",
+        # Manual kill-switch (#922) — the engine fails CLOSED if the read is
+        # missing, so the mock must stay signature-compatible.
+        "get_system_halt",
+        "set_system_halt",
     ],
 )
 def test_mock_and_real_database_signatures_are_compatible(method_name: str):

--- a/tests/mocks/mock_database.py
+++ b/tests/mocks/mock_database.py
@@ -596,6 +596,29 @@ class MockDatabaseManager:
         """Get the active session ID."""
         return self._current_session_id
 
+    def set_system_halt(self, active: bool, *, reason=None, source=None):
+        """Set the manual kill-switch flag (#922)."""
+        from src.database.manager import SystemHaltStatus
+
+        self._system_halt = SystemHaltStatus(
+            active=bool(active), reason=reason, source=source, updated_at=datetime.now(UTC)
+        )
+        return self._system_halt
+
+    def get_system_halt(self):
+        """Read the manual kill-switch flag; not-halted by default (#922).
+
+        Must exist on the mock: the engine's SystemHaltEnforcer fails CLOSED
+        (entries blocked) when this read raises.
+        """
+        from src.database.manager import SystemHaltStatus
+
+        return getattr(
+            self,
+            "_system_halt",
+            SystemHaltStatus(active=False, reason=None, source=None, updated_at=None),
+        )
+
     def recover_last_balance(self, session_id: int | None = None) -> float:
         """Recover the last balance for a session."""
         return self.get_current_balance(session_id)

--- a/tests/unit/cli/test_live.py
+++ b/tests/unit/cli/test_live.py
@@ -449,19 +449,47 @@ class TestControlStatus:
         assert result == 0
 
 
-class TestControlEmergencyStop:
-    """Tests for the emergency-stop subcommand of live-control."""
+class TestLiveControlParser:
+    """Parser-level contract for the live-control safety subcommands (#922)."""
 
-    def test_executes_emergency_stop(self):
-        """Test that emergency stop executes successfully."""
-        # Arrange
-        args = argparse.Namespace(control_cmd="emergency-stop")
+    @staticmethod
+    def _build_parser() -> argparse.ArgumentParser:
+        from cli.commands.live import register
 
-        # Act
-        result = _control(args)
+        parser = argparse.ArgumentParser()
+        register(parser.add_subparsers(dest="cmd"))
+        return parser
 
-        # Assert
-        assert result == 0
+    def test_emergency_stop_subcommand_removed(self):
+        """The simulated emergency-stop is gone — no fake safety commands."""
+        parser = self._build_parser()
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["live-control", "emergency-stop"])
+
+    def test_halt_subcommand_registered(self):
+        parser = self._build_parser()
+
+        ns = parser.parse_args(["live-control", "halt", "--env", "staging", "--reason", "drill"])
+
+        assert ns.control_cmd == "halt"
+        assert ns.env == "staging"
+        assert ns.reason == "drill"
+
+    def test_halt_requires_env(self):
+        parser = self._build_parser()
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["live-control", "halt"])
+
+    def test_resume_subcommand_registered(self):
+        parser = self._build_parser()
+
+        ns = parser.parse_args(["live-control", "resume", "--env", "production"])
+
+        assert ns.control_cmd == "resume"
+        assert ns.env == "production"
+        assert ns.reason is None
 
 
 class TestControlSwapStrategy:

--- a/tests/unit/cli/test_live_halt.py
+++ b/tests/unit/cli/test_live_halt.py
@@ -1,0 +1,188 @@
+"""Tests for `atb live-control halt` / `resume` — the manual kill-switch (#922).
+
+The commands write the durable ``system_halt`` DB flag for the TARGET
+environment (resolved from RAILWAY_*_DATABASE_URL env vars), emit a CRITICAL
+``system_events`` row + webhook alert, and print the resulting account state
+(open positions + their stops) via read-only queries.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli.commands.live_halt import halt_main, resume_main
+from src.database.manager import SystemHaltStatus
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+_STAGING_URL_VAR = "RAILWAY_STAGING_DATABASE_URL"
+_PRODUCTION_URL_VAR = "RAILWAY_PRODUCTION_DATABASE_URL"
+
+
+def _ns(control_cmd: str, env: str = "staging", reason: str | None = None) -> argparse.Namespace:
+    return argparse.Namespace(control_cmd=control_cmd, env=env, reason=reason)
+
+
+def _halt_status(active: bool, reason: str | None = None) -> SystemHaltStatus:
+    return SystemHaltStatus(
+        active=active,
+        reason=reason,
+        source="cli:test",
+        updated_at=datetime(2026, 7, 7, 12, 0, tzinfo=UTC),
+    )
+
+
+def _position(symbol="ETHUSDT", stop_loss=2400.0, stop_loss_order_id="sl-1"):
+    return {
+        "symbol": symbol,
+        "side": "LONG",
+        "quantity": 0.03,
+        "entry_price": 2450.0,
+        "stop_loss": stop_loss,
+        "stop_loss_order_id": stop_loss_order_id,
+        "take_profit": 2550.0,
+        "unrealized_pnl": -1.2,
+    }
+
+
+@pytest.fixture
+def db(monkeypatch):
+    """Patched DatabaseManager wired to a healthy staging environment."""
+    monkeypatch.setenv(_STAGING_URL_VAR, "postgresql://staging.example/db")
+    monkeypatch.delenv("ALERT_WEBHOOK_URL", raising=False)
+    mock_db = MagicMock()
+    mock_db.get_system_halt.return_value = _halt_status(False)
+    mock_db.set_system_halt.return_value = _halt_status(True, "drill")
+    mock_db.get_active_session_id.return_value = 7
+    mock_db.get_active_positions.return_value = [_position()]
+    with patch("cli.commands.live_halt.DatabaseManager", return_value=mock_db):
+        yield mock_db
+
+
+class TestEnvResolution:
+    def test_missing_env_url_var_errors_without_touching_db(self, monkeypatch, capsys):
+        monkeypatch.delenv(_PRODUCTION_URL_VAR, raising=False)
+        with patch("cli.commands.live_halt.DatabaseManager") as manager_cls:
+            result = halt_main(_ns("halt", env="production", reason="drill"))
+
+        assert result == 1
+        manager_cls.assert_not_called()
+        assert _PRODUCTION_URL_VAR in capsys.readouterr().out
+
+    def test_db_connection_failure_returns_error(self, monkeypatch, capsys):
+        monkeypatch.setenv(_STAGING_URL_VAR, "postgresql://staging.example/db")
+        with patch(
+            "cli.commands.live_halt.DatabaseManager",
+            side_effect=ConnectionError("unreachable"),
+        ):
+            result = halt_main(_ns("halt", reason="drill"))
+
+        assert result == 1
+        assert "unreachable" in capsys.readouterr().out
+
+
+class TestHalt:
+    def test_halt_sets_flag_and_emits_critical_event(self, db, capsys):
+        result = halt_main(_ns("halt", reason="kill-switch drill"))
+
+        assert result == 0
+        args, kwargs = db.set_system_halt.call_args
+        assert args == (True,)
+        assert kwargs["reason"] == "kill-switch drill"
+        assert kwargs["source"].startswith("cli:")
+        event_kwargs = db.log_event.call_args.kwargs
+        assert event_kwargs["severity"] == "critical"
+        assert event_kwargs["error_code"] == "SYSTEM_HALT_COMMAND"
+        out = capsys.readouterr().out
+        assert "HALT" in out
+        assert "kill-switch drill" in out
+
+    def test_halt_prints_open_positions_and_stops(self, db, capsys):
+        halt_main(_ns("halt", reason="drill"))
+
+        out = capsys.readouterr().out
+        assert "ETHUSDT" in out
+        assert "2400" in out  # stop price
+        assert "sl-1" in out  # stop-loss exchange order id
+
+    def test_halt_flags_position_without_stop(self, db, capsys):
+        db.get_active_positions.return_value = [_position(stop_loss=None, stop_loss_order_id=None)]
+
+        halt_main(_ns("halt", reason="drill"))
+
+        assert "NO STOP" in capsys.readouterr().out
+
+    def test_halt_is_idempotent_when_already_active(self, db, capsys):
+        db.get_system_halt.return_value = _halt_status(True, "earlier drill")
+
+        result = halt_main(_ns("halt", reason="again"))
+
+        assert result == 0
+        db.set_system_halt.assert_not_called()
+        db.log_event.assert_not_called()
+        assert "already" in capsys.readouterr().out.lower()
+
+    def test_halt_posts_webhook_when_configured(self, db, monkeypatch):
+        monkeypatch.setenv("ALERT_WEBHOOK_URL", "https://hooks.example/alert")
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        with patch("requests.post", return_value=response) as post:
+            halt_main(_ns("halt", reason="drill"))
+
+        post.assert_called_once()
+        assert post.call_args.args[0] == "https://hooks.example/alert"
+        assert db.log_event.call_args.kwargs["alert_sent"] is True
+
+    def test_halt_without_webhook_records_undelivered_alert(self, db, capsys):
+        halt_main(_ns("halt", reason="drill"))
+
+        assert db.log_event.call_args.kwargs["alert_sent"] is False
+        assert "no alert webhook" in capsys.readouterr().out.lower()
+
+    def test_halt_survives_event_write_failure(self, db, capsys):
+        """The flag write is the protective action; observability must not fail it."""
+        db.log_event.side_effect = RuntimeError("events table locked")
+
+        result = halt_main(_ns("halt", reason="drill"))
+
+        assert result == 0
+        db.set_system_halt.assert_called_once()
+
+
+class TestResume:
+    def test_resume_clears_flag_and_emits_event(self, db, capsys):
+        db.get_system_halt.return_value = _halt_status(True, "drill")
+        db.set_system_halt.return_value = _halt_status(False, "drill complete")
+
+        result = resume_main(_ns("resume", reason="drill complete"))
+
+        assert result == 0
+        args, kwargs = db.set_system_halt.call_args
+        assert args == (False,)
+        assert kwargs["reason"] == "drill complete"
+        event_kwargs = db.log_event.call_args.kwargs
+        assert event_kwargs["severity"] == "warning"
+        assert event_kwargs["error_code"] == "SYSTEM_RESUME_COMMAND"
+        assert "RESUME" in capsys.readouterr().out
+
+    def test_resume_is_idempotent_when_not_halted(self, db, capsys):
+        db.get_system_halt.return_value = _halt_status(False)
+
+        result = resume_main(_ns("resume"))
+
+        assert result == 0
+        db.set_system_halt.assert_not_called()
+        db.log_event.assert_not_called()
+        assert "already" in capsys.readouterr().out.lower()
+
+    def test_resume_prints_account_state(self, db, capsys):
+        db.get_system_halt.return_value = _halt_status(True, "drill")
+        db.set_system_halt.return_value = _halt_status(False)
+
+        resume_main(_ns("resume"))
+
+        assert "ETHUSDT" in capsys.readouterr().out

--- a/tests/unit/cli/test_live_halt.py
+++ b/tests/unit/cli/test_live_halt.py
@@ -152,6 +152,39 @@ class TestHalt:
         assert result == 0
         db.set_system_halt.assert_called_once()
 
+    def test_halt_echoes_masked_target_host_before_mutation(self, db, monkeypatch, capsys):
+        """The resolved DB host is printed (credentials masked) BEFORE the flag
+        write, so a mis-set RAILWAY_*_DATABASE_URL is visible to the operator."""
+        monkeypatch.setenv(
+            _STAGING_URL_VAR, "postgresql://bot:s3cretpw@db.staging.rlwy.net:5432/railway"
+        )
+
+        halt_main(_ns("halt", reason="drill"))
+
+        out = capsys.readouterr().out
+        assert "db.staging.rlwy.net:5432/railway" in out
+        assert "s3cretpw" not in out
+        assert "bot:" not in out
+        target_line = next(i for i, line in enumerate(out.splitlines()) if "target:" in line)
+        mutation_line = next(i for i, line in enumerate(out.splitlines()) if "HALT set" in line)
+        assert target_line < mutation_line
+
+    def test_halt_source_survives_getpass_failure(self, db, monkeypatch):
+        """Operator attribution must never block the flag write (#929 review)."""
+        monkeypatch.delenv("USER", raising=False)
+        with patch("cli.commands.live_halt.getpass.getuser", side_effect=OSError("no passwd")):
+            result = halt_main(_ns("halt", reason="drill"))
+
+        assert result == 0
+        assert db.set_system_halt.call_args.kwargs["source"] == "cli:unknown"
+
+    def test_halt_source_falls_back_to_user_env(self, db, monkeypatch):
+        monkeypatch.setenv("USER", "ops-oncall")
+        with patch("cli.commands.live_halt.getpass.getuser", side_effect=KeyError("uid")):
+            halt_main(_ns("halt", reason="drill"))
+
+        assert db.set_system_halt.call_args.kwargs["source"] == "cli:ops-oncall"
+
 
 class TestResume:
     def test_resume_clears_flag_and_emits_event(self, db, capsys):

--- a/tests/unit/database/test_system_control_flags.py
+++ b/tests/unit/database/test_system_control_flags.py
@@ -1,0 +1,75 @@
+"""DatabaseManager ``system_halt`` control flag: durable manual kill-switch state (#922).
+
+The manual kill-switch (`atb live-control halt`) persists a single
+``system_control_flags`` row named ``system_halt`` that the live trading loop
+polls each iteration. These tests run against a real in-memory SQLite database
+to exercise the actual upsert/read semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.database.manager import DatabaseManager
+from src.database.models import SystemControlFlag
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+@pytest.fixture
+def db() -> DatabaseManager:
+    return DatabaseManager("sqlite:///:memory:")
+
+
+class TestSystemHaltFlag:
+    def test_defaults_to_inactive_when_row_missing(self, db):
+        """A fresh database reads as not-halted (fail-open for normal boot)."""
+        status = db.get_system_halt()
+
+        assert status.active is False
+        assert status.reason is None
+        assert status.source is None
+        assert status.updated_at is None
+
+    def test_set_halt_persists_reason_and_source(self, db):
+        """Halting durably records who pulled the switch and why."""
+        db.set_system_halt(True, reason="kill-switch drill", source="cli:alex")
+
+        status = db.get_system_halt()
+
+        assert status.active is True
+        assert status.reason == "kill-switch drill"
+        assert status.source == "cli:alex"
+        assert status.updated_at is not None
+
+    def test_resume_clears_halt(self, db):
+        """An explicit resume flips the flag off and records the resume reason."""
+        db.set_system_halt(True, reason="drill", source="cli:alex")
+
+        db.set_system_halt(False, reason="drill complete", source="cli:alex")
+        status = db.get_system_halt()
+
+        assert status.active is False
+        assert status.reason == "drill complete"
+
+    def test_set_returns_persisted_snapshot(self, db):
+        """The setter returns the state it just wrote (for CLI printouts)."""
+        snapshot = db.set_system_halt(True, reason="macro event", source="cli:ops")
+
+        assert snapshot.active is True
+        assert snapshot.reason == "macro event"
+        assert snapshot.source == "cli:ops"
+        assert snapshot.updated_at is not None
+
+    def test_upsert_reuses_single_row(self, db):
+        """Repeated halt/resume cycles update one row, not append rows."""
+        db.set_system_halt(True, reason="a", source="s")
+        db.set_system_halt(False, reason="b", source="s")
+        db.set_system_halt(True, reason="c", source="s")
+
+        with db.get_session() as session:
+            assert session.query(SystemControlFlag).count() == 1
+
+        status = db.get_system_halt()
+        assert status.active is True
+        assert status.reason == "c"

--- a/tests/unit/engines/live/test_system_halt_enforcer.py
+++ b/tests/unit/engines/live/test_system_halt_enforcer.py
@@ -148,3 +148,93 @@ def test_event_failure_does_not_undo_protective_action():
     SystemHaltEnforcer(state, halt).check()  # must not raise
 
     assert halt.active is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed startup: never-successfully-polled state is not trusted
+# ---------------------------------------------------------------------------
+
+
+def test_state_unestablished_until_first_successful_poll():
+    """`established` flips only on a successful poll — never on failure."""
+    state = _State(RuntimeError("db unreachable"))
+    halt = SystemHaltState()
+    enforcer = SystemHaltEnforcer(state, halt)
+
+    assert halt.established is False
+    enforcer.check()
+    assert halt.established is False  # failed poll cannot establish truth
+
+    state.status = _status(False)
+    enforcer.check()
+    assert halt.established is True
+
+
+def test_prime_failure_fails_closed_and_records_unverified_event():
+    """Boot with a dead DB: state stays unestablished and the operator is paged."""
+    state = _State(RuntimeError("db unreachable at boot"))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).prime()
+
+    assert halt.established is False
+    assert len(state.events) == 1
+    event = state.events[0]
+    assert event["error_code"] == "SYSTEM_HALT_UNVERIFIED"
+    assert event["severity"] == "critical"
+    assert event["alert"] is True
+
+
+def test_prime_healthy_boot_establishes_without_events():
+    """Boot with DB up and no halt row: trading starts immediately, quietly."""
+    state = _State(_status(False))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).prime()
+
+    assert halt.established is True
+    assert halt.active is False
+    assert state.events == []
+
+
+def test_prime_with_active_row_activates_and_announces():
+    """Boot with an active halt row: the halt is enforced from construction."""
+    state = _State(_status(True, "pre-restart drill"))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).prime()
+
+    assert halt.established is True
+    assert halt.active is True
+    assert len(state.events) == 1
+    assert state.events[0]["error_code"] == "SYSTEM_HALT"
+
+
+def test_prime_event_failure_still_fails_closed():
+    """The unverified-boot page failing cannot flip the state to trading."""
+
+    class _ExplodingState(_State):
+        def _record_event(self, *args, **kwargs):
+            raise RuntimeError("event sink down")
+
+    state = _ExplodingState(RuntimeError("db unreachable"))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).prime()  # must not raise
+
+    assert halt.established is False
+
+
+def test_non_boolean_active_value_does_not_halt():
+    """Only an explicit boolean True halts — a mocked/garbage status must not
+    phantom-halt an engine (real reads coerce the column to bool)."""
+    state = _State(
+        SystemHaltStatus(active=object(), reason=None, source=None, updated_at=None)  # type: ignore[arg-type]
+    )
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).check()
+
+    assert halt.active is False
+    assert halt.established is True
+    assert state.events == []

--- a/tests/unit/engines/live/test_system_halt_enforcer.py
+++ b/tests/unit/engines/live/test_system_halt_enforcer.py
@@ -1,0 +1,150 @@
+"""Unit tests for the manual system-halt loop enforcer (#922).
+
+The enforcer polls the DB ``system_halt`` control flag once per trading-loop
+iteration and mirrors it into the loop-owned ``SystemHaltState`` that the
+entry/scale-in gates consult. Transitions emit operator-visible events;
+poll failures keep the last-known state (a DB outage can never silently
+clear an active halt).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.database.manager import SystemHaltStatus
+from src.engines.live.monitoring.system_halt_enforcer import SystemHaltEnforcer
+from src.engines.live.system_halt import SystemHaltState
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class _State:
+    """Minimal engine-state stub: a swappable halt status + event recorder."""
+
+    def __init__(self, status: SystemHaltStatus | Exception):
+        self.status = status
+        self.events: list[dict] = []
+        self.db_manager = SimpleNamespace(get_system_halt=self._get_system_halt)
+
+    def _get_system_halt(self) -> SystemHaltStatus:
+        if isinstance(self.status, Exception):
+            raise self.status
+        return self.status
+
+    def _record_event(self, event_type, message, **kwargs):
+        self.events.append({"message": message, **kwargs})
+
+
+def _status(active: bool, reason: str | None = None) -> SystemHaltStatus:
+    return SystemHaltStatus(active=active, reason=reason, source="cli:test", updated_at=None)
+
+
+def test_halt_flag_activates_state_and_records_critical_event():
+    state = _State(_status(True, "kill-switch drill"))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).check()
+
+    assert halt.active is True
+    assert halt.reason == "kill-switch drill"
+    assert len(state.events) == 1
+    event = state.events[0]
+    assert event["error_code"] == "SYSTEM_HALT"
+    assert event["severity"] == "critical"
+    assert event["alert"] is True
+    assert "kill-switch drill" in event["message"]
+
+
+def test_repeated_active_checks_do_not_duplicate_events():
+    state = _State(_status(True, "drill"))
+    halt = SystemHaltState()
+    enforcer = SystemHaltEnforcer(state, halt)
+
+    for _ in range(3):
+        enforcer.check()
+
+    assert halt.active is True
+    assert len(state.events) == 1
+
+
+def test_clear_flag_deactivates_and_records_resume_event():
+    state = _State(_status(True, "drill"))
+    halt = SystemHaltState()
+    enforcer = SystemHaltEnforcer(state, halt)
+    enforcer.check()
+
+    state.status = _status(False, "drill complete")
+    enforcer.check()
+
+    assert halt.active is False
+    assert halt.reason is None
+    assert len(state.events) == 2
+    resume = state.events[1]
+    assert resume["error_code"] == "SYSTEM_HALT_CLEARED"
+    assert resume["severity"] == "warning"
+    assert resume["alert"] is True
+
+
+def test_inactive_flag_records_no_events():
+    state = _State(_status(False))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).check()
+
+    assert halt.active is False
+    assert state.events == []
+
+
+def test_poll_failure_keeps_active_halt_latched():
+    """A DB outage must never silently release an active halt."""
+    state = _State(_status(True, "drill"))
+    halt = SystemHaltState()
+    enforcer = SystemHaltEnforcer(state, halt)
+    enforcer.check()
+
+    state.status = RuntimeError("db unreachable")
+    enforcer.check()
+
+    assert halt.active is True
+    assert halt.reason == "drill"
+    assert len(state.events) == 1  # no spurious clear/halt events
+
+
+def test_poll_failure_when_not_halted_stays_not_halted():
+    state = _State(RuntimeError("db unreachable"))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).check()  # must not raise
+
+    assert halt.active is False
+    assert state.events == []
+
+
+def test_reason_updates_while_halted_without_new_event():
+    state = _State(_status(True, "first reason"))
+    halt = SystemHaltState()
+    enforcer = SystemHaltEnforcer(state, halt)
+    enforcer.check()
+
+    state.status = _status(True, "amended reason")
+    enforcer.check()
+
+    assert halt.reason == "amended reason"
+    assert len(state.events) == 1
+
+
+def test_event_failure_does_not_undo_protective_action():
+    """Protective action first: a failing event sink cannot unset the halt."""
+
+    class _ExplodingState(_State):
+        def _record_event(self, *args, **kwargs):
+            raise RuntimeError("event sink down")
+
+    state = _ExplodingState(_status(True, "drill"))
+    halt = SystemHaltState()
+
+    SystemHaltEnforcer(state, halt).check()  # must not raise
+
+    assert halt.active is True

--- a/tests/unit/engines/live/test_system_halt_gate.py
+++ b/tests/unit/engines/live/test_system_halt_gate.py
@@ -1,0 +1,358 @@
+"""Manual system halt: entry/scale-in suppression + engine wiring (#922).
+
+While the DB-backed ``system_halt`` flag is mirrored active, the live engine
+must not INCREASE exposure — new entries (component, chokepoint, legacy short)
+and scale-ins are skipped with FEATURE_ENTRY_PAUSE semantics, while exits,
+partial exits, stop-loss management and reconciliation continue untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, create_autospec, patch
+
+import pandas as pd
+import pytest
+
+from src.database.manager import SystemHaltStatus
+from src.engines.live.execution.entry_coordinator import (
+    LiveEntryCoordinator,
+    LiveEntryEngineState,
+)
+from src.engines.live.execution.exit_handler import LiveExitHandler
+from src.engines.live.system_halt import SystemHaltState
+from src.engines.shared.models import PositionSide
+from src.strategies.components import SignalDirection
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+def _make_component_state(*, notional: float = 150.0) -> MagicMock:
+    """Backref for the direct ComponentStrategy path of check_entry_conditions."""
+    from src.strategies.components import Strategy as ComponentStrategy
+
+    state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = False
+    state._is_runtime_strategy.return_value = False
+    state.current_balance = 1000.0
+    state.max_position_size = 1.0
+    state.trading_session_id = None
+    state.db_manager = None
+
+    strategy = MagicMock(spec=ComponentStrategy)
+    decision = MagicMock()
+    decision.position_size = notional
+    decision.signal.direction = SignalDirection.BUY
+    decision.signal.strength = 0.9
+    decision.signal.confidence = 0.8
+    strategy.process_candle.return_value = decision
+    strategy.get_stop_loss_price.return_value = 45000.0
+    state.strategy = strategy
+
+    state._extract_indicators.return_value = {}
+    state._extract_sentiment_data.return_value = {}
+    state._extract_ml_predictions.return_value = {}
+    state._build_component_positions.return_value = []
+    state._get_correlation_context.return_value = None
+    state._resolve_take_profit_pct.return_value = 0.3
+    state._apply_dynamic_risk_adjustment.side_effect = lambda original_size, current_time: (
+        original_size
+    )
+    return state
+
+
+def _run_entry_check(state: MagicMock, halt: SystemHaltState) -> LiveEntryCoordinator:
+    coordinator = LiveEntryCoordinator(engine_state=state, system_halt=halt)
+    coordinator.execute_entry = MagicMock()  # type: ignore[method-assign]
+    df = pd.DataFrame({"close": [50000.0]})
+    coordinator.check_entry_conditions(
+        df=df,
+        current_index=0,
+        symbol="BTCUSDT",
+        current_price=50000.0,
+        current_time=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# Halt ACTIVE: entries suppressed on every path
+# ---------------------------------------------------------------------------
+
+
+def test_halt_skips_entry_check_before_strategy_evaluation():
+    state = _make_component_state()
+    halt = SystemHaltState(active=True, reason="kill-switch drill")
+
+    coordinator = _run_entry_check(state, halt)
+
+    coordinator.execute_entry.assert_not_called()
+    state.strategy.process_candle.assert_not_called()
+
+
+def test_halt_blocks_execute_entry_locked_defense_in_depth():
+    """Even a direct entry-execution call is refused while halted."""
+    state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = False
+    state.live_entry_handler = MagicMock()
+    state.live_position_tracker = MagicMock()
+    state.live_position_tracker.has_position_for_symbol.return_value = False
+    state.live_position_tracker.position_count = 0
+    state.risk_manager = MagicMock()
+    state.risk_manager.get_max_concurrent_positions.return_value = 1
+    state.max_position_size = 1.0
+    halt = SystemHaltState(active=True, reason="drill")
+
+    coordinator = LiveEntryCoordinator(engine_state=state, system_halt=halt)
+    coordinator.execute_entry_locked(
+        symbol="BTCUSDT",
+        side=PositionSide.LONG,
+        size=0.1,
+        price=50000.0,
+        stop_loss=49000.0,
+        take_profit=51000.0,
+        signal_strength=0.8,
+        signal_confidence=0.7,
+    )
+
+    state.live_entry_handler.execute_entry.assert_not_called()
+
+
+def test_halt_blocks_legacy_short_entry():
+    state = create_autospec(LiveEntryEngineState, instance=True)
+    state._close_only_mode = False
+    state._is_runtime_strategy.return_value = False
+    strategy = MagicMock()
+    strategy.check_short_entry_conditions.return_value = True
+    strategy.get_risk_overrides.return_value = {"position_sizer": "x"}
+    state.strategy = strategy
+    halt = SystemHaltState(active=True, reason="drill")
+
+    coordinator = LiveEntryCoordinator(engine_state=state, system_halt=halt)
+    coordinator.execute_entry = MagicMock()  # type: ignore[method-assign]
+    coordinator.process_legacy_short_entry(
+        df=MagicMock(),
+        current_index=0,
+        symbol="BTCUSDT",
+        current_price=50000.0,
+        current_time=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+    coordinator.execute_entry.assert_not_called()
+    strategy.check_short_entry_conditions.assert_not_called()
+
+
+def test_halt_warning_mentions_manual_halt_and_reason(caplog):
+    state = _make_component_state()
+    halt = SystemHaltState(active=True, reason="FOMC de-risk")
+
+    with caplog.at_level(logging.WARNING):
+        _run_entry_check(state, halt)
+
+    halt_warnings = [r for r in caplog.records if "MANUAL SYSTEM HALT" in r.message]
+    assert len(halt_warnings) == 1
+    assert "FOMC de-risk" in halt_warnings[0].message
+
+
+# ---------------------------------------------------------------------------
+# Halt ACTIVE: scale-ins suppressed, partial exits keep running
+# ---------------------------------------------------------------------------
+
+
+def _make_partial_ops_handler(
+    halt: SystemHaltState | None,
+    *,
+    should_exit: bool = False,
+    should_scale: bool = True,
+):
+    """LiveExitHandler wired for check_partial_operations with one position."""
+    position = MagicMock()
+    position.symbol = "BTCUSDT"
+    position.order_id = "order-1"
+    position.entry_time = datetime(2024, 1, 1, tzinfo=UTC)
+    position.current_size = 0.08
+    position.original_size = 0.08
+    position.size = 0.08
+
+    execution_engine = MagicMock()
+    execution_engine.fee_rate = 0.0
+    execution_engine.slippage_rate = 0.0
+    position_tracker = MagicMock()
+    position_tracker.positions = {"order-1": position}
+    position_tracker.apply_partial_exit.return_value = SimpleNamespace(
+        realized_pnl=1.0, new_current_size=0.04, partial_exits_taken=1
+    )
+    partial_manager = MagicMock()
+    partial_manager.check_partial_exit.side_effect = [
+        SimpleNamespace(should_exit=should_exit, exit_fraction=0.5, target_index=0),
+        SimpleNamespace(should_exit=False, exit_fraction=None, target_index=None),
+    ]
+    partial_manager.check_scale_in.return_value = SimpleNamespace(
+        should_scale=should_scale, scale_fraction=0.05, target_index=0
+    )
+    handler = LiveExitHandler(
+        execution_engine=execution_engine,
+        position_tracker=position_tracker,
+        execution_model=MagicMock(),
+        risk_manager=None,
+        partial_manager=partial_manager,
+        max_position_size=0.5,
+        system_halt=halt,
+    )
+    return handler, position_tracker
+
+
+def test_halt_suppresses_scale_in():
+    halt = SystemHaltState(active=True, reason="drill")
+    handler, tracker = _make_partial_ops_handler(halt, should_scale=True)
+
+    handler.check_partial_operations(
+        df=MagicMock(),
+        current_index=0,
+        current_price=51000.0,
+        current_balance=1000.0,
+    )
+
+    tracker.apply_scale_in.assert_not_called()
+
+
+def test_halt_keeps_partial_exits_running():
+    halt = SystemHaltState(active=True, reason="drill")
+    handler, tracker = _make_partial_ops_handler(halt, should_exit=True, should_scale=True)
+
+    handler.check_partial_operations(
+        df=MagicMock(),
+        current_index=0,
+        current_price=51000.0,
+        current_balance=1000.0,
+    )
+
+    tracker.apply_partial_exit.assert_called_once()
+    tracker.apply_scale_in.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Halt INACTIVE: behavior unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_inactive_halt_entries_proceed(monkeypatch):
+    monkeypatch.delenv("FEATURE_ENTRY_PAUSE", raising=False)
+    state = _make_component_state(notional=150.0)
+    halt = SystemHaltState()
+
+    coordinator = _run_entry_check(state, halt)
+
+    coordinator.execute_entry.assert_called_once()
+
+
+def test_inactive_halt_scale_in_proceeds(monkeypatch):
+    monkeypatch.delenv("FEATURE_ENTRY_PAUSE", raising=False)
+    handler, tracker = _make_partial_ops_handler(SystemHaltState(), should_scale=True)
+
+    handler.check_partial_operations(
+        df=MagicMock(),
+        current_index=0,
+        current_price=51000.0,
+        current_balance=1000.0,
+    )
+
+    tracker.apply_scale_in.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Engine wiring + in-loop behavior
+# ---------------------------------------------------------------------------
+
+
+def _make_engine():
+    """Real LiveTradingEngine with mocked externals (DB, provider, strategy)."""
+    with patch("src.engines.live.trading_engine.DatabaseManager"):
+        from src.engines.live.trading_engine import LiveTradingEngine
+
+        mock_strategy = MagicMock()
+        mock_strategy.get_risk_overrides.return_value = {}
+        mock_strategy.__class__.__name__ = "MockStrategy"
+        mock_strategy.config = {}
+
+        mock_dp = MagicMock()
+
+        engine = LiveTradingEngine(
+            strategy=mock_strategy,
+            data_provider=mock_dp,
+            enable_live_trading=False,
+            initial_balance=1000.0,
+            enable_dynamic_risk=False,
+            enable_hot_swapping=False,
+        )
+        return engine
+
+
+def test_engine_wires_shared_halt_state():
+    """One SystemHaltState instance: enforcer writes it, both gates read it."""
+    engine = _make_engine()
+
+    assert engine.entry_coordinator._entry_pause._halt_state is engine._system_halt
+    assert engine.live_exit_handler._entry_pause._halt_state is engine._system_halt
+    assert engine._system_halt_enforcer._halt is engine._system_halt
+
+
+def test_trading_loop_honors_halt_within_one_iteration():
+    """A halt flag already in the DB blocks entries on the very first iteration.
+
+    The enforcer poll runs at the top of the loop iteration, so the halt is
+    mirrored BEFORE entry evaluation of that same iteration; exits still run.
+    """
+    engine = _make_engine()
+    engine.db_manager.get_system_halt.return_value = SystemHaltStatus(
+        active=True, reason="drill", source="cli:test", updated_at=None
+    )
+
+    rows = 5
+    idx = pd.date_range(end=datetime.now(UTC), periods=rows, freq="1h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [50000.0] * rows,
+            "high": [51000.0] * rows,
+            "low": [49000.0] * rows,
+            "close": [50500.0] * rows,
+            "volume": [100.0] * rows,
+        },
+        index=idx,
+    )
+
+    halt_seen_by_entry_check: list[bool] = []
+    halt_seen_by_exit_check: list[bool] = []
+
+    engine._ensure_ws_health_monitor_alive = MagicMock()
+    engine._drain_pending_fill_exits = MagicMock()
+    engine._get_latest_data = MagicMock(return_value=df)
+    engine._is_data_fresh = MagicMock(return_value=True)
+    engine._prepare_strategy_dataframe = MagicMock(side_effect=lambda d: d)
+    engine._is_context_ready = MagicMock(return_value=(True, "ready"))
+    engine._runtime_process_decision = MagicMock(return_value=None)
+    engine._check_entry_conditions = MagicMock(
+        side_effect=lambda *a, **k: halt_seen_by_entry_check.append(engine._system_halt.active)
+    )
+    engine._check_exit_conditions = MagicMock(
+        side_effect=lambda *a, **k: halt_seen_by_exit_check.append(engine._system_halt.active)
+    )
+    engine._update_performance_metrics = MagicMock()
+    engine._check_max_drawdown = MagicMock()
+    engine._log_periodic_account_state = MagicMock()
+    engine._log_status = MagicMock()
+    engine._calculate_adaptive_interval = MagicMock(return_value=0)
+    engine._sleep_with_interrupt = MagicMock()
+    engine.stop = MagicMock()
+
+    engine.is_running = True
+    engine._trading_loop("BTCUSDT", "1h", max_steps=1)
+
+    # Halt mirrored from the DB before entry evaluation of the SAME iteration.
+    assert halt_seen_by_entry_check == [True]
+    # Exit management still ran while halted.
+    assert halt_seen_by_exit_check == [True]
+    # The legacy short path went through the real gate and evaluated nothing.
+    engine.strategy.check_short_entry_conditions.assert_not_called()

--- a/tests/unit/engines/live/test_system_halt_gate.py
+++ b/tests/unit/engines/live/test_system_halt_gate.py
@@ -84,7 +84,7 @@ def _run_entry_check(state: MagicMock, halt: SystemHaltState) -> LiveEntryCoordi
 
 def test_halt_skips_entry_check_before_strategy_evaluation():
     state = _make_component_state()
-    halt = SystemHaltState(active=True, reason="kill-switch drill")
+    halt = SystemHaltState(active=True, reason="kill-switch drill", established=True)
 
     coordinator = _run_entry_check(state, halt)
 
@@ -103,7 +103,7 @@ def test_halt_blocks_execute_entry_locked_defense_in_depth():
     state.risk_manager = MagicMock()
     state.risk_manager.get_max_concurrent_positions.return_value = 1
     state.max_position_size = 1.0
-    halt = SystemHaltState(active=True, reason="drill")
+    halt = SystemHaltState(active=True, reason="drill", established=True)
 
     coordinator = LiveEntryCoordinator(engine_state=state, system_halt=halt)
     coordinator.execute_entry_locked(
@@ -128,7 +128,7 @@ def test_halt_blocks_legacy_short_entry():
     strategy.check_short_entry_conditions.return_value = True
     strategy.get_risk_overrides.return_value = {"position_sizer": "x"}
     state.strategy = strategy
-    halt = SystemHaltState(active=True, reason="drill")
+    halt = SystemHaltState(active=True, reason="drill", established=True)
 
     coordinator = LiveEntryCoordinator(engine_state=state, system_halt=halt)
     coordinator.execute_entry = MagicMock()  # type: ignore[method-assign]
@@ -146,7 +146,7 @@ def test_halt_blocks_legacy_short_entry():
 
 def test_halt_warning_mentions_manual_halt_and_reason(caplog):
     state = _make_component_state()
-    halt = SystemHaltState(active=True, reason="FOMC de-risk")
+    halt = SystemHaltState(active=True, reason="FOMC de-risk", established=True)
 
     with caplog.at_level(logging.WARNING):
         _run_entry_check(state, halt)
@@ -205,7 +205,7 @@ def _make_partial_ops_handler(
 
 
 def test_halt_suppresses_scale_in():
-    halt = SystemHaltState(active=True, reason="drill")
+    halt = SystemHaltState(active=True, reason="drill", established=True)
     handler, tracker = _make_partial_ops_handler(halt, should_scale=True)
 
     handler.check_partial_operations(
@@ -219,7 +219,7 @@ def test_halt_suppresses_scale_in():
 
 
 def test_halt_keeps_partial_exits_running():
-    halt = SystemHaltState(active=True, reason="drill")
+    halt = SystemHaltState(active=True, reason="drill", established=True)
     handler, tracker = _make_partial_ops_handler(halt, should_exit=True, should_scale=True)
 
     handler.check_partial_operations(
@@ -241,7 +241,7 @@ def test_halt_keeps_partial_exits_running():
 def test_inactive_halt_entries_proceed(monkeypatch):
     monkeypatch.delenv("FEATURE_ENTRY_PAUSE", raising=False)
     state = _make_component_state(notional=150.0)
-    halt = SystemHaltState()
+    halt = SystemHaltState(established=True)
 
     coordinator = _run_entry_check(state, halt)
 
@@ -250,7 +250,9 @@ def test_inactive_halt_entries_proceed(monkeypatch):
 
 def test_inactive_halt_scale_in_proceeds(monkeypatch):
     monkeypatch.delenv("FEATURE_ENTRY_PAUSE", raising=False)
-    handler, tracker = _make_partial_ops_handler(SystemHaltState(), should_scale=True)
+    handler, tracker = _make_partial_ops_handler(
+        SystemHaltState(established=True), should_scale=True
+    )
 
     handler.check_partial_operations(
         df=MagicMock(),
@@ -267,10 +269,20 @@ def test_inactive_halt_scale_in_proceeds(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _make_engine():
-    """Real LiveTradingEngine with mocked externals (DB, provider, strategy)."""
-    with patch("src.engines.live.trading_engine.DatabaseManager"):
+def _make_engine(get_system_halt=None, **engine_kwargs):
+    """Real LiveTradingEngine with mocked externals (DB, provider, strategy).
+
+    ``get_system_halt`` configures the DB mock BEFORE construction so boot-time
+    priming reads see it (a SystemHaltStatus return value or an Exception
+    side effect).
+    """
+    with patch("src.engines.live.trading_engine.DatabaseManager") as manager_cls:
         from src.engines.live.trading_engine import LiveTradingEngine
+
+        if isinstance(get_system_halt, Exception):
+            manager_cls.return_value.get_system_halt.side_effect = get_system_halt
+        elif get_system_halt is not None:
+            manager_cls.return_value.get_system_halt.return_value = get_system_halt
 
         mock_strategy = MagicMock()
         mock_strategy.get_risk_overrides.return_value = {}
@@ -286,8 +298,45 @@ def _make_engine():
             initial_balance=1000.0,
             enable_dynamic_risk=False,
             enable_hot_swapping=False,
+            **engine_kwargs,
         )
         return engine
+
+
+def _run_one_loop_iteration(engine, *, entry_probe, exit_probe):
+    """Drive one real `_trading_loop` iteration with the data pipeline mocked."""
+    rows = 5
+    idx = pd.date_range(end=datetime.now(UTC), periods=rows, freq="1h", tz="UTC")
+    df = pd.DataFrame(
+        {
+            "open": [50000.0] * rows,
+            "high": [51000.0] * rows,
+            "low": [49000.0] * rows,
+            "close": [50500.0] * rows,
+            "volume": [100.0] * rows,
+        },
+        index=idx,
+    )
+
+    engine._ensure_ws_health_monitor_alive = MagicMock()
+    engine._drain_pending_fill_exits = MagicMock()
+    engine._get_latest_data = MagicMock(return_value=df)
+    engine._is_data_fresh = MagicMock(return_value=True)
+    engine._prepare_strategy_dataframe = MagicMock(side_effect=lambda d: d)
+    engine._is_context_ready = MagicMock(return_value=(True, "ready"))
+    engine._runtime_process_decision = MagicMock(return_value=None)
+    engine._check_entry_conditions = MagicMock(side_effect=entry_probe)
+    engine._check_exit_conditions = MagicMock(side_effect=exit_probe)
+    engine._update_performance_metrics = MagicMock()
+    engine._check_max_drawdown = MagicMock()
+    engine._log_periodic_account_state = MagicMock()
+    engine._log_status = MagicMock()
+    engine._calculate_adaptive_interval = MagicMock(return_value=0)
+    engine._sleep_with_interrupt = MagicMock()
+    engine.stop = MagicMock()
+
+    engine.is_running = True
+    engine._trading_loop("BTCUSDT", "1h", max_steps=1)
 
 
 def test_engine_wires_shared_halt_state():
@@ -310,45 +359,13 @@ def test_trading_loop_honors_halt_within_one_iteration():
         active=True, reason="drill", source="cli:test", updated_at=None
     )
 
-    rows = 5
-    idx = pd.date_range(end=datetime.now(UTC), periods=rows, freq="1h", tz="UTC")
-    df = pd.DataFrame(
-        {
-            "open": [50000.0] * rows,
-            "high": [51000.0] * rows,
-            "low": [49000.0] * rows,
-            "close": [50500.0] * rows,
-            "volume": [100.0] * rows,
-        },
-        index=idx,
-    )
-
     halt_seen_by_entry_check: list[bool] = []
     halt_seen_by_exit_check: list[bool] = []
-
-    engine._ensure_ws_health_monitor_alive = MagicMock()
-    engine._drain_pending_fill_exits = MagicMock()
-    engine._get_latest_data = MagicMock(return_value=df)
-    engine._is_data_fresh = MagicMock(return_value=True)
-    engine._prepare_strategy_dataframe = MagicMock(side_effect=lambda d: d)
-    engine._is_context_ready = MagicMock(return_value=(True, "ready"))
-    engine._runtime_process_decision = MagicMock(return_value=None)
-    engine._check_entry_conditions = MagicMock(
-        side_effect=lambda *a, **k: halt_seen_by_entry_check.append(engine._system_halt.active)
+    _run_one_loop_iteration(
+        engine,
+        entry_probe=lambda *a, **k: halt_seen_by_entry_check.append(engine._system_halt.active),
+        exit_probe=lambda *a, **k: halt_seen_by_exit_check.append(engine._system_halt.active),
     )
-    engine._check_exit_conditions = MagicMock(
-        side_effect=lambda *a, **k: halt_seen_by_exit_check.append(engine._system_halt.active)
-    )
-    engine._update_performance_metrics = MagicMock()
-    engine._check_max_drawdown = MagicMock()
-    engine._log_periodic_account_state = MagicMock()
-    engine._log_status = MagicMock()
-    engine._calculate_adaptive_interval = MagicMock(return_value=0)
-    engine._sleep_with_interrupt = MagicMock()
-    engine.stop = MagicMock()
-
-    engine.is_running = True
-    engine._trading_loop("BTCUSDT", "1h", max_steps=1)
 
     # Halt mirrored from the DB before entry evaluation of the SAME iteration.
     assert halt_seen_by_entry_check == [True]
@@ -356,3 +373,98 @@ def test_trading_loop_honors_halt_within_one_iteration():
     assert halt_seen_by_exit_check == [True]
     # The legacy short path went through the real gate and evaluated nothing.
     engine.strategy.check_short_entry_conditions.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed startup (#929 review P1): never-successfully-polled = halted
+# ---------------------------------------------------------------------------
+
+
+def test_unestablished_state_blocks_entries_fail_closed(caplog):
+    """A never-successfully-polled halt state gates entries (fail closed)."""
+    state = _make_component_state()
+    halt = SystemHaltState()  # unestablished default
+
+    with caplog.at_level(logging.WARNING):
+        coordinator = _run_entry_check(state, halt)
+
+    coordinator.execute_entry.assert_not_called()
+    state.strategy.process_candle.assert_not_called()
+    unverified = [r for r in caplog.records if "UNVERIFIED" in r.message]
+    assert len(unverified) == 1
+
+
+def test_unestablished_state_blocks_scale_in():
+    handler, tracker = _make_partial_ops_handler(SystemHaltState(), should_scale=True)
+
+    handler.check_partial_operations(
+        df=MagicMock(),
+        current_index=0,
+        current_price=51000.0,
+        current_balance=1000.0,
+    )
+
+    tracker.apply_scale_in.assert_not_called()
+
+
+def test_boot_with_dead_db_fails_closed_until_first_successful_poll():
+    """Boot while the DB is unreachable (whether or not an active halt row
+    exists): entries stay blocked; exits keep running."""
+    engine = _make_engine(get_system_halt=RuntimeError("db unreachable at boot"))
+
+    assert engine._system_halt.established is False
+
+    exit_ran: list[bool] = []
+    _run_one_loop_iteration(
+        engine,
+        entry_probe=lambda *a, **k: None,
+        exit_probe=lambda *a, **k: exit_ran.append(True),
+    )
+
+    # Still unestablished (poll failing) -> the real gates refuse new risk.
+    assert engine._system_halt.established is False
+    assert engine.entry_coordinator._entry_pause.paused("probe") is True
+    engine.strategy.check_short_entry_conditions.assert_not_called()
+    # Exits are never gated, even fail-closed.
+    assert exit_ran == [True]
+
+
+def test_healthy_boot_establishes_state_and_trades_immediately(monkeypatch):
+    """DB up + no halt row at boot: no fail-closed window, entries evaluated."""
+    monkeypatch.delenv("FEATURE_ENTRY_PAUSE", raising=False)
+    engine = _make_engine(
+        get_system_halt=SystemHaltStatus(active=False, reason=None, source=None, updated_at=None)
+    )
+
+    # Priming read at construction established the state before the loop.
+    assert engine._system_halt.established is True
+    assert engine._system_halt.active is False
+
+    entries_evaluated: list[bool] = []
+    engine.strategy.check_short_entry_conditions.return_value = False
+    _run_one_loop_iteration(
+        engine,
+        entry_probe=lambda *a, **k: entries_evaluated.append(True),
+        exit_probe=lambda *a, **k: None,
+    )
+
+    assert entries_evaluated == [True]
+    # The real legacy-short gate let evaluation through (halt inactive).
+    engine.strategy.check_short_entry_conditions.assert_called_once()
+
+
+def test_injected_exit_handler_rebound_to_shared_halt_state():
+    """A DI-injected exit handler must not bypass the manual halt (#929 review)."""
+    execution_engine = MagicMock()
+    execution_engine.fee_rate = 0.0
+    execution_engine.slippage_rate = 0.0
+    injected = LiveExitHandler(
+        execution_engine=execution_engine,
+        position_tracker=MagicMock(),
+        execution_model=MagicMock(),
+    )
+
+    engine = _make_engine(exit_handler=injected)
+
+    assert engine.live_exit_handler is injected
+    assert injected._entry_pause._halt_state is engine._system_halt


### PR DESCRIPTION
## Summary

Closes #922 — the manual kill-switch was vapor: `atb live-control halt` (the command
`risk-limits.json` declares as `kill_switch.manual_trigger_command`) did not exist, and
`atb live-control emergency-stop` printed "(simulated)" and exited 0. This PR makes the
human/PM manual halt REAL.

```bash
atb live-control halt   --env production|staging|development [--reason "..."]
atb live-control resume --env ... [--reason "..."]
```

## Mechanism chosen (restartless, DB-backed)

- **`halt` upserts a durable `system_halt` row** in the target environment's new
  `system_control_flags` table (env resolved via `RAILWAY_PRODUCTION_DATABASE_URL` /
  `RAILWAY_STAGING_DATABASE_URL` / `DATABASE_URL` — same vars the heartbeat monitor uses).
  The table is created by the existing `Base.metadata.create_all` boot path (and on CLI
  connect), so no manual migration step.
- **The running engine polls the flag at the TOP of every trading-loop iteration** via a new
  `SystemHaltEnforcer` (`src/engines/live/monitoring/system_halt_enforcer.py`, same pattern as
  the drawdown/circuit-breaker enforcers) and mirrors it into a loop-owned `SystemHaltState`.
- **Enforcement reuses the existing FEATURE_ENTRY_PAUSE gate** (`EntryPauseGate`, #835/#848
  lineage): the shared halt state is consulted at all four exposure-increase chokepoints —
  entry evaluation, `execute_entry_locked`, the legacy short path, and scale-ins. Exits,
  partial exits, stop-loss management and reconciliation are untouched. Nothing is liquidated.

**Latency (command → effect): at most ONE trading-loop iteration** — the poll runs before
entry evaluation of the same iteration, so the bound is the adaptive check interval
(30–300 s per `DEFAULT_MIN_CHECK_INTERVAL`/`DEFAULT_MAX_CHECK_INTERVAL`; ~2 min at prod
cadence). No restart, no redeploy.

**Fallback path (documented, not preferred):** `railway variables --set FEATURE_ENTRY_PAUSE=true`
on the target service. A Railway variable change triggers a redeploy, so it carries ~3 minutes
of latency; the CLI error output points at it when the DB is unreachable.

## Safety properties

- **Fail-safe polling**: a DB outage keeps the last-known state — an active halt can never be
  silently released by a failed poll (and one is never spuriously tripped; the existing
  DB-outage close-only guard covers prolonged outages).
- **Fail-CLOSED startup** (review round 1, P1): until the flag has been successfully read ONCE
  (priming read at engine construction, retried every loop iteration), the entry gates treat
  the state as halted — a reboot behind an unreachable database cannot trade past an operator
  halt it never managed to read. An unverifiable boot pages the operator
  (`error_code=SYSTEM_HALT_UNVERIFIED`); a healthy boot establishes the state at construction
  and trades immediately. Exits/stops/reconciliation are never gated, fail-closed included.
- **Idempotent**: halting twice / resuming twice reports "already ACTIVE/CLEAR" and exits 0
  without duplicate events.
- **Independent of close-only mode**: `resume` clears only the manual halt — it cannot
  accidentally clear a drawdown-guard or circuit-breaker trip (those latch/re-trip on their
  own logic).
- **Protective action before observability** (both sides): the flag write / state mirror
  happens before events and webhooks; announcement failures never undo enforcement.
- Concurrent first-ever halt writers can race the unique-name INSERT; the setter retries as an
  UPDATE — a kill-switch must not fail on a duplicate pull.

## Observability

- CLI emits `system_events`: `SYSTEM_HALT_COMMAND` (critical) / `SYSTEM_RESUME_COMMAND`
  (warning), with `alert_sent` reflecting real webhook delivery (`ALERT_WEBHOOK_URL`).
- Engine emits `SYSTEM_HALT` (critical, alert) when it honors the flag and
  `SYSTEM_HALT_CLEARED` (warning, alert) on resume — the enforcement proof.
- Both commands print the resulting account state via read-only queries, append-friendly
  one-fact-per-line: active session, open positions with their protective stops
  (`sl=... (order ...)`), take-profits and uPnL; positions without a stop are flagged
  **`NO STOP — position is UNPROTECTED`**.
- New monitoring signature added to `.claude/LESSONS.md` §5.2.

## emergency-stop: REMOVED (decision + rationale)

`emergency-stop` was a simulated no-op. Wiring it to "halt + cancel pending entry orders" was
considered and rejected: cancelling exchange orders from an **out-of-process CLI** races the
running engine's OrderTracker (a fill can land between list-and-cancel, producing exactly the
untracked-position/phantom classes this repo has fought), and the engine already times out /
cancels unfilled entries itself. The safe manual lever is `halt`: it guarantees no NEW risk
while the engine's own order lifecycle finishes in-flight work under its locks. Per the issue's
"no simulated safety commands may exist", the subcommand and its parser are deleted (a test now
asserts the parser rejects it).

## risk-limits.json (human-owned — NOT edited)

The Board should ratify `kill_switch.manual_trigger_command` at the next sitting to:

```
atb live-control halt --env production --reason "<why>"
```

(The current value `atb live-control halt` is now a real command; only the recommended
`--env`/`--reason` usage needs ratifying.)

## Testing

TDD — all new tests written failing-first:

- `tests/unit/database/test_system_control_flags.py` — durable flag upsert/read on a real
  SQLite DB (missing-row default, reason/source persistence, resume, single-row upsert).
- `tests/unit/engines/live/test_system_halt_enforcer.py` — halt mirrored within one check;
  CRITICAL event once (idempotent repeats); resume event; poll failure keeps an active halt
  latched; event-sink failure cannot undo enforcement.
- `tests/unit/engines/live/test_system_halt_gate.py` — halt blocks entry evaluation /
  `execute_entry_locked` / legacy short / scale-ins; partial exits keep running; reason in the
  rate-limited warning; **engine wiring** (one shared state instance across enforcer + both
  gates) and an **in-loop test**: with the flag already in the DB, one real `_trading_loop`
  iteration sees the halt BEFORE entry evaluation while exit checks still run and the real
  legacy-short gate blocks.
- `tests/unit/cli/test_live_halt.py` — env-var resolution failure, DB connect failure, flag +
  event + webhook emission (`alert_sent` truthfulness), position/stop printout, `NO STOP`
  flagging, idempotency, event-write failure never fails the (already durable) halt.
- `tests/unit/cli/test_live.py` — emergency-stop parser removal + halt/resume registration.
- Existing `test_entry_pause.py` suite unchanged and green (FEATURE_ENTRY_PAUSE semantics
  preserved, including log-message compatibility).
- Full unit suite: **4376 passed, 5 failed, 1 skipped** (73 min, 4 workers). All new halt
  tests green (30/30 halt-related results PASSED in-suite).
- Quality on changed files: `black` ✅ `ruff` ✅ `mypy` ✅ (all 10 src/cli files) `bandit` ✅
- End-to-end CLI smoke test against a real database (halt → idempotent halt → resume) ✔

**The 5 suite failures are pre-existing/environmental, not from this change** — each was
re-run on a clean `origin/develop` throwaway worktree in the same sandbox and fails
IDENTICALLY there (same assertion values):
`test_engine_prediction.py::test_predict_success` (0.0 == 105.5),
`test_engine_structured.py::test_predict_uses_feature_selector_with_schema` (0.0 == 101.0),
`test_indicators.py::test_indicators_performance` (wall-clock perf bound),
`test_model_architectures.py::test_inference_speed_benchmark` (perf bound),
`test_backtesting_comprehensive_edge_cases.py::test_one_minute_timeframe` (timeout).
All are model-availability/perf-bound in this sandbox; green in CI.

## Review round 1 — consolidated fixes (arch REQUEST-CHANGES + code nits)

- **[P1] Fail-closed startup**: `SystemHaltState.established` (False until the first
  SUCCESSFUL poll) + `SystemHaltEnforcer.prime()` at engine construction. The entry gates
  treat an unestablished state as halted; an unverifiable boot logs CRITICAL + emits
  `SYSTEM_HALT_UNVERIFIED` (alert). Healthy boot establishes at construction — zero trading
  delay. Failing-first tests: boot with dead DB (halted until first successful poll, exits
  unaffected — engine-level loop test), healthy boot (trades immediately, engine-level),
  prime with active row (halt enforced + announced), prime event-sink failure (still
  fail-closed), plus gate-level unestablished tests for entries and scale-ins.
- **[P2] Alembic migration** `0012_add_system_control_flags` (0011 pattern, existence-guarded
  both directions since runtime `create_all` may already have made the table). Verified
  against a fresh Postgres (`alembic upgrade head` → table + unique index, head=0012) and
  against a create_all-first DB (guarded upgrade no-ops cleanly).
- **[P3] CLI echoes the masked resolved DB target** (`target: env=... db=host:port/dbname
  (from $VAR)`) BEFORE any mutation; credentials never printed (test asserts ordering and
  masking). Latency docs corrected to 30–300 s (`DEFAULT_MIN_CHECK_INTERVAL` floor).
- **[P3] `getpass.getuser()` hardened**: `_operator_source()` falls back to `$USER`/"unknown"
  on OSError/KeyError — operator attribution can never block the flag write (failing-first
  tests for both fallbacks).
- **[P3] DI-injected exit handler rebound**: `LiveExitHandler.bind_system_halt()` called
  unconditionally by the engine, so injected handlers' scale-ins cannot bypass the halt
  (failing-first wiring test).
- `tests/mocks/MockDatabaseManager` gained `get_system_halt`/`set_system_halt` (the
  fail-closed change surfaced the missing method by design — parity engines went fail-closed),
  and both methods were added to the mock↔real signature-contract test.

## Staging validation plan (kill-switch-drill step 4)

1. Merge + deploy `develop` to staging (`/deploy-staging`); confirm boot.
2. `atb live-control halt --env staging --reason "kill-switch drill #922"` — expect the
   flag-set line, account state, and a `SYSTEM_HALT_COMMAND` system_event.
3. Within one loop iteration (≤ check interval), confirm in staging logs:
   `🛑 MANUAL SYSTEM HALT ENFORCED ...` and a `system_events` row `error_code=SYSTEM_HALT`.
4. **Observe one skipped entry evaluation cycle**: `MANUAL SYSTEM HALT active (reason: ...) —
   skipping entry evaluation for <SYMBOL>` while `Decision:`/exit/reconciliation lines continue.
5. `atb live-control resume --env staging --reason "drill complete"` — expect
   `✅ Manual system halt cleared` + `SYSTEM_HALT_CLEARED`, and the next cycle evaluating
   entries again.
6. Record the drill result in `.claude/state/log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

