### PR TITLE
fix: read model.evaluate metrics by key, save model before diagnostics can lose it

### DIFF
--- a/src/ml/training_pipeline/artifacts.py
+++ b/src/ml/training_pipeline/artifacts.py
@@ -206,8 +206,14 @@ def evaluate_model_performance(
             "tensorflow is required for model performance evaluation but is not installed. "
             "Install it with: pip install tensorflow"
         )
-    train_loss, train_rmse = model.evaluate(X_train, y_train, verbose=0)
-    test_loss, test_rmse = model.evaluate(X_test, y_test, verbose=0)
+    # A positional unpack assumes every architecture compiles with exactly one metric
+    # (loss + rmse). attention_lstm and tcn compile with metrics=[rmse, mae], so
+    # model.evaluate() returns 3 values there -- read by key instead, which is robust
+    # to any per-architecture metric set.
+    train_metrics = model.evaluate(X_train, y_train, verbose=0, return_dict=True)
+    test_metrics = model.evaluate(X_test, y_test, verbose=0, return_dict=True)
+    train_loss, train_rmse = train_metrics["loss"], train_metrics["rmse"]
+    test_loss, test_rmse = test_metrics["loss"], test_metrics["rmse"]
     test_predictions = model.predict(X_test, verbose=0)
 
     if close_scaler is not None:

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -237,19 +237,35 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
             verbose=1,
         )
 
-        robustness_results = (
-            validate_model_robustness(model, X_val, y_val, feature_names, has_sentiment)
-            if ctx.config.diagnostics.evaluate_robustness
-            else {}
-        )
-        evaluation_results = evaluate_model_performance(
-            model,
-            X_train,
-            y_train,
-            X_val,
-            y_val,
-            scalers.get("close"),
-        )
+        # Diagnostics run after model.fit() but before save_artifacts. A crash here
+        # (e.g. a per-architecture metric-set mismatch) must not discard a fully-trained
+        # model with nothing persisted -- degrade to a metadata gap instead, and let only
+        # a genuine training/data failure (the outer except below) abort without saving.
+        robustness_results: Any
+        evaluation_results: Any
+        try:
+            robustness_results = (
+                validate_model_robustness(model, X_val, y_val, feature_names, has_sentiment)
+                if ctx.config.diagnostics.evaluate_robustness
+                else {}
+            )
+            evaluation_results = evaluate_model_performance(
+                model,
+                X_train,
+                y_train,
+                X_val,
+                y_val,
+                scalers.get("close"),
+            )
+        except (ValueError, RuntimeError, KeyError) as exc:
+            logger.error(
+                "Post-training evaluation/robustness diagnostics failed: %s. "
+                "Saving the trained model anyway with a diagnostics-error placeholder.",
+                exc,
+                exc_info=True,
+            )
+            robustness_results = {}
+            evaluation_results = {"error": str(exc)}
 
         # force_price_only bundles stay in price/ even though they share `atb train
         # price`'s basic/ contract: writing to basic/ here would implicitly repoint

--- a/tests/unit/training_pipeline/test_ml_training_artifacts.py
+++ b/tests/unit/training_pipeline/test_ml_training_artifacts.py
@@ -272,8 +272,8 @@ class TestEvaluateModelPerformance:
         # Arrange
         model = MagicMock()
         model.evaluate.side_effect = [
-            (0.1, 0.3),  # train_loss, train_rmse
-            (0.2, 0.4),  # test_loss, test_rmse
+            {"loss": 0.1, "rmse": 0.3},  # train
+            {"loss": 0.2, "rmse": 0.4},  # test
         ]
         model.predict.return_value = np.array([[0.5], [0.6], [0.7]])
 
@@ -295,13 +295,41 @@ class TestEvaluateModelPerformance:
         assert result["test_loss"] == 0.2
         assert result["train_rmse"] == 0.3
         assert result["test_rmse"] == 0.4
+        model.evaluate.assert_called_with(X_test, y_test, verbose=0, return_dict=True)
+
+    def test_evaluate_handles_extra_compiled_metrics(self):
+        """Regression guard for #936: architectures compiling with metrics=[rmse, mae]
+        return a 3-entry dict from model.evaluate(return_dict=True). Reading by key
+        must ignore the extra "mae" entry instead of positionally unpacking it.
+        """
+        # Arrange
+        model = MagicMock()
+        model.evaluate.side_effect = [
+            {"loss": 0.1, "rmse": 0.3, "mae": 0.25},  # train
+            {"loss": 0.2, "rmse": 0.4, "mae": 0.35},  # test
+        ]
+        model.predict.return_value = np.array([[0.5], [0.6], [0.7]])
+
+        X_train = np.random.rand(10, 120, 5).astype(np.float32)
+        y_train = np.random.rand(10).astype(np.float32)
+        X_test = np.random.rand(3, 120, 5).astype(np.float32)
+        y_test = np.array([0.5, 0.6, 0.7])
+
+        # Act - must not raise ValueError: too many values to unpack
+        result = evaluate_model_performance(model, X_train, y_train, X_test, y_test)
+
+        # Assert
+        assert result["train_loss"] == 0.1
+        assert result["train_rmse"] == 0.3
+        assert result["test_loss"] == 0.2
+        assert result["test_rmse"] == 0.4
 
     def test_mape_calculation_with_scaler(self):
         # Arrange
         from sklearn.preprocessing import MinMaxScaler
 
         model = MagicMock()
-        model.evaluate.side_effect = [(0.1, 0.3), (0.2, 0.4)]
+        model.evaluate.side_effect = [{"loss": 0.1, "rmse": 0.3}, {"loss": 0.2, "rmse": 0.4}]
         model.predict.return_value = np.array([[0.5], [0.6], [0.7]])
 
         X_train = np.random.rand(10, 120, 5).astype(np.float32)
@@ -324,7 +352,7 @@ class TestEvaluateModelPerformance:
     def test_mape_handles_near_zero_values(self):
         # Arrange
         model = MagicMock()
-        model.evaluate.side_effect = [(0.1, 0.3), (0.2, 0.4)]
+        model.evaluate.side_effect = [{"loss": 0.1, "rmse": 0.3}, {"loss": 0.2, "rmse": 0.4}]
         model.predict.return_value = np.array([[0.5], [0.6], [0.7]])
 
         X_train = np.random.rand(10, 120, 5).astype(np.float32)
@@ -342,7 +370,7 @@ class TestEvaluateModelPerformance:
     def test_mape_caps_extreme_outliers(self):
         # Arrange
         model = MagicMock()
-        model.evaluate.side_effect = [(0.1, 0.3), (0.2, 0.4)]
+        model.evaluate.side_effect = [{"loss": 0.1, "rmse": 0.3}, {"loss": 0.2, "rmse": 0.4}]
         model.predict.return_value = np.array([[100.0], [100.0], [100.0]])
 
         X_train = np.random.rand(10, 120, 5).astype(np.float32)

--- a/tests/unit/training_pipeline/test_ml_training_models.py
+++ b/tests/unit/training_pipeline/test_ml_training_models.py
@@ -1,5 +1,6 @@
 """Unit tests for ML training pipeline model factories module."""
 
+import numpy as np
 import pytest
 
 try:
@@ -12,6 +13,7 @@ except ImportError:
     tf = None  # type: ignore
     callbacks = None  # type: ignore
 
+from src.ml.training_pipeline.artifacts import evaluate_model_performance
 from src.ml.training_pipeline.models import (
     build_price_only_model,
     create_model,
@@ -405,3 +407,51 @@ class TestCreateModelTrainerContract:
         assert isinstance(model, tf.keras.Model)
         assert model.input_shape == (None, 120, 5)
         assert model.output_shape == (None, 1)
+
+
+# lstm/cnn_lstm compile with a single metric ([rmse]); attention_lstm/tcn/tcn_attention
+# compile with two ([rmse, mae]). tft is excluded: it's a binary direction-classification
+# model (loss=binary_crossentropy, metrics=[accuracy, auc]) with no "rmse" key at all --
+# a fundamentally different evaluation contract that evaluate_model_performance was never
+# meant to score, not an instance of this regression.
+EVAL_COMPATIBLE_MATRIX = [
+    (model_type, variant)
+    for model_type in ["lstm", "cnn_lstm", "attention_lstm", "tcn", "tcn_attention"]
+    for variant in ["default", "lightweight", "deep"]
+]
+
+
+@pytest.mark.fast
+@pytest.mark.skipif(not _TENSORFLOW_AVAILABLE, reason="TensorFlow not installed")
+class TestCreateModelEvaluationContract:
+    """Regression guard for #936: every CLI-selectable, regression-scored
+    (model_type, variant) pair must survive a real evaluate_model_performance() call,
+    not just construction (see TestCreateModelTrainerContract above). attention_lstm and
+    tcn/tcn_attention compile with metrics=[rmse, mae] -- a 3-value model.evaluate()
+    return that crashed the positional 2-value unpack this evaluate_model_performance
+    used before #936, destroying a fully-trained model on SageMaker. Construction alone
+    never exercises model.evaluate() and would not have caught it.
+    """
+
+    @pytest.mark.parametrize(("model_type", "variant"), EVAL_COMPATIBLE_MATRIX)
+    def test_evaluate_model_performance_does_not_crash(self, model_type, variant):
+        # Arrange - tiny synthetic data, no training needed to exercise model.evaluate()
+        input_shape = (120, 5)
+        model = create_model(
+            model_type=model_type,
+            input_shape=input_shape,
+            variant=variant,
+            has_sentiment=False,
+        )
+        rng = np.random.default_rng(0)
+        X_train = rng.random((4, *input_shape)).astype("float32")
+        y_train = rng.random(4).astype("float32")
+        X_test = rng.random((3, *input_shape)).astype("float32")
+        y_test = rng.random(3).astype("float32")
+
+        # Act
+        result = evaluate_model_performance(model, X_train, y_train, X_test, y_test)
+
+        # Assert
+        assert set(result) == {"train_loss", "test_loss", "train_rmse", "test_rmse", "mape"}
+        assert all(np.isfinite(v) for v in result.values())

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -304,7 +304,7 @@ class TestRunTrainingPipeline:
         model = MagicMock()
         model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
         model.predict.return_value = np.random.rand(10, 1)
-        model.evaluate.side_effect = [(0.1, 0.3), (0.2, 0.4)]
+        model.evaluate.side_effect = [{"loss": 0.1, "rmse": 0.3}, {"loss": 0.2, "rmse": 0.4}]
         mock_create_model.return_value = model
 
         # Mock artifacts
@@ -665,3 +665,50 @@ class TestRunTrainingPipeline:
         # Assert - should not fail on timezone mismatch
         # Will fail on other things (like insufficient data), but that's expected
         assert result.success is False
+
+    def test_evaluation_crash_does_not_lose_trained_model(self, tmp_path):
+        """Regression guard for #936: evaluate_model_performance/validate_model_robustness
+        run after model.fit() but before save_artifacts. A crash there previously
+        discarded a fully-trained model with nothing persisted. Diagnostics failures
+        must degrade to a metadata gap instead of aborting the run without saving.
+        """
+        # Arrange
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+        price_df = self._make_price_df()
+        feature_df = price_df.copy()
+        feature_df["close_scaled"] = 0.5
+
+        stack, mocks = self._pipeline_mocks()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+            mocks["evaluate_model_performance"].side_effect = ValueError(
+                "too many values to unpack (expected 2)"
+            )
+
+            # Act
+            result = self._run_pipeline_with_mocks(ctx, price_df, mocks)
+
+        # Assert - the trained model is still saved despite the diagnostics crash
+        assert result.success is True, result.metadata
+        mocks["save_artifacts"].assert_called_once()
+        assert "error" in result.metadata["evaluation_results"]
+        assert "too many values to unpack" in result.metadata["evaluation_results"]["error"]


### PR DESCRIPTION
## Summary

- `evaluate_model_performance` (`src/ml/training_pipeline/artifacts.py:209`) positionally unpacked `model.evaluate()`'s return into exactly 2 values (`loss, rmse`). `attention_lstm` (both variants), `tcn/default`, and `tcn_attention` all compile with `metrics=[rmse, mae]`, so `model.evaluate()` returns 3 values there, raising `ValueError: too many values to unpack (expected 2)`.
- Confirmed live on SageMaker: a job trained successfully to early-stop, then crashed in evaluation — since evaluation runs *before* artifact save (`pipeline.py:245`), the crash destroyed the fully-trained model with nothing persisted (~75 min of billable GPU time lost across two jobs).
- Fix: read metrics by key via `model.evaluate(..., return_dict=True)` instead of positional unpack — robust to any per-architecture metric set.
- Resilience fix: wrap the post-training evaluation/robustness diagnostics block in `pipeline.py` in a try/except so a future diagnostics-stage crash degrades to a metadata gap (`evaluation_results = {"error": ...}`) instead of destroying the already-trained model artifact.
- Regression guard: extended the #925 construction-smoke matrix (`TestCreateModelTrainerContract`) with a new `TestCreateModelEvaluationContract` that runs each compiled model through `evaluate_model_performance` on tiny synthetic data, across all 5 regression-scored architectures (`lstm`, `cnn_lstm`, `attention_lstm`, `tcn`, `tcn_attention`) × 3 variants. `tft` is excluded — it's a binary direction-classification architecture (`loss=binary_crossentropy`, `metrics=[accuracy, auc]`) with no `rmse` key, a different evaluation contract entirely, not an instance of this regression.

Closes #936.

## Testing performed

- TDD: added failing tests first, confirmed each failed against the unfixed code for the exact reason described in the issue (`ValueError: too many values to unpack`), then implemented the fix and confirmed all pass.
- Reverted the production fix locally and reran the new `TestCreateModelEvaluationContract` matrix to confirm it fails specifically on `attention_lstm`, `tcn`, and `tcn_attention` (the confirmed blast radius) — proving this test would have caught #936 before it reached SageMaker.
- `pytest tests/unit/training_pipeline/` — 228 passed.
- `atb dev quality --changed` — black, ruff, mypy all pass.

## Test plan

- [x] Unit tests added/updated and passing (`test_ml_training_artifacts.py`, `test_ml_training_pipeline.py`, `test_ml_training_models.py`)
- [x] `atb dev quality --changed` clean
- [ ] CI green