### PR TITLE
feat(ml): TARGET-REDESIGN tournament Phase 2 scaffolding (labels, classification signal path, meta-labeling, exam harness)

### DIFF
--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -21,6 +21,7 @@ from src.config.constants import (
 )
 from src.data_providers.exchange_interface import OrderSide, OrderType
 from src.engines.backtest.models import ActiveTrade, Trade
+from src.engines.shared.barrier_touch import check_barrier_touch
 from src.engines.shared.execution.execution_model import ExecutionModel
 from src.engines.shared.execution.market_snapshot import MarketSnapshot
 from src.engines.shared.execution.order_intent import OrderIntent
@@ -587,37 +588,36 @@ class ExitHandler:
         # Convert PositionSide enum to string for comparisons
         side_str = to_side_string(trade.side)
 
-        # Check stop loss
+        # Check stop loss / take profit using the shared OHLC barrier-touch
+        # helper (single source of truth also reused by the training
+        # pipeline's triple-barrier label simulator — see
+        # src/engines/shared/barrier_touch.py).
         hit_stop_loss = False
         sl_exit_price = current_price
-        if self.enable_engine_risk_exits and trade.stop_loss is not None:
-            stop_loss_val = float(trade.stop_loss)
-            if side_str == "long":
-                hit_stop_loss = candle_low <= stop_loss_val
-                if hit_stop_loss:
-                    # When price gaps through the stop, the position could have exited
-                    # anywhere between the stop price and the candle low. Use the worst
-                    # case (candle low) for conservative backtest assumptions.
-                    sl_exit_price = candle_low
-            else:
-                hit_stop_loss = candle_high >= stop_loss_val
-                if hit_stop_loss:
-                    # When price gaps through the stop, the position could have exited
-                    # anywhere between the stop price and the candle high. Use the worst
-                    # case (candle high) for conservative backtest assumptions.
-                    sl_exit_price = candle_high
-
-        # Check take profit
         hit_take_profit = False
         tp_exit_price = current_price
-        if self.enable_engine_risk_exits and trade.take_profit is not None:
-            take_profit_val = float(trade.take_profit)
-            if side_str == "long":
-                hit_take_profit = candle_high >= take_profit_val
-            else:
-                hit_take_profit = candle_low <= take_profit_val
+        if self.enable_engine_risk_exits:
+            barrier_result = check_barrier_touch(
+                side=side_str,
+                candle_high=candle_high,
+                candle_low=candle_low,
+                stop_loss_price=(
+                    float(trade.stop_loss) if trade.stop_loss is not None else None
+                ),
+                take_profit_price=(
+                    float(trade.take_profit) if trade.take_profit is not None else None
+                ),
+            )
+            hit_stop_loss = barrier_result.hit_stop_loss
+            if hit_stop_loss:
+                # When price gaps through the stop, the position could have exited
+                # anywhere between the stop price and the candle extreme. Use the
+                # worst case (candle low for longs, candle high for shorts) for
+                # conservative backtest assumptions.
+                sl_exit_price = barrier_result.stop_loss_exit_price
+            hit_take_profit = barrier_result.hit_take_profit
             if hit_take_profit:
-                tp_exit_price = take_profit_val
+                tp_exit_price = barrier_result.take_profit_exit_price
 
         # Check time limit. Capture the policy-specific reason (e.g.
         # "Max holding period", "Weekend flat", "End of day flat") so it

--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -601,9 +601,7 @@ class ExitHandler:
                 side=side_str,
                 candle_high=candle_high,
                 candle_low=candle_low,
-                stop_loss_price=(
-                    float(trade.stop_loss) if trade.stop_loss is not None else None
-                ),
+                stop_loss_price=(float(trade.stop_loss) if trade.stop_loss is not None else None),
                 take_profit_price=(
                     float(trade.take_profit) if trade.take_profit is not None else None
                 ),

--- a/src/engines/shared/barrier_touch.py
+++ b/src/engines/shared/barrier_touch.py
@@ -1,0 +1,106 @@
+"""Pure OHLC-based stop-loss/take-profit barrier-touch detection.
+
+Single source of truth for "did this bar's high/low cross a stop-loss or
+take-profit level" — extracted from
+``ExitHandler.check_exit_conditions`` so both live/backtest position exits
+and the training pipeline's triple-barrier label simulator
+(``src/ml/training_pipeline/labels.py``) agree bar-for-bar on what counts as
+a barrier touch. Reusing this function (instead of hand-rolling the
+comparison a second time) is the explicit instruction in the TARGET-REDESIGN
+tournament preregistration (§2c, §8): triple-barrier labels must reuse
+``src/engines/shared/`` fill logic, not reimplement it.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+_VALID_SIDES = frozenset({"long", "short"})
+
+
+@dataclass(frozen=True)
+class BarrierTouchResult:
+    """Whether a bar's high/low crossed the stop-loss/take-profit levels.
+
+    Attributes:
+        hit_stop_loss: True if the stop-loss level was crossed this bar.
+        hit_take_profit: True if the take-profit level was crossed this bar.
+        stop_loss_exit_price: Worst-case (gap-through) fill price if
+            ``hit_stop_loss`` — candle low for longs, candle high for shorts.
+            Defined even when ``hit_stop_loss`` is False (equals the
+            relevant candle extreme), so callers never branch on None.
+        take_profit_exit_price: Fill price if ``hit_take_profit`` — exactly
+            the take-profit level (no gap-through assumption), matching
+            ExitHandler's existing convention. Defined even when
+            ``hit_take_profit`` is False.
+
+    Both flags are reported independently; resolving same-bar ambiguity
+    (both barriers touched in one candle) is a caller concern. The existing
+    money-path convention (``ExitHandler.check_exit_conditions``) resolves
+    it stop-loss-first (conservative); label-generation callers should do
+    the same for consistency with what the exam harness would have actually
+    executed.
+    """
+
+    hit_stop_loss: bool
+    hit_take_profit: bool
+    stop_loss_exit_price: float
+    take_profit_exit_price: float
+
+
+def check_barrier_touch(
+    side: str,
+    candle_high: float,
+    candle_low: float,
+    stop_loss_price: float | None,
+    take_profit_price: float | None,
+) -> BarrierTouchResult:
+    """Check whether a bar's high/low crossed the stop-loss/take-profit levels.
+
+    Args:
+        side: ``"long"`` or ``"short"``.
+        candle_high: Bar high (caller is responsible for any NaN fallback —
+            this function assumes finite inputs, matching ExitHandler's
+            pre-validated candle_high/candle_low).
+        candle_low: Bar low.
+        stop_loss_price: Stop-loss level, or None if no stop-loss is set.
+        take_profit_price: Take-profit level, or None if no take-profit is set.
+
+    Returns:
+        BarrierTouchResult with both hit flags and exit prices.
+
+    Raises:
+        ValueError: If ``side`` is not "long" or "short".
+    """
+    if side not in _VALID_SIDES:
+        raise ValueError(f"side must be 'long' or 'short', got {side!r}")
+
+    is_long = side == "long"
+
+    hit_stop_loss = False
+    stop_loss_exit_price = candle_low if is_long else candle_high
+    if stop_loss_price is not None and math.isfinite(stop_loss_price):
+        if is_long:
+            hit_stop_loss = candle_low <= stop_loss_price
+        else:
+            hit_stop_loss = candle_high >= stop_loss_price
+
+    hit_take_profit = False
+    take_profit_exit_price = take_profit_price if take_profit_price is not None else candle_high
+    if take_profit_price is not None and math.isfinite(take_profit_price):
+        if is_long:
+            hit_take_profit = candle_high >= take_profit_price
+        else:
+            hit_take_profit = candle_low <= take_profit_price
+        take_profit_exit_price = take_profit_price
+
+    return BarrierTouchResult(
+        hit_stop_loss=hit_stop_loss,
+        hit_take_profit=hit_take_profit,
+        stop_loss_exit_price=stop_loss_exit_price,
+        take_profit_exit_price=take_profit_exit_price,
+    )
+
+
+__all__ = ["BarrierTouchResult", "check_barrier_touch"]

--- a/src/ml/training_pipeline/config.py
+++ b/src/ml/training_pipeline/config.py
@@ -62,11 +62,26 @@ class TrainingConfig:
     model_type: str = "cnn_lstm"  # cnn_lstm, attention_lstm, tcn, tcn_attention, lstm
     model_variant: str = "default"  # default, lightweight, deep
 
+    # Training target selection (TARGET-REDESIGN tournament, GH #933 Phase 2).
+    # "regression" preserves the incumbent next-bar price-regression target
+    # exactly. Cross-validating model_type against target_type (the #947
+    # guard) happens at run_training_pipeline() entry, NOT here -- see
+    # validate_target_head_compatibility() in task_types.py. Keeping that
+    # check out of __post_init__ means a TrainingConfig stays freely
+    # constructible (e.g. `atb train cloud --model-type tft`, which has no
+    # --target-type flag yet) and only fails when a run is actually
+    # attempted with an incompatible pairing.
+    target_type: str = "regression"
+    target_horizon: int = 1  # forward bars; used by binary_direction/smoothed_return
+
     # Valid model types and variants for validation
     _VALID_MODEL_TYPES = frozenset(
         {"cnn_lstm", "adaptive", "default", "attention_lstm", "tcn", "tcn_attention", "tft", "lstm"}
     )
     _VALID_MODEL_VARIANTS = frozenset({"default", "lightweight", "deep"})
+    _VALID_TARGET_TYPES = frozenset(
+        {"regression", "binary_direction", "triple_barrier", "smoothed_return"}
+    )
 
     def __post_init__(self):
         """Validate training configuration parameters for fail-fast behavior."""
@@ -96,6 +111,15 @@ class TrainingConfig:
                 f"model_variant must be one of {sorted(self._VALID_MODEL_VARIANTS)}, "
                 f"got '{self.model_variant}'"
             )
+        # Validate target_type (membership only -- model_type/target_type
+        # cross-compatibility is checked at run_training_pipeline() entry)
+        if self.target_type not in self._VALID_TARGET_TYPES:
+            raise ValueError(
+                f"target_type must be one of {sorted(self._VALID_TARGET_TYPES)}, "
+                f"got '{self.target_type}'"
+            )
+        if self.target_horizon <= 0:
+            raise ValueError(f"target_horizon must be positive, got {self.target_horizon}")
 
     def days_requested(self) -> int:
         """Calculate number of days in the training date range.

--- a/src/ml/training_pipeline/labels.py
+++ b/src/ml/training_pipeline/labels.py
@@ -1,0 +1,263 @@
+"""Alternative training-target label generation.
+
+Implements the label definitions for the TARGET-REDESIGN tournament entrants
+(see docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md
+§2/§8): binary fixed-horizon direction classification (b), triple-barrier
+ternary classification (c), and smoothed forward return (d). Meta-labeling
+(a) lives in ``meta_labels.py`` since it depends on running a primary signal
+generator forward, not just transforming the close-price series.
+
+Every function here reads FORWARD bars by construction (the whole point of a
+training target). Each returns a ``LabelResult`` with an explicit
+``horizon_bars`` (the forward window each label consumes) and a
+``valid_mask`` marking which rows have a *fully realized* label — the
+trailing rows of any series cannot have a valid label because there is no
+future data to compute them from, and must never be silently zero-filled
+(that would be a lookahead-adjacent correctness bug: a "0"/"down" label that
+actually means "unknown" is indistinguishable from a real one downstream).
+
+``horizon_bars`` is exposed so the fold-runner's purge/embargo logic (per
+the preregistration §3) knows exactly how many forward bars each entrant's
+label reads, per entrant, without having to infer it from label code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from src.engines.shared.barrier_touch import check_barrier_touch
+
+_REQUIRED_TRIPLE_BARRIER_COLUMNS = ("close", "high", "low")
+
+
+@dataclass(frozen=True)
+class LabelResult:
+    """A generated label series plus its forward-lookahead metadata.
+
+    Attributes:
+        values: Label array, same length as the input series. Entries where
+            ``valid_mask`` is False are placeholders (0 for integer labels,
+            NaN for float labels) and must be excluded before training —
+            they do not mean "label is 0", they mean "label is unknown".
+        valid_mask: True where the label is fully realized (had enough
+            forward data to resolve).
+        horizon_bars: Number of forward bars this label type consumes at
+            each row (fixed for binary_direction/smoothed_return; the
+            maximum possible for triple_barrier, whose actual per-row
+            resolution can be earlier).
+    """
+
+    values: np.ndarray
+    valid_mask: np.ndarray
+    horizon_bars: int
+
+
+def _validate_horizon(horizon: int) -> None:
+    if horizon < 1:
+        raise ValueError(f"horizon must be >= 1, got {horizon}")
+
+
+def binary_direction_labels(close: pd.Series, horizon: int = 1) -> LabelResult:
+    """Binary fixed-horizon direction label: ``1 if close[t+H] > close[t] else 0``.
+
+    Entrant (b) per the preregistration §2b. ``H=1`` isolates "does a
+    classification loss/output type alone help" from "does horizon help"
+    (same horizon as the incumbent next-bar regression target).
+
+    Args:
+        close: Close price series (chronological, no gaps assumed).
+        horizon: Forward horizon in bars, H >= 1.
+
+    Returns:
+        LabelResult with int64 values in {0, 1}.
+    """
+    _validate_horizon(horizon)
+    close_arr = close.to_numpy(dtype=np.float64)
+    n = len(close_arr)
+
+    values = np.zeros(n, dtype=np.int64)
+    valid_mask = np.zeros(n, dtype=bool)
+
+    n_valid = n - horizon
+    if n_valid > 0:
+        future = close_arr[horizon:]
+        current = close_arr[:n_valid]
+        values[:n_valid] = (future > current).astype(np.int64)
+        valid_mask[:n_valid] = True
+
+    return LabelResult(values=values, valid_mask=valid_mask, horizon_bars=horizon)
+
+
+def smoothed_forward_return_labels(close: pd.Series, horizon: int) -> LabelResult:
+    """Smoothed forward return: mean of close-to-close returns over the next N bars.
+
+    Entrant (d) per the preregistration §2d (FreqAI convention):
+    ``y = mean(close[t+1..t+N] returns from close[t])``.
+
+    Args:
+        close: Close price series.
+        horizon: Forward window N in bars, N >= 1.
+
+    Returns:
+        LabelResult with float64 values; invalid rows are NaN.
+    """
+    _validate_horizon(horizon)
+    close_arr = close.to_numpy(dtype=np.float64)
+    n = len(close_arr)
+
+    values = np.full(n, np.nan, dtype=np.float64)
+    valid_mask = np.zeros(n, dtype=bool)
+
+    n_valid = n - horizon
+    if n_valid > 0:
+        # sum(close[t+1 .. t+horizon]) via a prefix-sum, so the whole
+        # computation is vectorized rather than looping per row.
+        prefix_sum = np.concatenate(([0.0], np.cumsum(close_arr)))
+        idx = np.arange(n_valid)
+        forward_sum = prefix_sum[idx + 1 + horizon] - prefix_sum[idx + 1]
+        mean_future_close = forward_sum / horizon
+        values[idx] = mean_future_close / close_arr[idx] - 1.0
+        valid_mask[idx] = True
+
+    return LabelResult(values=values, valid_mask=valid_mask, horizon_bars=horizon)
+
+
+def triple_barrier_labels(
+    df: pd.DataFrame,
+    take_profit_pct: float,
+    stop_loss_pct: float,
+    max_holding_bars: int,
+) -> LabelResult:
+    """Triple-barrier ternary label using intrabar high/low fill logic.
+
+    Entrant (c) per the preregistration §2c: for each bar, simulate forward
+    with an upper barrier ``+take_profit_pct`` and lower barrier
+    ``-stop_loss_pct`` (both anchored to ``close[t]``, applied symmetrically
+    — the label describes the price path, not a directional bet) and a
+    vertical time barrier at ``max_holding_bars``. Label = {+1, -1, 0} for
+    whichever barrier is hit first.
+
+    Reuses ``src.engines.shared.barrier_touch.check_barrier_touch`` — the
+    same intrabar high/low comparison ``ExitHandler`` uses for live/backtest
+    stop-loss/take-profit detection — per the preregistration's explicit
+    instruction not to hand-roll this a second time (§8). Same-bar
+    ambiguity (both barriers touched in one candle) resolves stop-loss-first,
+    matching that money-path convention.
+
+    Args:
+        df: DataFrame with "close", "high", "low" columns (chronological).
+        take_profit_pct: Upper barrier distance as a fraction (e.g. 0.04).
+        stop_loss_pct: Lower barrier distance as a fraction (e.g. 0.05).
+        max_holding_bars: Vertical (time) barrier in bars.
+
+    Returns:
+        LabelResult with int64 values in {-1, 0, 1}. ``horizon_bars`` is
+        ``max_holding_bars`` (the maximum a row could consume; individual
+        rows may resolve earlier via a barrier touch).
+
+    Raises:
+        ValueError: Missing required columns, or non-positive parameters.
+    """
+    missing = [c for c in _REQUIRED_TRIPLE_BARRIER_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"triple_barrier_labels requires columns {_REQUIRED_TRIPLE_BARRIER_COLUMNS}, "
+            f"missing: {missing}"
+        )
+    if take_profit_pct <= 0:
+        raise ValueError(f"take_profit_pct must be > 0, got {take_profit_pct}")
+    if stop_loss_pct <= 0:
+        raise ValueError(f"stop_loss_pct must be > 0, got {stop_loss_pct}")
+    if max_holding_bars < 1:
+        raise ValueError(f"max_holding_bars must be >= 1, got {max_holding_bars}")
+
+    close = df["close"].to_numpy(dtype=np.float64)
+    high = df["high"].to_numpy(dtype=np.float64)
+    low = df["low"].to_numpy(dtype=np.float64)
+    n = len(close)
+
+    values = np.zeros(n, dtype=np.int64)
+    valid_mask = np.zeros(n, dtype=bool)
+
+    for t in range(n):
+        entry_price = close[t]
+        stop_loss_price = entry_price * (1.0 - stop_loss_pct)
+        take_profit_price = entry_price * (1.0 + take_profit_pct)
+        max_bar = min(t + max_holding_bars, n - 1)
+
+        resolved = False
+        for bar in range(t + 1, max_bar + 1):
+            touch = check_barrier_touch(
+                side="long",
+                candle_high=high[bar],
+                candle_low=low[bar],
+                stop_loss_price=stop_loss_price,
+                take_profit_price=take_profit_price,
+            )
+            if touch.hit_stop_loss:
+                values[t] = -1
+                valid_mask[t] = True
+                resolved = True
+                break
+            if touch.hit_take_profit:
+                values[t] = 1
+                valid_mask[t] = True
+                resolved = True
+                break
+
+        if not resolved:
+            reached_full_vertical_barrier = max_bar == t + max_holding_bars
+            if reached_full_vertical_barrier:
+                values[t] = 0
+                valid_mask[t] = True
+            # else: truncated at series end without resolution -- leave
+            # invalid (valid_mask[t] stays False). This is NOT the same as
+            # "0" -- it means we don't know what would have happened.
+
+    return LabelResult(values=values, valid_mask=valid_mask, horizon_bars=max_holding_bars)
+
+
+def target_horizon_bars(
+    target_type: str,
+    *,
+    horizon: int | None = None,
+    max_holding_bars: int | None = None,
+) -> int:
+    """Return the forward horizon (in bars) a target_type's label consumes.
+
+    Lets the fold-runner's purge/embargo logic (preregistration §3) look up
+    an entrant's lookahead window without materializing labels.
+
+    Args:
+        target_type: One of "binary_direction", "smoothed_return",
+            "triple_barrier".
+        horizon: Required for "binary_direction"/"smoothed_return".
+        max_holding_bars: Required for "triple_barrier".
+
+    Returns:
+        The forward horizon in bars.
+
+    Raises:
+        ValueError: Unknown target_type, or the required param is missing.
+    """
+    if target_type in ("binary_direction", "smoothed_return"):
+        if horizon is None:
+            raise ValueError(f"target_type={target_type!r} requires 'horizon'")
+        return horizon
+    if target_type == "triple_barrier":
+        if max_holding_bars is None:
+            raise ValueError(f"target_type={target_type!r} requires 'max_holding_bars'")
+        return max_holding_bars
+    raise ValueError(f"Unknown target_type: {target_type!r}")
+
+
+__all__ = [
+    "LabelResult",
+    "binary_direction_labels",
+    "smoothed_forward_return_labels",
+    "target_horizon_bars",
+    "triple_barrier_labels",
+]

--- a/src/ml/training_pipeline/labels.py
+++ b/src/ml/training_pipeline/labels.py
@@ -92,10 +92,12 @@ def binary_direction_labels(close: pd.Series, horizon: int = 1) -> LabelResult:
 
 
 def smoothed_forward_return_labels(close: pd.Series, horizon: int) -> LabelResult:
-    """Smoothed forward return: mean of close-to-close returns over the next N bars.
+    """Smoothed forward return: mean price ratio over the next N bars (FreqAI convention).
 
     Entrant (d) per the preregistration §2d (FreqAI convention):
-    ``y = mean(close[t+1..t+N] returns from close[t])``.
+    ``y = mean(close[t+1..t+N]) / close[t] - 1`` -- the mean of the next N
+    closes expressed as a return relative to ``close[t]`` (not the mean of N
+    separately-computed bar-over-bar returns, though the two are related).
 
     Args:
         close: Close price series.

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -1,0 +1,287 @@
+"""Meta-labeling entrant (a) scaffolding.
+
+Preregistration §2a: label = 1 if simulating the primary signal's fired
+trade through the exam-harness exit geometry closes net-profitable after
+fees, else 0. Feature set: 48-bar trailing realized volatility of
+bar-over-bar returns, rolling hit-rate of the primary signal over its
+trailing 20 fired signals, session/time-of-day bucket (cyclical encoding),
+``EnhancedRegimeDetector``'s regime label (reused, not reimplemented), and
+the primary model's own ``predicted_return`` magnitude as ONE feature among
+the above -- never the sole feature (the richer-feature-set requirement is
+the whole point of entrant (a): #912 already falsified the primary signal's
+own magnitude as a standalone confidence channel).
+
+Separate from ``labels.py`` because meta-labeling needs the primary
+signal's actual fire points (a live ``SignalGenerator`` run forward over the
+corpus), not just a transform of the close-price series.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from src.engines.shared.barrier_touch import check_barrier_touch
+from src.engines.shared.cost_calculator import CostCalculator
+from src.regime.enhanced_detector import EnhancedRegimeDetector
+from src.strategies.components.signal_generator import SignalDirection
+
+if TYPE_CHECKING:
+    from src.strategies.components.signal_generator import SignalGenerator
+
+# Feature-set constants, per preregistration §2a's exact spec.
+REALIZED_VOL_WINDOW_BARS = 48
+HIT_RATE_LOOKBACK_FIRES = 20
+_HOURS_PER_DAY = 24.0
+
+_VALID_DIRECTIONS = frozenset({1, -1})
+
+
+@dataclass(frozen=True)
+class PrimarySignalRecord:
+    """A single non-HOLD fire from the primary signal generator.
+
+    Attributes:
+        index: Bar index in the DataFrame the signal fired at.
+        direction: 1 for BUY (long), -1 for SELL (short). Never 0 -- only
+            fired (non-HOLD) bars are recorded.
+        predicted_return: The primary signal's own predicted_return at the
+            fire point (from Signal.metadata["predicted_return"]), used as
+            ONE meta-label feature among several, per the preregistration's
+            explicit "never the sole feature" requirement.
+    """
+
+    index: int
+    direction: int
+    predicted_return: float
+
+
+def run_primary_signal_forward(
+    signal_generator: SignalGenerator,
+    df: pd.DataFrame,
+    start_index: int | None = None,
+) -> list[PrimarySignalRecord]:
+    """Run a primary SignalGenerator forward over df, recording every fire.
+
+    This is preregistration §2a/§8 step (i): "running the CURRENT incumbent
+    signal generator forward over the training corpus to find its fire
+    points." Reuses the SignalGenerator interface directly (generate_signal)
+    rather than reimplementing prediction logic.
+
+    Args:
+        signal_generator: The primary (incumbent) SignalGenerator instance.
+        df: OHLCV DataFrame to run forward over.
+        start_index: First index to evaluate. Defaults to
+            ``signal_generator.warmup_period``.
+
+    Returns:
+        A list of PrimarySignalRecord, one per non-HOLD bar, in order.
+    """
+    start = start_index if start_index is not None else signal_generator.warmup_period
+    records: list[PrimarySignalRecord] = []
+    for index in range(start, len(df)):
+        signal = signal_generator.generate_signal(df, index)
+        if signal.direction == SignalDirection.HOLD:
+            continue
+        direction = 1 if signal.direction == SignalDirection.BUY else -1
+        predicted_return = float(signal.metadata.get("predicted_return", 0.0))
+        records.append(
+            PrimarySignalRecord(index=index, direction=direction, predicted_return=predicted_return)
+        )
+    return records
+
+
+def simulate_fired_trade_profitability(
+    df: pd.DataFrame,
+    fire_index: int,
+    direction: int,
+    take_profit_pct: float,
+    stop_loss_pct: float,
+    max_holding_bars: int,
+    cost_calculator: CostCalculator | None = None,
+) -> bool | None:
+    """Simulate a fired trade through the exam harness's exit geometry.
+
+    Reuses ``check_barrier_touch`` (the same intrabar high/low logic
+    ``ExitHandler`` uses) directionally: barriers are placed above/below
+    entry according to the fired side (long: TP above/SL below; short: TP
+    below/SL above), scanning forward until the first barrier touch or the
+    vertical (time) barrier at ``max_holding_bars``. Net profitability
+    subtracts a round-trip fee estimate (``2 * cost_calculator.fee_rate``,
+    slippage not modeled -- a documented approximation for a *label*, not a
+    real execution).
+
+    Args:
+        df: DataFrame with "close", "high", "low" columns.
+        fire_index: Bar index the primary signal fired at (the entry bar).
+        direction: 1 for a fired long, -1 for a fired short.
+        take_profit_pct: Take-profit distance as a fraction.
+        stop_loss_pct: Stop-loss distance as a fraction.
+        max_holding_bars: Vertical (time) barrier in bars.
+        cost_calculator: Fee model; defaults to CostCalculator()'s defaults.
+
+    Returns:
+        True if net-profitable after fees, False if not, None if the trade
+        is unresolved (truncated at series end with no forward data) --
+        callers must drop unresolved fire points, never treat None as False.
+
+    Raises:
+        ValueError: direction is not 1 or -1.
+    """
+    if direction not in _VALID_DIRECTIONS:
+        raise ValueError(f"direction must be 1 (long) or -1 (short), got {direction}")
+
+    cost_calculator = cost_calculator or CostCalculator()
+    side = "long" if direction == 1 else "short"
+
+    close = df["close"].to_numpy(dtype=np.float64)
+    high = df["high"].to_numpy(dtype=np.float64)
+    low = df["low"].to_numpy(dtype=np.float64)
+    n = len(close)
+
+    entry_price = close[fire_index]
+    if direction == 1:
+        stop_loss_price = entry_price * (1.0 - stop_loss_pct)
+        take_profit_price = entry_price * (1.0 + take_profit_pct)
+    else:
+        stop_loss_price = entry_price * (1.0 + stop_loss_pct)
+        take_profit_price = entry_price * (1.0 - take_profit_pct)
+
+    max_bar = min(fire_index + max_holding_bars, n - 1)
+    exit_price: float | None = None
+    for bar in range(fire_index + 1, max_bar + 1):
+        touch = check_barrier_touch(
+            side=side,
+            candle_high=high[bar],
+            candle_low=low[bar],
+            stop_loss_price=stop_loss_price,
+            take_profit_price=take_profit_price,
+        )
+        if touch.hit_stop_loss:
+            exit_price = touch.stop_loss_exit_price
+            break
+        if touch.hit_take_profit:
+            exit_price = touch.take_profit_exit_price
+            break
+
+    if exit_price is None:
+        reached_full_vertical_barrier = max_bar == fire_index + max_holding_bars
+        if not reached_full_vertical_barrier:
+            return None  # truncated at series end -- unresolved
+        exit_price = close[max_bar]
+
+    raw_pct_return = direction * (exit_price - entry_price) / entry_price
+    round_trip_cost_pct = 2.0 * cost_calculator.fee_rate
+    return bool((raw_pct_return - round_trip_cost_pct) > 0.0)
+
+
+def _realized_volatility_series(close: pd.Series, window: int) -> pd.Series:
+    """48-bar trailing realized volatility of bar-over-bar returns.
+
+    A plain ``rolling(window).std()`` -- causal by construction (each row
+    only reads its own trailing window), so a lookup at any fire index
+    never sees data from bars after it.
+    """
+    returns = close.pct_change()
+    return returns.rolling(window=window).std()
+
+
+def _session_cyclical_encoding(timestamp: pd.Timestamp) -> tuple[float, float]:
+    """Cyclical (sin, cos) encoding of hour-of-day, per §2a's spec."""
+    hour_fraction = timestamp.hour / _HOURS_PER_DAY
+    angle = 2.0 * math.pi * hour_fraction
+    return math.sin(angle), math.cos(angle)
+
+
+def build_meta_label_features(
+    df: pd.DataFrame,
+    fired_signals: Sequence[PrimarySignalRecord],
+    labels: Sequence[bool],
+    regime_detector: EnhancedRegimeDetector | None = None,
+    realized_vol_window: int = REALIZED_VOL_WINDOW_BARS,
+    hit_rate_lookback: int = HIT_RATE_LOOKBACK_FIRES,
+) -> pd.DataFrame:
+    """Build the meta-labeling feature set, per preregistration §2a.
+
+    One row per fired signal. Every feature is causal: it reads only bars
+    at-or-before the fire index, and (for rolling_hit_rate_20) only STRICTLY
+    PRIOR fires' labels -- never the fire's own label or any later fire.
+
+    Args:
+        df: OHLCV DataFrame the fires were recorded against.
+        fired_signals: PrimarySignalRecord list from run_primary_signal_forward,
+            in chronological order.
+        labels: Resolved profitability label per fire (same order/length as
+            fired_signals) -- typically simulate_fired_trade_profitability()'s
+            output with unresolved (None) fires already filtered out by the
+            caller.
+        regime_detector: Reused EnhancedRegimeDetector instance; a fresh one
+            is created if not supplied.
+        realized_vol_window: Trailing bars for realized volatility (default 48).
+        hit_rate_lookback: Trailing PRIOR fires for rolling hit-rate (default 20).
+
+    Returns:
+        DataFrame with one row per fire: index, realized_vol_48,
+        rolling_hit_rate_20, session_sin, session_cos, regime_trend,
+        regime_volatility, regime_confidence, predicted_return_magnitude,
+        label.
+
+    Raises:
+        ValueError: len(fired_signals) != len(labels).
+    """
+    if len(fired_signals) != len(labels):
+        raise ValueError(
+            f"fired_signals and labels must have the same length, "
+            f"got {len(fired_signals)} and {len(labels)}"
+        )
+
+    detector = regime_detector or EnhancedRegimeDetector()
+    realized_vol = _realized_volatility_series(df["close"], realized_vol_window)
+
+    label_ints = [1 if bool(label) else 0 for label in labels]
+
+    rows: list[dict[str, float | int]] = []
+    for position, fire in enumerate(fired_signals):
+        prior_labels = label_ints[:position]
+        if prior_labels:
+            recent_prior = prior_labels[-hit_rate_lookback:]
+            rolling_hit_rate = float(np.mean(recent_prior))
+        else:
+            rolling_hit_rate = float("nan")
+
+        timestamp = df.index[fire.index]
+        session_sin, session_cos = _session_cyclical_encoding(pd.Timestamp(timestamp))
+
+        regime = detector.detect_regime(df, fire.index)
+
+        rows.append(
+            {
+                "index": fire.index,
+                "realized_vol_48": float(realized_vol.iloc[fire.index]),
+                "rolling_hit_rate_20": rolling_hit_rate,
+                "session_sin": session_sin,
+                "session_cos": session_cos,
+                "regime_trend": regime.trend.value,
+                "regime_volatility": regime.volatility.value,
+                "regime_confidence": float(regime.confidence),
+                "predicted_return_magnitude": abs(fire.predicted_return),
+                "label": label_ints[position],
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+__all__ = [
+    "HIT_RATE_LOOKBACK_FIRES",
+    "REALIZED_VOL_WINDOW_BARS",
+    "PrimarySignalRecord",
+    "build_meta_label_features",
+    "run_primary_signal_forward",
+    "simulate_fired_trade_profitability",
+]

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -245,7 +245,7 @@ def build_meta_label_features(
 
     label_ints = [1 if bool(label) else 0 for label in labels]
 
-    rows: list[dict[str, float | int]] = []
+    rows: list[dict[str, Any]] = []
     for position, fire in enumerate(fired_signals):
         prior_labels = label_ints[:position]
         if prior_labels:

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -14,6 +14,15 @@ own magnitude as a standalone confidence channel).
 Separate from ``labels.py`` because meta-labeling needs the primary
 signal's actual fire points (a live ``SignalGenerator`` run forward over the
 corpus), not just a transform of the close-price series.
+
+Causality note on ``rolling_hit_rate_20`` specifically: a prior fire's
+profitability label is only "known" once that fire's own trade has
+resolved (up to ``max_holding_bars`` -- 336 by default, 14 days -- after it
+fired), not at the moment it fired. With dense fires this resolution can
+land well after a LATER fire's own index, so the hit-rate feature only
+includes prior fires whose resolution bar (``TradeResolution.exit_index``)
+is at-or-before the current fire's index -- never a prior fire that hasn't
+resolved yet as of "now."
 """
 
 from __future__ import annotations
@@ -21,7 +30,7 @@ from __future__ import annotations
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -96,7 +105,26 @@ def run_primary_signal_forward(
     return records
 
 
-def simulate_fired_trade_profitability(
+@dataclass(frozen=True)
+class TradeResolution:
+    """The outcome of a simulated fired trade, AND when it became knowable.
+
+    Attributes:
+        profitable: True if net-profitable after fees, False if not.
+        exit_index: The bar index where the outcome was determined --
+            either the bar a barrier was touched on, or the vertical/time
+            exit bar. Callers building features from PRIOR fires' outcomes
+            (e.g. a rolling hit-rate) must not treat a fire's label as
+            "known" before this bar -- doing so leaks the fire's own
+            forward price path into an earlier bar's feature. See
+            ``build_meta_label_features``'s ``rolling_hit_rate_20``.
+    """
+
+    profitable: bool
+    exit_index: int
+
+
+def resolve_fired_trade(
     df: pd.DataFrame,
     fire_index: int,
     direction: int,
@@ -104,7 +132,7 @@ def simulate_fired_trade_profitability(
     stop_loss_pct: float,
     max_holding_bars: int,
     cost_calculator: CostCalculator | None = None,
-) -> bool | None:
+) -> TradeResolution | None:
     """Simulate a fired trade through the exam harness's exit geometry.
 
     Reuses ``check_barrier_touch`` (the same intrabar high/low logic
@@ -126,9 +154,10 @@ def simulate_fired_trade_profitability(
         cost_calculator: Fee model; defaults to CostCalculator()'s defaults.
 
     Returns:
-        True if net-profitable after fees, False if not, None if the trade
+        A TradeResolution (profitable + exit_index), or None if the trade
         is unresolved (truncated at series end with no forward data) --
-        callers must drop unresolved fire points, never treat None as False.
+        callers must drop unresolved fire points, never treat None as an
+        unprofitable outcome.
 
     Raises:
         ValueError: direction is not 1 or -1.
@@ -154,6 +183,7 @@ def simulate_fired_trade_profitability(
 
     max_bar = min(fire_index + max_holding_bars, n - 1)
     exit_price: float | None = None
+    exit_index: int | None = None
     for bar in range(fire_index + 1, max_bar + 1):
         touch = check_barrier_touch(
             side=side,
@@ -164,9 +194,11 @@ def simulate_fired_trade_profitability(
         )
         if touch.hit_stop_loss:
             exit_price = touch.stop_loss_exit_price
+            exit_index = bar
             break
         if touch.hit_take_profit:
             exit_price = touch.take_profit_exit_price
+            exit_index = bar
             break
 
     if exit_price is None:
@@ -174,10 +206,51 @@ def simulate_fired_trade_profitability(
         if not reached_full_vertical_barrier:
             return None  # truncated at series end -- unresolved
         exit_price = close[max_bar]
+        exit_index = max_bar
 
     raw_pct_return = direction * (exit_price - entry_price) / entry_price
     round_trip_cost_pct = 2.0 * cost_calculator.fee_rate
-    return bool((raw_pct_return - round_trip_cost_pct) > 0.0)
+    profitable = bool((raw_pct_return - round_trip_cost_pct) > 0.0)
+    # cast: exit_index is always set on every path that reaches here (either
+    # inside the touch loop before `break`, or the vertical-exit branch above).
+    return TradeResolution(profitable=profitable, exit_index=cast(int, exit_index))
+
+
+def simulate_fired_trade_profitability(
+    df: pd.DataFrame,
+    fire_index: int,
+    direction: int,
+    take_profit_pct: float,
+    stop_loss_pct: float,
+    max_holding_bars: int,
+    cost_calculator: CostCalculator | None = None,
+) -> bool | None:
+    """Simulate a fired trade, returning only the profitable/not outcome.
+
+    Thin wrapper over ``resolve_fired_trade`` for callers that only need
+    the boolean outcome. Callers building rolling features over PRIOR
+    fires' outcomes (e.g. ``build_meta_label_features``'s
+    ``rolling_hit_rate_20``) need the resolution BAR too (when the outcome
+    became knowable, not just what it was) to stay causal -- use
+    ``resolve_fired_trade`` directly for that.
+
+    Returns:
+        True if net-profitable after fees, False if not, None if the trade
+        is unresolved (truncated at series end) -- never treat None as False.
+
+    Raises:
+        ValueError: direction is not 1 or -1.
+    """
+    resolution = resolve_fired_trade(
+        df,
+        fire_index,
+        direction,
+        take_profit_pct,
+        stop_loss_pct,
+        max_holding_bars,
+        cost_calculator,
+    )
+    return resolution.profitable if resolution is not None else None
 
 
 def _realized_volatility_series(close: pd.Series, window: int) -> pd.Series:
@@ -201,7 +274,7 @@ def _session_cyclical_encoding(timestamp: pd.Timestamp) -> tuple[float, float]:
 def build_meta_label_features(
     df: pd.DataFrame,
     fired_signals: Sequence[PrimarySignalRecord],
-    labels: Sequence[bool],
+    resolutions: Sequence[TradeResolution],
     regime_detector: EnhancedRegimeDetector | None = None,
     realized_vol_window: int = REALIZED_VOL_WINDOW_BARS,
     hit_rate_lookback: int = HIT_RATE_LOOKBACK_FIRES,
@@ -209,21 +282,25 @@ def build_meta_label_features(
     """Build the meta-labeling feature set, per preregistration §2a.
 
     One row per fired signal. Every feature is causal: it reads only bars
-    at-or-before the fire index, and (for rolling_hit_rate_20) only STRICTLY
-    PRIOR fires' labels -- never the fire's own label or any later fire.
+    at-or-before the fire index. ``rolling_hit_rate_20`` additionally only
+    uses PRIOR fires whose trade had actually RESOLVED
+    (``resolution.exit_index <= fire.index``) by the current fire's index --
+    a prior fire that hasn't resolved yet as of "now" is excluded, because
+    its label depends on bars strictly after the current fire (see the
+    module docstring's causality note).
 
     Args:
         df: OHLCV DataFrame the fires were recorded against.
         fired_signals: PrimarySignalRecord list from run_primary_signal_forward,
             in chronological order.
-        labels: Resolved profitability label per fire (same order/length as
-            fired_signals) -- typically simulate_fired_trade_profitability()'s
-            output with unresolved (None) fires already filtered out by the
-            caller.
+        resolutions: TradeResolution per fire (same order/length as
+            fired_signals) -- typically resolve_fired_trade()'s output with
+            unresolved (None) fires already filtered out by the caller.
         regime_detector: Reused EnhancedRegimeDetector instance; a fresh one
             is created if not supplied.
         realized_vol_window: Trailing bars for realized volatility (default 48).
-        hit_rate_lookback: Trailing PRIOR fires for rolling hit-rate (default 20).
+        hit_rate_lookback: Trailing eligible PRIOR fires for rolling hit-rate
+            (default 20).
 
     Returns:
         DataFrame with one row per fire: index, realized_vol_48,
@@ -232,24 +309,30 @@ def build_meta_label_features(
         label.
 
     Raises:
-        ValueError: len(fired_signals) != len(labels).
+        ValueError: len(fired_signals) != len(resolutions).
     """
-    if len(fired_signals) != len(labels):
+    if len(fired_signals) != len(resolutions):
         raise ValueError(
-            f"fired_signals and labels must have the same length, "
-            f"got {len(fired_signals)} and {len(labels)}"
+            f"fired_signals and resolutions must have the same length, "
+            f"got {len(fired_signals)} and {len(resolutions)}"
         )
 
     detector = regime_detector or EnhancedRegimeDetector()
     realized_vol = _realized_volatility_series(df["close"], realized_vol_window)
 
-    label_ints = [1 if bool(label) else 0 for label in labels]
-
     rows: list[dict[str, Any]] = []
     for position, fire in enumerate(fired_signals):
-        prior_labels = label_ints[:position]
-        if prior_labels:
-            recent_prior = prior_labels[-hit_rate_lookback:]
+        # Only prior fires that had RESOLVED by this fire's own index are
+        # "known" information at this point in time -- a prior fire whose
+        # trade is still open (exit_index > fire.index) would leak that
+        # fire's own future price path into this feature.
+        eligible_prior = [
+            resolutions[i].profitable
+            for i in range(position)
+            if resolutions[i].exit_index <= fire.index
+        ]
+        if eligible_prior:
+            recent_prior = eligible_prior[-hit_rate_lookback:]
             rolling_hit_rate = float(np.mean(recent_prior))
         else:
             rolling_hit_rate = float("nan")
@@ -270,7 +353,7 @@ def build_meta_label_features(
                 "regime_volatility": regime.volatility.value,
                 "regime_confidence": float(regime.confidence),
                 "predicted_return_magnitude": abs(fire.predicted_return),
-                "label": label_ints[position],
+                "label": 1 if resolutions[position].profitable else 0,
             }
         )
 
@@ -281,7 +364,9 @@ __all__ = [
     "HIT_RATE_LOOKBACK_FIRES",
     "REALIZED_VOL_WINDOW_BARS",
     "PrimarySignalRecord",
+    "TradeResolution",
     "build_meta_label_features",
+    "resolve_fired_trade",
     "run_primary_signal_forward",
     "simulate_fired_trade_profitability",
 ]

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -52,7 +52,12 @@ from src.ml.training_pipeline.labels import (
     triple_barrier_labels,
 )
 from src.ml.training_pipeline.models import create_model, get_model_callbacks
-from src.ml.training_pipeline.task_types import validate_target_head_compatibility
+from src.ml.training_pipeline.task_types import (
+    get_model_task_type,
+    get_target_class_labels,
+    validate_target_head_compatibility,
+)
+from src.prediction.distribution_stats import FrozenDistribution
 from src.prediction.features.price_only import PriceOnlyFeatureExtractor
 
 logger = logging.getLogger(__name__)
@@ -360,6 +365,38 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
             robustness_results = {}
             evaluation_results = {"error": str(exc)}
 
+        # Classification/distribution metadata contract (TARGET-REDESIGN
+        # tournament, #933 Phase 2): the producer half of what OnnxRunner
+        # (task_type/class_labels) and SmoothedReturnExamSignalGenerator
+        # (target_distribution) consume. task_type is always written
+        # (get_model_task_type already validated compatible with
+        # ctx.config.target_type by the #947 guard at the top of this
+        # function, so it never raises here). class_labels only applies to
+        # classification target types. target_distribution is computed ONCE
+        # from y_train ONLY (never X_val/y_val) -- the harness-wide rule
+        # that the confidence mapping must never see eval-window data.
+        # Diagnostics-only: a failure here degrades gracefully (same
+        # pattern as the evaluation/robustness block above) rather than
+        # discarding an already-trained model.
+        target_type_metadata: dict[str, Any] = {
+            "task_type": get_model_task_type(ctx.config.model_type).value
+        }
+        class_labels = get_target_class_labels(ctx.config.target_type)
+        if class_labels is not None:
+            target_type_metadata["class_labels"] = class_labels
+        if ctx.config.target_type == "smoothed_return":
+            try:
+                target_type_metadata["target_distribution"] = FrozenDistribution.from_samples(
+                    np.abs(y_train)
+                ).to_metadata()
+            except ValueError as exc:
+                logger.warning(
+                    "Failed to compute target_distribution metadata for smoothed_return: "
+                    "%s. Entrant (d)'s percentile-rank confidence will be unavailable for "
+                    "this model until retrained.",
+                    exc,
+                )
+
         # force_price_only bundles stay in price/ even though they share `atb train
         # price`'s basic/ contract: writing to basic/ here would implicitly repoint
         # basic/latest — the symlink live strategies load. Promotion into basic/ is
@@ -381,6 +418,7 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
                 "end_date": ctx.config.end_date.isoformat(),
                 "architecture": ctx.config.model_type,  # New: model architecture
                 "architecture_variant": ctx.config.model_variant,  # New: architecture variant
+                "target_type": ctx.config.target_type,
             },
             "evaluation_results": evaluation_results,
             "diagnostics": {
@@ -388,6 +426,7 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
                 "robustness": ctx.config.diagnostics.evaluate_robustness,
                 "onnx": ctx.config.diagnostics.convert_to_onnx,
             },
+            **target_type_metadata,
         }
 
         output_dir = ctx.paths.models_dir

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -24,6 +24,11 @@ except ImportError:
     if not TYPE_CHECKING:
         tf = None
 
+from src.config.constants import (
+    DEFAULT_MAX_HOLDING_HOURS,
+    DEFAULT_STOP_LOSS_PCT,
+    DEFAULT_TAKE_PROFIT_PCT,
+)
 from src.ml.training_pipeline import TrainingContext
 from src.ml.training_pipeline.artifacts import (
     ArtifactPaths,
@@ -40,7 +45,14 @@ from src.ml.training_pipeline.features import (
 )
 from src.ml.training_pipeline.gpu_config import configure_gpu
 from src.ml.training_pipeline.ingestion import download_price_data, load_sentiment_data
+from src.ml.training_pipeline.labels import (
+    LabelResult,
+    binary_direction_labels,
+    smoothed_forward_return_labels,
+    triple_barrier_labels,
+)
 from src.ml.training_pipeline.models import create_model, get_model_callbacks
+from src.ml.training_pipeline.task_types import validate_target_head_compatibility
 from src.prediction.features.price_only import PriceOnlyFeatureExtractor
 
 logger = logging.getLogger(__name__)
@@ -125,6 +137,66 @@ def enable_mixed_precision(enabled: bool) -> None:
         logger.debug("Full exception trace:", exc_info=True)
 
 
+def _build_alt_target(
+    target_type: str,
+    target_horizon: int,
+    merged_df: pd.DataFrame,
+    feature_data: pd.DataFrame,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute an alternative-target label array aligned to feature_data's rows.
+
+    Labels are computed on the full ``merged_df`` timeline (the raw OHLCV
+    data, before feature-engineering warmup rows are dropped) so forward-
+    horizon lookups see genuinely future bars, then reindexed onto
+    ``feature_data``'s row index -- feature engineering may have dropped
+    leading rows for rolling-window warmup, and the target array must stay
+    row-aligned with the feature array `create_sequences` will pair it with.
+
+    Args:
+        target_type: One of "binary_direction", "smoothed_return",
+            "triple_barrier" (never "regression" -- callers keep the
+            existing unconditional close-price target for that case).
+        target_horizon: Forward horizon in bars (binary_direction /
+            smoothed_return only; triple_barrier uses the ratified
+            risk-limits.json stop/take-profit/max-holding-hours defaults
+            instead, per the TARGET-REDESIGN tournament preregistration §2c).
+        merged_df: Raw OHLCV DataFrame (pre-feature-engineering).
+        feature_data: Post-feature-engineering DataFrame to align labels to.
+
+    Returns:
+        Tuple of (target_array, valid_mask), both aligned to feature_data's
+        row order. valid_mask is False for any row without a fully-realized
+        forward label (trailing rows, or rows feature engineering added that
+        merged_df never had) -- callers must drop those rows from BOTH the
+        feature and target arrays before training, never zero-fill them.
+    """
+    label: LabelResult
+    if target_type == "binary_direction":
+        label = binary_direction_labels(merged_df["close"], horizon=target_horizon)
+    elif target_type == "smoothed_return":
+        label = smoothed_forward_return_labels(merged_df["close"], horizon=target_horizon)
+    elif target_type == "triple_barrier":
+        label = triple_barrier_labels(
+            merged_df,
+            take_profit_pct=DEFAULT_TAKE_PROFIT_PCT,
+            stop_loss_pct=DEFAULT_STOP_LOSS_PCT,
+            # max_holding_bars assumes 1 bar == 1 hour (the tournament's
+            # fixed 1h timeframe); a genuine bars-per-hour conversion for
+            # other timeframes is out of scope for this scaffolding.
+            max_holding_bars=DEFAULT_MAX_HOLDING_HOURS,
+        )
+    else:
+        raise ValueError(f"No label generator wired for target_type={target_type!r}")
+
+    label_values = pd.Series(label.values, index=merged_df.index)
+    label_valid = pd.Series(label.valid_mask, index=merged_df.index)
+
+    aligned_values = label_values.reindex(feature_data.index).to_numpy(dtype=np.float32)
+    aligned_valid = label_valid.reindex(feature_data.index).fillna(False).to_numpy(dtype=bool)
+
+    return aligned_values, aligned_valid
+
+
 def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
     """Run the training pipeline."""
     if not _TENSORFLOW_AVAILABLE:
@@ -141,6 +213,12 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
     else:
         logger.info("[CPU] Training will use CPU")
     try:
+        # #947 guard: refuse loudly, before any download/GPU work is spent,
+        # when model_type's compiled head is incompatible with target_type
+        # (e.g. tft's binary sigmoid/BCE head trained against the regression
+        # close target -- previously silent, garbage-model failure).
+        validate_target_head_compatibility(ctx.config.model_type, ctx.config.target_type)
+
         price_df = download_price_data(ctx)
         sentiment_df = load_sentiment_data(ctx)
         if sentiment_df is None or sentiment_df.empty:
@@ -196,6 +274,21 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
                 merged_df.copy(), sentiment_assessment, ctx.config.sequence_length
             )
             target_array = feature_data["close"].to_numpy(dtype=np.float32)
+
+        # Alternative training targets (TARGET-REDESIGN tournament, #933
+        # Phase 2): derive the label from merged_df's raw OHLCV data instead
+        # of the incumbent regression close target, then drop rows without a
+        # fully-realized forward label from BOTH arrays before sequencing.
+        if ctx.config.target_type != "regression":
+            target_array, valid_mask = _build_alt_target(
+                ctx.config.target_type,
+                ctx.config.target_horizon,
+                merged_df,
+                feature_data,
+            )
+            feature_data = feature_data[valid_mask]
+            target_array = target_array[valid_mask]
+
         feature_array = feature_data[feature_names].to_numpy(dtype=np.float32)
         sequences, targets = create_sequences(
             feature_array,

--- a/src/ml/training_pipeline/task_types.py
+++ b/src/ml/training_pipeline/task_types.py
@@ -54,6 +54,23 @@ TARGET_TASK_TYPES: dict[str, TaskType] = {
     "meta_label": TaskType.BINARY_CLASSIFICATION,
 }
 
+# Canonical class_labels ordering per classification target_type -- these
+# ARE the direction values (see onnx_runner.py's
+# _process_classification_output: argmax index -> class_labels[index] IS
+# the signal direction, no separate mapping table). Persisted into model
+# metadata at training time so OnnxRunner/exam_signal_generator can
+# interpret a classifier's raw probability vector without guessing the
+# class order.
+#
+# "meta_label" is deliberately absent: its classifier output is a
+# profitability GATE on the primary signal's own direction (P(trade
+# profitable)), not a direction prediction itself -- it has no canonical
+# direction-value class_labels ordering in this sense.
+TARGET_CLASS_LABELS: dict[str, list[int]] = {
+    "binary_direction": [-1, 1],
+    "triple_barrier": [-1, 0, 1],
+}
+
 
 def get_model_task_type(model_type: str) -> TaskType:
     """Return the task type a model_type's compiled head expects.
@@ -84,6 +101,21 @@ def get_target_task_type(target_type: str) -> TaskType:
     return task_type
 
 
+def get_target_class_labels(target_type: str) -> list[int] | None:
+    """Return the canonical class_labels ordering for a target_type.
+
+    Args:
+        target_type: Label type selector (see TARGET_TASK_TYPES).
+
+    Returns:
+        An ordered list of direction values (see TARGET_CLASS_LABELS), or
+        None for a REGRESSION-task target_type (regression/smoothed_return
+        have no class_labels -- their metadata contract needs only
+        task_type, plus target_distribution for smoothed_return).
+    """
+    return TARGET_CLASS_LABELS.get(target_type)
+
+
 def validate_target_head_compatibility(model_type: str, target_type: str) -> None:
     """Refuse loudly when a model_type's head is incompatible with the target.
 
@@ -112,9 +144,11 @@ def validate_target_head_compatibility(model_type: str, target_type: str) -> Non
 
 __all__ = [
     "MODEL_TASK_TYPES",
+    "TARGET_CLASS_LABELS",
     "TARGET_TASK_TYPES",
     "TaskType",
     "get_model_task_type",
+    "get_target_class_labels",
     "get_target_task_type",
     "validate_target_head_compatibility",
 ]

--- a/src/ml/training_pipeline/task_types.py
+++ b/src/ml/training_pipeline/task_types.py
@@ -64,8 +64,7 @@ def get_model_task_type(model_type: str) -> TaskType:
     task_type = MODEL_TASK_TYPES.get(model_type.lower())
     if task_type is None:
         raise ValueError(
-            f"Unknown model_type: {model_type!r}. "
-            f"Known model types: {sorted(MODEL_TASK_TYPES)}"
+            f"Unknown model_type: {model_type!r}. " f"Known model types: {sorted(MODEL_TASK_TYPES)}"
         )
     return task_type
 

--- a/src/ml/training_pipeline/task_types.py
+++ b/src/ml/training_pipeline/task_types.py
@@ -1,0 +1,121 @@
+"""Model/target task-type declarations and the #947 compatibility guard.
+
+`create_model()` (`models.py`) dispatches to architectures with fixed,
+already-compiled heads: every family except `tft` compiles a regression head
+(`loss="mse"`, an `rmse` metric); `tft` compiles a binary-classification head
+(`loss="binary_crossentropy"`, sigmoid output). Before this module existed,
+`pipeline.py` built the regression close/close_normalized target
+unconditionally regardless of `model_type` — training `tft` silently fit a
+classification head against a continuous price target: no crash, no
+warning, garbage model (GH #947, the 4th instance of the per-architecture
+contract-drift family after #928/#931/#936).
+
+This module is the single source of truth both `pipeline.py` (to derive the
+right target for a given `model_type`) and its regression-guard tests
+consult, so the two can never drift out of sync silently.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TaskType(Enum):
+    """What kind of target a model's compiled head expects."""
+
+    REGRESSION = "regression"
+    BINARY_CLASSIFICATION = "binary_classification"
+    TERNARY_CLASSIFICATION = "ternary_classification"
+
+
+# Every model_type selectable via `create_model()` (models.py), by task type.
+# "adaptive"/"default" are cnn_lstm aliases (models.py:200).
+MODEL_TASK_TYPES: dict[str, TaskType] = {
+    "lstm": TaskType.REGRESSION,
+    "cnn_lstm": TaskType.REGRESSION,
+    "adaptive": TaskType.REGRESSION,
+    "default": TaskType.REGRESSION,
+    "attention_lstm": TaskType.REGRESSION,
+    "tcn": TaskType.REGRESSION,
+    "tcn_attention": TaskType.REGRESSION,
+    "tft": TaskType.BINARY_CLASSIFICATION,
+}
+
+# Every target_type the training pipeline can build a label for, by task
+# type. "regression" is the incumbent next-bar price-regression target
+# (pipeline.py's current unconditional behavior); "meta_label" is built by
+# meta_labels.py rather than labels.py but is listed here so the guard
+# covers it too.
+TARGET_TASK_TYPES: dict[str, TaskType] = {
+    "regression": TaskType.REGRESSION,
+    "binary_direction": TaskType.BINARY_CLASSIFICATION,
+    "triple_barrier": TaskType.TERNARY_CLASSIFICATION,
+    "smoothed_return": TaskType.REGRESSION,
+    "meta_label": TaskType.BINARY_CLASSIFICATION,
+}
+
+
+def get_model_task_type(model_type: str) -> TaskType:
+    """Return the task type a model_type's compiled head expects.
+
+    Raises:
+        ValueError: model_type is not a recognized `create_model()` architecture.
+    """
+    task_type = MODEL_TASK_TYPES.get(model_type.lower())
+    if task_type is None:
+        raise ValueError(
+            f"Unknown model_type: {model_type!r}. "
+            f"Known model types: {sorted(MODEL_TASK_TYPES)}"
+        )
+    return task_type
+
+
+def get_target_task_type(target_type: str) -> TaskType:
+    """Return the task type a target_type's label produces.
+
+    Raises:
+        ValueError: target_type is not a recognized label type.
+    """
+    task_type = TARGET_TASK_TYPES.get(target_type)
+    if task_type is None:
+        raise ValueError(
+            f"Unknown target_type: {target_type!r}. "
+            f"Known target types: {sorted(TARGET_TASK_TYPES)}"
+        )
+    return task_type
+
+
+def validate_target_head_compatibility(model_type: str, target_type: str) -> None:
+    """Refuse loudly when a model_type's head is incompatible with the target.
+
+    This is the #947 guard: a model_type's compiled head (regression MSE
+    loss, binary sigmoid/BCE, ...) must match the task type of the label
+    being built for it. Call this before any data download / training work
+    starts, so an incompatible combination fails fast and cheap.
+
+    Args:
+        model_type: Architecture selector passed to `create_model()`.
+        target_type: Label type selector (see TARGET_TASK_TYPES).
+
+    Raises:
+        ValueError: Either type is unrecognized, or they're incompatible.
+    """
+    model_task = get_model_task_type(model_type)
+    target_task = get_target_task_type(target_type)
+
+    if model_task is not target_task:
+        raise ValueError(
+            f"model_type={model_type!r} has a {model_task.value} head, incompatible "
+            f"with target_type={target_type!r} (produces a {target_task.value} label). "
+            f"Pick a model_type/target_type pair with matching task types."
+        )
+
+
+__all__ = [
+    "MODEL_TASK_TYPES",
+    "TARGET_TASK_TYPES",
+    "TaskType",
+    "get_model_task_type",
+    "get_target_task_type",
+    "validate_target_head_compatibility",
+]

--- a/src/prediction/distribution_stats.py
+++ b/src/prediction/distribution_stats.py
@@ -1,0 +1,149 @@
+"""Training-set-derived distribution statistics for confidence scoring.
+
+Harness-wide rule (TARGET-REDESIGN tournament preregistration §2/§4): every
+entrant's raw output converts to signal strength/confidence via statistics
+of its OWN training-set target distribution (percentile/z-score), computed
+once on the training split and never updated using eval-window data --
+never a hardcoded constant. The `confidence = |return| x 12` class of
+formula (``ml_signal_generator.py``'s ``CONFIDENCE_MULTIPLIER``) is
+prohibited everywhere in this tournament.
+
+This module is the literal FreqAI ``&*_std``/``&*_mean``-equivalent pattern
+the Board directive names for entrant (d) (smoothed forward return): a
+frozen percentile table built once at training time on the training-set
+distribution of ``|predicted_smoothed_return|``, persisted into model
+metadata, and consulted at inference time via linear interpolation.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FrozenDistribution:
+    """A percentile table computed once on a training split.
+
+    ``values`` must be sorted strictly ascending; ``percentiles[i]`` is the
+    percentage (0-100) of the training-set distribution at or below
+    ``values[i]``.
+    """
+
+    values: tuple[float, ...]
+    percentiles: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.values) != len(self.percentiles):
+            raise ValueError(
+                f"values and percentiles must be the same length, got "
+                f"{len(self.values)} and {len(self.percentiles)}"
+            )
+        if len(self.values) < 2:
+            raise ValueError("distribution needs at least 2 points to interpolate")
+        if list(self.values) != sorted(self.values):
+            raise ValueError("values must be sorted ascending")
+
+    @classmethod
+    def from_samples(cls, samples: Sequence[float], num_points: int = 101) -> FrozenDistribution:
+        """Build a frozen percentile table from raw training-set samples.
+
+        Computes ``num_points`` evenly-spaced percentiles (default 101 ->
+        0, 1, ..., 100) of ``samples``. Call this ONCE at training time and
+        persist the result (``to_metadata()``) into model metadata -- never
+        recompute it on eval-window data (that would leak eval-window
+        information into the "training-set-only" confidence mapping the
+        harness-wide rule requires).
+
+        Args:
+            samples: Raw training-set values (e.g. |predicted_smoothed_return|
+                over the training split). Non-finite values are dropped.
+            num_points: Number of percentile grid points (default 101).
+
+        Returns:
+            A FrozenDistribution ready for percentile_rank_confidence().
+
+        Raises:
+            ValueError: No finite samples were provided.
+        """
+        arr = np.asarray(samples, dtype=np.float64)
+        arr = arr[np.isfinite(arr)]
+        if arr.size == 0:
+            raise ValueError("samples must contain at least one finite value")
+
+        pct_grid = np.linspace(0.0, 100.0, num_points)
+        raw_values = np.percentile(arr, pct_grid)
+
+        # np.percentile can produce a non-strictly-increasing sequence when
+        # the underlying distribution has repeated/constant regions (e.g.
+        # many identical predictions) -- dedupe while preserving
+        # monotonicity so interpolation stays well-defined.
+        dedup_values: list[float] = []
+        dedup_pcts: list[float] = []
+        last_value: float | None = None
+        for value, pct in zip(raw_values, pct_grid, strict=True):
+            value_f = float(value)
+            if last_value is None or value_f > last_value:
+                dedup_values.append(value_f)
+                dedup_pcts.append(float(pct))
+                last_value = value_f
+
+        if len(dedup_values) < 2:
+            # Fully degenerate (every sample identical) -- fabricate a
+            # 2-point table so interpolation still works; any input maps
+            # near the single observed value's percentile.
+            base = float(arr[0])
+            dedup_values = [base, base + 1e-12]
+            dedup_pcts = [0.0, 100.0]
+
+        return cls(values=tuple(dedup_values), percentiles=tuple(dedup_pcts))
+
+    def to_metadata(self) -> dict[str, list[float]]:
+        """Serialize to a JSON-safe dict for model metadata.json."""
+        return {"values": list(self.values), "percentiles": list(self.percentiles)}
+
+    @classmethod
+    def from_metadata(cls, data: dict) -> FrozenDistribution:
+        """Deserialize from a model metadata.json dict (see to_metadata())."""
+        return cls(values=tuple(data["values"]), percentiles=tuple(data["percentiles"]))
+
+
+def percentile_rank_confidence(value: float, distribution: FrozenDistribution) -> float:
+    """Map a raw value to a [0, 1] confidence via a frozen percentile table.
+
+    This is the harness-wide fix for the prohibited ``confidence = |x| * C``
+    formula: instead of an arbitrary constant, confidence is where
+    ``value`` falls within its OWN training-set distribution, expressed as
+    a fraction (percentile / 100). Values outside the training-set range
+    clamp to the nearest edge rather than extrapolating.
+
+    Args:
+        value: Raw magnitude to score (callers pass e.g.
+            ``abs(predicted_return)`` for entrant (d)).
+        distribution: A FrozenDistribution built at training time.
+
+    Returns:
+        Confidence in [0.0, 1.0]. NaN input returns 0.0 (matches the
+        existing "invalid prediction -> zero confidence" convention used
+        throughout the signal-generator layer).
+    """
+    if not math.isfinite(value):
+        return 0.0
+
+    values = distribution.values
+    percentiles = distribution.percentiles
+
+    if value <= values[0]:
+        pct = percentiles[0]
+    elif value >= values[-1]:
+        pct = percentiles[-1]
+    else:
+        pct = float(np.interp(value, values, percentiles))
+
+    return max(0.0, min(1.0, pct / 100.0))
+
+
+__all__ = ["FrozenDistribution", "percentile_rank_confidence"]

--- a/src/prediction/engine.py
+++ b/src/prediction/engine.py
@@ -65,6 +65,11 @@ class PredictionResult:
     cache_hit: bool = False
     error: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Ordered class probabilities for classification bundles, propagated
+    # from ModelPrediction.probabilities. None for every regression bundle
+    # (purely additive -- see docs/prediction.md and OnnxRunner's
+    # _process_classification_output).
+    probabilities: tuple[float, ...] | None = None
 
 
 class PredictionEngine:
@@ -187,6 +192,7 @@ class PredictionEngine:
             bundle = self._resolve_bundle(model_name)
             model = bundle.runner
             prepared_features = self._prepare_features_for_bundle(bundle, features, features_df)
+            final_probabilities: tuple[float, ...] | None = None
 
             # Make prediction (with optional ensemble)
             if self._ensemble_aggregator is None:
@@ -200,11 +206,17 @@ class PredictionEngine:
                 final_conf = prediction.confidence
                 final_dir = prediction.direction
                 final_model_name = prediction.model_name
+                final_probabilities = getattr(prediction, "probabilities", None)
                 member_preds = None
                 features_used = self._count_features_used(prepared_features)
 
-                # Apply rolling MinMax denormalization if needed
-                final_price = self._apply_rolling_denormalization(final_price, bundle, data)
+                if final_probabilities is None:
+                    # Apply rolling MinMax denormalization if needed. Classification
+                    # bundles have no price to denormalize -- probabilities is the
+                    # authoritative output there (see PredictionResult.probabilities);
+                    # skipping this also avoids the finite-price guard below rejecting
+                    # a classifier's deliberate NaN price placeholder.
+                    final_price = self._apply_rolling_denormalization(final_price, bundle, data)
             else:
                 # Run all available structured runners for ensemble
                 preds = []
@@ -321,6 +333,7 @@ class PredictionEngine:
                 inference_time=inference_time,
                 features_used=features_used,
                 cache_hit=cache_hit,
+                probabilities=final_probabilities,
                 metadata={
                     "data_length": len(data),
                     "feature_extraction_time": feature_time,

--- a/src/prediction/models/onnx_runner.py
+++ b/src/prediction/models/onnx_runner.py
@@ -633,6 +633,15 @@ class OnnxRunner:
         # Cast: _process_output only calls this after verifying metadata holds price_normalization.
         metadata = cast(dict[str, Any], self.model_metadata)
         price_params = metadata["price_normalization"]
+        # rolling_minmax is PredictionEngine._apply_rolling_denormalization's
+        # scheme (uses the input window's own min/max), not this mean/std-based
+        # method -- every live model's metadata carries this method with no
+        # mean/std, so without this guard the branch below would log a
+        # WARNING on every single prediction (log-spam on the live money
+        # path, see #948 fix-round P2). Silently skip rather than warn: this
+        # is expected, not a misconfiguration.
+        if price_params.get("method") == "rolling_minmax":
+            return pred
         # Validate required normalization parameters exist
         if "std" not in price_params or "mean" not in price_params:
             logging.warning(

--- a/src/prediction/models/onnx_runner.py
+++ b/src/prediction/models/onnx_runner.py
@@ -6,6 +6,7 @@ This module provides functionality to run ONNX models for prediction.
 
 import json
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -51,6 +52,11 @@ class ModelPrediction:
     direction: int  # 1, 0, -1
     model_name: str
     inference_time: float
+    # Ordered class probabilities for classification bundles (task_type=
+    # "binary_classification"/"ternary_classification" in model metadata),
+    # None for every regression bundle -- purely additive, see
+    # OnnxRunner._process_classification_output.
+    probabilities: tuple[float, ...] | None = None
 
 
 class OnnxRunner:
@@ -206,10 +212,15 @@ class OnnxRunner:
     def predict(self, features: np.ndarray) -> ModelPrediction:
         """Run prediction on features with optional caching"""
         start_time = time.time()
+        # Classification bundles are not cached: the cache only stores
+        # price/confidence/direction (_build_cache_config/_cache_result), so
+        # a cache hit would silently drop probabilities -- always run fresh
+        # inference for them instead of caching a lossy result.
+        is_classification = self._is_classification_task()
 
         try:
             # Check cache first if enabled
-            if self.cache_manager and self.config.prediction_cache_enabled:
+            if self.cache_manager and self.config.prediction_cache_enabled and not is_classification:
                 cache_result = self._check_cache(features)
                 if cache_result is not None:
                     # Return cached result
@@ -268,8 +279,8 @@ class OnnxRunner:
 
             inference_time = time.time() - start_time
 
-            # Cache the result if enabled
-            if self.cache_manager and self.config.prediction_cache_enabled:
+            # Cache the result if enabled (classification excluded, see above)
+            if self.cache_manager and self.config.prediction_cache_enabled and not is_classification:
                 self._cache_result(features, prediction)
 
             return ModelPrediction(
@@ -278,10 +289,16 @@ class OnnxRunner:
                 direction=prediction["direction"],
                 model_name=os.path.basename(self.model_path),
                 inference_time=inference_time,
+                probabilities=prediction.get("probabilities"),
             )
 
         except Exception as e:
             raise RuntimeError(f"Prediction failed: {e}") from e
+
+    def _is_classification_task(self) -> bool:
+        """True when model_metadata declares a classification task_type."""
+        task_type = (self.model_metadata or {}).get("task_type", "regression")
+        return task_type in ("binary_classification", "ternary_classification")
 
     def _build_cache_config(self) -> dict[str, Any]:
         """Build the config dict used as part of cache keys."""
@@ -475,6 +492,10 @@ class OnnxRunner:
         if output.size == 0:
             raise ValueError("Model output tensor is empty - cannot extract prediction")
 
+        if self._is_classification_task():
+            task_type = cast(dict[str, Any], self.model_metadata)["task_type"]
+            return self._process_classification_output(output, task_type)
+
         # Extract scalar prediction
         if output.shape == (1, 1, 1):
             pred = output[0][0][0]
@@ -495,6 +516,78 @@ class OnnxRunner:
         direction = self._calculate_direction(pred)
 
         return {"price": float(pred), "confidence": confidence, "direction": direction}
+
+    def _process_classification_output(
+        self, output: np.ndarray, task_type: str
+    ) -> dict[str, Any]:
+        """Process a classification model's raw output into a prediction dict.
+
+        Metadata MUST declare "class_labels": an ordered list of direction
+        values in {-1, 0, 1} matching the probability vector's class order
+        (e.g. a binary "up" classifier: [-1, 1]; ternary triple-barrier:
+        [-1, 0, 1]). class_labels ARE the direction values directly -- no
+        separate mapping table, so there's nowhere for the two to drift
+        apart. Confidence is the raw P(argmax class) -- the harness-wide
+        rule (TARGET-REDESIGN tournament preregistration §2/§4) is that any
+        calibration correction happens upstream (a Platt/isotonic scaling
+        step fit at training time), never a hardcoded conversion constant
+        here.
+
+        price is always NaN for classification predictions -- there is no
+        real price output to report, and NaN (not 0.0) is deliberate: it
+        forces any consumer that doesn't explicitly branch on `probabilities`
+        to fail loud (PredictionEngine's finite-price check) rather than
+        silently treating a placeholder as a real price.
+        """
+        metadata = cast(dict[str, Any], self.model_metadata)
+        class_labels = metadata.get("class_labels")
+        if not class_labels:
+            raise ValueError(
+                f"Model metadata task_type={task_type!r} but no 'class_labels' declared -- "
+                "cannot interpret classification output without an explicit class order."
+            )
+
+        flattened = np.asarray(output).flatten().astype(np.float64)
+        if flattened.size == 0:
+            raise ValueError("Flattened classification output is empty - cannot extract prediction")
+
+        if task_type == "binary_classification":
+            if flattened.size != 1:
+                raise ValueError(
+                    f"binary_classification expects a single sigmoid output value, "
+                    f"got shape {output.shape}"
+                )
+            if len(class_labels) != 2:
+                raise ValueError(
+                    f"binary_classification requires exactly 2 class_labels, got {class_labels}"
+                )
+            p_up = float(flattened[0])
+            if not math.isfinite(p_up):
+                raise ValueError(f"Non-finite classification output: {p_up}")
+            p_up = min(1.0, max(0.0, p_up))
+            probabilities = np.array([1.0 - p_up, p_up], dtype=np.float64)
+        elif task_type == "ternary_classification":
+            if flattened.size != len(class_labels):
+                raise ValueError(
+                    f"ternary_classification output has {flattened.size} values but "
+                    f"{len(class_labels)} class_labels were declared: {class_labels}"
+                )
+            if not np.all(np.isfinite(flattened)):
+                raise ValueError(f"Non-finite classification output: {flattened.tolist()}")
+            probabilities = flattened
+        else:
+            raise ValueError(f"Unknown classification task_type: {task_type!r}")
+
+        argmax_idx = int(np.argmax(probabilities))
+        direction = int(class_labels[argmax_idx])
+        confidence = float(probabilities[argmax_idx])
+
+        return {
+            "price": float("nan"),
+            "confidence": confidence,
+            "direction": direction,
+            "probabilities": tuple(float(p) for p in probabilities),
+        }
 
     def _denormalize_price(self, pred: float) -> float:
         """Denormalize price prediction"""

--- a/src/prediction/models/onnx_runner.py
+++ b/src/prediction/models/onnx_runner.py
@@ -220,7 +220,11 @@ class OnnxRunner:
 
         try:
             # Check cache first if enabled
-            if self.cache_manager and self.config.prediction_cache_enabled and not is_classification:
+            if (
+                self.cache_manager
+                and self.config.prediction_cache_enabled
+                and not is_classification
+            ):
                 cache_result = self._check_cache(features)
                 if cache_result is not None:
                     # Return cached result
@@ -280,7 +284,11 @@ class OnnxRunner:
             inference_time = time.time() - start_time
 
             # Cache the result if enabled (classification excluded, see above)
-            if self.cache_manager and self.config.prediction_cache_enabled and not is_classification:
+            if (
+                self.cache_manager
+                and self.config.prediction_cache_enabled
+                and not is_classification
+            ):
                 self._cache_result(features, prediction)
 
             return ModelPrediction(
@@ -517,9 +525,7 @@ class OnnxRunner:
 
         return {"price": float(pred), "confidence": confidence, "direction": direction}
 
-    def _process_classification_output(
-        self, output: np.ndarray, task_type: str
-    ) -> dict[str, Any]:
+    def _process_classification_output(self, output: np.ndarray, task_type: str) -> dict[str, Any]:
         """Process a classification model's raw output into a prediction dict.
 
         Metadata MUST declare "class_labels": an ordered list of direction

--- a/src/prediction/models/onnx_runner.py
+++ b/src/prediction/models/onnx_runner.py
@@ -10,6 +10,7 @@ import math
 import os
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal, cast
 
 import numpy as np
@@ -28,6 +29,11 @@ from .execution_providers import get_preferred_providers
 
 # Constants for numerical stability
 EPSILON = 1e-8  # Small value to prevent division by zero
+
+# Tolerances for validating a ternary_classification head's raw output looks
+# like softmax probabilities (not raw logits) -- see _process_classification_output.
+_PROBABILITY_RANGE_TOLERANCE = 1e-3  # slack around [0, 1] for float rounding
+_PROBABILITY_SUM_TOLERANCE = 1e-2  # slack around sum == 1.0
 
 # Metadata load timeout (fixed, not configurable - metadata files are small)
 METADATA_LOAD_TIMEOUT = 10.0
@@ -172,7 +178,16 @@ class OnnxRunner:
         Raises:
             TimeoutError: If metadata loading exceeds timeout.
         """
-        metadata_path = self.model_path.replace(".onnx", "_metadata.json")
+        # metadata.json lives alongside model.onnx in the SAME directory --
+        # the convention every writer (save_artifacts) and every other
+        # reader (PredictionModelRegistry, cloud artifact sync) uses. A
+        # prior `{stem}_metadata.json` sidecar-naming convention here never
+        # matched anything any writer produced, so this method always fell
+        # through to the hardcoded defaults in production regardless of what
+        # metadata.json actually contained (root cause of #948's review
+        # finding that OnnxRunner could never see task_type/class_labels/
+        # target_distribution even once pipeline.py started writing them).
+        metadata_path = str(Path(self.model_path).with_name("metadata.json"))
         try:
 
             def _read_metadata():
@@ -580,7 +595,25 @@ class OnnxRunner:
                 )
             if not np.all(np.isfinite(flattened)):
                 raise ValueError(f"Non-finite classification output: {flattened.tolist()}")
-            probabilities = flattened
+            # A ternary head that emits raw logits instead of softmax
+            # probabilities would otherwise pass through silently: argmax
+            # still (coincidentally) picks the right class, but confidence
+            # (P(argmax)) could read outside [0,1] and `probabilities`
+            # wouldn't sum to 1 -- fail loud instead, matching the binary
+            # path's [0,1] clamping guarantee.
+            probability_sum = float(np.sum(flattened))
+            out_of_range = np.any(flattened < -_PROBABILITY_RANGE_TOLERANCE) or np.any(
+                flattened > 1.0 + _PROBABILITY_RANGE_TOLERANCE
+            )
+            sum_off = not math.isclose(probability_sum, 1.0, abs_tol=_PROBABILITY_SUM_TOLERANCE)
+            if out_of_range or sum_off:
+                raise ValueError(
+                    f"ternary_classification output {flattened.tolist()} does not look like "
+                    f"softmax probabilities (sum={probability_sum:.6f}, expected ~1.0, each "
+                    f"value in [0,1]) -- the model head may be emitting raw logits instead of "
+                    f"softmax output."
+                )
+            probabilities = np.clip(flattened, 0.0, 1.0)
         else:
             raise ValueError(f"Unknown classification task_type: {task_type!r}")
 

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -1,0 +1,365 @@
+"""Exam-only classification-native and percentile-rank signal generators.
+
+Built for the TARGET-REDESIGN tournament exam harness (preregistration §5):
+entrants (a)/(b)/(c) (classifiers) plug in via ``ClassificationExamSignalGenerator``,
+entrant (d) (smoothed forward return) via ``SmoothedReturnExamSignalGenerator``.
+Both consume ``PredictionResult`` from the classification-native prediction
+path (``src/prediction/engine.py``/``onnx_runner.py``) and both convert raw
+model output to signal confidence via the harness-wide rule: statistics of
+the model's OWN training-set target distribution, never a hardcoded
+constant. The ``confidence = |return| * 12`` formula
+(``ml_signal_generator.py``'s ``CONFIDENCE_MULTIPLIER``) is prohibited here.
+
+Deliberately a SEPARATE module from ``ml_signal_generator.py``
+(``MLBasicSignalGenerator``/``MLSignalGenerator``) -- those are live,
+money-path code with their own cross-symbol-fallback hardening this
+exam-only research harness does not need, and this scaffolding does not
+modify them.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+from src.prediction import PredictionConfig, PredictionEngine, PredictionResult
+from src.prediction.distribution_stats import FrozenDistribution, percentile_rank_confidence
+from src.prediction.features.pipeline import FeaturePipeline
+from src.prediction.features.price_only import PriceOnlyFeatureExtractor
+from src.strategies.components.regime_context import RegimeContext
+from src.strategies.components.signal_generator import Signal, SignalDirection, SignalGenerator
+
+logger = logging.getLogger(__name__)
+
+_PRICE_ONLY_PIPELINE_CONFIG = {
+    "technical_features": {"enabled": False},
+    "sentiment_features": {"enabled": False},
+    "market_features": {"enabled": False},
+    "price_only_features": {"enabled": False},
+}
+
+
+def _build_price_only_prediction_engine(sequence_length: int) -> PredictionEngine | None:
+    """Build a price-only PredictionEngine for the exam harness.
+
+    Mirrors MLBasicSignalGenerator's feature-pipeline setup (price-only
+    extractor, no sentiment/technical/market features) without its
+    cross-symbol-substitution guard machinery -- that hardening exists for
+    live trading and is not needed for this exam-only research harness.
+    """
+    try:
+        config = PredictionConfig.from_config_manager()
+        config.enable_sentiment = False
+        config.enable_market_microstructure = False
+        engine = PredictionEngine(config)
+        engine.feature_pipeline = FeaturePipeline(
+            config=_PRICE_ONLY_PIPELINE_CONFIG,
+            custom_extractors=[PriceOnlyFeatureExtractor(normalization_window=sequence_length)],
+        )
+        health = engine.health_check()
+        if health.get("status") != "healthy":
+            logger.warning("Exam signal generator: prediction engine health degraded: %s", health)
+        return engine
+    except Exception:
+        logger.exception("Exam signal generator: prediction engine initialization failed")
+        return None
+
+
+class ClassificationExamSignalGenerator(SignalGenerator):
+    """Consumes a classifier bundle's probability output directly.
+
+    ``direction`` is already mapped to {-1, 0, 1} by the bundle's
+    ``class_labels`` metadata (see ``OnnxRunner._process_classification_output``);
+    ``confidence`` is the raw P(argmax class) -- bounded [0, 1] by
+    construction, no percentile-rank/multiplier transform needed for the
+    *value* itself (still subject to a calibration-correction step fit at
+    training time, per the preregistration §2 -- this signal generator
+    consumes whatever probability the bundle reports).
+    """
+
+    def __init__(
+        self,
+        name: str = "classification_exam_signal_generator",
+        sequence_length: int = 120,
+        model_name: str | None = None,
+    ) -> None:
+        super().__init__(name)
+        self.sequence_length = sequence_length
+        self.model_name = model_name
+        self.prediction_engine = _build_price_only_prediction_engine(sequence_length)
+
+    def generate_signal(
+        self, df: Any, index: int, regime: RegimeContext | None = None
+    ) -> Signal:
+        self.validate_inputs(df, index)
+
+        if index < self.sequence_length:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={
+                    "generator": self.name,
+                    "reason": "insufficient_history",
+                    "index": index,
+                    "required_length": self.sequence_length,
+                },
+            )
+
+        result = self._predict(df, index)
+        if result is None or result.error is not None or result.probabilities is None:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={
+                    "generator": self.name,
+                    "reason": "prediction_failed_or_not_classification",
+                    "index": index,
+                },
+            )
+
+        confidence = max(0.0, min(1.0, float(result.confidence)))
+        raw_direction = int(result.direction)
+        if raw_direction > 0:
+            direction = SignalDirection.BUY
+        elif raw_direction < 0:
+            direction = SignalDirection.SELL
+        else:
+            direction = SignalDirection.HOLD
+
+        metadata: dict[str, Any] = {
+            "generator": self.name,
+            "probabilities": result.probabilities,
+            "raw_direction": raw_direction,
+            "index": index,
+            "sequence_length": self.sequence_length,
+            "engine_model_name": self.model_name,
+        }
+        if direction == SignalDirection.SELL:
+            metadata["enter_short"] = True
+
+        # No separate "magnitude" for a classifier output -- confidence
+        # doubles as strength (same convention as the incumbent
+        # regression signal generators, which scale strength from the same
+        # signal that drives confidence).
+        return Signal(
+            direction=direction, strength=confidence, confidence=confidence, metadata=metadata
+        )
+
+    def get_confidence(self, df: Any, index: int) -> float:
+        self.validate_inputs(df, index)
+        if index < self.sequence_length:
+            return 0.0
+        result = self._predict(df, index)
+        if result is None or result.error is not None or result.probabilities is None:
+            return 0.0
+        return max(0.0, min(1.0, float(result.confidence)))
+
+    def _predict(self, df: Any, index: int) -> PredictionResult | None:
+        if self.prediction_engine is None:
+            return None
+        window_df = df[["open", "high", "low", "close", "volume"]].iloc[
+            index - self.sequence_length : index
+        ]
+        try:
+            if self.model_name:
+                return self.prediction_engine.predict(window_df, model_name=self.model_name)
+            return self.prediction_engine.predict(window_df)
+        except Exception:
+            logger.exception(
+                "ClassificationExamSignalGenerator: prediction error at index %d", index
+            )
+            return None
+
+    @property
+    def warmup_period(self) -> int:
+        return self.sequence_length
+
+    def get_parameters(self) -> dict[str, Any]:
+        params = super().get_parameters()
+        params.update({"sequence_length": self.sequence_length, "model_name": self.model_name})
+        return params
+
+
+class SmoothedReturnExamSignalGenerator(SignalGenerator):
+    """Entrant (d): regression output, confidence via percentile-rank.
+
+    Confidence is ``percentile_rank_confidence(|predicted_return|,
+    distribution)`` against a FROZEN training-set distribution loaded from
+    the resolved bundle's metadata (``metadata["target_distribution"]``,
+    a ``FrozenDistribution.to_metadata()`` payload persisted at training
+    time) -- the harness-wide rule's clearest application, and the direct
+    fix for the prohibited ``× 12`` formula. A bundle with no
+    ``target_distribution`` metadata degrades to HOLD rather than falling
+    back to any hardcoded formula.
+    """
+
+    def __init__(
+        self,
+        name: str = "smoothed_return_exam_signal_generator",
+        sequence_length: int = 120,
+        model_name: str | None = None,
+        long_entry_threshold: float = 0.0,
+        short_entry_threshold: float = 0.0,
+    ) -> None:
+        super().__init__(name)
+        self.sequence_length = sequence_length
+        self.model_name = model_name
+        self.long_entry_threshold = long_entry_threshold
+        self.short_entry_threshold = short_entry_threshold
+        self.prediction_engine = _build_price_only_prediction_engine(sequence_length)
+
+    def generate_signal(
+        self, df: Any, index: int, regime: RegimeContext | None = None
+    ) -> Signal:
+        self.validate_inputs(df, index)
+
+        if index < self.sequence_length:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={
+                    "generator": self.name,
+                    "reason": "insufficient_history",
+                    "index": index,
+                    "required_length": self.sequence_length,
+                },
+            )
+
+        result = self._predict(df, index)
+        if result is None or result.error is not None:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={"generator": self.name, "reason": "prediction_failed", "index": index},
+            )
+
+        current_price = df["close"].iloc[index]
+        prediction = result.price
+        if not (math.isfinite(prediction) and math.isfinite(current_price) and current_price > 0):
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={
+                    "generator": self.name,
+                    "reason": "invalid_prediction_or_price",
+                    "prediction": prediction,
+                    "current_price": current_price,
+                    "index": index,
+                },
+            )
+
+        predicted_return = (prediction - current_price) / current_price
+
+        distribution = self._distribution_for(result)
+        if distribution is None:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={
+                    "generator": self.name,
+                    "reason": "missing_target_distribution",
+                    "predicted_return": predicted_return,
+                    "index": index,
+                },
+            )
+
+        confidence = percentile_rank_confidence(abs(predicted_return), distribution)
+
+        if predicted_return > self.long_entry_threshold:
+            direction = SignalDirection.BUY
+        elif predicted_return < -self.short_entry_threshold:
+            direction = SignalDirection.SELL
+        else:
+            direction = SignalDirection.HOLD
+
+        metadata: dict[str, Any] = {
+            "generator": self.name,
+            "prediction": prediction,
+            "current_price": current_price,
+            "predicted_return": predicted_return,
+            "index": index,
+            "sequence_length": self.sequence_length,
+            "engine_model_name": self.model_name,
+        }
+        if direction == SignalDirection.SELL:
+            metadata["enter_short"] = True
+
+        return Signal(
+            direction=direction, strength=confidence, confidence=confidence, metadata=metadata
+        )
+
+    def get_confidence(self, df: Any, index: int) -> float:
+        self.validate_inputs(df, index)
+        if index < self.sequence_length:
+            return 0.0
+        result = self._predict(df, index)
+        if result is None or result.error is not None:
+            return 0.0
+        current_price = df["close"].iloc[index]
+        prediction = result.price
+        if not (math.isfinite(prediction) and math.isfinite(current_price) and current_price > 0):
+            return 0.0
+        predicted_return = (prediction - current_price) / current_price
+        distribution = self._distribution_for(result)
+        if distribution is None:
+            return 0.0
+        return percentile_rank_confidence(abs(predicted_return), distribution)
+
+    def _predict(self, df: Any, index: int) -> PredictionResult | None:
+        if self.prediction_engine is None:
+            return None
+        window_df = df[["open", "high", "low", "close", "volume"]].iloc[
+            index - self.sequence_length : index
+        ]
+        try:
+            if self.model_name:
+                return self.prediction_engine.predict(window_df, model_name=self.model_name)
+            return self.prediction_engine.predict(window_df)
+        except Exception:
+            logger.exception(
+                "SmoothedReturnExamSignalGenerator: prediction error at index %d", index
+            )
+            return None
+
+    def _distribution_for(self, result: PredictionResult) -> FrozenDistribution | None:
+        if self.prediction_engine is None:
+            return None
+        info = self.prediction_engine.get_model_info(result.model_name)
+        bundle_metadata = info.get("metadata") or {}
+        raw = bundle_metadata.get("target_distribution")
+        if not raw:
+            return None
+        try:
+            return FrozenDistribution.from_metadata(raw)
+        except (KeyError, ValueError, TypeError):
+            logger.warning(
+                "SmoothedReturnExamSignalGenerator: invalid target_distribution metadata for %s",
+                result.model_name,
+            )
+            return None
+
+    @property
+    def warmup_period(self) -> int:
+        return self.sequence_length
+
+    def get_parameters(self) -> dict[str, Any]:
+        params = super().get_parameters()
+        params.update(
+            {
+                "sequence_length": self.sequence_length,
+                "model_name": self.model_name,
+                "long_entry_threshold": self.long_entry_threshold,
+                "short_entry_threshold": self.short_entry_threshold,
+            }
+        )
+        return params
+
+
+__all__ = ["ClassificationExamSignalGenerator", "SmoothedReturnExamSignalGenerator"]

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -89,9 +89,7 @@ class ClassificationExamSignalGenerator(SignalGenerator):
         self.model_name = model_name
         self.prediction_engine = _build_price_only_prediction_engine(sequence_length)
 
-    def generate_signal(
-        self, df: Any, index: int, regime: RegimeContext | None = None
-    ) -> Signal:
+    def generate_signal(self, df: Any, index: int, regime: RegimeContext | None = None) -> Signal:
         self.validate_inputs(df, index)
 
         if index < self.sequence_length:
@@ -211,9 +209,7 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
         self.short_entry_threshold = short_entry_threshold
         self.prediction_engine = _build_price_only_prediction_engine(sequence_length)
 
-    def generate_signal(
-        self, df: Any, index: int, regime: RegimeContext | None = None
-    ) -> Signal:
+    def generate_signal(self, df: Any, index: int, regime: RegimeContext | None = None) -> Signal:
         self.validate_inputs(df, index)
 
         if index < self.sequence_length:

--- a/src/strategies/exam_target_redesign.py
+++ b/src/strategies/exam_target_redesign.py
@@ -1,0 +1,130 @@
+"""Exam-only strategy factory for the TARGET-REDESIGN tournament.
+
+Mirrors ``src/strategies/ml_basic.py``'s ``create_ml_basic_strategy`` wiring
+pattern exactly (``CoreRiskAdapter(EngineRiskManager(RiskParameters(...)))``
++ ``ConfidenceWeightedSizer(base_fraction=0.2, min_confidence=0.3)``) --
+deliberately NOT HyperGrowth's ``FlatRiskManager`` +
+``FixedFractionSizer(adjust_for_confidence=False)`` wiring, which #938
+proved cannot express confidence/magnitude differences between candidates
+at all (the load-bearing fix this exam harness depends on).
+
+Stop/target geometry defaults to the Board-ratified ``risk-limits.json``
+defaults (``DEFAULT_STOP_LOSS_PCT``/``DEFAULT_TAKE_PROFIT_PCT`` = 5%/4%,
+``max_holding_hours=336``) -- NOT prod HyperGrowth's 10%/30% (see the
+TARGET-REDESIGN tournament preregistration §5/§9 Deviation 2, and entrant
+(c)'s triple-barrier labels, which use the same defaults for
+self-consistency between what the label encodes and what the exam executes).
+
+Takes a pluggable ``signal_generator`` since one exam harness serves all
+four TARGET-REDESIGN entrants: ``ClassificationExamSignalGenerator`` for
+(a) meta-labeling / (b) binary direction / (c) triple-barrier, and
+``SmoothedReturnExamSignalGenerator`` for (d) smoothed forward return
+(both in ``src/strategies/components/exam_signal_generator.py``).
+"""
+
+from __future__ import annotations
+
+from src.config.constants import (
+    DEFAULT_MAX_HOLDING_HOURS,
+    DEFAULT_STOP_LOSS_PCT,
+    DEFAULT_STRATEGY_BASE_FRACTION,
+    DEFAULT_STRATEGY_MIN_CONFIDENCE,
+    DEFAULT_TAKE_PROFIT_PCT,
+)
+from src.risk.risk_manager import RiskManager as EngineRiskManager
+from src.risk.risk_manager import RiskParameters
+from src.strategies.components import (
+    ConfidenceWeightedSizer,
+    CoreRiskAdapter,
+    EnhancedRegimeDetector,
+    SignalGenerator,
+    Strategy,
+)
+
+DEFAULT_EXAM_STRATEGY_NAME = "TargetRedesignExam"
+
+
+def create_exam_strategy(
+    signal_generator: SignalGenerator,
+    name: str = DEFAULT_EXAM_STRATEGY_NAME,
+    *,
+    base_fraction: float = DEFAULT_STRATEGY_BASE_FRACTION,
+    min_confidence: float = DEFAULT_STRATEGY_MIN_CONFIDENCE,
+    min_confidence_floor: float = 0.0,
+    stop_loss_pct: float = DEFAULT_STOP_LOSS_PCT,
+    take_profit_pct: float = DEFAULT_TAKE_PROFIT_PCT,
+    max_holding_hours: int = DEFAULT_MAX_HOLDING_HOURS,
+) -> Strategy:
+    """Build the TARGET-REDESIGN tournament's shared exam-only strategy.
+
+    Every entrant's reformed SignalGenerator plugs into this SAME wiring
+    (preregistration §5) -- money-metric comparability across entrants
+    depends on it (two entrants that agree on direction but differ in
+    confidence WILL produce differently-sized trades under
+    ConfidenceWeightedSizer, unlike HyperGrowth's flat sizer, per #938).
+
+    Args:
+        signal_generator: The entrant's SignalGenerator instance (already
+            constructed/configured by the caller).
+        name: Strategy name (used in logs/metadata; give each entrant a
+            distinct name, e.g. "EntrantB_BinaryDirection").
+        base_fraction: ConfidenceWeightedSizer base fraction (default 0.2,
+            matching ml_basic/ml_adaptive's DEFAULT_STRATEGY_BASE_FRACTION).
+        min_confidence: Minimum signal confidence before any position is
+            opened (default 0.3, DEFAULT_STRATEGY_MIN_CONFIDENCE).
+        min_confidence_floor: Lower bound on the confidence factor once the
+            min_confidence gate has passed (0.0 disables).
+        stop_loss_pct: Stop-loss distance (default: ratified risk-limits.json
+            default, 5%).
+        take_profit_pct: Take-profit distance (default: ratified
+            risk-limits.json default, 4%).
+        max_holding_hours: Vertical/time exit barrier (default: ratified
+            risk-limits.json operational.max_holding_hours, 336).
+
+    Returns:
+        Configured Strategy instance.
+    """
+    risk_parameters = RiskParameters(
+        default_take_profit_pct=take_profit_pct,
+        time_exits={"max_holding_hours": max_holding_hours},
+    )
+    core_risk_manager = EngineRiskManager(risk_parameters)
+    risk_manager = CoreRiskAdapter(core_risk_manager)
+
+    risk_overrides = {
+        "position_sizer": "confidence_weighted",
+        "base_fraction": base_fraction,
+        "max_fraction": base_fraction,
+        "stop_loss_pct": stop_loss_pct,
+        "take_profit_pct": take_profit_pct,
+        "time_exits": {"max_holding_hours": max_holding_hours},
+    }
+    risk_manager.set_strategy_overrides(risk_overrides)
+
+    position_sizer = ConfidenceWeightedSizer(
+        base_fraction=base_fraction,
+        min_confidence=min_confidence,
+        min_confidence_floor=min_confidence_floor,
+    )
+    regime_detector = EnhancedRegimeDetector()
+
+    strategy = Strategy(
+        name=name,
+        signal_generator=signal_generator,
+        risk_manager=risk_manager,
+        position_sizer=position_sizer,
+        regime_detector=regime_detector,
+    )
+    # Also register on the Strategy object itself: build_time_exit_policy
+    # (src/engines/shared/risk_configuration.py) checks
+    # strategy.get_risk_overrides() BEFORE falling back to the risk
+    # manager's own params -- and that fallback only works when the raw
+    # PortfolioRiskManager (not the CoreRiskAdapter wrapper) is passed in.
+    # Setting it here makes max_holding_hours resolve correctly regardless
+    # of which object an engine passes to build_time_exit_policy.
+    strategy.set_risk_overrides(risk_overrides)
+
+    return strategy
+
+
+__all__ = ["DEFAULT_EXAM_STRATEGY_NAME", "create_exam_strategy"]

--- a/tests/unit/engines/shared/test_barrier_touch.py
+++ b/tests/unit/engines/shared/test_barrier_touch.py
@@ -1,0 +1,152 @@
+"""Unit tests for the shared OHLC barrier-touch helper.
+
+This is the pure function extracted from ExitHandler.check_exit_conditions's
+stop-loss/take-profit high/low comparison — the single source of truth reused
+by both the live/backtest exit handler and the triple-barrier label
+simulator (see docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md
+Deviation 2 / #8 engineering inventory).
+"""
+
+import math
+
+import pytest
+
+from src.engines.shared.barrier_touch import BarrierTouchResult, check_barrier_touch
+
+
+class TestLongStopLoss:
+    def test_stop_loss_triggered_when_low_at_or_below_stop(self):
+        result = check_barrier_touch(
+            side="long",
+            candle_high=101.0,
+            candle_low=94.0,
+            stop_loss_price=95.0,
+            take_profit_price=None,
+        )
+        assert result.hit_stop_loss is True
+        # Worst-case (gap-through) fill: candle low, not the stop price itself.
+        assert result.stop_loss_exit_price == pytest.approx(94.0)
+
+    def test_stop_loss_not_triggered_when_low_above_stop(self):
+        result = check_barrier_touch(
+            side="long",
+            candle_high=101.0,
+            candle_low=96.0,
+            stop_loss_price=95.0,
+            take_profit_price=None,
+        )
+        assert result.hit_stop_loss is False
+
+    def test_stop_loss_boundary_is_inclusive(self):
+        result = check_barrier_touch(
+            side="long",
+            candle_high=101.0,
+            candle_low=95.0,
+            stop_loss_price=95.0,
+            take_profit_price=None,
+        )
+        assert result.hit_stop_loss is True
+        assert result.stop_loss_exit_price == pytest.approx(95.0)
+
+
+class TestLongTakeProfit:
+    def test_take_profit_triggered_when_high_at_or_above_target(self):
+        result = check_barrier_touch(
+            side="long",
+            candle_high=106.0,
+            candle_low=99.0,
+            stop_loss_price=None,
+            take_profit_price=104.0,
+        )
+        assert result.hit_take_profit is True
+        # Fills exactly at the take-profit level (not the gap-through high).
+        assert result.take_profit_exit_price == pytest.approx(104.0)
+
+    def test_take_profit_not_triggered_when_high_below_target(self):
+        result = check_barrier_touch(
+            side="long",
+            candle_high=103.0,
+            candle_low=99.0,
+            stop_loss_price=None,
+            take_profit_price=104.0,
+        )
+        assert result.hit_take_profit is False
+
+
+class TestShortSide:
+    def test_short_stop_loss_uses_candle_high(self):
+        result = check_barrier_touch(
+            side="short",
+            candle_high=106.0,
+            candle_low=99.0,
+            stop_loss_price=105.0,
+            take_profit_price=None,
+        )
+        assert result.hit_stop_loss is True
+        assert result.stop_loss_exit_price == pytest.approx(106.0)
+
+    def test_short_take_profit_uses_candle_low(self):
+        result = check_barrier_touch(
+            side="short",
+            candle_high=101.0,
+            candle_low=94.0,
+            stop_loss_price=None,
+            take_profit_price=95.0,
+        )
+        assert result.hit_take_profit is True
+        assert result.take_profit_exit_price == pytest.approx(95.0)
+
+
+class TestBothBarriersInSameBar:
+    def test_both_hit_reports_both_flags_stop_loss_priority_left_to_caller(self):
+        """Both flags are reported independently; SL-over-TP priority is a
+        caller concern (matches ExitHandler.check_exit_conditions, which
+        checks `if hit_stop_loss: ... elif hit_take_profit: ...`)."""
+        result = check_barrier_touch(
+            side="long",
+            candle_high=110.0,
+            candle_low=90.0,
+            stop_loss_price=95.0,
+            take_profit_price=104.0,
+        )
+        assert result.hit_stop_loss is True
+        assert result.hit_take_profit is True
+
+
+class TestNoLevelsConfigured:
+    def test_none_stop_loss_never_triggers(self):
+        result = check_barrier_touch(
+            side="long",
+            candle_high=200.0,
+            candle_low=1.0,
+            stop_loss_price=None,
+            take_profit_price=None,
+        )
+        assert result.hit_stop_loss is False
+        assert result.hit_take_profit is False
+
+
+class TestInvalidSide:
+    def test_unknown_side_raises(self):
+        with pytest.raises(ValueError, match="side"):
+            check_barrier_touch(
+                side="sideways",
+                candle_high=101.0,
+                candle_low=99.0,
+                stop_loss_price=95.0,
+                take_profit_price=104.0,
+            )
+
+
+class TestResultIsFrozenDataclass:
+    def test_result_fields(self):
+        result = check_barrier_touch(
+            side="long",
+            candle_high=101.0,
+            candle_low=99.0,
+            stop_loss_price=None,
+            take_profit_price=None,
+        )
+        assert isinstance(result, BarrierTouchResult)
+        assert math.isfinite(result.stop_loss_exit_price)
+        assert math.isfinite(result.take_profit_exit_price)

--- a/tests/unit/predictions/test_distribution_stats.py
+++ b/tests/unit/predictions/test_distribution_stats.py
@@ -1,0 +1,123 @@
+"""Unit tests for training-set-derived distribution statistics.
+
+Harness-wide rule (TARGET-REDESIGN tournament preregistration §2d/§4): raw
+model output converts to confidence via statistics of its OWN training-set
+target distribution (percentile/z-score), computed once on the training
+split and never updated using eval-window data -- never a hardcoded
+constant. This is the direct fix for the prohibited `confidence = |x| * 12`
+formula (src/strategies/components/ml_signal_generator.py's
+CONFIDENCE_MULTIPLIER).
+"""
+
+import numpy as np
+import pytest
+
+from src.prediction.distribution_stats import (
+    FrozenDistribution,
+    percentile_rank_confidence,
+)
+
+
+class TestFrozenDistributionFromSamples:
+    def test_builds_monotonic_table(self):
+        samples = np.linspace(0.0, 1.0, 1000)
+        dist = FrozenDistribution.from_samples(samples)
+        assert list(dist.values) == sorted(dist.values)
+        assert list(dist.percentiles) == sorted(dist.percentiles)
+
+    def test_median_sample_lands_near_50th_percentile(self):
+        samples = np.linspace(0.0, 100.0, 10_000)
+        dist = FrozenDistribution.from_samples(samples)
+        confidence = percentile_rank_confidence(50.0, dist)
+        assert confidence == pytest.approx(0.5, abs=0.02)
+
+    def test_rejects_empty_samples(self):
+        with pytest.raises(ValueError):
+            FrozenDistribution.from_samples([])
+
+    def test_rejects_all_nan_samples(self):
+        with pytest.raises(ValueError):
+            FrozenDistribution.from_samples([float("nan"), float("nan")])
+
+    def test_constant_distribution_does_not_crash(self):
+        # A degenerate distribution (every training sample identical) must
+        # still produce a usable table, not divide-by-zero or crash.
+        dist = FrozenDistribution.from_samples([5.0] * 100)
+        confidence = percentile_rank_confidence(5.0, dist)
+        assert 0.0 <= confidence <= 1.0
+
+    def test_metadata_round_trip(self):
+        samples = np.linspace(0.0, 1.0, 500)
+        dist = FrozenDistribution.from_samples(samples)
+        restored = FrozenDistribution.from_metadata(dist.to_metadata())
+        assert restored.values == dist.values
+        assert restored.percentiles == dist.percentiles
+
+
+class TestFrozenDistributionValidation:
+    def test_rejects_mismatched_lengths(self):
+        with pytest.raises(ValueError, match="length"):
+            FrozenDistribution(values=(1.0, 2.0), percentiles=(0.0,))
+
+    def test_rejects_too_few_points(self):
+        with pytest.raises(ValueError):
+            FrozenDistribution(values=(1.0,), percentiles=(0.0,))
+
+    def test_rejects_unsorted_values(self):
+        with pytest.raises(ValueError, match="sorted"):
+            FrozenDistribution(values=(2.0, 1.0), percentiles=(0.0, 100.0))
+
+
+class TestPercentileRankConfidence:
+    @pytest.fixture
+    def dist(self):
+        # Hand-computable: values 0..100 map directly to percentile 0..100.
+        return FrozenDistribution(
+            values=tuple(float(v) for v in range(0, 101, 10)),
+            percentiles=tuple(float(v) for v in range(0, 101, 10)),
+        )
+
+    def test_exact_grid_point(self, dist):
+        assert percentile_rank_confidence(50.0, dist) == pytest.approx(0.5)
+
+    def test_interpolates_between_grid_points(self, dist):
+        # Halfway between values=40 (pct 40) and values=50 (pct 50) -> pct 45.
+        assert percentile_rank_confidence(45.0, dist) == pytest.approx(0.45)
+
+    def test_below_minimum_clamps_to_lowest_percentile(self, dist):
+        assert percentile_rank_confidence(-999.0, dist) == pytest.approx(0.0)
+
+    def test_above_maximum_clamps_to_highest_percentile(self, dist):
+        assert percentile_rank_confidence(999.0, dist) == pytest.approx(1.0)
+
+    def test_nan_value_returns_zero_confidence(self, dist):
+        assert percentile_rank_confidence(float("nan"), dist) == 0.0
+
+    def test_inf_value_returns_zero_confidence(self, dist):
+        # An infinite model output is a numerical bug, not a legitimate
+        # extreme prediction -- treated the same as NaN (0.0 confidence,
+        # degrade to HOLD upstream) rather than clamped to max confidence.
+        assert percentile_rank_confidence(float("inf"), dist) == 0.0
+
+    def test_result_always_in_unit_interval(self, dist):
+        for value in [-1e9, -1.0, 0.0, 25.0, 50.0, 75.0, 100.0, 1e9]:
+            confidence = percentile_rank_confidence(value, dist)
+            assert 0.0 <= confidence <= 1.0
+
+    def test_no_hardcoded_multiplier_used(self, dist):
+        """Doubling the input must NOT double the confidence -- this is the
+        entire point of using a frozen percentile table instead of the
+        prohibited `confidence = |x| * constant` formula."""
+        c1 = percentile_rank_confidence(20.0, dist)
+        c2 = percentile_rank_confidence(40.0, dist)
+        # A linear-multiplier formula would give c2 == 2 * c1; the
+        # percentile-rank formula need not (and here, given this fixture's
+        # linear grid, DOES happen to double -- so assert it holds for a
+        # genuinely nonlinear distribution instead).
+        skewed = FrozenDistribution(
+            values=(0.0, 1.0, 2.0, 100.0),
+            percentiles=(0.0, 90.0, 95.0, 100.0),
+        )
+        c_small = percentile_rank_confidence(1.0, skewed)
+        c_double = percentile_rank_confidence(2.0, skewed)
+        assert c_double != pytest.approx(2 * c_small)

--- a/tests/unit/predictions/test_distribution_stats.py
+++ b/tests/unit/predictions/test_distribution_stats.py
@@ -107,13 +107,12 @@ class TestPercentileRankConfidence:
     def test_no_hardcoded_multiplier_used(self, dist):
         """Doubling the input must NOT double the confidence -- this is the
         entire point of using a frozen percentile table instead of the
-        prohibited `confidence = |x| * constant` formula."""
-        c1 = percentile_rank_confidence(20.0, dist)
-        c2 = percentile_rank_confidence(40.0, dist)
-        # A linear-multiplier formula would give c2 == 2 * c1; the
-        # percentile-rank formula need not (and here, given this fixture's
-        # linear grid, DOES happen to double -- so assert it holds for a
-        # genuinely nonlinear distribution instead).
+        prohibited `confidence = |x| * constant` formula.
+
+        A linear-multiplier formula always gives confidence(2x) == 2 *
+        confidence(x); the percentile-rank formula need not (and on this
+        fixture's linear grid it happens to coincide -- so assert the
+        property on a genuinely nonlinear distribution instead)."""
         skewed = FrozenDistribution(
             values=(0.0, 1.0, 2.0, 100.0),
             percentiles=(0.0, 90.0, 95.0, 100.0),

--- a/tests/unit/predictions/test_engine_prediction_classification.py
+++ b/tests/unit/predictions/test_engine_prediction_classification.py
@@ -1,0 +1,149 @@
+"""PredictionEngine's classification-native path (TARGET-REDESIGN, #933 Phase 2).
+
+Purely additive over the regression path: a ModelPrediction with
+probabilities=None (every existing regression bundle) must flow through
+PredictionEngine.predict() byte-identically to before this feature existed
+-- covered explicitly below alongside the new classification behavior.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.prediction.config import PredictionConfig
+from src.prediction.engine import PredictionEngine, PredictionResult
+from src.prediction.models.onnx_runner import ModelPrediction
+from src.prediction.models.registry import StrategyModel
+
+
+def _make_bundle(runner: Mock, *, metadata: dict | None = None) -> StrategyModel:
+    return StrategyModel(
+        symbol="BTCUSDT",
+        timeframe="1h",
+        model_type="basic_binary_direction",
+        version_id="v1",
+        directory=Path("/tmp/BTCUSDT/basic_binary_direction/v1"),
+        metadata=metadata or {},
+        feature_schema=None,
+        metrics=None,
+        runner=runner,
+    )
+
+
+def _make_data(num_rows=120) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open": np.random.uniform(100, 110, num_rows),
+            "high": np.random.uniform(110, 120, num_rows),
+            "low": np.random.uniform(90, 100, num_rows),
+            "close": np.random.uniform(100, 110, num_rows),
+            "volume": np.random.uniform(1000, 2000, num_rows),
+        }
+    )
+
+
+class TestPredictionResultProbabilitiesField:
+    def test_default_none(self):
+        result = PredictionResult(
+            price=100.0,
+            confidence=0.5,
+            direction=1,
+            model_name="m",
+            timestamp=pd.Timestamp.now(tz="UTC"),
+            inference_time=0.01,
+            features_used=5,
+        )
+        assert result.probabilities is None
+
+
+@patch("src.prediction.engine.PredictionModelRegistry")
+@patch("src.prediction.engine.FeaturePipeline")
+class TestClassificationPredictionFlow:
+    def test_probabilities_propagate_to_result(self, mock_pipeline, mock_registry):
+        config = PredictionConfig()
+        engine = PredictionEngine(config)
+        engine.feature_pipeline.transform.return_value = np.random.random((1, 10))
+
+        mock_model = Mock()
+        mock_model.predict.return_value = ModelPrediction(
+            price=float("nan"),
+            confidence=0.82,
+            direction=1,
+            model_name="test_classifier",
+            inference_time=0.02,
+            probabilities=(0.18, 0.82),
+        )
+        bundle = _make_bundle(mock_model)
+        engine.model_registry.list_bundles.return_value = [bundle]
+        engine.model_registry.get_default_bundle.return_value = bundle
+
+        result = engine.predict(_make_data())
+
+        assert result.error is None
+        assert result.probabilities == pytest.approx((0.18, 0.82))
+        assert result.direction == 1
+        assert result.confidence == pytest.approx(0.82)
+
+    def test_classification_prediction_skips_price_denormalization(
+        self, mock_pipeline, mock_registry
+    ):
+        """A classification prediction's NaN price must NOT trip the
+        finite-price guard in _apply_rolling_denormalization -- that guard
+        exists to catch bad REGRESSION output, not to reject the (expected)
+        placeholder NaN a classifier reports."""
+        config = PredictionConfig()
+        engine = PredictionEngine(config)
+        engine.feature_pipeline.transform.return_value = np.random.random((1, 10))
+
+        mock_model = Mock()
+        mock_model.predict.return_value = ModelPrediction(
+            price=float("nan"),
+            confidence=0.6,
+            direction=-1,
+            model_name="test_classifier",
+            inference_time=0.02,
+            probabilities=(0.6, 0.4),
+        )
+        bundle = _make_bundle(
+            mock_model, metadata={"price_normalization": {"method": "rolling_minmax"}}
+        )
+        engine.model_registry.list_bundles.return_value = [bundle]
+        engine.model_registry.get_default_bundle.return_value = bundle
+
+        result = engine.predict(_make_data())
+
+        assert result.error is None
+        assert result.probabilities == pytest.approx((0.6, 0.4))
+
+
+@patch("src.prediction.engine.PredictionModelRegistry")
+@patch("src.prediction.engine.FeaturePipeline")
+class TestRegressionPathUnaffected:
+    """Guards that adding the classification path did not change a single
+    byte of behavior for every existing (regression) bundle."""
+
+    def test_regression_prediction_has_no_probabilities(self, mock_pipeline, mock_registry):
+        config = PredictionConfig()
+        engine = PredictionEngine(config)
+        engine.feature_pipeline.transform.return_value = np.random.random((1, 10))
+
+        mock_model = Mock()
+        mock_model.predict.return_value = ModelPrediction(
+            price=105.5,
+            confidence=0.85,
+            direction=1,
+            model_name="test_model",
+            inference_time=0.02,
+        )
+        bundle = _make_bundle(mock_model)
+        engine.model_registry.list_bundles.return_value = [bundle]
+        engine.model_registry.get_default_bundle.return_value = bundle
+
+        result = engine.predict(_make_data())
+
+        assert result.probabilities is None
+        assert result.price == 105.5
+        assert result.error is None

--- a/tests/unit/predictions/test_onnx_runner_classification.py
+++ b/tests/unit/predictions/test_onnx_runner_classification.py
@@ -6,6 +6,7 @@ every existing regression bundle has no "task_type" key in its metadata, so
 none of this code executes for them -- verified explicitly below.
 """
 
+import logging
 from unittest.mock import Mock, mock_open, patch
 
 import numpy as np
@@ -210,6 +211,72 @@ class TestRegressionUnaffected:
 
         assert result["price"] > 0
         assert result["direction"] == 1
+
+
+class TestRollingMinmaxDenormalizationSkipsWarning:
+    """PR #948 fix-round P2: fixing OnnxRunner._load_metadata to actually
+    read metadata.json (instead of a phantom sidecar file no writer ever
+    produced) means every LIVE model's price_normalization={"method":
+    "rolling_minmax"} metadata now reaches _process_output for real. That
+    scheme is PredictionEngine._apply_rolling_denormalization's job (it
+    uses the input window's own min/max), not OnnxRunner's mean/std-based
+    _denormalize_price -- which has no mean/std for rolling_minmax metadata
+    and would otherwise log a WARNING on every single live prediction
+    (log-spam that would trip the charter §5 log-signature monitors)."""
+
+    def _make_runner(self, config, metadata_json: str) -> OnnxRunner:
+        with (
+            patch("onnxruntime.InferenceSession", return_value=Mock()),
+            patch("builtins.open", mock_open(read_data=metadata_json)),
+        ):
+            return OnnxRunner("/tmp/test_model.onnx", config)
+
+    def test_rolling_minmax_metadata_produces_zero_warning_logs(self, config, caplog):
+        metadata = '{"sequence_length": 120, "price_normalization": {"method": "rolling_minmax"}}'
+        runner = self._make_runner(config, metadata)
+
+        with caplog.at_level(logging.WARNING):
+            result = runner._process_output(np.array([[[0.05]]]))
+
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        # Pass-through unchanged -- this scheme's denormalization is
+        # PredictionEngine's job, not OnnxRunner's.
+        assert result["price"] == pytest.approx(0.05)
+
+    def test_rolling_minmax_denormalize_price_returns_input_unchanged(self, config):
+        metadata = '{"sequence_length": 120, "price_normalization": {"method": "rolling_minmax"}}'
+        runner = self._make_runner(config, metadata)
+
+        assert runner._denormalize_price(0.42) == pytest.approx(0.42)
+
+    def test_non_rolling_minmax_method_with_missing_params_still_warns(self, config, caplog):
+        """The skip is specific to rolling_minmax -- a genuinely different
+        (misconfigured) normalization method must still warn loudly rather
+        than silently swallowing every missing-params case."""
+        metadata = '{"sequence_length": 120, "price_normalization": {"method": "zscore"}}'
+        runner = self._make_runner(config, metadata)
+
+        with caplog.at_level(logging.WARNING):
+            result = runner._process_output(np.array([[[0.05]]]))
+
+        assert [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert result["price"] == pytest.approx(0.05)
+
+    def test_rolling_minmax_with_mean_std_present_still_skips(self, config, caplog):
+        """Even if a rolling_minmax entry somehow also carried mean/std,
+        the method-based skip takes priority -- that scheme is never
+        mean/std-based, so applying mean/std to it would be wrong."""
+        metadata = (
+            '{"sequence_length": 120, "price_normalization": '
+            '{"method": "rolling_minmax", "mean": 1.0, "std": 2.0}}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        with caplog.at_level(logging.WARNING):
+            result = runner._process_output(np.array([[[0.05]]]))
+
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert result["price"] == pytest.approx(0.05)
 
 
 class TestModelPredictionProbabilitiesField:

--- a/tests/unit/predictions/test_onnx_runner_classification.py
+++ b/tests/unit/predictions/test_onnx_runner_classification.py
@@ -1,0 +1,258 @@
+"""Classification-native prediction path (TARGET-REDESIGN tournament, #933 Phase 2).
+
+Covers OnnxRunner's handling of classification model_metadata (task_type=
+"binary_classification"/"ternary_classification"), which is purely additive:
+every existing regression bundle has no "task_type" key in its metadata, so
+none of this code executes for them -- verified explicitly below.
+"""
+
+from unittest.mock import Mock, mock_open, patch
+
+import numpy as np
+import pytest
+
+from src.prediction.config import PredictionConfig
+from src.prediction.models.onnx_runner import ModelPrediction, OnnxRunner
+
+
+@pytest.fixture
+def config():
+    return PredictionConfig(
+        prediction_horizons=[1],
+        min_confidence_threshold=0.6,
+        max_prediction_latency=0.1,
+        model_registry_path="src/ml/models",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_providers():
+    with patch(
+        "src.prediction.models.onnx_runner.get_preferred_providers",
+        return_value=["CPUExecutionProvider"],
+    ):
+        yield
+
+
+class TestBinaryClassificationOutput:
+    def _make_runner(self, config, metadata_json: str) -> OnnxRunner:
+        with (
+            patch("onnxruntime.InferenceSession", return_value=Mock()),
+            patch("builtins.open", mock_open(read_data=metadata_json)),
+        ):
+            return OnnxRunner("/tmp/test_model.onnx", config)
+
+    def test_high_up_probability_maps_to_up_direction(self, config):
+        metadata = (
+            '{"sequence_length": 120, "task_type": "binary_classification", '
+            '"class_labels": [-1, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        output = np.array([[0.9]])  # P(up) = 0.9
+        result = runner._process_output(output)
+
+        assert result["direction"] == 1
+        assert result["confidence"] == pytest.approx(0.9)
+        assert result["probabilities"] == pytest.approx((0.1, 0.9))
+        # price is not a real output for a classifier -- NaN, never a
+        # spurious-looking real price a naive consumer could misread.
+        assert np.isnan(result["price"])
+
+    def test_low_up_probability_maps_to_down_direction(self, config):
+        metadata = (
+            '{"sequence_length": 120, "task_type": "binary_classification", '
+            '"class_labels": [-1, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        output = np.array([[0.2]])  # P(up) = 0.2 -> P(down) = 0.8
+        result = runner._process_output(output)
+
+        assert result["direction"] == -1
+        assert result["confidence"] == pytest.approx(0.8)
+        assert result["probabilities"] == pytest.approx((0.8, 0.2))
+
+    def test_missing_class_labels_raises(self, config):
+        metadata = '{"sequence_length": 120, "task_type": "binary_classification"}'
+        runner = self._make_runner(config, metadata)
+
+        with pytest.raises(ValueError, match="class_labels"):
+            runner._process_output(np.array([[0.7]]))
+
+    def test_wrong_class_label_count_raises(self, config):
+        metadata = (
+            '{"sequence_length": 120, "task_type": "binary_classification", '
+            '"class_labels": [-1, 0, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        with pytest.raises(ValueError, match="2 class_labels"):
+            runner._process_output(np.array([[0.7]]))
+
+    def test_non_finite_output_raises(self, config):
+        metadata = (
+            '{"sequence_length": 120, "task_type": "binary_classification", '
+            '"class_labels": [-1, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        with pytest.raises(ValueError, match="[Nn]on-finite"):
+            runner._process_output(np.array([[float("nan")]]))
+
+
+class TestTernaryClassificationOutput:
+    def _make_runner(self, config, metadata_json: str) -> OnnxRunner:
+        with (
+            patch("onnxruntime.InferenceSession", return_value=Mock()),
+            patch("builtins.open", mock_open(read_data=metadata_json)),
+        ):
+            return OnnxRunner("/tmp/test_model.onnx", config)
+
+    def test_softmax_output_argmax_and_confidence(self, config):
+        metadata = (
+            '{"sequence_length": 120, "task_type": "ternary_classification", '
+            '"class_labels": [-1, 0, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        # [P(down)=0.1, P(hold)=0.15, P(up)=0.75]
+        output = np.array([[0.1, 0.15, 0.75]])
+        result = runner._process_output(output)
+
+        assert result["direction"] == 1
+        assert result["confidence"] == pytest.approx(0.75)
+        assert result["probabilities"] == pytest.approx((0.1, 0.15, 0.75))
+
+    def test_hold_class_wins(self, config):
+        metadata = (
+            '{"sequence_length": 120, "task_type": "ternary_classification", '
+            '"class_labels": [-1, 0, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        output = np.array([[0.2, 0.6, 0.2]])
+        result = runner._process_output(output)
+
+        assert result["direction"] == 0
+        assert result["confidence"] == pytest.approx(0.6)
+
+    def test_output_class_count_mismatch_raises(self, config):
+        metadata = (
+            '{"sequence_length": 120, "task_type": "ternary_classification", '
+            '"class_labels": [-1, 0, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        with pytest.raises(ValueError, match="class_labels"):
+            runner._process_output(np.array([[0.5, 0.5]]))
+
+
+class TestRegressionUnaffected:
+    """The classification path is purely additive -- every existing
+    regression bundle has no task_type key, and must behave byte-identically
+    to before this feature existed."""
+
+    def test_no_task_type_key_uses_regression_path(self, config):
+        with (
+            patch("onnxruntime.InferenceSession", return_value=Mock()),
+            patch("builtins.open", mock_open(read_data='{"sequence_length": 120}')),
+        ):
+            runner = OnnxRunner("/tmp/test_model.onnx", config)
+
+        output = np.array([[[0.05]]])
+        result = runner._process_output(output)
+
+        assert result["price"] > 0
+        assert result["direction"] == 1
+        assert "probabilities" not in result or result.get("probabilities") is None
+
+    def test_explicit_regression_task_type_uses_regression_path(self, config):
+        with (
+            patch("onnxruntime.InferenceSession", return_value=Mock()),
+            patch(
+                "builtins.open",
+                mock_open(read_data='{"sequence_length": 120, "task_type": "regression"}'),
+            ),
+        ):
+            runner = OnnxRunner("/tmp/test_model.onnx", config)
+
+        output = np.array([[[0.05]]])
+        result = runner._process_output(output)
+
+        assert result["price"] > 0
+        assert result["direction"] == 1
+
+
+class TestModelPredictionProbabilitiesField:
+    def test_default_none(self):
+        pred = ModelPrediction(
+            price=100.0, confidence=0.5, direction=1, model_name="m", inference_time=0.01
+        )
+        assert pred.probabilities is None
+
+    def test_accepts_probabilities(self):
+        pred = ModelPrediction(
+            price=float("nan"),
+            confidence=0.8,
+            direction=1,
+            model_name="m",
+            inference_time=0.01,
+            probabilities=(0.2, 0.8),
+        )
+        assert pred.probabilities == (0.2, 0.8)
+
+
+class TestFullPredictionFlowClassification:
+    def test_predict_propagates_probabilities(self, config):
+        mock_session_instance = Mock()
+        mock_session_instance.run.return_value = [np.array([[0.85]])]
+        mock_input = Mock()
+        mock_input.name = "input"
+        mock_session_instance.get_inputs.return_value = [mock_input]
+
+        metadata = (
+            '{"sequence_length": 120, "task_type": "binary_classification", '
+            '"class_labels": [-1, 1]}'
+        )
+        with (
+            patch("onnxruntime.InferenceSession", return_value=mock_session_instance),
+            patch("builtins.open", mock_open(read_data=metadata)),
+        ):
+            runner = OnnxRunner("/tmp/test_model.onnx", config)
+            features = np.random.rand(120, 5).astype(np.float32)
+            prediction = runner.predict(features)
+
+        assert isinstance(prediction, ModelPrediction)
+        assert prediction.probabilities == pytest.approx((0.15, 0.85))
+        assert prediction.direction == 1
+        assert prediction.confidence == pytest.approx(0.85)
+
+    def test_classification_predictions_bypass_cache(self, config):
+        """No caching support for classification bundles yet (probabilities
+        would be lost on a cache hit, since the cache only stores
+        price/confidence/direction) -- every call must hit the session."""
+        mock_session_instance = Mock()
+        mock_session_instance.run.return_value = [np.array([[0.85]])]
+        mock_input = Mock()
+        mock_input.name = "input"
+        mock_session_instance.get_inputs.return_value = [mock_input]
+
+        metadata = (
+            '{"sequence_length": 120, "task_type": "binary_classification", '
+            '"class_labels": [-1, 1]}'
+        )
+        cache_manager = Mock()
+        config.prediction_cache_enabled = True
+        with (
+            patch("onnxruntime.InferenceSession", return_value=mock_session_instance),
+            patch("builtins.open", mock_open(read_data=metadata)),
+        ):
+            runner = OnnxRunner("/tmp/test_model.onnx", config, cache_manager=cache_manager)
+            features = np.random.rand(120, 5).astype(np.float32)
+            runner.predict(features)
+            runner.predict(features)
+
+        cache_manager.get.assert_not_called()
+        cache_manager.set.assert_not_called()
+        assert mock_session_instance.run.call_count == 2

--- a/tests/unit/predictions/test_onnx_runner_classification.py
+++ b/tests/unit/predictions/test_onnx_runner_classification.py
@@ -147,6 +147,34 @@ class TestTernaryClassificationOutput:
         with pytest.raises(ValueError, match="class_labels"):
             runner._process_output(np.array([[0.5, 0.5]]))
 
+    def test_raw_logits_instead_of_softmax_fails_loud(self, config):
+        """A ternary head exported emitting raw logits (not softmax
+        probabilities) must be rejected loudly -- argmax alone would
+        silently pick the right class while `confidence` reads outside
+        [0,1] and `probabilities` doesn't sum to 1."""
+        metadata = (
+            '{"sequence_length": 120, "task_type": "ternary_classification", '
+            '"class_labels": [-1, 0, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        logits = np.array([[2.0, -1.0, 3.0]])  # does not sum to 1, out of [0,1]
+        with pytest.raises(ValueError, match="softmax"):
+            runner._process_output(logits)
+
+    def test_near_one_sum_within_tolerance_is_accepted(self, config):
+        """Floating-point softmax rounding (sum=0.999999...) must not be
+        rejected -- only genuinely non-probability output should be."""
+        metadata = (
+            '{"sequence_length": 120, "task_type": "ternary_classification", '
+            '"class_labels": [-1, 0, 1]}'
+        )
+        runner = self._make_runner(config, metadata)
+
+        almost_one = np.array([[0.1, 0.2, 0.6999999]])  # sums to 0.9999999
+        result = runner._process_output(almost_one)
+        assert result["direction"] == 1
+
 
 class TestRegressionUnaffected:
     """The classification path is purely additive -- every existing

--- a/tests/unit/strategies/components/test_exam_signal_generator.py
+++ b/tests/unit/strategies/components/test_exam_signal_generator.py
@@ -1,0 +1,325 @@
+"""Unit tests for the exam-only classification-native signal generators.
+
+Built for the TARGET-REDESIGN tournament exam harness (§5): entrants
+(a)/(b)/(c) (classifiers) via ClassificationExamSignalGenerator, entrant (d)
+(smoothed forward return) via SmoothedReturnExamSignalGenerator. Deliberately
+separate from MLBasicSignalGenerator/MLSignalGenerator (money-path, live) --
+these tests never import or touch that module.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.prediction import PredictionResult
+from src.prediction.distribution_stats import FrozenDistribution
+from src.strategies.components.exam_signal_generator import (
+    ClassificationExamSignalGenerator,
+    SmoothedReturnExamSignalGenerator,
+)
+from src.strategies.components.signal_generator import SignalDirection
+
+
+def _make_df(length=150):
+    dates = pd.date_range("2023-01-01", periods=length, freq="1h")
+    rng = np.random.default_rng(42)
+    base_price = 50000.0
+    prices = [base_price]
+    for change in rng.normal(0, 0.02, length - 1):
+        prices.append(max(prices[-1] * (1 + change), 1000))
+    return pd.DataFrame(
+        {
+            "open": prices,
+            "high": [p * 1.01 for p in prices],
+            "low": [p * 0.99 for p in prices],
+            "close": prices,
+            "volume": rng.uniform(1000, 10000, length),
+        },
+        index=dates,
+    )
+
+
+@patch("src.strategies.components.exam_signal_generator.PredictionEngine")
+@patch("src.strategies.components.exam_signal_generator.PredictionConfig")
+class TestClassificationExamSignalGenerator:
+    def test_initialization(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+
+        assert generator.sequence_length == 120
+        assert generator.warmup_period == 120
+
+    def test_insufficient_history_holds(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 50)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.confidence == 0.0
+
+    def test_up_class_wins_produces_buy(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.direction = 1
+        mock_result.confidence = 0.82
+        mock_result.probabilities = (0.18, 0.82)
+        mock_engine.predict.return_value = mock_result
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.BUY
+        assert signal.confidence == pytest.approx(0.82)
+        assert signal.metadata["probabilities"] == (0.18, 0.82)
+
+    def test_down_class_wins_produces_sell_with_enter_short_flag(
+        self, mock_config_class, mock_engine_class
+    ):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.direction = -1
+        mock_result.confidence = 0.7
+        mock_result.probabilities = (0.7, 0.3)
+        mock_engine.predict.return_value = mock_result
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.SELL
+        assert signal.metadata["enter_short"] is True
+
+    def test_hold_class_wins(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.direction = 0
+        mock_result.confidence = 0.6
+        mock_result.probabilities = (0.2, 0.6, 0.2)
+        mock_engine.predict.return_value = mock_result
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.HOLD
+
+    def test_regression_bundle_no_probabilities_holds(self, mock_config_class, mock_engine_class):
+        """A regression bundle (probabilities=None) resolved by mistake must
+        degrade to HOLD, not crash or fabricate a direction from price."""
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.probabilities = None
+        mock_engine.predict.return_value = mock_result
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.confidence == 0.0
+
+    def test_prediction_error_holds(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = "boom"
+        mock_result.metadata = {}
+        mock_engine.predict.return_value = mock_result
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.HOLD
+
+    def test_get_confidence(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.direction = 1
+        mock_result.confidence = 0.55
+        mock_result.probabilities = (0.45, 0.55)
+        mock_engine.predict.return_value = mock_result
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = ClassificationExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        assert generator.get_confidence(df, 130) == pytest.approx(0.55)
+        assert generator.get_confidence(df, 50) == 0.0
+
+
+@patch("src.strategies.components.exam_signal_generator.PredictionEngine")
+@patch("src.strategies.components.exam_signal_generator.PredictionConfig")
+class TestSmoothedReturnExamSignalGenerator:
+    def _distribution_metadata(self):
+        dist = FrozenDistribution(
+            values=(0.0, 0.01, 0.02, 0.05, 0.10),
+            percentiles=(0.0, 25.0, 50.0, 90.0, 100.0),
+        )
+        return dist.to_metadata()
+
+    def test_initialization(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        assert generator.warmup_period == 120
+
+    def test_confidence_uses_percentile_rank_not_multiplier(
+        self, mock_config_class, mock_engine_class
+    ):
+        """The harness-wide fix for the prohibited ×12 formula: confidence
+        must come from the frozen training-set distribution, never a fixed
+        multiplier on |predicted_return|."""
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.model_name = "BTCUSDT:1h:smoothed_return:v1"
+        mock_engine.get_model_info.return_value = {
+            "metadata": {"target_distribution": self._distribution_metadata()}
+        }
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+        current_price = float(df["close"].iloc[130])
+        mock_result.price = current_price * 1.03  # controlled +3% predicted return
+        mock_engine.predict.return_value = mock_result
+
+        signal = generator.generate_signal(df, 130)
+
+        # Distribution grid (0%,25th=1%,50th=2%,90th=5%,100th=10%) -> a 3%
+        # move interpolates to ~63.3% confidence. A naive `|x| * 12`
+        # formula would instead give min(1, 0.03*12) = 0.36 -- assert the
+        # percentile-rank result is NOT that.
+        assert 0.0 <= signal.confidence <= 1.0
+        naive_multiplier_confidence = min(1.0, 0.03 * 12.0)
+        assert signal.confidence != pytest.approx(naive_multiplier_confidence)
+        assert signal.confidence == pytest.approx(0.6333, abs=0.01)
+
+    def test_missing_target_distribution_holds(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.price = 51000.0
+        mock_result.model_name = "BTCUSDT:1h:smoothed_return:v1"
+        mock_engine.predict.return_value = mock_result
+        mock_engine.get_model_info.return_value = {"metadata": {}}
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.metadata["reason"] == "missing_target_distribution"
+
+    def test_prediction_error_holds(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = "boom"
+        mock_result.metadata = {}
+        mock_engine.predict.return_value = mock_result
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.HOLD
+
+    def test_insufficient_history_holds(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 50)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.confidence == 0.0
+
+    def test_up_prediction_produces_buy_signal(self, mock_config_class, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.model_name = "BTCUSDT:1h:smoothed_return:v1"
+        mock_engine.get_model_info.return_value = {
+            "metadata": {"target_distribution": self._distribution_metadata()}
+        }
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+        current_price = float(df["close"].iloc[130])
+        mock_result.price = current_price * 1.05  # +5% predicted move
+        mock_engine.predict.return_value = mock_result
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.BUY
+        assert signal.metadata["predicted_return"] == pytest.approx(0.05, abs=1e-6)
+
+    def test_down_prediction_produces_sell_signal_with_enter_short(
+        self, mock_config_class, mock_engine_class
+    ):
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.model_name = "BTCUSDT:1h:smoothed_return:v1"
+        mock_engine.get_model_info.return_value = {
+            "metadata": {"target_distribution": self._distribution_metadata()}
+        }
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+        current_price = float(df["close"].iloc[130])
+        mock_result.price = current_price * 0.95  # -5% predicted move
+        mock_engine.predict.return_value = mock_result
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.SELL
+        assert signal.metadata["enter_short"] is True

--- a/tests/unit/strategies/test_exam_target_redesign.py
+++ b/tests/unit/strategies/test_exam_target_redesign.py
@@ -1,0 +1,146 @@
+"""Unit tests for the TARGET-REDESIGN tournament's exam-only strategy factory.
+
+Preregistration §5: a new exam-only strategy factory, mirroring
+src/strategies/ml_basic.py's wiring pattern exactly (CoreRiskAdapter(
+EngineRiskManager(RiskParameters(...))) + ConfidenceWeightedSizer(
+base_fraction=0.2, min_confidence=0.3)) -- NOT HyperGrowth's FlatRiskManager
++ FixedFractionSizer(adjust_for_confidence=False), which #938 proved cannot
+express confidence/magnitude differences at all.
+"""
+
+import pytest
+
+from src.config.constants import (
+    DEFAULT_MAX_HOLDING_HOURS,
+    DEFAULT_STOP_LOSS_PCT,
+    DEFAULT_STRATEGY_BASE_FRACTION,
+    DEFAULT_STRATEGY_MIN_CONFIDENCE,
+    DEFAULT_TAKE_PROFIT_PCT,
+)
+from src.strategies.components import (
+    ConfidenceWeightedSizer,
+    CoreRiskAdapter,
+    EnhancedRegimeDetector,
+    HoldSignalGenerator,
+    Strategy,
+)
+from src.strategies.exam_target_redesign import create_exam_strategy
+
+pytestmark = pytest.mark.unit
+
+
+class TestCreateExamStrategy:
+    def test_returns_a_strategy(self):
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        assert isinstance(strategy, Strategy)
+        assert strategy.signal_generator is not None
+        assert strategy.risk_manager is not None
+        assert strategy.position_sizer is not None
+        assert strategy.regime_detector is not None
+
+    def test_uses_the_supplied_signal_generator(self):
+        signal_generator = HoldSignalGenerator()
+        strategy = create_exam_strategy(signal_generator=signal_generator)
+
+        assert strategy.signal_generator is signal_generator
+
+    def test_uses_confidence_weighted_sizer_not_fixed_fraction(self):
+        """#938: FixedFractionSizer(adjust_for_confidence=False) (HyperGrowth's
+        wiring) cannot express confidence/magnitude differences at all --
+        this is the load-bearing fix, verified directly on the wired object."""
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        assert isinstance(strategy.position_sizer, ConfidenceWeightedSizer)
+
+    def test_confidence_weighted_sizer_default_params(self):
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        sizer = strategy.position_sizer
+        assert sizer.base_fraction == pytest.approx(DEFAULT_STRATEGY_BASE_FRACTION)
+        assert sizer.min_confidence == pytest.approx(DEFAULT_STRATEGY_MIN_CONFIDENCE)
+        assert sizer.min_confidence_floor == pytest.approx(0.0)
+
+    def test_confidence_weighted_sizer_params_are_overridable(self):
+        strategy = create_exam_strategy(
+            signal_generator=HoldSignalGenerator(),
+            base_fraction=0.15,
+            min_confidence=0.4,
+            min_confidence_floor=0.1,
+        )
+
+        sizer = strategy.position_sizer
+        assert sizer.base_fraction == pytest.approx(0.15)
+        assert sizer.min_confidence == pytest.approx(0.4)
+        assert sizer.min_confidence_floor == pytest.approx(0.1)
+
+    def test_uses_core_risk_adapter_wrapping_engine_risk_manager(self):
+        """NOT FlatRiskManager -- the ml_basic-pattern wiring."""
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        assert isinstance(strategy.risk_manager, CoreRiskAdapter)
+        assert type(strategy.risk_manager).__name__ != "FlatRiskManager"
+
+    def test_uses_enhanced_regime_detector(self):
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        assert isinstance(strategy.regime_detector, EnhancedRegimeDetector)
+
+    def test_default_stops_are_ratified_risk_limits_defaults_not_hypergrowth(self):
+        """Ratified risk-limits.json defaults (5%/4%), NOT prod HyperGrowth's
+        10%/30% -- per the preregistration §5/Deviation 2."""
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        assert strategy.risk_manager.stop_loss_pct == pytest.approx(DEFAULT_STOP_LOSS_PCT)
+        assert strategy.risk_manager.take_profit_pct == pytest.approx(DEFAULT_TAKE_PROFIT_PCT)
+        assert DEFAULT_STOP_LOSS_PCT == pytest.approx(0.05)
+        assert DEFAULT_TAKE_PROFIT_PCT == pytest.approx(0.04)
+
+    def test_stops_are_overridable(self):
+        strategy = create_exam_strategy(
+            signal_generator=HoldSignalGenerator(),
+            stop_loss_pct=0.03,
+            take_profit_pct=0.06,
+        )
+
+        assert strategy.risk_manager.stop_loss_pct == pytest.approx(0.03)
+        assert strategy.risk_manager.take_profit_pct == pytest.approx(0.06)
+
+    def test_max_holding_hours_defaults_to_336(self):
+        """Set on BOTH RiskParameters.time_exits (so any caller reading the
+        underlying PortfolioRiskManager.params sees it) and
+        Strategy._risk_overrides via set_risk_overrides (the priority-order
+        lookup build_time_exit_policy actually uses) -- verified end-to-end
+        through build_time_exit_policy itself."""
+        from src.engines.shared.risk_configuration import build_time_exit_policy
+
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        overrides = strategy.get_risk_overrides()
+        assert overrides["time_exits"] == {"max_holding_hours": DEFAULT_MAX_HOLDING_HOURS}
+        assert DEFAULT_MAX_HOLDING_HOURS == 336
+
+        policy = build_time_exit_policy(strategy, strategy.risk_manager)
+        assert policy is not None
+        assert policy.max_holding_hours == DEFAULT_MAX_HOLDING_HOURS
+
+    def test_max_holding_hours_overridable(self):
+        from src.engines.shared.risk_configuration import build_time_exit_policy
+
+        strategy = create_exam_strategy(
+            signal_generator=HoldSignalGenerator(), max_holding_hours=48
+        )
+
+        policy = build_time_exit_policy(strategy, strategy.risk_manager)
+        assert policy is not None
+        assert policy.max_holding_hours == 48
+
+    def test_custom_name(self):
+        strategy = create_exam_strategy(
+            signal_generator=HoldSignalGenerator(), name="EntrantB_BinaryDirection"
+        )
+        assert strategy.name == "EntrantB_BinaryDirection"
+
+    def test_default_name(self):
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+        assert strategy.name

--- a/tests/unit/training_pipeline/test_metadata_contract_round_trip.py
+++ b/tests/unit/training_pipeline/test_metadata_contract_round_trip.py
@@ -157,14 +157,19 @@ class TestPipelineWritesClassificationMetadata:
             targets = np.random.randint(0, 2, 50).astype(np.float32)
             mocks["create_sequences"].return_value = (sequences, targets)
             mocks["split_sequences"].return_value = (
-                sequences[:40], targets[:40], sequences[40:], targets[40:],
+                sequences[:40],
+                targets[:40],
+                sequences[40:],
+                targets[40:],
             )
             mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
             model = MagicMock()
             model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
             mocks["create_model"].return_value = model
             mocks["validate_model_robustness"].return_value = {}
-            mocks["evaluate_model_performance"].return_value = {"error": "diagnostics skipped in test"}
+            mocks["evaluate_model_performance"].return_value = {
+                "error": "diagnostics skipped in test"
+            }
             mocks["create_training_plots"].return_value = None
 
             result = run_training_pipeline(ctx)
@@ -214,14 +219,19 @@ class TestPipelineWritesClassificationMetadata:
             targets = np.random.uniform(-0.05, 0.05, 50).astype(np.float32)
             mocks["create_sequences"].return_value = (sequences, targets)
             mocks["split_sequences"].return_value = (
-                sequences[:40], targets[:40], sequences[40:], targets[40:],
+                sequences[:40],
+                targets[:40],
+                sequences[40:],
+                targets[40:],
             )
             mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
             model = MagicMock()
             model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
             mocks["create_model"].return_value = model
             mocks["validate_model_robustness"].return_value = {}
-            mocks["evaluate_model_performance"].return_value = {"error": "diagnostics skipped in test"}
+            mocks["evaluate_model_performance"].return_value = {
+                "error": "diagnostics skipped in test"
+            }
             mocks["create_training_plots"].return_value = None
 
             result = run_training_pipeline(ctx)
@@ -272,14 +282,19 @@ class TestPipelineWritesClassificationMetadata:
             targets = np.random.rand(50).astype(np.float32)
             mocks["create_sequences"].return_value = (sequences, targets)
             mocks["split_sequences"].return_value = (
-                sequences[:40], targets[:40], sequences[40:], targets[40:],
+                sequences[:40],
+                targets[:40],
+                sequences[40:],
+                targets[40:],
             )
             mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
             model = MagicMock()
             model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
             mocks["create_model"].return_value = model
             mocks["validate_model_robustness"].return_value = {}
-            mocks["evaluate_model_performance"].return_value = {"error": "diagnostics skipped in test"}
+            mocks["evaluate_model_performance"].return_value = {
+                "error": "diagnostics skipped in test"
+            }
             mocks["create_training_plots"].return_value = None
 
             result = run_training_pipeline(ctx)
@@ -406,9 +421,7 @@ class TestExamSignalGeneratorConsumesRealRegistryBundle:
                     "market_features": {"enabled": False},
                     "price_only_features": {"enabled": False},
                 },
-                custom_extractors=[
-                    PriceOnlyFeatureExtractor(normalization_window=sequence_length)
-                ],
+                custom_extractors=[PriceOnlyFeatureExtractor(normalization_window=sequence_length)],
             )
 
             generator = ClassificationExamSignalGenerator(

--- a/tests/unit/training_pipeline/test_metadata_contract_round_trip.py
+++ b/tests/unit/training_pipeline/test_metadata_contract_round_trip.py
@@ -1,0 +1,428 @@
+"""Producer -> consumer round-trip tests for the classification/distribution
+metadata contract (TARGET-REDESIGN tournament, #933 Phase 2, PR #948 review
+fix round).
+
+The gauntlet's architecture review found the consumer half of this contract
+(OnnxRunner, exam_signal_generator) shipped in full but nothing wrote
+task_type / class_labels / target_distribution into metadata.json at
+training time -- so a classifier bundle was unconsumable and entrant (d)
+always degraded to HOLD. These tests exercise BOTH halves for real:
+
+1. run_training_pipeline() (mostly mocked internals, but save_artifacts
+   runs for real) actually writes task_type/class_labels/target_distribution
+   into a real metadata.json on disk.
+2. A REAL PredictionModelRegistry loads that metadata.json into a REAL
+   OnnxRunner instance (only the onnxruntime.InferenceSession call itself is
+   mocked, matching this repo's existing ONNX unit-test convention --
+   tests/conftest.py stubs the `onnxruntime` module suite-wide for speed) and
+   a classification prediction round-trips without any loud-failure path
+   firing. This is exactly the registry/runner metadata-path fix:
+   OnnxRunner._load_metadata previously looked for a "{stem}_metadata.json"
+   sidecar that no writer in this codebase ever produced, so it silently
+   never saw metadata.json's real content regardless of what the registry
+   correctly loaded into StrategyModel.metadata.
+3. ClassificationExamSignalGenerator consumes a real registry-loaded
+   classifier end-to-end (no HOLD-degradation from missing probabilities).
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.ml.training_pipeline.config import (
+    DiagnosticsOptions,
+    TrainingConfig,
+    TrainingContext,
+    TrainingPaths,
+)
+from src.ml.training_pipeline.pipeline import run_training_pipeline
+from src.prediction.config import PredictionConfig
+from src.prediction.distribution_stats import FrozenDistribution, percentile_rank_confidence
+from src.prediction.engine import PredictionEngine
+from src.prediction.features.pipeline import FeaturePipeline
+from src.prediction.features.price_only import PriceOnlyFeatureExtractor
+from src.prediction.models.registry import PredictionModelRegistry
+from src.strategies.components.exam_signal_generator import ClassificationExamSignalGenerator
+
+
+@pytest.fixture(autouse=True)
+def _mock_providers():
+    """OnnxRunner._load_model calls get_preferred_providers() before
+    constructing InferenceSession; the stub `onnxruntime` module
+    (tests/conftest.py) has no get_available_providers, so this must be
+    mocked too (matches tests/unit/predictions/test_models.py's setup)."""
+    with patch(
+        "src.prediction.models.onnx_runner.get_preferred_providers",
+        return_value=["CPUExecutionProvider"],
+    ):
+        yield
+
+
+def _mock_inference_session(output_values: list[float]):
+    """A mock onnxruntime.InferenceSession that always returns the given
+    output vector, regardless of input -- matches this repo's existing
+    ONNX unit-test convention (see tests/unit/predictions/test_models.py),
+    since tests/conftest.py stubs the real `onnxruntime` module suite-wide.
+    """
+    session = MagicMock()
+    session.get_inputs.return_value = [SimpleNamespace(name="input")]
+    session.run.return_value = [np.array([output_values], dtype=np.float32)]
+    return session
+
+
+def _make_ohlcv_df(periods: int = 130) -> pd.DataFrame:
+    rng = np.random.default_rng(11)
+    closes = 100.0 + np.cumsum(rng.normal(0, 0.3, periods))
+    return pd.DataFrame(
+        {
+            "open": closes - 0.1,
+            "high": closes + 0.5,
+            "low": closes - 0.5,
+            "close": closes,
+            "volume": 1000.0 + rng.uniform(0, 50, periods),
+        },
+        index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+    )
+
+
+class TestPipelineWritesClassificationMetadata:
+    """Producer half: run_training_pipeline() writes the metadata contract
+    for real (save_artifacts is NOT mocked -- json.dump runs against a real
+    tmp_path)."""
+
+    def _pipeline_mocks_except_save_artifacts(self):
+        stack = ExitStack()
+        names = [
+            "configure_gpu",
+            "download_price_data",
+            "load_sentiment_data",
+            "create_robust_features",
+            "create_sequences",
+            "split_sequences",
+            "build_tf_datasets",
+            "create_model",
+            "validate_model_robustness",
+            "evaluate_model_performance",
+            "create_training_plots",
+            "enable_mixed_precision",
+        ]
+        mocks = {
+            name: stack.enter_context(patch(f"src.ml.training_pipeline.pipeline.{name}"))
+            for name in names
+        }
+        mocks["configure_gpu"].return_value = None
+        return stack, mocks
+
+    def test_binary_direction_writes_task_type_and_class_labels(self, tmp_path):
+        price_df = _make_ohlcv_df()
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+            model_type="tft",
+            target_type="binary_direction",
+            target_horizon=1,
+            diagnostics=DiagnosticsOptions(
+                generate_plots=False, evaluate_robustness=False, convert_to_onnx=False
+            ),
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path, data_dir=tmp_path / "data", models_dir=tmp_path / "models"
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+
+        stack, mocks = self._pipeline_mocks_except_save_artifacts()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            feature_df = price_df.copy()
+            feature_df["close_scaled"] = 0.5
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+            sequences = np.random.rand(50, 10, 1).astype(np.float32)
+            targets = np.random.randint(0, 2, 50).astype(np.float32)
+            mocks["create_sequences"].return_value = (sequences, targets)
+            mocks["split_sequences"].return_value = (
+                sequences[:40], targets[:40], sequences[40:], targets[40:],
+            )
+            mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
+            model = MagicMock()
+            model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
+            mocks["create_model"].return_value = model
+            mocks["validate_model_robustness"].return_value = {}
+            mocks["evaluate_model_performance"].return_value = {"error": "diagnostics skipped in test"}
+            mocks["create_training_plots"].return_value = None
+
+            result = run_training_pipeline(ctx)
+
+        assert result.success is True, result.metadata
+        metadata_path = result.artifact_paths.metadata_path
+        assert metadata_path.exists()
+        on_disk = json.loads(metadata_path.read_text())
+
+        assert on_disk["task_type"] == "binary_classification"
+        assert on_disk["class_labels"] == [-1, 1]
+        assert "target_distribution" not in on_disk
+
+    def test_smoothed_return_writes_task_type_and_target_distribution(self, tmp_path):
+        price_df = _make_ohlcv_df()
+
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+            target_type="smoothed_return",
+            target_horizon=3,
+            diagnostics=DiagnosticsOptions(
+                generate_plots=False, evaluate_robustness=False, convert_to_onnx=False
+            ),
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path, data_dir=tmp_path / "data", models_dir=tmp_path / "models"
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+
+        stack, mocks = self._pipeline_mocks_except_save_artifacts()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            feature_df = price_df.copy()
+            feature_df["close_scaled"] = 0.5
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+            sequences = np.random.rand(50, 10, 1).astype(np.float32)
+            targets = np.random.uniform(-0.05, 0.05, 50).astype(np.float32)
+            mocks["create_sequences"].return_value = (sequences, targets)
+            mocks["split_sequences"].return_value = (
+                sequences[:40], targets[:40], sequences[40:], targets[40:],
+            )
+            mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
+            model = MagicMock()
+            model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
+            mocks["create_model"].return_value = model
+            mocks["validate_model_robustness"].return_value = {}
+            mocks["evaluate_model_performance"].return_value = {"error": "diagnostics skipped in test"}
+            mocks["create_training_plots"].return_value = None
+
+            result = run_training_pipeline(ctx)
+
+        assert result.success is True, result.metadata
+        on_disk = json.loads(result.artifact_paths.metadata_path.read_text())
+
+        assert on_disk["task_type"] == "regression"
+        assert "class_labels" not in on_disk
+        assert "target_distribution" in on_disk
+        dist = FrozenDistribution.from_metadata(on_disk["target_distribution"])
+        # Round-trips into a usable distribution (doesn't raise, produces a
+        # bounded confidence for a representative value).
+        confidence = percentile_rank_confidence(0.02, dist)
+        assert 0.0 <= confidence <= 1.0
+
+    def test_regression_target_writes_task_type_only(self, tmp_path):
+        """The incumbent default target_type must still get task_type
+        written (harmless, self-describing) but no class_labels/
+        target_distribution (out of scope -- MLBasicSignalGenerator's own
+        confidence formula is untouched by this contract)."""
+        price_df = _make_ohlcv_df()
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path, data_dir=tmp_path / "data", models_dir=tmp_path / "models"
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+
+        stack, mocks = self._pipeline_mocks_except_save_artifacts()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            feature_df = price_df.copy()
+            feature_df["close_scaled"] = 0.5
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+            sequences = np.random.rand(50, 10, 1).astype(np.float32)
+            targets = np.random.rand(50).astype(np.float32)
+            mocks["create_sequences"].return_value = (sequences, targets)
+            mocks["split_sequences"].return_value = (
+                sequences[:40], targets[:40], sequences[40:], targets[40:],
+            )
+            mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
+            model = MagicMock()
+            model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
+            mocks["create_model"].return_value = model
+            mocks["validate_model_robustness"].return_value = {}
+            mocks["evaluate_model_performance"].return_value = {"error": "diagnostics skipped in test"}
+            mocks["create_training_plots"].return_value = None
+
+            result = run_training_pipeline(ctx)
+
+        assert result.success is True, result.metadata
+        on_disk = json.loads(result.artifact_paths.metadata_path.read_text())
+        assert on_disk["task_type"] == "regression"
+        assert "class_labels" not in on_disk
+        assert "target_distribution" not in on_disk
+
+
+class TestRealRegistryLoadedOnnxRunnerConsumesMetadata:
+    """Consumer half: a REAL PredictionModelRegistry + REAL OnnxRunner
+    (only onnxruntime.InferenceSession itself mocked, per this repo's
+    existing ONNX unit-test convention), loading a metadata.json shaped
+    exactly like the producer writes it."""
+
+    @staticmethod
+    def _make_bundle_dir(reg_root, symbol, model_type, version, metadata):
+        bundle_dir = reg_root / symbol / model_type / version
+        bundle_dir.mkdir(parents=True)
+        (bundle_dir / "model.onnx").write_bytes(b"placeholder -- InferenceSession is mocked below")
+        (bundle_dir / "metadata.json").write_text(json.dumps(metadata))
+        return bundle_dir
+
+    def test_binary_classifier_bundle_predicts_without_raising(self, tmp_path):
+        reg_root = tmp_path / "models"
+        self._make_bundle_dir(
+            reg_root,
+            "BTCUSDT",
+            "basic_binary_direction",
+            "2026-01-01_1h_v1",
+            {
+                "symbol": "BTCUSDT",
+                "model_type": "basic_binary_direction",
+                "timeframe": "1h",
+                "task_type": "binary_classification",
+                "class_labels": [-1, 1],
+            },
+        )
+
+        with patch("onnxruntime.InferenceSession", return_value=_mock_inference_session([0.82])):
+            cfg = PredictionConfig(model_registry_path=str(reg_root))
+            registry = PredictionModelRegistry(cfg)
+            bundle = registry.select_bundle(
+                symbol="BTCUSDT", model_type="basic_binary_direction", timeframe="1h"
+            )
+
+            # If the registry/runner metadata wiring were still broken, this
+            # would raise ValueError("... no 'class_labels' declared") --
+            # OnnxRunner would never have seen class_labels at all (proven
+            # by this same setup pre-fix: it raised exactly that).
+            features = np.random.rand(1, 120, 5).astype(np.float32)
+            prediction = bundle.runner.predict(features)
+
+        assert prediction.probabilities == pytest.approx((0.18, 0.82))
+        assert prediction.direction == 1
+        assert prediction.confidence == pytest.approx(0.82)
+
+    def test_ternary_classifier_bundle_predicts_without_raising(self, tmp_path):
+        reg_root = tmp_path / "models"
+        self._make_bundle_dir(
+            reg_root,
+            "BTCUSDT",
+            "basic_triple_barrier",
+            "2026-01-01_1h_v1",
+            {
+                "symbol": "BTCUSDT",
+                "model_type": "basic_triple_barrier",
+                "timeframe": "1h",
+                "task_type": "ternary_classification",
+                "class_labels": [-1, 0, 1],
+            },
+        )
+
+        with patch(
+            "onnxruntime.InferenceSession", return_value=_mock_inference_session([0.1, 0.2, 0.7])
+        ):
+            cfg = PredictionConfig(model_registry_path=str(reg_root))
+            registry = PredictionModelRegistry(cfg)
+            bundle = registry.select_bundle(
+                symbol="BTCUSDT", model_type="basic_triple_barrier", timeframe="1h"
+            )
+
+            features = np.random.rand(1, 120, 5).astype(np.float32)
+            prediction = bundle.runner.predict(features)
+
+        assert prediction.probabilities == pytest.approx((0.1, 0.2, 0.7))
+        assert prediction.direction == 1
+
+
+class TestExamSignalGeneratorConsumesRealRegistryBundle:
+    """Full chain: PredictionConfig -> PredictionEngine -> real registry ->
+    real OnnxRunner (InferenceSession mocked) -> ClassificationExamSignalGenerator."""
+
+    def test_classification_exam_signal_generator_end_to_end(self, tmp_path):
+        reg_root = tmp_path / "models"
+        TestRealRegistryLoadedOnnxRunnerConsumesMetadata._make_bundle_dir(
+            reg_root,
+            "BTCUSDT",
+            "basic_binary_direction",
+            "2026-01-01_1h_v1",
+            {
+                "symbol": "BTCUSDT",
+                "model_type": "basic_binary_direction",
+                "timeframe": "1h",
+                "task_type": "binary_classification",
+                "class_labels": [-1, 1],
+            },
+        )
+
+        with patch("onnxruntime.InferenceSession", return_value=_mock_inference_session([0.9])):
+            # Build a real, registry-backed PredictionEngine pointed at the
+            # tmp registry, with the same price-only feature pipeline the
+            # exam signal generators use (mirrors exam_signal_generator.py's
+            # _build_price_only_prediction_engine).
+            sequence_length = 120
+            engine_config = PredictionConfig(model_registry_path=str(reg_root))
+            engine = PredictionEngine(engine_config)
+            engine.feature_pipeline = FeaturePipeline(
+                config={
+                    "technical_features": {"enabled": False},
+                    "sentiment_features": {"enabled": False},
+                    "market_features": {"enabled": False},
+                    "price_only_features": {"enabled": False},
+                },
+                custom_extractors=[
+                    PriceOnlyFeatureExtractor(normalization_window=sequence_length)
+                ],
+            )
+
+            generator = ClassificationExamSignalGenerator(
+                sequence_length=sequence_length,
+                model_name="BTCUSDT:1h:basic_binary_direction:2026-01-01_1h_v1",
+            )
+            generator.prediction_engine = engine  # inject the real, tmp-registry-backed engine
+
+            df = _make_ohlcv_df(periods=150)
+            signal = generator.generate_signal(df, 130)
+
+        # The loud-failure/HOLD-degradation path fires when probabilities
+        # is None or result.error is set -- assert neither happened.
+        assert signal.metadata.get("reason") != "prediction_failed_or_not_classification"
+        assert "probabilities" in signal.metadata
+        assert signal.metadata["probabilities"] == pytest.approx((0.1, 0.9))
+        assert signal.confidence == pytest.approx(0.9)

--- a/tests/unit/training_pipeline/test_ml_training_config.py
+++ b/tests/unit/training_pipeline/test_ml_training_config.py
@@ -106,6 +106,10 @@ class TestTrainingConfig:
         assert config.force_price_only is False
         assert config.mixed_precision is True
         assert isinstance(config.diagnostics, DiagnosticsOptions)
+        # New fields (TARGET-REDESIGN scaffolding): default preserves the
+        # incumbent next-bar price-regression behavior exactly.
+        assert config.target_type == "regression"
+        assert config.target_horizon == 1
 
     def test_custom_values(self):
         # Arrange
@@ -173,6 +177,62 @@ class TestTrainingConfig:
                 end_date=datetime(2024, 12, 31),
                 model_variant="huge",
             )
+
+    def test_accepts_target_type_and_horizon(self):
+        # Arrange & Act
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+            target_type="triple_barrier",
+            target_horizon=6,
+        )
+
+        # Assert
+        assert config.target_type == "triple_barrier"
+        assert config.target_horizon == 6
+
+    def test_rejects_unknown_target_type(self):
+        # Act & Assert
+        with pytest.raises(ValueError, match="target_type"):
+            TrainingConfig(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 12, 31),
+                target_type="not_a_real_target",
+            )
+
+    def test_rejects_non_positive_target_horizon(self):
+        # Act & Assert
+        with pytest.raises(ValueError, match="target_horizon"):
+            TrainingConfig(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 12, 31),
+                target_horizon=0,
+            )
+
+    def test_config_construction_does_not_cross_validate_model_vs_target(self):
+        """TrainingConfig construction only validates each field is a known
+        value -- it does NOT cross-validate model_type against target_type.
+        That cross-check (the #947 guard) runs at run_training_pipeline()
+        entry instead, so config objects remain freely constructible/mutable
+        before a run, and CLI callers that don't yet expose --target-type
+        (e.g. `atb train cloud --model-type tft`) are unaffected."""
+        # tft (binary_classification head) + default target_type=regression
+        # would fail the cross-check, but must NOT fail here.
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+            model_type="tft",
+        )
+        assert config.model_type == "tft"
+        assert config.target_type == "regression"
 
     def test_days_requested(self):
         # Arrange

--- a/tests/unit/training_pipeline/test_ml_training_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_labels.py
@@ -136,9 +136,7 @@ class TestTripleBarrierLabels:
         # t=4: entry=104, TP=109.2, SL=100.88. bar 5 only -> low=99<=100.88 -> SL (-1), valid
         # t=5: last bar, no forward data at all -> invalid
         np.testing.assert_array_equal(result.values[:5], [1, 1, -1, -1, -1])
-        np.testing.assert_array_equal(
-            result.valid_mask, [True, True, True, True, True, False]
-        )
+        np.testing.assert_array_equal(result.valid_mask, [True, True, True, True, True, False])
 
     def test_vertical_barrier_when_neither_touched(self):
         """Flat price path within the full window -> label 0 (vertical/time barrier)."""

--- a/tests/unit/training_pipeline/test_ml_training_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_labels.py
@@ -1,0 +1,225 @@
+"""Unit tests for alternative training-target label generation.
+
+Covers the TARGET-REDESIGN tournament entrants (b) binary direction,
+(c) triple-barrier ternary, (d) smoothed forward return — per
+docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md §2/§8.
+
+Label-generation correctness gets special paranoia here (per the #838
+partial-exit units-bug lesson): every function has a hand-computable fixture,
+and lookahead boundaries are explicitly tested — a label at bar t must never
+be consumable as a feature at bar t, and the trailing bars that lack a full
+forward horizon must be marked invalid, not silently zero-filled.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.ml.training_pipeline.labels import (
+    LabelResult,
+    binary_direction_labels,
+    smoothed_forward_return_labels,
+    target_horizon_bars,
+    triple_barrier_labels,
+)
+
+
+class TestBinaryDirectionLabels:
+    def test_hand_computable_horizon_1(self):
+        close = pd.Series([100.0, 101.0, 99.0, 99.0, 105.0])
+        result = binary_direction_labels(close, horizon=1)
+
+        assert isinstance(result, LabelResult)
+        assert result.horizon_bars == 1
+        # t=0: close[1]=101 > close[0]=100 -> up (1)
+        # t=1: close[2]=99 > close[1]=101? no -> down (0)
+        # t=2: close[3]=99 > close[2]=99? no (equal) -> down (0)
+        # t=3: close[4]=105 > close[3]=99 -> up (1)
+        # t=4: no forward bar -> invalid
+        np.testing.assert_array_equal(result.values[:4], [1, 0, 0, 1])
+        np.testing.assert_array_equal(result.valid_mask, [True, True, True, True, False])
+
+    def test_hand_computable_horizon_2(self):
+        close = pd.Series([100.0, 101.0, 99.0, 105.0, 90.0])
+        result = binary_direction_labels(close, horizon=2)
+
+        assert result.horizon_bars == 2
+        # t=0: close[2]=99 vs close[0]=100 -> down (0)
+        # t=1: close[3]=105 vs close[1]=101 -> up (1)
+        # t=2, t=3, t=4: no bar at t+2 within range for t=2 (close[4]=90 vs close[2]=99 -> down(0))
+        # t=3, t=4: invalid (t+2 out of range)
+        np.testing.assert_array_equal(result.values[:3], [0, 1, 0])
+        np.testing.assert_array_equal(result.valid_mask, [True, True, True, False, False])
+
+    def test_rejects_non_positive_horizon(self):
+        with pytest.raises(ValueError, match="horizon"):
+            binary_direction_labels(pd.Series([100.0, 101.0]), horizon=0)
+
+    def test_no_lookahead_label_at_t_unaffected_by_future_beyond_horizon(self):
+        """Changing a bar strictly beyond t+horizon must not change label[t]."""
+        base = pd.Series([100.0, 101.0, 102.0, 103.0, 104.0])
+        mutated = base.copy()
+        mutated.iloc[4] = 1.0  # crash the far-future bar
+        r1 = binary_direction_labels(base, horizon=1)
+        r2 = binary_direction_labels(mutated, horizon=1)
+        # label[0] only depends on close[0], close[1] -- unaffected by index 4
+        assert r1.values[0] == r2.values[0]
+        assert r1.valid_mask[0] == r2.valid_mask[0]
+
+
+class TestSmoothedForwardReturnLabels:
+    def test_hand_computable_horizon_2(self):
+        close = pd.Series([100.0, 102.0, 104.0, 103.0, 105.0])
+        result = smoothed_forward_return_labels(close, horizon=2)
+
+        assert result.horizon_bars == 2
+        # t=0: mean(close[1],close[2]) = 103 -> (103/100 - 1) = 0.03
+        # t=1: mean(close[2],close[3]) = 103.5 -> (103.5/102 - 1) = 0.0147058823...
+        # t=2: mean(close[3],close[4]) = 104 -> (104/104 - 1) = 0.0
+        assert result.values[0] == pytest.approx(0.03, abs=1e-9)
+        assert result.values[1] == pytest.approx(0.014705882352941176, abs=1e-9)
+        assert result.values[2] == pytest.approx(0.0, abs=1e-9)
+        np.testing.assert_array_equal(result.valid_mask, [True, True, True, False, False])
+
+    def test_horizon_1_matches_single_bar_return(self):
+        close = pd.Series([100.0, 110.0, 90.0])
+        result = smoothed_forward_return_labels(close, horizon=1)
+        assert result.values[0] == pytest.approx(0.10, abs=1e-9)
+        assert result.values[1] == pytest.approx(-0.181818181818, abs=1e-9)
+        np.testing.assert_array_equal(result.valid_mask, [True, True, False])
+
+    def test_rejects_non_positive_horizon(self):
+        with pytest.raises(ValueError, match="horizon"):
+            smoothed_forward_return_labels(pd.Series([100.0, 101.0]), horizon=0)
+
+    def test_invalid_rows_are_nan(self):
+        close = pd.Series([100.0, 101.0, 102.0])
+        result = smoothed_forward_return_labels(close, horizon=2)
+        assert np.isnan(result.values[1])
+        assert np.isnan(result.values[2])
+
+
+class TestTripleBarrierLabels:
+    """Hand-computable fixture (per task instructions): a tiny synthetic OHLC
+    series where the correct label at every bar is derivable on paper.
+
+    take_profit_pct=0.05, stop_loss_pct=0.03, max_holding_bars=3.
+
+    idx:    0     1     2     3     4     5
+    close: 100   101   103   106   104   100
+    high:  100   102   104   107   105   101
+    low:    99   100   102   105   103    99
+    """
+
+    @staticmethod
+    def _fixture_df() -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "close": [100.0, 101.0, 103.0, 106.0, 104.0, 100.0],
+                "high": [100.0, 102.0, 104.0, 107.0, 105.0, 101.0],
+                "low": [99.0, 100.0, 102.0, 105.0, 103.0, 99.0],
+            }
+        )
+
+    def test_hand_computed_labels(self):
+        df = self._fixture_df()
+        result = triple_barrier_labels(
+            df, take_profit_pct=0.05, stop_loss_pct=0.03, max_holding_bars=3
+        )
+
+        assert result.horizon_bars == 3
+        # t=0: entry=100, TP=105, SL=97. bars 1,2,3 -> bar3 high=107>=105 -> TP (+1)
+        # t=1: entry=101, TP=106.05, SL=97.97. bars 2,3,4 -> bar3 high=107>=106.05 -> TP (+1)
+        # t=2: entry=103, TP=108.15, SL=99.91. bars 3,4,5 -> bar5 low=99<=99.91 -> SL (-1)
+        # t=3: entry=106, TP=111.3, SL=102.82. bars 4,5 (only 2, truncated window)
+        #      -> bar5 low=99<=102.82 -> SL (-1), still VALID (resolved within window)
+        # t=4: entry=104, TP=109.2, SL=100.88. bar 5 only -> low=99<=100.88 -> SL (-1), valid
+        # t=5: last bar, no forward data at all -> invalid
+        np.testing.assert_array_equal(result.values[:5], [1, 1, -1, -1, -1])
+        np.testing.assert_array_equal(
+            result.valid_mask, [True, True, True, True, True, False]
+        )
+
+    def test_vertical_barrier_when_neither_touched(self):
+        """Flat price path within the full window -> label 0 (vertical/time barrier)."""
+        df = pd.DataFrame(
+            {
+                "close": [100.0, 100.0, 100.0],
+                "high": [100.0, 100.0, 100.0],
+                "low": [100.0, 100.0, 100.0],
+            }
+        )
+        result = triple_barrier_labels(
+            df, take_profit_pct=0.5, stop_loss_pct=0.5, max_holding_bars=1
+        )
+        assert result.values[0] == 0
+        assert result.valid_mask[0] is np.True_ or result.valid_mask[0] is True
+
+    def test_stop_loss_priority_when_both_touched_same_bar(self):
+        """Same-bar SL+TP touch resolves to SL (matches the ExitHandler /
+        check_barrier_touch money-path convention: conservative tie-break)."""
+        df = pd.DataFrame(
+            {
+                "close": [100.0, 100.0],
+                "high": [200.0, 200.0],  # far above any take-profit
+                "low": [1.0, 1.0],  # far below any stop-loss
+            }
+        )
+        result = triple_barrier_labels(
+            df, take_profit_pct=0.05, stop_loss_pct=0.05, max_holding_bars=1
+        )
+        assert result.values[0] == -1
+        assert result.valid_mask[0]
+
+    def test_no_lookahead_beyond_resolution_bar(self):
+        """Once a barrier resolves the label, mutating bars strictly after the
+        resolution bar must not change the label (a label at t must not be
+        sensitive to bars beyond what actually determined the outcome)."""
+        df = self._fixture_df()
+        mutated = df.copy()
+        mutated.loc[5, "high"] = 1000.0  # crash a bar that resolves nothing new for t=0/t=1
+        r1 = triple_barrier_labels(df, take_profit_pct=0.05, stop_loss_pct=0.03, max_holding_bars=3)
+        r2 = triple_barrier_labels(
+            mutated, take_profit_pct=0.05, stop_loss_pct=0.03, max_holding_bars=3
+        )
+        # t=0 and t=1 both resolve at bar 3 (TP), strictly before bar 5 -- unaffected.
+        assert r1.values[0] == r2.values[0]
+        assert r1.values[1] == r2.values[1]
+
+    def test_rejects_missing_columns(self):
+        df = pd.DataFrame({"close": [100.0, 101.0]})
+        with pytest.raises(ValueError, match="high|low"):
+            triple_barrier_labels(df, take_profit_pct=0.05, stop_loss_pct=0.03, max_holding_bars=1)
+
+    @pytest.mark.parametrize(
+        ("take_profit_pct", "stop_loss_pct", "max_holding_bars"),
+        [(0.0, 0.05, 1), (0.05, 0.0, 1), (0.05, 0.05, 0)],
+    )
+    def test_rejects_non_positive_params(self, take_profit_pct, stop_loss_pct, max_holding_bars):
+        df = pd.DataFrame({"close": [100.0], "high": [100.0], "low": [100.0]})
+        with pytest.raises(ValueError):
+            triple_barrier_labels(
+                df,
+                take_profit_pct=take_profit_pct,
+                stop_loss_pct=stop_loss_pct,
+                max_holding_bars=max_holding_bars,
+            )
+
+
+class TestTargetHorizonBars:
+    def test_binary_direction(self):
+        assert target_horizon_bars("binary_direction", horizon=6) == 6
+
+    def test_smoothed_return(self):
+        assert target_horizon_bars("smoothed_return", horizon=6) == 6
+
+    def test_triple_barrier(self):
+        assert target_horizon_bars("triple_barrier", max_holding_bars=336) == 336
+
+    def test_missing_required_param_raises(self):
+        with pytest.raises(ValueError):
+            target_horizon_bars("binary_direction")
+
+    def test_unknown_target_type_raises(self):
+        with pytest.raises(ValueError, match="target_type"):
+            target_horizon_bars("not_a_real_target")

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -22,7 +22,9 @@ import pytest
 
 from src.ml.training_pipeline.meta_labels import (
     PrimarySignalRecord,
+    TradeResolution,
     build_meta_label_features,
+    resolve_fired_trade,
     run_primary_signal_forward,
     simulate_fired_trade_profitability,
 )
@@ -245,6 +247,90 @@ class TestSimulateFiredTradeProfitability:
             )
 
 
+class TestResolveFiredTrade:
+    """resolve_fired_trade() is simulate_fired_trade_profitability()'s
+    superset -- same hand-computed fixture, plus the resolution bar index
+    that build_meta_label_features needs to stay causal."""
+
+    @staticmethod
+    def _fixture_df() -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "close": [100.0, 101.0, 103.0, 106.0, 104.0, 97.0],
+                "high": [100.0, 102.0, 104.0, 107.0, 105.0, 98.0],
+                "low": [99.0, 100.0, 102.0, 105.0, 103.0, 96.0],
+            }
+        )
+
+    def test_exit_index_is_the_barrier_touch_bar(self):
+        df = self._fixture_df()
+        # fire at t=0: resolves at bar3 (TP touch) per the hand-computed
+        # fixture in TestSimulateFiredTradeProfitability.
+        resolution = resolve_fired_trade(
+            df,
+            fire_index=0,
+            direction=1,
+            take_profit_pct=0.05,
+            stop_loss_pct=0.03,
+            max_holding_bars=3,
+        )
+        assert resolution == TradeResolution(profitable=True, exit_index=3)
+
+    def test_exit_index_is_the_vertical_exit_bar_when_no_barrier_touched(self):
+        df = pd.DataFrame(
+            {
+                "close": [100.0, 100.0, 100.0],
+                "high": [100.0, 100.0, 100.0],
+                "low": [100.0, 100.0, 100.0],
+            }
+        )
+        resolution = resolve_fired_trade(
+            df,
+            fire_index=0,
+            direction=1,
+            take_profit_pct=0.5,
+            stop_loss_pct=0.5,
+            max_holding_bars=1,
+        )
+        assert resolution == TradeResolution(profitable=False, exit_index=1)
+
+    def test_unresolved_trade_returns_none(self):
+        df = self._fixture_df()
+        resolution = resolve_fired_trade(
+            df,
+            fire_index=5,
+            direction=1,
+            take_profit_pct=0.05,
+            stop_loss_pct=0.03,
+            max_holding_bars=3,
+        )
+        assert resolution is None
+
+    def test_simulate_fired_trade_profitability_matches_resolve_fired_trade(self):
+        """The thin-wrapper contract: same profitable/None outcome as the
+        richer function, for every hand-computed fixture case."""
+        df = self._fixture_df()
+        for fire_index, direction in [(0, 1), (3, 1), (3, -1), (5, 1)]:
+            resolution = resolve_fired_trade(
+                df,
+                fire_index=fire_index,
+                direction=direction,
+                take_profit_pct=0.05,
+                stop_loss_pct=0.03,
+                max_holding_bars=3,
+            )
+            simple = simulate_fired_trade_profitability(
+                df,
+                fire_index=fire_index,
+                direction=direction,
+                take_profit_pct=0.05,
+                stop_loss_pct=0.03,
+                max_holding_bars=3,
+            )
+            expected = resolution.profitable if resolution is not None else None
+            assert simple == expected
+
+
 class TestBuildMetaLabelFeatures:
     @staticmethod
     def _synthetic_df(periods=300):
@@ -261,6 +347,19 @@ class TestBuildMetaLabelFeatures:
             index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
         )
 
+    @staticmethod
+    def _resolved_next_bar(
+        fires: list[PrimarySignalRecord], labels: list[bool]
+    ) -> list[TradeResolution]:
+        """Resolutions that resolve the bar right after each fire -- the
+        simplest case, used by tests that don't care about resolution
+        timing specifically (every fire here is >=2 bars apart, so "resolved
+        next bar" is always eligible for any later fire's hit-rate)."""
+        return [
+            TradeResolution(profitable=label, exit_index=fire.index + 1)
+            for fire, label in zip(fires, labels, strict=True)
+        ]
+
     def test_returns_one_row_per_fire_with_expected_columns(self):
         df = self._synthetic_df()
         fires = [
@@ -268,9 +367,9 @@ class TestBuildMetaLabelFeatures:
             PrimarySignalRecord(index=120, direction=-1, predicted_return=-0.02),
             PrimarySignalRecord(index=150, direction=1, predicted_return=0.005),
         ]
-        labels = [True, False, True]
+        resolutions = self._resolved_next_bar(fires, [True, False, True])
 
-        features = build_meta_label_features(df, fires, labels)
+        features = build_meta_label_features(df, fires, resolutions)
 
         assert len(features) == 3
         expected_columns = {
@@ -292,32 +391,33 @@ class TestBuildMetaLabelFeatures:
     def test_predicted_return_magnitude_is_absolute_value(self):
         df = self._synthetic_df()
         fires = [PrimarySignalRecord(index=100, direction=-1, predicted_return=-0.03)]
-        features = build_meta_label_features(df, fires, [True])
+        features = build_meta_label_features(df, fires, self._resolved_next_bar(fires, [True]))
         assert features["predicted_return_magnitude"].iloc[0] == pytest.approx(0.03)
 
     def test_cyclical_session_encoding_is_on_unit_circle(self):
         df = self._synthetic_df()
         fires = [PrimarySignalRecord(index=100, direction=1, predicted_return=0.01)]
-        features = build_meta_label_features(df, fires, [True])
+        features = build_meta_label_features(df, fires, self._resolved_next_bar(fires, [True]))
         sin_val = features["session_sin"].iloc[0]
         cos_val = features["session_cos"].iloc[0]
         assert sin_val**2 + cos_val**2 == pytest.approx(1.0, abs=1e-9)
 
     def test_rolling_hit_rate_uses_only_strictly_prior_fires(self):
-        """Leak-boundary test: the rolling hit-rate feature at fire index t
-        must be computable from prior fires ONLY -- mutating a LATER fire's
-        label must not change an EARLIER fire's hit-rate feature."""
+        """A LATER fire's label must never affect an EARLIER fire's
+        hit-rate feature (list-ordering causality -- necessary but not
+        sufficient; see test_rolling_hit_rate_excludes_unresolved_prior_fires
+        below for the resolution-TIME causality this alone does not cover)."""
         df = self._synthetic_df()
         fires = [
             PrimarySignalRecord(index=100, direction=1, predicted_return=0.01),
             PrimarySignalRecord(index=110, direction=1, predicted_return=0.01),
             PrimarySignalRecord(index=120, direction=1, predicted_return=0.01),
         ]
-        labels_a = [True, True, True]
-        labels_b = [True, True, False]  # only the LAST label differs
+        resolutions_a = self._resolved_next_bar(fires, [True, True, True])
+        resolutions_b = self._resolved_next_bar(fires, [True, True, False])  # only LAST differs
 
-        features_a = build_meta_label_features(df, fires, labels_a)
-        features_b = build_meta_label_features(df, fires, labels_b)
+        features_a = build_meta_label_features(df, fires, resolutions_a)
+        features_b = build_meta_label_features(df, fires, resolutions_b)
 
         # First fire has zero prior fires -- hit rate must be NaN in both cases.
         assert np.isnan(features_a["rolling_hit_rate_20"].iloc[0])
@@ -328,19 +428,56 @@ class TestBuildMetaLabelFeatures:
             features_b["rolling_hit_rate_20"].iloc[1]
         )
 
+    def test_rolling_hit_rate_excludes_unresolved_prior_fires(self):
+        """P1 regression test: a prior fire's label must be excluded from a
+        later fire's rolling_hit_rate_20 unless the prior fire had actually
+        RESOLVED (exit_index <= current fire's index) by then. With
+        max_holding_bars=336 and dense fires, a prior fire commonly resolves
+        LONG after a nearby later fire -- using its label anyway leaks that
+        prior fire's own future price path into the earlier bar's feature.
+        This test fails on the pre-fix code (which used ALL strictly-prior
+        fires regardless of resolution time)."""
+        df = self._synthetic_df()
+        fire_a = PrimarySignalRecord(index=50, direction=1, predicted_return=0.01)
+        fire_b = PrimarySignalRecord(
+            index=55, direction=1, predicted_return=0.01
+        )  # fires before A resolves
+        fire_c = PrimarySignalRecord(
+            index=250, direction=1, predicted_return=0.01
+        )  # fires after A resolves
+        fires = [fire_a, fire_b, fire_c]
+
+        resolution_a = TradeResolution(profitable=True, exit_index=200)  # resolves late
+        resolution_b = TradeResolution(profitable=False, exit_index=56)
+        resolution_c = TradeResolution(profitable=False, exit_index=251)
+        resolutions = [resolution_a, resolution_b, resolution_c]
+
+        features = build_meta_label_features(df, fires, resolutions)
+
+        # B fires at index 55, BEFORE A resolves (exit_index=200 > 55) --
+        # A must be excluded. B has no other eligible prior fires -> NaN.
+        assert np.isnan(features["rolling_hit_rate_20"].iloc[1])
+
+        # C fires at index 250, AFTER A resolves (200 <= 250) -- A IS
+        # eligible, and B (exit_index=56 <= 250) is too.
+        # mean([A.profitable=True, B.profitable=False]) = 0.5.
+        assert features["rolling_hit_rate_20"].iloc[2] == pytest.approx(0.5)
+
     def test_rolling_hit_rate_hand_computed(self):
         df = self._synthetic_df()
         fires = [
             PrimarySignalRecord(index=100 + 5 * i, direction=1, predicted_return=0.01)
             for i in range(4)
         ]
-        # Prior-fire labels for fire[3]'s hit-rate: fires[0..2] = [True, True, False]
-        labels = [True, True, False, True]
+        # Prior-fire labels for fire[3]'s hit-rate: fires[0..2] = [True, True, False],
+        # each resolved the bar right after it fires (well before fire[3]'s
+        # own index) -- all three are eligible.
+        resolutions = self._resolved_next_bar(fires, [True, True, False, True])
 
-        features = build_meta_label_features(df, fires, labels)
+        features = build_meta_label_features(df, fires, resolutions)
 
-        # fire[3]'s rolling_hit_rate_20 = hit rate over its (up to 20) prior
-        # fires = mean([True, True, False]) = 2/3.
+        # fire[3]'s rolling_hit_rate_20 = hit rate over its (up to 20)
+        # eligible prior fires = mean([True, True, False]) = 2/3.
         assert features["rolling_hit_rate_20"].iloc[3] == pytest.approx(2.0 / 3.0)
 
     def test_realized_vol_feature_does_not_use_bars_after_fire_index(self):
@@ -351,8 +488,9 @@ class TestBuildMetaLabelFeatures:
         mutated.iloc[105:, mutated.columns.get_loc("close")] = 99999.0
 
         fires = [PrimarySignalRecord(index=100, direction=1, predicted_return=0.01)]
-        features_orig = build_meta_label_features(df, fires, [True])
-        features_mut = build_meta_label_features(mutated, fires, [True])
+        resolutions = self._resolved_next_bar(fires, [True])
+        features_orig = build_meta_label_features(df, fires, resolutions)
+        features_mut = build_meta_label_features(mutated, fires, resolutions)
 
         assert features_orig["realized_vol_48"].iloc[0] == pytest.approx(
             features_mut["realized_vol_48"].iloc[0]
@@ -366,14 +504,18 @@ class TestBuildMetaLabelFeatures:
         df = self._synthetic_df()
         fires = [PrimarySignalRecord(index=150, direction=1, predicted_return=0.01)]
 
-        features = build_meta_label_features(df, fires, [True])
+        features = build_meta_label_features(df, fires, self._resolved_next_bar(fires, [True]))
 
         assert features["regime_trend"].iloc[0] in {t.value for t in TrendLabel}
         assert features["regime_volatility"].iloc[0] in {v.value for v in VolLabel}
         assert 0.0 <= features["regime_confidence"].iloc[0] <= 1.0
 
-    def test_mismatched_fires_and_labels_length_raises(self):
+    def test_mismatched_fires_and_resolutions_length_raises(self):
         df = self._synthetic_df()
         fires = [PrimarySignalRecord(index=100, direction=1, predicted_return=0.01)]
+        resolutions = [
+            TradeResolution(profitable=True, exit_index=101),
+            TradeResolution(profitable=False, exit_index=201),
+        ]
         with pytest.raises(ValueError, match="length"):
-            build_meta_label_features(df, fires, [True, False])
+            build_meta_label_features(df, fires, resolutions)

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -136,7 +136,11 @@ class TestSimulateFiredTradeProfitability:
         # exit_price=105. raw_pct_return = (105-100)/100 = 0.05. Fee-rate
         # default 0.001 round-trip 0.002 -- still net profitable.
         result = simulate_fired_trade_profitability(
-            df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            df,
+            fire_index=0,
+            direction=1,
+            take_profit_pct=0.05,
+            stop_loss_pct=0.03,
             max_holding_bars=3,
         )
         assert result is True
@@ -146,7 +150,11 @@ class TestSimulateFiredTradeProfitability:
         # fire at t=3, entry=106, TP=111.3, SL=102.82: bars 4,5 (truncated
         # window, only 2 bars) -> bar5 low=96<=102.82 -> SL hit.
         result = simulate_fired_trade_profitability(
-            df, fire_index=3, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            df,
+            fire_index=3,
+            direction=1,
+            take_profit_pct=0.05,
+            stop_loss_pct=0.03,
             max_holding_bars=3,
         )
         assert result is False
@@ -158,7 +166,11 @@ class TestSimulateFiredTradeProfitability:
         # touch. bar5: high=98,low=96 -> TP (low<=100.7) -> exit=100.7.
         # raw_pct_return = direction(-1) * (100.7-106)/106 = 0.05 -> profitable.
         result = simulate_fired_trade_profitability(
-            df, fire_index=3, direction=-1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            df,
+            fire_index=3,
+            direction=-1,
+            take_profit_pct=0.05,
+            stop_loss_pct=0.03,
             max_holding_bars=3,
         )
         assert result is True
@@ -173,7 +185,11 @@ class TestSimulateFiredTradeProfitability:
             }
         )
         result = simulate_fired_trade_profitability(
-            df, fire_index=0, direction=1, take_profit_pct=0.5, stop_loss_pct=0.5,
+            df,
+            fire_index=0,
+            direction=1,
+            take_profit_pct=0.5,
+            stop_loss_pct=0.5,
             max_holding_bars=1,
         )
         # raw_pct_return = 0 (flat), minus fees -> unprofitable.
@@ -184,7 +200,11 @@ class TestSimulateFiredTradeProfitability:
         trade -- must return None (unresolved), never False or True."""
         df = self._fixture_df()
         result = simulate_fired_trade_profitability(
-            df, fire_index=5, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            df,
+            fire_index=5,
+            direction=1,
+            take_profit_pct=0.05,
+            stop_loss_pct=0.03,
             max_holding_bars=3,
         )
         assert result is None
@@ -203,7 +223,11 @@ class TestSimulateFiredTradeProfitability:
             }
         )
         result = simulate_fired_trade_profitability(
-            df, fire_index=0, direction=1, take_profit_pct=0.5, stop_loss_pct=0.5,
+            df,
+            fire_index=0,
+            direction=1,
+            take_profit_pct=0.5,
+            stop_loss_pct=0.5,
             max_holding_bars=1,
         )
         assert result is False
@@ -212,7 +236,11 @@ class TestSimulateFiredTradeProfitability:
         df = self._fixture_df()
         with pytest.raises(ValueError, match="direction"):
             simulate_fired_trade_profitability(
-                df, fire_index=0, direction=0, take_profit_pct=0.05, stop_loss_pct=0.03,
+                df,
+                fire_index=0,
+                direction=0,
+                take_profit_pct=0.05,
+                stop_loss_pct=0.03,
                 max_holding_bars=3,
             )
 

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -1,0 +1,351 @@
+"""Unit tests for meta-labeling entrant (a) scaffolding.
+
+Preregistration §2a: label = 1 if simulating the primary signal's fired
+trade through the exam-harness exit geometry closes net-profitable after
+fees, else 0. Feature set: 48-bar trailing realized volatility, rolling
+hit-rate of the primary signal's trailing 20 fires, session/time-of-day
+cyclical encoding, EnhancedRegimeDetector's regime label (reused, not
+reimplemented), and the primary model's own predicted_return magnitude as
+ONE feature among the above.
+
+Label-generation correctness gets special paranoia (per the #838 units-bug
+lesson): simulate_fired_trade_profitability has a hand-computable fixture,
+and every feature-builder test asserts explicit leak boundaries (a feature
+at fire index t must not be affected by bars after t).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.ml.training_pipeline.meta_labels import (
+    PrimarySignalRecord,
+    build_meta_label_features,
+    run_primary_signal_forward,
+    simulate_fired_trade_profitability,
+)
+from src.strategies.components.signal_generator import Signal, SignalDirection, SignalGenerator
+
+
+class _StubSignalGenerator(SignalGenerator):
+    """Deterministic canned-signal generator for testing run_primary_signal_forward."""
+
+    def __init__(self, signals_by_index: dict[int, Signal], warmup: int = 5):
+        super().__init__("stub_signal_generator")
+        self._signals_by_index = signals_by_index
+        self._warmup = warmup
+
+    def generate_signal(self, df, index, regime=None) -> Signal:
+        return self._signals_by_index.get(
+            index,
+            Signal(direction=SignalDirection.HOLD, strength=0.0, confidence=0.0, metadata={}),
+        )
+
+    def get_confidence(self, df, index) -> float:
+        return 0.0
+
+    @property
+    def warmup_period(self) -> int:
+        return self._warmup
+
+
+class TestRunPrimarySignalForward:
+    def test_records_only_non_hold_fires(self):
+        df = pd.DataFrame({"close": range(20)})
+        signals = {
+            6: Signal(
+                direction=SignalDirection.BUY,
+                strength=0.5,
+                confidence=0.5,
+                metadata={"predicted_return": 0.01},
+            ),
+            9: Signal(
+                direction=SignalDirection.SELL,
+                strength=0.5,
+                confidence=0.5,
+                metadata={"predicted_return": -0.02},
+            ),
+        }
+        generator = _StubSignalGenerator(signals, warmup=5)
+
+        records = run_primary_signal_forward(generator, df)
+
+        assert [r.index for r in records] == [6, 9]
+        assert records[0].direction == 1
+        assert records[0].predicted_return == pytest.approx(0.01)
+        assert records[1].direction == -1
+        assert records[1].predicted_return == pytest.approx(-0.02)
+
+    def test_starts_at_warmup_period_by_default(self):
+        df = pd.DataFrame({"close": range(10)})
+        signals = {
+            2: Signal(
+                direction=SignalDirection.BUY, strength=1.0, confidence=1.0, metadata={}
+            ),  # before warmup, must be skipped
+            6: Signal(direction=SignalDirection.BUY, strength=1.0, confidence=1.0, metadata={}),
+        }
+        generator = _StubSignalGenerator(signals, warmup=5)
+
+        records = run_primary_signal_forward(generator, df)
+
+        assert [r.index for r in records] == [6]
+
+    def test_explicit_start_index_overrides_warmup(self):
+        df = pd.DataFrame({"close": range(10)})
+        signals = {
+            2: Signal(direction=SignalDirection.BUY, strength=1.0, confidence=1.0, metadata={}),
+        }
+        generator = _StubSignalGenerator(signals, warmup=5)
+
+        records = run_primary_signal_forward(generator, df, start_index=0)
+
+        assert [r.index for r in records] == [2]
+
+    def test_no_fires_returns_empty_list(self):
+        df = pd.DataFrame({"close": range(10)})
+        generator = _StubSignalGenerator({}, warmup=0)
+
+        assert run_primary_signal_forward(generator, df) == []
+
+
+class TestSimulateFiredTradeProfitability:
+    """Hand-computable fixture: take_profit_pct=0.05, stop_loss_pct=0.03,
+    max_holding_bars=3.
+
+    idx:    0     1     2     3     4     5
+    close: 100   101   103   106   104    97
+    high:  100   102   104   107   105    98
+    low:    99   100   102   105   103    96
+    """
+
+    @staticmethod
+    def _fixture_df() -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "close": [100.0, 101.0, 103.0, 106.0, 104.0, 97.0],
+                "high": [100.0, 102.0, 104.0, 107.0, 105.0, 98.0],
+                "low": [99.0, 100.0, 102.0, 105.0, 103.0, 96.0],
+            }
+        )
+
+    def test_long_fire_hits_take_profit_is_profitable_net_of_fees(self):
+        df = self._fixture_df()
+        # fire at t=0, entry=100, TP=105, SL=97: bar3 high=107>=105 -> TP hit,
+        # exit_price=105. raw_pct_return = (105-100)/100 = 0.05. Fee-rate
+        # default 0.001 round-trip 0.002 -- still net profitable.
+        result = simulate_fired_trade_profitability(
+            df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            max_holding_bars=3,
+        )
+        assert result is True
+
+    def test_long_fire_hits_stop_loss_is_unprofitable(self):
+        df = self._fixture_df()
+        # fire at t=3, entry=106, TP=111.3, SL=102.82: bars 4,5 (truncated
+        # window, only 2 bars) -> bar5 low=96<=102.82 -> SL hit.
+        result = simulate_fired_trade_profitability(
+            df, fire_index=3, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            max_holding_bars=3,
+        )
+        assert result is False
+
+    def test_short_fire_profits_when_price_falls(self):
+        df = self._fixture_df()
+        # fire SHORT at t=3, entry=106. Short TP = 106*(1-0.05)=100.7,
+        # short SL = 106*(1+0.03)=109.18. bar4: high=105,low=103 -> no
+        # touch. bar5: high=98,low=96 -> TP (low<=100.7) -> exit=100.7.
+        # raw_pct_return = direction(-1) * (100.7-106)/106 = 0.05 -> profitable.
+        result = simulate_fired_trade_profitability(
+            df, fire_index=3, direction=-1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            max_holding_bars=3,
+        )
+        assert result is True
+
+    def test_vertical_barrier_exit_uses_close_of_max_holding_bar(self):
+        # Flat price -> neither barrier touched -> vertical exit at close.
+        df = pd.DataFrame(
+            {
+                "close": [100.0, 100.0, 100.0],
+                "high": [100.0, 100.0, 100.0],
+                "low": [100.0, 100.0, 100.0],
+            }
+        )
+        result = simulate_fired_trade_profitability(
+            df, fire_index=0, direction=1, take_profit_pct=0.5, stop_loss_pct=0.5,
+            max_holding_bars=1,
+        )
+        # raw_pct_return = 0 (flat), minus fees -> unprofitable.
+        assert result is False
+
+    def test_truncated_window_without_resolution_is_unresolved(self):
+        """Fire point near series end with no forward data to resolve the
+        trade -- must return None (unresolved), never False or True."""
+        df = self._fixture_df()
+        result = simulate_fired_trade_profitability(
+            df, fire_index=5, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            max_holding_bars=3,
+        )
+        assert result is None
+
+    def test_fee_awareness_flips_marginal_trade_to_unprofitable(self):
+        """A raw-positive move smaller than the round-trip fee cost must be
+        labeled unprofitable -- this is the entire point of simulating
+        "net of fees," not just sign(raw return)."""
+        df = pd.DataFrame(
+            {
+                # +0.05% move over 1 bar -- smaller than a 0.2% round-trip fee
+                # (2 * DEFAULT_FEE_RATE=0.001).
+                "close": [100.0, 100.05],
+                "high": [100.0, 100.05],
+                "low": [100.0, 100.05],
+            }
+        )
+        result = simulate_fired_trade_profitability(
+            df, fire_index=0, direction=1, take_profit_pct=0.5, stop_loss_pct=0.5,
+            max_holding_bars=1,
+        )
+        assert result is False
+
+    def test_rejects_invalid_direction(self):
+        df = self._fixture_df()
+        with pytest.raises(ValueError, match="direction"):
+            simulate_fired_trade_profitability(
+                df, fire_index=0, direction=0, take_profit_pct=0.05, stop_loss_pct=0.03,
+                max_holding_bars=3,
+            )
+
+
+class TestBuildMetaLabelFeatures:
+    @staticmethod
+    def _synthetic_df(periods=300):
+        rng = np.random.default_rng(7)
+        closes = 100.0 + np.cumsum(rng.normal(0, 0.3, periods))
+        return pd.DataFrame(
+            {
+                "open": closes - 0.1,
+                "high": closes + 0.5,
+                "low": closes - 0.5,
+                "close": closes,
+                "volume": 1000.0 + rng.uniform(0, 50, periods),
+            },
+            index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+        )
+
+    def test_returns_one_row_per_fire_with_expected_columns(self):
+        df = self._synthetic_df()
+        fires = [
+            PrimarySignalRecord(index=100, direction=1, predicted_return=0.01),
+            PrimarySignalRecord(index=120, direction=-1, predicted_return=-0.02),
+            PrimarySignalRecord(index=150, direction=1, predicted_return=0.005),
+        ]
+        labels = [True, False, True]
+
+        features = build_meta_label_features(df, fires, labels)
+
+        assert len(features) == 3
+        expected_columns = {
+            "index",
+            "realized_vol_48",
+            "rolling_hit_rate_20",
+            "session_sin",
+            "session_cos",
+            "regime_trend",
+            "regime_volatility",
+            "regime_confidence",
+            "predicted_return_magnitude",
+            "label",
+        }
+        assert expected_columns.issubset(set(features.columns))
+        assert list(features["index"]) == [100, 120, 150]
+        assert list(features["label"]) == [1, 0, 1]
+
+    def test_predicted_return_magnitude_is_absolute_value(self):
+        df = self._synthetic_df()
+        fires = [PrimarySignalRecord(index=100, direction=-1, predicted_return=-0.03)]
+        features = build_meta_label_features(df, fires, [True])
+        assert features["predicted_return_magnitude"].iloc[0] == pytest.approx(0.03)
+
+    def test_cyclical_session_encoding_is_on_unit_circle(self):
+        df = self._synthetic_df()
+        fires = [PrimarySignalRecord(index=100, direction=1, predicted_return=0.01)]
+        features = build_meta_label_features(df, fires, [True])
+        sin_val = features["session_sin"].iloc[0]
+        cos_val = features["session_cos"].iloc[0]
+        assert sin_val**2 + cos_val**2 == pytest.approx(1.0, abs=1e-9)
+
+    def test_rolling_hit_rate_uses_only_strictly_prior_fires(self):
+        """Leak-boundary test: the rolling hit-rate feature at fire index t
+        must be computable from prior fires ONLY -- mutating a LATER fire's
+        label must not change an EARLIER fire's hit-rate feature."""
+        df = self._synthetic_df()
+        fires = [
+            PrimarySignalRecord(index=100, direction=1, predicted_return=0.01),
+            PrimarySignalRecord(index=110, direction=1, predicted_return=0.01),
+            PrimarySignalRecord(index=120, direction=1, predicted_return=0.01),
+        ]
+        labels_a = [True, True, True]
+        labels_b = [True, True, False]  # only the LAST label differs
+
+        features_a = build_meta_label_features(df, fires, labels_a)
+        features_b = build_meta_label_features(df, fires, labels_b)
+
+        # First fire has zero prior fires -- hit rate must be NaN in both cases.
+        assert np.isnan(features_a["rolling_hit_rate_20"].iloc[0])
+        assert np.isnan(features_b["rolling_hit_rate_20"].iloc[0])
+        # Second fire's hit-rate depends only on fire[0]'s label (same in
+        # both) -- must be identical regardless of fire[2]'s label.
+        assert features_a["rolling_hit_rate_20"].iloc[1] == pytest.approx(
+            features_b["rolling_hit_rate_20"].iloc[1]
+        )
+
+    def test_rolling_hit_rate_hand_computed(self):
+        df = self._synthetic_df()
+        fires = [
+            PrimarySignalRecord(index=100 + 5 * i, direction=1, predicted_return=0.01)
+            for i in range(4)
+        ]
+        # Prior-fire labels for fire[3]'s hit-rate: fires[0..2] = [True, True, False]
+        labels = [True, True, False, True]
+
+        features = build_meta_label_features(df, fires, labels)
+
+        # fire[3]'s rolling_hit_rate_20 = hit rate over its (up to 20) prior
+        # fires = mean([True, True, False]) = 2/3.
+        assert features["rolling_hit_rate_20"].iloc[3] == pytest.approx(2.0 / 3.0)
+
+    def test_realized_vol_feature_does_not_use_bars_after_fire_index(self):
+        """Leak-boundary test: mutating bars strictly AFTER a fire's index
+        must not change that fire's realized_vol_48 feature."""
+        df = self._synthetic_df()
+        mutated = df.copy()
+        mutated.iloc[105:, mutated.columns.get_loc("close")] = 99999.0
+
+        fires = [PrimarySignalRecord(index=100, direction=1, predicted_return=0.01)]
+        features_orig = build_meta_label_features(df, fires, [True])
+        features_mut = build_meta_label_features(mutated, fires, [True])
+
+        assert features_orig["realized_vol_48"].iloc[0] == pytest.approx(
+            features_mut["realized_vol_48"].iloc[0]
+        )
+
+    def test_regime_label_is_reused_from_enhanced_regime_detector(self):
+        """The regime feature must come from EnhancedRegimeDetector.detect_regime
+        (reused), not a hand-rolled regime computation."""
+        from src.regime.detector import TrendLabel, VolLabel
+
+        df = self._synthetic_df()
+        fires = [PrimarySignalRecord(index=150, direction=1, predicted_return=0.01)]
+
+        features = build_meta_label_features(df, fires, [True])
+
+        assert features["regime_trend"].iloc[0] in {t.value for t in TrendLabel}
+        assert features["regime_volatility"].iloc[0] in {v.value for v in VolLabel}
+        assert 0.0 <= features["regime_confidence"].iloc[0] <= 1.0
+
+    def test_mismatched_fires_and_labels_length_raises(self):
+        df = self._synthetic_df()
+        fires = [PrimarySignalRecord(index=100, direction=1, predicted_return=0.01)]
+        with pytest.raises(ValueError, match="length"):
+            build_meta_label_features(df, fires, [True, False])

--- a/tests/unit/training_pipeline/test_ml_training_models.py
+++ b/tests/unit/training_pipeline/test_ml_training_models.py
@@ -19,6 +19,11 @@ from src.ml.training_pipeline.models import (
     create_model,
     default_callbacks,
 )
+from src.ml.training_pipeline.task_types import (
+    TaskType,
+    get_model_task_type,
+    validate_target_head_compatibility,
+)
 
 
 @pytest.mark.fast
@@ -455,3 +460,106 @@ class TestCreateModelEvaluationContract:
         # Assert
         assert set(result) == {"train_loss", "test_loss", "train_rmse", "test_rmse", "mape"}
         assert all(np.isfinite(v) for v in result.values())
+
+
+def _infer_actual_task_type(model) -> TaskType:
+    """Ground-truth task type inferred from a REAL compiled model's loss.
+
+    Every architecture in this codebase today compiles either "mse"
+    (regression) or "binary_crossentropy" (binary classification, currently
+    only tft) -- if a future architecture compiles something else, this
+    helper intentionally has no silent fallback for it.
+    """
+    loss_name = str(model.loss).lower()
+    if "binary_crossentropy" in loss_name or "bce" in loss_name:
+        return TaskType.BINARY_CLASSIFICATION
+    if "mse" in loss_name or "mean_squared_error" in loss_name:
+        return TaskType.REGRESSION
+    raise AssertionError(
+        f"Unrecognized compiled loss {model.loss!r} -- "
+        "_infer_actual_task_type needs a new branch, and task_types.py's "
+        "MODEL_TASK_TYPES needs the corresponding entry."
+    )
+
+
+@pytest.mark.fast
+@pytest.mark.skipif(not _TENSORFLOW_AVAILABLE, reason="TensorFlow not installed")
+class TestModelTaskTypeMatchesRealCompiledHead:
+    """Regression guard for #947: task_types.MODEL_TASK_TYPES must never
+    silently drift from what a real create_model() build actually compiles.
+
+    TestCreateModelTrainerContract (above) catches per-architecture
+    CONSTRUCTION-kwarg drift (#928); TestCreateModelEvaluationContract
+    catches per-architecture EVALUATION-metric drift (#936); this catches
+    per-architecture TARGET/LOSS drift (#947) -- the same contract-drift
+    family, one axis further, caught here instead of on a live SageMaker job.
+    """
+
+    @pytest.mark.parametrize(("model_type", "variant"), TRAINER_MODEL_MATRIX)
+    def test_declared_task_type_matches_compiled_loss(self, model_type, variant):
+        # Arrange
+        model = create_model(
+            model_type=model_type,
+            input_shape=(120, 5),
+            variant=variant,
+            has_sentiment=False,
+        )
+
+        # Act
+        declared = get_model_task_type(model_type)
+        actual = _infer_actual_task_type(model)
+
+        # Assert
+        assert declared == actual, (
+            f"task_types.MODEL_TASK_TYPES[{model_type!r}] = {declared} but the "
+            f"real compiled model's loss ({model.loss!r}) implies {actual} -- "
+            f"update MODEL_TASK_TYPES in task_types.py to match."
+        )
+
+
+# Every model_type x target_type pairing the training pipeline could be
+# asked to run. Extends the #937 15-pair smoke matrix's spirit -- assert
+# the PER-PAIR verdict, not just "some pairs work" -- to target/loss
+# compatibility (the #947 guard, task_types.validate_target_head_compatibility).
+TARGET_COMPATIBILITY_MATRIX = [
+    (model_type, target_type)
+    for model_type in ["lstm", "cnn_lstm", "attention_lstm", "tcn", "tcn_attention", "tft"]
+    for target_type in ["regression", "binary_direction", "triple_barrier", "smoothed_return"]
+]
+
+# Compatible pairs: regression-headed architectures need a REGRESSION-task
+# target (regression or smoothed_return, both continuous); tft's binary
+# sigmoid/BCE head needs binary_direction. triple_barrier is
+# TERNARY_CLASSIFICATION and has no compatible architecture yet (the
+# per-entrant ternary-head model factory is explicitly deferred by the
+# TARGET-REDESIGN preregistration §8/Next-steps -- shared label/signal
+# infrastructure ships first) -- every triple_barrier pairing must be
+# rejected today, and this set is the single place that needs updating
+# once a ternary architecture exists.
+_COMPATIBLE_MODEL_TARGET_PAIRS = {
+    ("lstm", "regression"),
+    ("lstm", "smoothed_return"),
+    ("cnn_lstm", "regression"),
+    ("cnn_lstm", "smoothed_return"),
+    ("attention_lstm", "regression"),
+    ("attention_lstm", "smoothed_return"),
+    ("tcn", "regression"),
+    ("tcn", "smoothed_return"),
+    ("tcn_attention", "regression"),
+    ("tcn_attention", "smoothed_return"),
+    ("tft", "binary_direction"),
+}
+
+
+class TestValidateTargetHeadCompatibilityMatrix:
+    """Per-pair (model_type, target_type) compatibility verdicts (#947)."""
+
+    @pytest.mark.parametrize(("model_type", "target_type"), TARGET_COMPATIBILITY_MATRIX)
+    def test_compatibility_verdict(self, model_type, target_type):
+        should_be_compatible = (model_type, target_type) in _COMPATIBLE_MODEL_TARGET_PAIRS
+
+        if should_be_compatible:
+            validate_target_head_compatibility(model_type, target_type)  # must not raise
+        else:
+            with pytest.raises(ValueError, match="incompatible"):
+                validate_target_head_compatibility(model_type, target_type)

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -666,6 +666,207 @@ class TestRunTrainingPipeline:
         # Will fail on other things (like insufficient data), but that's expected
         assert result.success is False
 
+    def test_incompatible_target_type_fails_loud_before_download(self, tmp_path):
+        """#947 guard: model_type's head must match target_type's task type.
+        tft (binary_classification head) + target_type=regression (the
+        default) previously trained silently against the wrong target --
+        must now fail loudly, and fast (before any data download)."""
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            model_type="tft",
+            target_type="regression",
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+
+        with patch("src.ml.training_pipeline.pipeline.download_price_data") as mock_download:
+            result = run_training_pipeline(ctx)
+
+        assert result.success is False
+        assert "incompatible" in result.metadata["error"]
+        mock_download.assert_not_called()
+
+    def test_compatible_classification_target_passes_the_guard(self, tmp_path):
+        """tft + binary_direction is the compatible pairing -- must NOT be
+        rejected by the guard (only fails later for unrelated pipeline
+        reasons, since data isn't mocked in this test)."""
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            model_type="tft",
+            target_type="binary_direction",
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+
+        with patch("src.ml.training_pipeline.pipeline.download_price_data") as mock_download:
+            mock_download.side_effect = RuntimeError("stop after the guard, unrelated to it")
+            result = run_training_pipeline(ctx)
+
+        # Guard passed (download was actually attempted); failure is the
+        # unrelated injected error, not an "incompatible" guard rejection.
+        mock_download.assert_called_once()
+        assert result.success is False
+        assert "incompatible" not in result.metadata["error"]
+
+    def test_binary_direction_target_builds_labels_from_raw_close(self, tmp_path):
+        """target_type=binary_direction must override the regression target
+        with binary_direction_labels() output, row-aligned to feature_data,
+        with trailing unresolved rows dropped from BOTH feature and target
+        arrays (never silently zero-filled)."""
+        from src.ml.training_pipeline.labels import binary_direction_labels
+
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+            model_type="tft",
+            target_type="binary_direction",
+            target_horizon=1,
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+        price_df = self._make_price_df()
+
+        # create_robust_features mocked to a byte-identical copy of price_df
+        # (plus a feature column) so feature_data's index is the SAME as
+        # merged_df's -- isolates the alt-target alignment/truncation logic
+        # from feature-engineering warmup-row-dropping concerns.
+        feature_df = price_df.copy()
+        feature_df["close_scaled"] = 0.5
+
+        stack, mocks = self._pipeline_mocks()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+
+            result = self._run_pipeline_with_mocks(ctx, price_df, mocks)
+
+        assert result.success is True, result.metadata
+        feature_array, target_array, seq_len = mocks["create_sequences"].call_args.args
+        assert seq_len == 10
+
+        expected_label = binary_direction_labels(price_df["close"], horizon=1)
+        expected_target = expected_label.values[expected_label.valid_mask].astype(np.float32)
+        expected_rows = int(expected_label.valid_mask.sum())
+
+        assert len(target_array) == expected_rows
+        assert len(feature_array) == expected_rows
+        np.testing.assert_array_equal(target_array, expected_target)
+        # Every value is 0 or 1 -- confirms the classification label (not the
+        # continuous close price) reached create_sequences.
+        assert set(np.unique(target_array)).issubset({0.0, 1.0})
+
+    def test_smoothed_return_target_builds_labels_from_raw_close(self, tmp_path):
+        """target_type=smoothed_return overrides the regression target with
+        smoothed_forward_return_labels() output (still a REGRESSION task
+        type, so a regression-headed model_type is compatible)."""
+        from src.ml.training_pipeline.labels import smoothed_forward_return_labels
+
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+            target_type="smoothed_return",
+            target_horizon=3,
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+        price_df = self._make_price_df()
+
+        feature_df = price_df.copy()
+        feature_df["close_scaled"] = 0.5
+
+        stack, mocks = self._pipeline_mocks()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+
+            result = self._run_pipeline_with_mocks(ctx, price_df, mocks)
+
+        assert result.success is True, result.metadata
+        feature_array, target_array, _ = mocks["create_sequences"].call_args.args
+
+        expected_label = smoothed_forward_return_labels(price_df["close"], horizon=3)
+        expected_target = expected_label.values[expected_label.valid_mask].astype(np.float32)
+
+        assert len(target_array) == len(feature_array)
+        np.testing.assert_allclose(target_array, expected_target, rtol=1e-5)
+
+    def test_regression_target_type_is_byte_identical_to_current_behavior(self, tmp_path):
+        """target_type="regression" (the default) must produce EXACTLY the
+        existing target_array -- no truncation, no row drops."""
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=1,
+            sequence_length=10,
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path,
+            data_dir=tmp_path / "data",
+            models_dir=tmp_path / "models",
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+        price_df = self._make_price_df()
+        feature_df = price_df.copy()
+        feature_df["close_scaled"] = 0.5
+
+        stack, mocks = self._pipeline_mocks()
+        with stack:
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+            result = self._run_pipeline_with_mocks(ctx, price_df, mocks)
+
+        assert result.success is True, result.metadata
+        _, target_array, _ = mocks["create_sequences"].call_args.args
+        np.testing.assert_allclose(target_array, feature_df["close"].to_numpy(dtype=np.float32))
+        assert len(target_array) == len(feature_df)
+
     def test_evaluation_crash_does_not_lose_trained_model(self, tmp_path):
         """Regression guard for #936: evaluate_model_performance/validate_model_robustness
         run after model.fit() but before save_artifacts. A crash there previously

--- a/tests/unit/training_pipeline/test_ml_training_task_types.py
+++ b/tests/unit/training_pipeline/test_ml_training_task_types.py
@@ -13,6 +13,7 @@ from src.ml.training_pipeline.task_types import (
     TARGET_TASK_TYPES,
     TaskType,
     get_model_task_type,
+    get_target_class_labels,
     get_target_task_type,
     validate_target_head_compatibility,
 )
@@ -111,3 +112,33 @@ class TestValidateTargetHeadCompatibility:
         message = str(exc_info.value)
         assert "tft" in message
         assert "regression" in message
+
+
+class TestGetTargetClassLabels:
+    """class_labels ARE the direction values (see onnx_runner.py's
+    _process_classification_output) -- ordered to match the probability
+    vector's class order."""
+
+    def test_binary_direction(self):
+        assert get_target_class_labels("binary_direction") == [-1, 1]
+
+    def test_triple_barrier(self):
+        assert get_target_class_labels("triple_barrier") == [-1, 0, 1]
+
+    def test_regression_has_no_class_labels(self):
+        assert get_target_class_labels("regression") is None
+
+    def test_smoothed_return_has_no_class_labels(self):
+        assert get_target_class_labels("smoothed_return") is None
+
+    def test_every_classification_target_type_has_class_labels(self):
+        for target_type, task_type in TARGET_TASK_TYPES.items():
+            if task_type is TaskType.REGRESSION:
+                continue
+            if target_type == "meta_label":
+                # meta_label's classification output is a profitability gate
+                # on the primary signal's own direction, not a direction
+                # prediction itself -- it has no canonical class_labels
+                # ordering in the direction-value sense this function covers.
+                continue
+            assert get_target_class_labels(target_type) is not None, target_type

--- a/tests/unit/training_pipeline/test_ml_training_task_types.py
+++ b/tests/unit/training_pipeline/test_ml_training_task_types.py
@@ -1,0 +1,113 @@
+"""Unit tests for the model/target task-type compatibility guard (#947).
+
+`models_tft.py` compiles a binary-classification head (sigmoid, BCE loss),
+but before this guard existed `pipeline.py` built the regression close
+target unconditionally -- training tft silently fit a classification head
+against a continuous price target (no crash, no warning, garbage model).
+This guard must refuse loudly on any (model_type, target_type) mismatch.
+"""
+
+import pytest
+
+from src.ml.training_pipeline.task_types import (
+    TARGET_TASK_TYPES,
+    TaskType,
+    get_model_task_type,
+    get_target_task_type,
+    validate_target_head_compatibility,
+)
+
+
+class TestGetModelTaskType:
+    @pytest.mark.parametrize(
+        "model_type",
+        ["lstm", "cnn_lstm", "adaptive", "default", "attention_lstm", "tcn", "tcn_attention"],
+    )
+    def test_regression_architectures(self, model_type):
+        assert get_model_task_type(model_type) is TaskType.REGRESSION
+
+    def test_tft_is_binary_classification(self):
+        assert get_model_task_type("tft") is TaskType.BINARY_CLASSIFICATION
+
+    def test_case_insensitive(self):
+        assert get_model_task_type("TFT") is TaskType.BINARY_CLASSIFICATION
+        assert get_model_task_type("CNN_LSTM") is TaskType.REGRESSION
+
+    def test_unknown_model_type_raises(self):
+        with pytest.raises(ValueError, match="model_type"):
+            get_model_task_type("not_a_real_architecture")
+
+
+class TestGetTargetTaskType:
+    def test_regression(self):
+        assert get_target_task_type("regression") is TaskType.REGRESSION
+
+    def test_binary_direction(self):
+        assert get_target_task_type("binary_direction") is TaskType.BINARY_CLASSIFICATION
+
+    def test_triple_barrier(self):
+        assert get_target_task_type("triple_barrier") is TaskType.TERNARY_CLASSIFICATION
+
+    def test_smoothed_return(self):
+        assert get_target_task_type("smoothed_return") is TaskType.REGRESSION
+
+    def test_meta_label(self):
+        assert get_target_task_type("meta_label") is TaskType.BINARY_CLASSIFICATION
+
+    def test_unknown_target_type_raises(self):
+        with pytest.raises(ValueError, match="target_type"):
+            get_target_task_type("not_a_real_target")
+
+    def test_every_target_type_covered(self):
+        # Every key in TARGET_TASK_TYPES must resolve via get_target_task_type
+        # (defends against the two falling out of sync).
+        for target_type in TARGET_TASK_TYPES:
+            assert get_target_task_type(target_type) == TARGET_TASK_TYPES[target_type]
+
+
+class TestValidateTargetHeadCompatibility:
+    def test_regression_architecture_with_regression_target_is_compatible(self):
+        validate_target_head_compatibility("cnn_lstm", "regression")  # no raise
+
+    def test_regression_architecture_with_smoothed_return_is_compatible(self):
+        # smoothed_return is REGRESSION task type -- compatible with any
+        # regression-headed architecture.
+        validate_target_head_compatibility("attention_lstm", "smoothed_return")  # no raise
+
+    def test_tft_with_binary_direction_is_compatible(self):
+        validate_target_head_compatibility("tft", "binary_direction")  # no raise
+
+    def test_tft_with_default_regression_target_raises(self):
+        """This is the exact #947 bug: tft (binary_classification head) trained
+        against the regression target with no error today. Must raise now."""
+        with pytest.raises(ValueError, match="incompatible"):
+            validate_target_head_compatibility("tft", "regression")
+
+    def test_regression_architecture_with_binary_direction_raises(self):
+        with pytest.raises(ValueError, match="incompatible"):
+            validate_target_head_compatibility("cnn_lstm", "binary_direction")
+
+    def test_regression_architecture_with_triple_barrier_raises(self):
+        with pytest.raises(ValueError, match="incompatible"):
+            validate_target_head_compatibility("lstm", "triple_barrier")
+
+    def test_tft_with_triple_barrier_raises(self):
+        """tft is a binary head; ternary triple-barrier needs a 3-class head
+        that doesn't exist among the current architectures yet."""
+        with pytest.raises(ValueError, match="incompatible"):
+            validate_target_head_compatibility("tft", "triple_barrier")
+
+    def test_unknown_model_type_raises(self):
+        with pytest.raises(ValueError, match="model_type"):
+            validate_target_head_compatibility("not_a_real_architecture", "regression")
+
+    def test_unknown_target_type_raises(self):
+        with pytest.raises(ValueError, match="target_type"):
+            validate_target_head_compatibility("cnn_lstm", "not_a_real_target")
+
+    def test_error_message_names_both_types(self):
+        with pytest.raises(ValueError) as exc_info:
+            validate_target_head_compatibility("tft", "regression")
+        message = str(exc_info.value)
+        assert "tft" in message
+        assert "regression" in message


### PR DESCRIPTION
## Summary

Phase 2 engineering scaffolding for the TARGET-REDESIGN tournament (GH #933), per the LOCKED preregistration doc `docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md` (§2 entrant specs, §5 exam harness, §8 engineering inventory). **No training runs, cloud jobs, or backtests were executed** — this PR is build-only, per the dispatch brief.

Five pieces, in the doc's own recommended dependency order:

1. **Alternative label generation** (`src/ml/training_pipeline/labels.py`): binary fixed-horizon direction labels, triple-barrier ternary labels, smoothed forward-return labels. Triple-barrier reuses a new shared pure function (`src/engines/shared/barrier_touch.py`, extracted from `ExitHandler.check_exit_conditions`'s SL/TP intrabar high/low comparison — full backtest suite green, behavior-preserving) instead of hand-rolling the barrier logic a second time, per the doc's explicit instruction. Every label exposes its forward horizon and a `valid_mask` — trailing rows without a fully-realized forward label are never silently zero-filled.

2. **#947 guard** (`src/ml/training_pipeline/task_types.py`): `validate_target_head_compatibility()` refuses loudly when a `model_type`'s compiled head (regression MSE vs `tft`'s binary sigmoid/BCE) is incompatible with the `target_type` being built — closes the silent-garbage-model bug where `tft` trained against the regression close target with no error. Runs at `run_training_pipeline()` entry, before any download/GPU work. Extends the #937 15-pair smoke matrix (`test_ml_training_models.py`) with a real-compiled-head ground-truth check (18 pairs) and a full `model_type × target_type` compatibility matrix (24 pairs).

3. **Classification-native prediction/signal path**: `ModelPrediction`/`PredictionResult` gain a `probabilities` field (purely additive — `None` for every existing regression bundle, verified explicitly). `OnnxRunner` interprets `model_metadata.task_type` + `class_labels` (direction values in {-1,0,1}, no separate mapping table) to produce argmax→direction, P(argmax)→confidence. New `src/prediction/distribution_stats.py` (`FrozenDistribution`/`percentile_rank_confidence`) is the harness-wide fix for the prohibited `confidence = |x| × 12` formula. New `src/strategies/components/exam_signal_generator.py` (`ClassificationExamSignalGenerator`, `SmoothedReturnExamSignalGenerator`) consumes these — deliberately a separate module from `MLBasicSignalGenerator`/`MLSignalGenerator`, which are untouched.

4. **Meta-labeling entrant (a) scaffolding** (`src/ml/training_pipeline/meta_labels.py`): runs a primary `SignalGenerator` forward to find fire points, simulates each fired trade through the exam-harness exit geometry (reusing `check_barrier_touch` directionally, net of fees) for the profitable/not label, and builds the richer feature set per §2a (48-bar realized vol, rolling hit-rate over the trailing 20 prior fires, cyclical session encoding, `EnhancedRegimeDetector`'s regime label (reused), primary signal's own `predicted_return` magnitude as one feature among several).

5. **Exam-only strategy factory** (`src/strategies/exam_target_redesign.py`): `create_exam_strategy()` mirrors `create_ml_basic_strategy()`'s wiring (`CoreRiskAdapter(EngineRiskManager(RiskParameters(...)))` + `ConfidenceWeightedSizer(base_fraction=0.2, min_confidence=0.3)`) — **not** HyperGrowth's `FlatRiskManager`/`FixedFractionSizer`, which #938 proved cannot express confidence/magnitude differences at all. Ratified `risk-limits.json` defaults (5%/4%/336h), not HyperGrowth's 10%/30%. Takes a pluggable `signal_generator` so one harness serves all four entrants.

Closes #947.

## Testing performed

- TDD throughout: every behavior has a failing-first test.
- Triple-barrier and meta-label profitability simulation each have a hand-computable fixture test (paper-derivable expected labels), per the #838 partial-exit-units-bug lesson about plausible-looking financial arithmetic.
- Explicit lookahead/leak-boundary tests: label validity masks, meta-label feature causality (mutating bars/fires strictly after a given index must not change that index's label/feature), rolling hit-rate uses only strictly-prior fires.
- `exit_handler.py`'s barrier-touch extraction: full `tests/unit/backtesting/` suite green (134 passed) confirms byte-identical behavior.
- Regression-path-unaffected tests at every classification-path touch point (`onnx_runner.py`, `engine.py`) confirm zero behavior change for existing regression bundles.
- `atb dev quality --changed --branch origin/develop` clean (black/ruff/mypy); `bandit` reports zero findings on the full changed-file set.
- Full unit suite: **5026 passed, 1 skipped** (pre-existing, unrelated).

## Test plan

- [x] Unit tests added/updated and passing
- [x] `atb dev quality --changed` clean
- [x] Full unit suite green
- [ ] CI green
- [ ] Two-reviewer gauntlet (architecture-reviewer + code-reviewer) — money-path-adjacent code (`src/prediction/engine.py`, `src/prediction/models/onnx_runner.py`, `src/engines/backtest/execution/exit_handler.py`); PM will run this before merge, per dispatch instructions. Do not merge without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)