### PR TITLE
feat(ml): TARGET-REDESIGN tournament Phase 2b — wiring completion (CLI, ternary head, meta-label pipeline, exam harness, acceptance tests)

### DIFF
--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -403,3 +403,10 @@ Ref: GH #933, PR #946 (docs/target-tournament-prereg)
 
 ---
 
+## 2026-07-10 · track-record · ml-engineer
+TARGET-REDESIGN tournament (GH #933) · event: wired (Phase 2b — not a training run or promotion)
+An execution agent found PR #948's Phase 2 scaffolding was unit-tested but not reachable end-to-end via any CLI entry point. This round closed that gap across 6 items: (1) `--target-type`/`--target-horizon` threaded through both `atb train` and `atb train cloud` (incl. SageMaker container-side plumbing); (2) `tft_ternary` architecture added (3-class softmax), unblocking entrant (c) triple-barrier; (3) meta-labeling training driver + hand-rolled sklearn->ONNX export + causal exam consumer wired end-to-end, unblocking entrant (a); (4) exam-only strategies registered in `backtest.py`'s CLI loader (never added to the live runner) + `PredictionModelRegistry.get_bundle_by_key()`/`ATB_MODEL_VERSION_OVERRIDE` pinning so exam folds can pin a specific non-latest version; (5) disposed all 3 outstanding claude[bot] PR #948 review comments plus 5 more bugs found only by actually running the real path (most consequential: `exam_target_redesign.py` used the CORE risk manager's `"confidence_weighted"` sizer-type string, which reads a `"prediction_confidence"` indicator nothing in the codebase populates — silently zeroed every trade for all four entrants regardless of signal; fixed to `"fixed_fraction"`, matching `ml_basic.py`); (6) one real, non-mocked, subprocess-based end-to-end acceptance test per entrant (`tests/integration/tournament/test_entrant_dry_runs.py`) — synthetic OHLCV -> train via the real CLI -> correctly-registered+timeframed artifact -> exam backtest via the real CLI with version pinning -> >=1 real trade.
+Metrics: N/A — no training run or model promotion occurred this round. All 4 entrants confirmed running end-to-end (individually and together, 406s combined, clean teardown); quality gate and full unit suite (4273 passed) green. Ref: issue #949, PR (feat/target-tournament-wiring -> develop, not yet opened/merged at time of this entry)
+
+---
+

--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -34,6 +34,7 @@ from src.strategies import (
 from src.strategies.components import Strategy
 from src.strategies.exam_target_redesign import (
     create_exam_binary_direction_strategy,
+    create_exam_meta_label_strategy,
     create_exam_smoothed_return_strategy,
     create_exam_triple_barrier_strategy,
 )
@@ -69,6 +70,7 @@ def _load_strategy(strategy_name: str, symbol: str | None = None):
         "exam_binary_direction": create_exam_binary_direction_strategy,
         "exam_triple_barrier": create_exam_triple_barrier_strategy,
         "exam_smoothed_return": create_exam_smoothed_return_strategy,
+        "exam_meta_label": create_exam_meta_label_strategy,
     }
 
     try:

--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -32,6 +32,11 @@ from src.strategies import (
     create_momentum_leverage_strategy,
 )
 from src.strategies.components import Strategy
+from src.strategies.exam_target_redesign import (
+    create_exam_binary_direction_strategy,
+    create_exam_smoothed_return_strategy,
+    create_exam_triple_barrier_strategy,
+)
 from src.trading.symbols.factory import SymbolFactory
 
 logger = logging.getLogger("atb.backtest")
@@ -54,6 +59,16 @@ def _load_strategy(strategy_name: str, symbol: str | None = None):
         "kelly_momentum": create_kelly_momentum_strategy,
         "leveraged_regime": create_leveraged_regime_strategy,
         "hyper_growth": create_hyper_growth_strategy,
+        # TARGET-REDESIGN tournament exam-only strategies (GH #933, Phase 2b
+        # item 4). EXAM-ONLY BY DESIGN -- backtest CLI is the ONLY place
+        # these are registered. Do NOT add these to src/strategies/__init__
+        # .py's general exports or src/engines/live/runner.py's strategy
+        # dict; the tournament's research harness (ConfidenceWeightedSizer
+        # + ratified risk-limits defaults) is deliberately separate from
+        # anything a live/paper trading session could select.
+        "exam_binary_direction": create_exam_binary_direction_strategy,
+        "exam_triple_barrier": create_exam_triple_barrier_strategy,
+        "exam_smoothed_return": create_exam_smoothed_return_strategy,
     }
 
     try:

--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -115,34 +115,46 @@ def _handle(ns: argparse.Namespace) -> int:
         strategy = _load_strategy(ns.strategy, symbol=ns.symbol)
         logger.info(f"Loaded strategy: {strategy.name}")
 
-        # Provider - use factory for automatic failover support
-        from src.data_providers.provider_factory import create_data_provider
+        if getattr(ns, "mock_data", False):
+            # Test-only escape hatch (mirrors `atb live --mock-data`,
+            # src/engines/live/runner.py): deterministic synthetic OHLCV,
+            # zero network, zero disk cache -- never a real provider or
+            # create_data_provider() dispatch. Never set for a real backtest.
+            from src.data_providers.data_provider import DataProvider
+            from src.data_providers.mock_data_provider import MockDataProvider
 
-        provider = create_data_provider(provider_type=ns.provider)
-        if ns.no_cache:
-            data_provider = provider
-            logger.info("Data caching disabled")
+            data_provider: DataProvider = MockDataProvider(seed=42)
+            logger.info("Using MockDataProvider (--mock-data): no network, no cache")
         else:
-            from src.data_providers.cached_data_provider import CachedDataProvider
+            # Provider - use factory for automatic failover support
+            from src.data_providers.provider_factory import create_data_provider
 
-            # Determine appropriate cache TTL based on provider state
-            from src.infrastructure.runtime.cache import (
-                DataProviderProtocol,
-                get_cache_ttl_for_provider,
-            )
+            provider = create_data_provider(provider_type=ns.provider)
+            if ns.no_cache:
+                data_provider = provider
+                logger.info("Data caching disabled")
+            else:
+                from src.data_providers.cached_data_provider import CachedDataProvider
 
-            # cast: get_cache_ttl_for_provider only reads _client behind a hasattr guard,
-            # so any provider instance is safe even if it lacks the attribute
-            cache_ttl = get_cache_ttl_for_provider(
-                cast(DataProviderProtocol, provider), ns.cache_ttl
-            )
-            cached_provider = CachedDataProvider(provider, cache_ttl_hours=cache_ttl)
-            data_provider = cached_provider
-            logger.info(f"Using cached data provider (TTL: {cache_ttl} hours)")
-            cache_info = cached_provider.get_cache_info()
-            logger.info(
-                f"Cache info: {cache_info['total_files']} files, {cache_info['total_size_mb']} MB"
-            )
+                # Determine appropriate cache TTL based on provider state
+                from src.infrastructure.runtime.cache import (
+                    DataProviderProtocol,
+                    get_cache_ttl_for_provider,
+                )
+
+                # cast: get_cache_ttl_for_provider only reads _client behind a hasattr guard,
+                # so any provider instance is safe even if it lacks the attribute
+                cache_ttl = get_cache_ttl_for_provider(
+                    cast(DataProviderProtocol, provider), ns.cache_ttl
+                )
+                cached_provider = CachedDataProvider(provider, cache_ttl_hours=cache_ttl)
+                data_provider = cached_provider
+                logger.info(f"Using cached data provider (TTL: {cache_ttl} hours)")
+                cache_info = cached_provider.get_cache_info()
+                logger.info(
+                    f"Cache info: {cache_info['total_files']} files, "
+                    f"{cache_info['total_size_mb']} MB"
+                )
 
         sentiment_provider = None
         if ns.use_sentiment:
@@ -242,9 +254,9 @@ def _handle(ns: argparse.Namespace) -> int:
                 print(f"{year:<8} {results['yearly_returns'][year]:>12.2f}")
             print("=" * 50)
 
-        if not ns.no_cache:
+        if not ns.no_cache and not getattr(ns, "mock_data", False):
             # cached_provider is always bound here: it is assigned on the same
-            # `not ns.no_cache` branch above.
+            # `not ns.no_cache and not mock_data` branch above.
             final_cache_info = cached_provider.get_cache_info()
             logger.info(
                 f"Final cache info: {final_cache_info['total_files']} files, {final_cache_info['total_size_mb']} MB"
@@ -344,6 +356,13 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         choices=["auto", "binance", "coinbase", "coingecko"],
         default="auto",
         help="Data provider: auto=Binance→CoinGecko failover (recommended), binance=Binance only, coinbase=Coinbase only, coingecko=CoinGecko only - default: auto",
+    )
+    p.add_argument(
+        "--mock-data",
+        action="store_true",
+        help="Use deterministic synthetic OHLCV data instead of a real "
+        "provider (mirrors `atb live --mock-data`). Test/CI use only -- "
+        "never set for a real backtest.",
     )
     p.add_argument(
         "--max-drawdown",

--- a/cli/commands/train.py
+++ b/cli/commands/train.py
@@ -98,10 +98,14 @@ def _handle_model(ns: argparse.Namespace) -> int:
             "tft",
             "tft_ternary",
             "lstm",
+            "lightgbm",
         ],
         help="Model architecture (cnn_lstm, attention_lstm, tcn, tcn_attention, tft, "
-        "tft_ternary, lstm). tft_ternary is the 3-class TARGET-REDESIGN tournament "
-        "entrant (c) head -- pair it with --target-type triple_barrier.",
+        "tft_ternary, lstm, lightgbm). tft_ternary is the 3-class TARGET-REDESIGN "
+        "tournament entrant (c) head -- pair it with --target-type triple_barrier. "
+        "lightgbm requires the optional lightgbm dependency (not installed by default) "
+        "and is unrelated to --target-type meta_label, which always trains a sklearn "
+        "LogisticRegression regardless of --model-type.",
     )
     parser.add_argument(
         "--model-variant",
@@ -114,11 +118,16 @@ def _handle_model(ns: argparse.Namespace) -> int:
         "--target-type",
         type=str,
         default="regression",
-        choices=["regression", "binary_direction", "triple_barrier", "smoothed_return"],
+        choices=[
+            "regression",
+            "binary_direction",
+            "triple_barrier",
+            "smoothed_return",
+            "meta_label",
+        ],
         help="Training target (default: regression, the incumbent next-bar price target). "
         "TARGET-REDESIGN tournament entrants: binary_direction (b), triple_barrier (c), "
-        "smoothed_return (d). meta_label (a) is not selectable here -- it needs a primary "
-        "signal generator to run forward first; see --primary-model-type.",
+        "smoothed_return (d), meta_label (a). meta_label requires --primary-model-type.",
     )
     parser.add_argument(
         "--target-horizon",

--- a/cli/commands/train.py
+++ b/cli/commands/train.py
@@ -90,8 +90,18 @@ def _handle_model(ns: argparse.Namespace) -> int:
         "--model-type",
         type=str,
         default="cnn_lstm",
-        choices=["cnn_lstm", "attention_lstm", "tcn", "tcn_attention", "lstm"],
-        help="Model architecture (cnn_lstm, attention_lstm, tcn, tcn_attention, lstm)",
+        choices=[
+            "cnn_lstm",
+            "attention_lstm",
+            "tcn",
+            "tcn_attention",
+            "tft",
+            "tft_ternary",
+            "lstm",
+        ],
+        help="Model architecture (cnn_lstm, attention_lstm, tcn, tcn_attention, tft, "
+        "tft_ternary, lstm). tft_ternary is the 3-class TARGET-REDESIGN tournament "
+        "entrant (c) head -- pair it with --target-type triple_barrier.",
     )
     parser.add_argument(
         "--model-variant",

--- a/cli/commands/train.py
+++ b/cli/commands/train.py
@@ -100,6 +100,31 @@ def _handle_model(ns: argparse.Namespace) -> int:
         choices=["default", "lightweight", "deep"],
         help="Model variant (default, lightweight, deep)",
     )
+    parser.add_argument(
+        "--target-type",
+        type=str,
+        default="regression",
+        choices=["regression", "binary_direction", "triple_barrier", "smoothed_return"],
+        help="Training target (default: regression, the incumbent next-bar price target). "
+        "TARGET-REDESIGN tournament entrants: binary_direction (b), triple_barrier (c), "
+        "smoothed_return (d). meta_label (a) is not selectable here -- it needs a primary "
+        "signal generator to run forward first; see --primary-model-type.",
+    )
+    parser.add_argument(
+        "--target-horizon",
+        type=int,
+        default=1,
+        help="Forward horizon in bars for binary_direction/smoothed_return targets "
+        "(default: 1; ignored by regression/triple_barrier).",
+    )
+    parser.add_argument(
+        "--primary-model-type",
+        type=str,
+        default=None,
+        help="Registry model_type of the primary signal to run forward when "
+        "--target-type meta_label is used (e.g. 'basic'). Required for meta_label, "
+        "ignored otherwise.",
+    )
 
     # Parse the arguments from ns.args
     args = parser.parse_args(ns.args or [])

--- a/cli/commands/train_cloud.py
+++ b/cli/commands/train_cloud.py
@@ -374,7 +374,16 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
                 print()
                 print("  Metrics:")
                 for key, value in result.metrics.items():
-                    print(f"    {key}: {value:.4f}")
+                    # Metrics can carry a non-numeric diagnostics-error
+                    # placeholder (pipeline.py's evaluation-degradation path,
+                    # e.g. {"error": "..."} when evaluate_model_performance
+                    # itself failed) -- format numerically only when
+                    # possible so a degraded-but-successful training run
+                    # doesn't crash the CLI at the final summary print.
+                    if isinstance(value, int | float) and not isinstance(value, bool):
+                        print(f"    {key}: {value:.4f}")
+                    else:
+                        print(f"    {key}: {value}")
             print("=" * 60)
             return 0
         else:

--- a/cli/commands/train_cloud.py
+++ b/cli/commands/train_cloud.py
@@ -145,8 +145,18 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         "--model-type",
         type=str,
         default="cnn_lstm",
-        choices=["lstm", "cnn_lstm", "attention_lstm", "tcn", "tcn_attention", "tft"],
-        help="Model architecture (default: cnn_lstm)",
+        choices=[
+            "lstm",
+            "cnn_lstm",
+            "attention_lstm",
+            "tcn",
+            "tcn_attention",
+            "tft",
+            "tft_ternary",
+        ],
+        help="Model architecture (default: cnn_lstm). tft_ternary is the 3-class "
+        "TARGET-REDESIGN tournament entrant (c) head -- pair it with "
+        "--target-type triple_barrier.",
     )
     parser.add_argument(
         "--model-variant",

--- a/cli/commands/train_cloud.py
+++ b/cli/commands/train_cloud.py
@@ -156,6 +156,22 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         help="Architecture variant (default: default)",
     )
     parser.add_argument(
+        "--target-type",
+        type=str,
+        default="regression",
+        choices=["regression", "binary_direction", "triple_barrier", "smoothed_return"],
+        help="Training target (default: regression, the incumbent next-bar price target). "
+        "TARGET-REDESIGN tournament entrants: binary_direction (b), triple_barrier (c), "
+        "smoothed_return (d).",
+    )
+    parser.add_argument(
+        "--target-horizon",
+        type=int,
+        default=1,
+        help="Forward horizon in bars for binary_direction/smoothed_return targets "
+        "(default: 1; ignored by regression/triple_barrier).",
+    )
+    parser.add_argument(
         "--instance-type",
         type=str,
         default="ml.g4dn.xlarge",
@@ -242,6 +258,8 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         force_price_only=args.force_price_only,
         model_type=args.model_type,
         model_variant=args.model_variant,
+        target_type=args.target_type,
+        target_horizon=args.target_horizon,
         diagnostics=DiagnosticsOptions(
             generate_plots=False,  # Skip plots in cloud (no display)
             evaluate_robustness=True,
@@ -275,6 +293,7 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
     print(f"  Batch Size:      {args.batch_size}")
     print(f"  Sequence Length: {args.sequence_length}")
     print(f"  Architecture:    {args.model_type} ({args.model_variant})")
+    print(f"  Target:          {args.target_type} (horizon={args.target_horizon})")
     print()
     print(f"  Provider:        {provider.provider_name}")
     print(f"  Instance:        {args.instance_type}")

--- a/cli/commands/train_cloud.py
+++ b/cli/commands/train_cloud.py
@@ -199,6 +199,13 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         "ignored otherwise.",
     )
     parser.add_argument(
+        "--mock-data",
+        action="store_true",
+        help="Use deterministic synthetic OHLCV data instead of the real "
+        "Binance-backed corpus (mirrors `atb live --mock-data`). Test/CI use "
+        "only -- never set for a real training run.",
+    )
+    parser.add_argument(
         "--instance-type",
         type=str,
         default="ml.g4dn.xlarge",
@@ -288,6 +295,7 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         target_type=args.target_type,
         target_horizon=args.target_horizon,
         primary_model_type=args.primary_model_type,
+        use_mock_data=args.mock_data,
         diagnostics=DiagnosticsOptions(
             generate_plots=False,  # Skip plots in cloud (no display)
             evaluate_robustness=True,

--- a/cli/commands/train_cloud.py
+++ b/cli/commands/train_cloud.py
@@ -153,10 +153,13 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
             "tcn_attention",
             "tft",
             "tft_ternary",
+            "lightgbm",
         ],
         help="Model architecture (default: cnn_lstm). tft_ternary is the 3-class "
         "TARGET-REDESIGN tournament entrant (c) head -- pair it with "
-        "--target-type triple_barrier.",
+        "--target-type triple_barrier. lightgbm requires the optional lightgbm "
+        "dependency (not installed by default) and is unrelated to --target-type "
+        "meta_label, which always trains a sklearn LogisticRegression.",
     )
     parser.add_argument(
         "--model-variant",
@@ -169,10 +172,16 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         "--target-type",
         type=str,
         default="regression",
-        choices=["regression", "binary_direction", "triple_barrier", "smoothed_return"],
+        choices=[
+            "regression",
+            "binary_direction",
+            "triple_barrier",
+            "smoothed_return",
+            "meta_label",
+        ],
         help="Training target (default: regression, the incumbent next-bar price target). "
         "TARGET-REDESIGN tournament entrants: binary_direction (b), triple_barrier (c), "
-        "smoothed_return (d).",
+        "smoothed_return (d), meta_label (a). meta_label requires --primary-model-type.",
     )
     parser.add_argument(
         "--target-horizon",
@@ -180,6 +189,14 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         default=1,
         help="Forward horizon in bars for binary_direction/smoothed_return targets "
         "(default: 1; ignored by regression/triple_barrier).",
+    )
+    parser.add_argument(
+        "--primary-model-type",
+        type=str,
+        default=None,
+        help="Registry model_type of the primary signal to run forward when "
+        "--target-type meta_label is used (e.g. 'basic'). Required for meta_label, "
+        "ignored otherwise.",
     )
     parser.add_argument(
         "--instance-type",
@@ -270,6 +287,7 @@ def _handle_cloud(ns: argparse.Namespace) -> int:
         model_variant=args.model_variant,
         target_type=args.target_type,
         target_horizon=args.target_horizon,
+        primary_model_type=args.primary_model_type,
         diagnostics=DiagnosticsOptions(
             generate_plots=False,  # Skip plots in cloud (no display)
             evaluate_robustness=True,

--- a/cli/commands/train_commands.py
+++ b/cli/commands/train_commands.py
@@ -77,6 +77,7 @@ def train_model_main(args) -> int:
         model_variant=getattr(args, "model_variant", "default"),
         target_type=getattr(args, "target_type", "regression"),
         target_horizon=getattr(args, "target_horizon", 1),
+        primary_model_type=getattr(args, "primary_model_type", None),
     )
 
     ctx = TrainingContext(config=config)

--- a/cli/commands/train_commands.py
+++ b/cli/commands/train_commands.py
@@ -75,6 +75,8 @@ def train_model_main(args) -> int:
         diagnostics=_diagnostics_from_args(args),
         model_type=getattr(args, "model_type", "cnn_lstm"),
         model_variant=getattr(args, "model_variant", "default"),
+        target_type=getattr(args, "target_type", "regression"),
+        target_horizon=getattr(args, "target_horizon", 1),
     )
 
     ctx = TrainingContext(config=config)

--- a/src/infrastructure/runtime/paths.py
+++ b/src/infrastructure/runtime/paths.py
@@ -68,3 +68,33 @@ def get_project_root() -> Path:
     Uses lru_cache for thread-safe lazy initialization.
     """
     return find_project_root()
+
+
+def get_model_registry_root() -> Path:
+    """Resolve the model registry root directory.
+
+    Honors the ``MODEL_REGISTRY_PATH`` environment variable when set -- the
+    same key ``PredictionConfig.model_registry_path`` reads (via
+    ConfigManager) for the READ side (``PredictionModelRegistry``/backtest
+    bundle lookups). Reusing it here for the WRITE side
+    (``TrainingPaths.default()``'s ``models_dir``,
+    ``promote_model_version``'s default ``registry_root``) lets a single env
+    var redirect both sides consistently -- e.g. for acceptance-test
+    hermeticity, so trained/promoted artifacts never touch the real
+    ``src/ml/models/`` registry.
+
+    An absolute override replaces the path outright; a relative one
+    resolves against ``get_project_root()``. Unset (the common case)
+    preserves the existing default: ``{project_root}/src/ml/models``.
+
+    Deliberately NOT cached (unlike ``get_project_root``) -- reading a plain
+    env var is cheap, and caching would make it impossible for a
+    within-process caller (e.g. a test using ``monkeypatch.setenv``) to
+    change the override after the first call.
+    """
+    override = os.getenv("MODEL_REGISTRY_PATH")
+    root = get_project_root()
+    if not override:
+        return root / "src" / "ml" / "models"
+    override_path = Path(override)
+    return override_path if override_path.is_absolute() else root / override_path

--- a/src/ml/cloud/entrypoint.py
+++ b/src/ml/cloud/entrypoint.py
@@ -85,6 +85,7 @@ def parse_hyperparameters(params: dict) -> dict:
         # hyperparameters must be strings) -- normalize back to None so
         # TrainingConfig's own required-when-meta_label check applies.
         "primary_model_type": params.get("primary_model_type") or None,
+        "use_mock_data": params.get("use_mock_data", "false").lower() == "true",
     }
 
 
@@ -134,6 +135,7 @@ def run_training(parsed_params: dict) -> int:
             target_type=parsed_params["target_type"],
             target_horizon=parsed_params["target_horizon"],
             primary_model_type=parsed_params.get("primary_model_type"),
+            use_mock_data=parsed_params.get("use_mock_data", False),
             diagnostics=DiagnosticsOptions(
                 generate_plots=False,  # No display in container
                 evaluate_robustness=True,

--- a/src/ml/cloud/entrypoint.py
+++ b/src/ml/cloud/entrypoint.py
@@ -76,6 +76,10 @@ def parse_hyperparameters(params: dict) -> dict:
         # older CLIs keep training the incumbent cnn_lstm architecture.
         "model_type": params.get("model_type", "cnn_lstm"),
         "model_variant": params.get("model_variant", "default"),
+        # Training target selection; defaults match TrainingConfig so jobs
+        # submitted by older CLIs keep training the incumbent regression target.
+        "target_type": params.get("target_type", "regression"),
+        "target_horizon": int(params.get("target_horizon", "1")),
     }
 
 
@@ -122,6 +126,8 @@ def run_training(parsed_params: dict) -> int:
             mixed_precision=parsed_params["mixed_precision"],
             model_type=parsed_params["model_type"],
             model_variant=parsed_params["model_variant"],
+            target_type=parsed_params["target_type"],
+            target_horizon=parsed_params["target_horizon"],
             diagnostics=DiagnosticsOptions(
                 generate_plots=False,  # No display in container
                 evaluate_robustness=True,
@@ -142,6 +148,7 @@ def run_training(parsed_params: dict) -> int:
         logger.info(f"Data range: {start_date} to {end_date}")
         logger.info(f"Epochs: {config.epochs}, Batch size: {config.batch_size}")
         logger.info(f"Architecture: {config.model_type} (variant: {config.model_variant})")
+        logger.info(f"Target: {config.target_type} (horizon: {config.target_horizon})")
 
         # Run training
         result = run_training_pipeline(ctx)

--- a/src/ml/cloud/entrypoint.py
+++ b/src/ml/cloud/entrypoint.py
@@ -80,6 +80,11 @@ def parse_hyperparameters(params: dict) -> dict:
         # submitted by older CLIs keep training the incumbent regression target.
         "target_type": params.get("target_type", "regression"),
         "target_horizon": int(params.get("target_horizon", "1")),
+        # Required only when target_type == "meta_label" (entrant (a));
+        # orchestrator.py sends "" for an unset value (SageMaker
+        # hyperparameters must be strings) -- normalize back to None so
+        # TrainingConfig's own required-when-meta_label check applies.
+        "primary_model_type": params.get("primary_model_type") or None,
     }
 
 
@@ -128,6 +133,7 @@ def run_training(parsed_params: dict) -> int:
             model_variant=parsed_params["model_variant"],
             target_type=parsed_params["target_type"],
             target_horizon=parsed_params["target_horizon"],
+            primary_model_type=parsed_params.get("primary_model_type"),
             diagnostics=DiagnosticsOptions(
                 generate_plots=False,  # No display in container
                 evaluate_robustness=True,

--- a/src/ml/cloud/entrypoint.py
+++ b/src/ml/cloud/entrypoint.py
@@ -143,6 +143,39 @@ def run_training(parsed_params: dict) -> int:
             ),
         )
 
+        # Cheap, pre-flight self-consistency check ("closes the pay-then-fail
+        # class", PR #950 review): assert the TrainingConfig actually built
+        # matches what was requested in hyperparameters.json BEFORE any GPU
+        # time is spent inside run_training_pipeline. Guards against a future
+        # refactor of the constructor call above (a copy-paste error wiring
+        # the wrong source field, or a key-name desync between this file's
+        # parse_hyperparameters and orchestrator.py's _build_job_spec)
+        # silently training the WRONG target on a paid instance with no
+        # error -- entrant (d) smoothed_return shares REGRESSION task_type
+        # with the incumbent, so the #947 head-compatibility guard would NOT
+        # catch this class of drift.
+        if (
+            config.target_type != parsed_params["target_type"]
+            or config.target_horizon != parsed_params["target_horizon"]
+        ):
+            error_msg = (
+                "target_type/target_horizon mismatch after TrainingConfig "
+                f"construction: requested target_type={parsed_params['target_type']!r} "
+                f"target_horizon={parsed_params['target_horizon']!r}, but the "
+                f"constructed config has target_type={config.target_type!r} "
+                f"target_horizon={config.target_horizon!r}. Refusing to train "
+                "the wrong target."
+            )
+            logger.error(error_msg)
+            write_failure_file(error_msg)
+            return 1
+        logger.info(
+            "Target confirmed: target_type=%s target_horizon=%s "
+            "(matches hyperparameters.json request)",
+            config.target_type,
+            config.target_horizon,
+        )
+
         # Override paths for SageMaker
         paths = TrainingPaths(
             project_root=Path("/opt/ml/code"),

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from time import perf_counter
 
-from src.infrastructure.runtime.paths import get_project_root
+from src.infrastructure.runtime.paths import get_model_registry_root
 from src.ml.cloud.artifacts.latest_link import update_latest_symlink
 from src.ml.cloud.artifacts.s3_manager import S3ArtifactManager
 from src.ml.cloud.config import CloudTrainingConfig
@@ -466,8 +466,15 @@ class CloudTrainingOrchestrator:
             else:
                 symbol = config_symbol
 
-            # Sync to local registry
-            local_registry = get_project_root() / "src" / "ml" / "models"
+            # Sync to local registry. get_model_registry_root() honors
+            # MODEL_REGISTRY_PATH (the same key PredictionConfig.model_registry_path
+            # reads) -- this is the FINAL destination every trained bundle
+            # (cloud or local provider) lands in, so it must agree with
+            # TrainingPaths.default()/promote_model_version's own default or
+            # a MODEL_REGISTRY_PATH override (e.g. for acceptance-test
+            # hermeticity, PR #950 review item 5) would silently miss this
+            # sync step and still write into the real registry.
+            local_registry = get_model_registry_root()
 
             # Artifacts are already extracted locally by provider.download_artifacts()
             # Use _sync_local_artifacts for both local and cloud providers

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -351,6 +351,7 @@ class CloudTrainingOrchestrator:
                 # SageMaker hyperparameters must be strings; "" round-trips
                 # to None on the parsing side (entrypoint.py::parse_hyperparameters).
                 "primary_model_type": tc.primary_model_type or "",
+                "use_mock_data": str(tc.use_mock_data).lower(),
             },
         )
 

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -346,6 +346,8 @@ class CloudTrainingOrchestrator:
                 "mixed_precision": str(tc.mixed_precision).lower(),
                 "model_type": tc.model_type,
                 "model_variant": tc.model_variant,
+                "target_type": tc.target_type,
+                "target_horizon": str(tc.target_horizon),
             },
         )
 

--- a/src/ml/cloud/orchestrator.py
+++ b/src/ml/cloud/orchestrator.py
@@ -348,6 +348,9 @@ class CloudTrainingOrchestrator:
                 "model_variant": tc.model_variant,
                 "target_type": tc.target_type,
                 "target_horizon": str(tc.target_horizon),
+                # SageMaker hyperparameters must be strings; "" round-trips
+                # to None on the parsing side (entrypoint.py::parse_hyperparameters).
+                "primary_model_type": tc.primary_model_type or "",
             },
         )
 

--- a/src/ml/cloud/promotion.py
+++ b/src/ml/cloud/promotion.py
@@ -14,7 +14,7 @@ import re
 import shutil
 from pathlib import Path
 
-from src.infrastructure.runtime.paths import get_project_root
+from src.infrastructure.runtime.paths import get_model_registry_root
 from src.ml.cloud.artifacts.latest_link import update_latest_symlink
 from src.ml.cloud.exceptions import ModelPromotionError
 
@@ -50,7 +50,8 @@ def promote_model_version(
         target_type: Namespace to copy the bundle into (default: basic)
         set_latest: Also point ``{target_type}/latest`` at the promoted version.
             Without this flag the live-loading symlink is never touched.
-        registry_root: Model registry root (default: ``src/ml/models``)
+        registry_root: Model registry root (default: ``get_model_registry_root()``,
+            i.e. ``src/ml/models`` unless ``MODEL_REGISTRY_PATH`` is set)
 
     Returns:
         Path to the promoted bundle directory
@@ -64,7 +65,7 @@ def promote_model_version(
     source_type = _validate_component(source_type, "source_type")
     target_type = _validate_component(target_type, "target_type")
 
-    root = registry_root or (get_project_root() / "src" / "ml" / "models")
+    root = registry_root or get_model_registry_root()
     source_dir = root / symbol / source_type / version_id
     target_dir = root / symbol / target_type / version_id
 

--- a/src/ml/cloud/providers/local.py
+++ b/src/ml/cloud/providers/local.py
@@ -190,6 +190,7 @@ class LocalProvider(CloudTrainingProvider):
                 target_type=hp.get("target_type", "regression"),
                 target_horizon=int(hp.get("target_horizon", "1")),
                 primary_model_type=hp.get("primary_model_type") or None,
+                use_mock_data=hp.get("use_mock_data", "false").lower() == "true",
                 # Skip plots and robustness for faster local testing
                 diagnostics=DiagnosticsOptions(
                     generate_plots=False,

--- a/src/ml/cloud/providers/local.py
+++ b/src/ml/cloud/providers/local.py
@@ -165,7 +165,15 @@ class LocalProvider(CloudTrainingProvider):
             )
             from src.ml.training_pipeline.pipeline import run_training_pipeline
 
-            # Convert spec to TrainingConfig
+            # Convert spec to TrainingConfig. spec.hyperparameters carries
+            # everything that isn't a typed TrainingJobSpec field (mirrors
+            # entrypoint.py::parse_hyperparameters' defaults exactly, since
+            # this provider exists specifically to exercise the SAME CLI ->
+            # hyperparameters -> TrainingConfig path SageMaker jobs use,
+            # without AWS -- previously this dict was read from at ALL,
+            # so `atb train cloud --provider local` silently trained
+            # cnn_lstm/regression regardless of --model-type/--target-type).
+            hp = spec.hyperparameters or {}
             config = TrainingConfig(
                 symbol=spec.symbol,
                 timeframe=spec.timeframe,
@@ -174,6 +182,13 @@ class LocalProvider(CloudTrainingProvider):
                 epochs=spec.epochs,
                 batch_size=spec.batch_size,
                 sequence_length=spec.sequence_length,
+                force_sentiment=hp.get("force_sentiment", "false").lower() == "true",
+                force_price_only=hp.get("force_price_only", "false").lower() == "true",
+                mixed_precision=hp.get("mixed_precision", "true").lower() == "true",
+                model_type=hp.get("model_type", "cnn_lstm"),
+                model_variant=hp.get("model_variant", "default"),
+                target_type=hp.get("target_type", "regression"),
+                target_horizon=int(hp.get("target_horizon", "1")),
                 # Skip plots and robustness for faster local testing
                 diagnostics=DiagnosticsOptions(
                     generate_plots=False,

--- a/src/ml/cloud/providers/local.py
+++ b/src/ml/cloud/providers/local.py
@@ -189,6 +189,7 @@ class LocalProvider(CloudTrainingProvider):
                 model_variant=hp.get("model_variant", "default"),
                 target_type=hp.get("target_type", "regression"),
                 target_horizon=int(hp.get("target_horizon", "1")),
+                primary_model_type=hp.get("primary_model_type") or None,
                 # Skip plots and robustness for faster local testing
                 diagnostics=DiagnosticsOptions(
                     generate_plots=False,

--- a/src/ml/training_pipeline/config.py
+++ b/src/ml/training_pipeline/config.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
-from src.infrastructure.runtime.paths import get_project_root
+from src.infrastructure.runtime.paths import get_model_registry_root, get_project_root
 
 
 @dataclass
@@ -30,12 +30,18 @@ class TrainingPaths:
     def default(cls) -> TrainingPaths:
         """Create default training paths based on project root.
 
+        ``models_dir`` comes from ``get_model_registry_root()``, which
+        honors the ``MODEL_REGISTRY_PATH`` environment variable when set --
+        the same key ``PredictionConfig.model_registry_path`` reads on the
+        backtest/prediction READ side, so one env var redirects both sides
+        consistently (e.g. for acceptance-test hermeticity).
+
         Returns:
             TrainingPaths configured for local development
         """
         root = get_project_root()
         data_dir = root / "data"
-        models_dir = root / "src" / "ml" / "models"
+        models_dir = get_model_registry_root()
         data_dir.mkdir(parents=True, exist_ok=True)
         models_dir.mkdir(parents=True, exist_ok=True)
         return cls(project_root=root, data_dir=data_dir, models_dir=models_dir)

--- a/src/ml/training_pipeline/config.py
+++ b/src/ml/training_pipeline/config.py
@@ -74,6 +74,13 @@ class TrainingConfig:
     target_type: str = "regression"
     target_horizon: int = 1  # forward bars; used by binary_direction/smoothed_return
 
+    # Registry model_type of the primary signal to run forward when
+    # target_type="meta_label" (entrant (a) -- meta_label's label depends on
+    # simulating an ALREADY-TRAINED primary signal's fired trades, not a
+    # transform of the close-price series). Required when target_type ==
+    # "meta_label" (validated below), ignored otherwise.
+    primary_model_type: str | None = None
+
     # Valid model types and variants for validation
     _VALID_MODEL_TYPES = frozenset(
         {
@@ -86,11 +93,12 @@ class TrainingConfig:
             "tft",
             "tft_ternary",
             "lstm",
+            "lightgbm",
         }
     )
     _VALID_MODEL_VARIANTS = frozenset({"default", "lightweight", "deep"})
     _VALID_TARGET_TYPES = frozenset(
-        {"regression", "binary_direction", "triple_barrier", "smoothed_return"}
+        {"regression", "binary_direction", "triple_barrier", "smoothed_return", "meta_label"}
     )
 
     def __post_init__(self):
@@ -130,6 +138,12 @@ class TrainingConfig:
             )
         if self.target_horizon <= 0:
             raise ValueError(f"target_horizon must be positive, got {self.target_horizon}")
+        if self.target_type == "meta_label" and not self.primary_model_type:
+            raise ValueError(
+                "primary_model_type is required when target_type='meta_label' -- "
+                "it names the registry model_type of the primary signal to run "
+                "forward and meta-label (e.g. 'basic')."
+            )
 
     def days_requested(self) -> int:
         """Calculate number of days in the training date range.

--- a/src/ml/training_pipeline/config.py
+++ b/src/ml/training_pipeline/config.py
@@ -76,7 +76,17 @@ class TrainingConfig:
 
     # Valid model types and variants for validation
     _VALID_MODEL_TYPES = frozenset(
-        {"cnn_lstm", "adaptive", "default", "attention_lstm", "tcn", "tcn_attention", "tft", "lstm"}
+        {
+            "cnn_lstm",
+            "adaptive",
+            "default",
+            "attention_lstm",
+            "tcn",
+            "tcn_attention",
+            "tft",
+            "tft_ternary",
+            "lstm",
+        }
     )
     _VALID_MODEL_VARIANTS = frozenset({"default", "lightweight", "deep"})
     _VALID_TARGET_TYPES = frozenset(

--- a/src/ml/training_pipeline/config.py
+++ b/src/ml/training_pipeline/config.py
@@ -81,6 +81,14 @@ class TrainingConfig:
     # "meta_label" (validated below), ignored otherwise.
     primary_model_type: str | None = None
 
+    # Test-only escape hatch: routes load_training_corpus (ingestion.py) to
+    # MockDataProvider (deterministic synthetic OHLCV, no network) instead of
+    # the real Binance-backed cache. Mirrors `atb live --mock-data`'s
+    # existing pattern (src/engines/live/runner.py). Never set in production
+    # training -- exists so acceptance/integration tests can exercise the
+    # REAL training pipeline end-to-end without a network dependency.
+    use_mock_data: bool = False
+
     # Valid model types and variants for validation
     _VALID_MODEL_TYPES = frozenset(
         {

--- a/src/ml/training_pipeline/ingestion.py
+++ b/src/ml/training_pipeline/ingestion.py
@@ -6,6 +6,7 @@ import logging
 import os
 from datetime import UTC, timedelta
 from pathlib import Path
+from typing import Any
 
 import pandas as pd
 
@@ -223,15 +224,27 @@ def load_training_corpus(ctx: TrainingContext) -> pd.DataFrame:
     Raises:
         RuntimeError: If the corpus cannot be fetched or fails coverage validation
     """
-    from src.config.paths import get_cache_dir
-    from src.data_providers.binance_provider import BinanceProvider
-    from src.data_providers.cached_data_provider import CachedDataProvider
-
-    provider = CachedDataProvider(BinanceProvider(), cache_dir=str(get_cache_dir()))
     # End-of-day boundaries (ctx.start_iso/end_iso) so the corpus covers the full
     # requested last day instead of truncating it at midnight.
     query_start = pd.Timestamp(ctx.start_iso)
     query_end = pd.Timestamp(ctx.end_iso)
+
+    if ctx.config.use_mock_data:
+        # Test-only escape hatch (mirrors `atb live --mock-data`,
+        # src/engines/live/runner.py): deterministic synthetic OHLCV, zero
+        # network, zero disk cache -- lets acceptance/integration tests
+        # exercise the REAL training pipeline end-to-end. Never set by any
+        # production CLI path.
+        from src.data_providers.mock_data_provider import MockDataProvider
+
+        provider: Any = MockDataProvider(seed=42)
+    else:
+        from src.config.paths import get_cache_dir
+        from src.data_providers.binance_provider import BinanceProvider
+        from src.data_providers.cached_data_provider import CachedDataProvider
+
+        provider = CachedDataProvider(BinanceProvider(), cache_dir=str(get_cache_dir()))
+
     try:
         df = provider.get_historical_data(
             ctx.symbol_exchange,

--- a/src/ml/training_pipeline/labels.py
+++ b/src/ml/training_pipeline/labels.py
@@ -121,8 +121,22 @@ def smoothed_forward_return_labels(close: pd.Series, horizon: int) -> LabelResul
         idx = np.arange(n_valid)
         forward_sum = prefix_sum[idx + 1 + horizon] - prefix_sum[idx + 1]
         mean_future_close = forward_sum / horizon
-        values[idx] = mean_future_close / close_arr[idx] - 1.0
-        valid_mask[idx] = True
+
+        # close_arr[idx] (the entry price, close[t]) is the divisor -- a
+        # zero/negative/non-finite entry price must not silently produce
+        # inf/nan written into the label array as if it were a valid,
+        # fully-realized row. Guard BEFORE dividing (not divide-then-
+        # discard) so a corrupted entry price never raises a numpy
+        # RuntimeWarning either. Only the divisor is checked here; a
+        # legitimate (if unusual) zero/negative FUTURE close is not an
+        # error -- that is real market data, not a corrupted read.
+        divisor = close_arr[idx]
+        safe_divisor = np.isfinite(divisor) & (divisor > 0)
+
+        computed = np.full(n_valid, np.nan, dtype=np.float64)
+        computed[safe_divisor] = mean_future_close[safe_divisor] / divisor[safe_divisor] - 1.0
+        values[idx] = computed
+        valid_mask[idx] = safe_divisor
 
     return LabelResult(values=values, valid_mask=valid_mask, horizon_bars=horizon)
 

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -375,12 +375,140 @@ def build_meta_label_features(
     return pd.DataFrame(rows)
 
 
+# Fixed feature order for the sklearn LogisticRegression classifier --
+# single source of truth for BOTH training (encode_meta_label_features_for_
+# training) and inference (encode_meta_label_feature_row) so the two can
+# never drift out of sync. Also documents the ONNX graph's expected input
+# column order (sklearn_onnx_export.py has no column names of its own).
+META_LABEL_FEATURE_ORDER: tuple[str, ...] = (
+    "realized_vol_48",
+    "rolling_hit_rate_20",
+    "session_sin",
+    "session_cos",
+    "regime_trend_encoded",
+    "regime_volatility_encoded",
+    "regime_confidence",
+    "predicted_return_magnitude",
+)
+
+# Fixed numeric codes for the string regime enums (TrendLabel/VolLabel) --
+# sklearn needs numeric input. -1/0/1 for trend mirrors down/range/up
+# ordering; 0/1 for volatility is a plain low/high indicator.
+_TREND_ENCODING: dict[str, float] = {"trend_down": -1.0, "range": 0.0, "trend_up": 1.0}
+_VOLATILITY_ENCODING: dict[str, float] = {"low_vol": 0.0, "high_vol": 1.0}
+
+# rolling_hit_rate_20 is NaN for a fire with no eligible prior resolved
+# fires yet (see build_meta_label_features docstring) -- fill with a
+# neutral prior (neither a good nor bad track record) rather than 0.0
+# (which would read as "100% of trailing fires unprofitable", actively
+# misleading the classifier for the earliest fires in any training corpus).
+_NEUTRAL_HIT_RATE_PRIOR = 0.5
+
+
+def encode_meta_label_feature_row(
+    *,
+    realized_vol_48: float,
+    rolling_hit_rate_20: float,
+    session_sin: float,
+    session_cos: float,
+    regime_trend: str,
+    regime_volatility: str,
+    regime_confidence: float,
+    predicted_return_magnitude: float,
+) -> np.ndarray:
+    """Encode ONE meta-label feature row into META_LABEL_FEATURE_ORDER.
+
+    The inference-time counterpart to
+    ``encode_meta_label_features_for_training`` -- used by the exam
+    harness's stateful ``MetaLabelExamSignalGenerator``, which computes
+    features incrementally (one fire at a time) rather than as a batch
+    DataFrame. Must encode identically to the training-time batch encoder
+    for the same logical values (verified directly by a regression test).
+
+    Args:
+        realized_vol_48: 48-bar trailing realized volatility.
+        rolling_hit_rate_20: Rolling hit-rate of prior RESOLVED fires, or
+            NaN if none are eligible yet (filled with a neutral 0.5 prior).
+        session_sin: sin(2*pi*hour/24) cyclical encoding.
+        session_cos: cos(2*pi*hour/24) cyclical encoding.
+        regime_trend: EnhancedRegimeDetector's TrendLabel.value string.
+        regime_volatility: EnhancedRegimeDetector's VolLabel.value string.
+        regime_confidence: EnhancedRegimeDetector's regime confidence, [0,1].
+        predicted_return_magnitude: abs() of the primary signal's own
+            predicted_return at the fire point.
+
+    Returns:
+        float32 array of shape (len(META_LABEL_FEATURE_ORDER),).
+
+    Raises:
+        KeyError: regime_trend/regime_volatility is not a recognized enum value.
+    """
+    hit_rate = (
+        _NEUTRAL_HIT_RATE_PRIOR
+        if rolling_hit_rate_20 is None or math.isnan(rolling_hit_rate_20)
+        else float(rolling_hit_rate_20)
+    )
+    values = {
+        "realized_vol_48": float(realized_vol_48),
+        "rolling_hit_rate_20": hit_rate,
+        "session_sin": float(session_sin),
+        "session_cos": float(session_cos),
+        "regime_trend_encoded": _TREND_ENCODING[regime_trend],
+        "regime_volatility_encoded": _VOLATILITY_ENCODING[regime_volatility],
+        "regime_confidence": float(regime_confidence),
+        "predicted_return_magnitude": float(predicted_return_magnitude),
+    }
+    return np.array([values[name] for name in META_LABEL_FEATURE_ORDER], dtype=np.float32)
+
+
+def encode_meta_label_features_for_training(
+    features_df: pd.DataFrame,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Encode build_meta_label_features()'s output into (X, y) training arrays.
+
+    One row per fire, columns in META_LABEL_FEATURE_ORDER -- ready for
+    ``sklearn.linear_model.LogisticRegression.fit(X, y)``.
+
+    Args:
+        features_df: Output of ``build_meta_label_features``.
+
+    Returns:
+        (X, y): X is float32 shape (n_fires, len(META_LABEL_FEATURE_ORDER)),
+        y is the "label" column, shape (n_fires,).
+
+    Raises:
+        ValueError: features_df is empty.
+    """
+    if features_df.empty:
+        raise ValueError("features_df is empty -- no fired signals to train on")
+
+    rows = [
+        encode_meta_label_feature_row(
+            realized_vol_48=row["realized_vol_48"],
+            rolling_hit_rate_20=row["rolling_hit_rate_20"],
+            session_sin=row["session_sin"],
+            session_cos=row["session_cos"],
+            regime_trend=row["regime_trend"],
+            regime_volatility=row["regime_volatility"],
+            regime_confidence=row["regime_confidence"],
+            predicted_return_magnitude=row["predicted_return_magnitude"],
+        )
+        for _, row in features_df.iterrows()
+    ]
+    X = np.stack(rows).astype(np.float32)
+    y = features_df["label"].to_numpy(dtype=np.float32)
+    return X, y
+
+
 __all__ = [
     "HIT_RATE_LOOKBACK_FIRES",
+    "META_LABEL_FEATURE_ORDER",
     "REALIZED_VOL_WINDOW_BARS",
     "PrimarySignalRecord",
     "TradeResolution",
     "build_meta_label_features",
+    "encode_meta_label_feature_row",
+    "encode_meta_label_features_for_training",
     "resolve_fired_trade",
     "run_primary_signal_forward",
     "simulate_fired_trade_profitability",

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -268,6 +268,44 @@ def simulate_fired_trade_profitability(
     return resolution.profitable if resolution is not None else None
 
 
+def resolution_ordered_hit_rate(resolved: Sequence[tuple[int, int, bool]], lookback: int) -> float:
+    """Rolling hit-rate over the last ``lookback`` RESOLVED fires.
+
+    Single source of truth for ``rolling_hit_rate_20``, used identically by
+    training (``build_meta_label_features``) and the exam-time consumer
+    (``MetaLabelExamSignalGenerator._rolling_hit_rate``) so the two windowing
+    conventions can never drift apart again.
+
+    A fire's profitability only becomes "known" at its RESOLUTION bar
+    (``exit_index``), not its fire bar -- and fires can resolve
+    out-of-fire-order (a long-held early fire commonly resolves after a
+    later, quickly-resolved one; see the module docstring's causality
+    note). The online exam path naturally builds its history in
+    ``(exit_index, fire_index)`` order: bars are processed in strictly
+    increasing index order, and within a single resolution bar, multiple
+    fires resolve in their original registration (fire) order. Training
+    reconstructs the SAME ordering from a fully-resolved offline corpus by
+    sorting explicitly here -- this function always re-sorts before
+    windowing, so callers may pass an already-ordered or unordered
+    sequence.
+
+    Args:
+        resolved: ``(exit_index, fire_index, profitable)`` tuples for every
+            fire resolved so far, in any order.
+        lookback: Number of most-recent (by the ordering above) resolved
+            fires to average over.
+
+    Returns:
+        Mean of the last ``lookback`` profitability outcomes, or NaN if
+        ``resolved`` is empty.
+    """
+    if not resolved:
+        return float("nan")
+    ordered = sorted(resolved, key=lambda item: (item[0], item[1]))
+    recent = [profitable for _, _, profitable in ordered[-lookback:]]
+    return float(np.mean(recent))
+
+
 def _realized_volatility_series(close: pd.Series, window: int) -> pd.Series:
     """48-bar trailing realized volatility of bar-over-bar returns.
 
@@ -340,17 +378,16 @@ def build_meta_label_features(
         # Only prior fires that had RESOLVED by this fire's own index are
         # "known" information at this point in time -- a prior fire whose
         # trade is still open (exit_index > fire.index) would leak that
-        # fire's own future price path into this feature.
+        # fire's own future price path into this feature. The eligible set
+        # is windowed by resolution_ordered_hit_rate in (exit_index,
+        # fire_index) order -- NOT this loop's fire-order iteration -- to
+        # match MetaLabelExamSignalGenerator's online windowing exactly.
         eligible_prior = [
-            resolutions[i].profitable
+            (resolutions[i].exit_index, fired_signals[i].index, resolutions[i].profitable)
             for i in range(position)
             if resolutions[i].exit_index <= fire.index
         ]
-        if eligible_prior:
-            recent_prior = eligible_prior[-hit_rate_lookback:]
-            rolling_hit_rate = float(np.mean(recent_prior))
-        else:
-            rolling_hit_rate = float("nan")
+        rolling_hit_rate = resolution_ordered_hit_rate(eligible_prior, hit_rate_lookback)
 
         timestamp = df.index[fire.index]
         session_sin, session_cos = _session_cyclical_encoding(pd.Timestamp(timestamp))
@@ -509,6 +546,7 @@ __all__ = [
     "build_meta_label_features",
     "encode_meta_label_feature_row",
     "encode_meta_label_features_for_training",
+    "resolution_ordered_hit_rate",
     "resolve_fired_trade",
     "run_primary_signal_forward",
     "simulate_fired_trade_profitability",

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -37,6 +37,7 @@ import pandas as pd
 
 from src.engines.shared.barrier_touch import check_barrier_touch
 from src.engines.shared.cost_calculator import CostCalculator
+from src.performance.metrics import Side, pnl_percent
 from src.regime.enhanced_detector import EnhancedRegimeDetector
 from src.strategies.components.signal_generator import SignalDirection
 
@@ -174,6 +175,15 @@ def resolve_fired_trade(
     n = len(close)
 
     entry_price = close[fire_index]
+    # CODE.md#L133: validate entry_price > 0 before any P&L or stop-loss
+    # calculation -- a zero/negative/non-finite close at fire_index (bad
+    # tick, gap-fill, corrupted data) must raise loudly here, not silently
+    # produce NaN barrier levels and mislabel the row downstream.
+    if not math.isfinite(entry_price) or entry_price <= 0:
+        raise ValueError(
+            f"entry_price must be positive and finite, got {entry_price} at "
+            f"fire_index={fire_index}"
+        )
     if direction == 1:
         stop_loss_price = entry_price * (1.0 - stop_loss_pct)
         take_profit_price = entry_price * (1.0 + take_profit_pct)
@@ -208,7 +218,12 @@ def resolve_fired_trade(
         exit_price = close[max_bar]
         exit_index = max_bar
 
-    raw_pct_return = direction * (exit_price - entry_price) / entry_price
+    # Reuse the shared P&L primitive (CODE.md#L331: "never duplicate
+    # financial logic") instead of hand-rolling the calculation -- also
+    # validates exit_price is positive/finite, since it derives from OHLC
+    # data (barrier touch price / vertical exit close) just like entry_price.
+    side_enum = Side.LONG if direction == 1 else Side.SHORT
+    raw_pct_return = pnl_percent(entry_price, exit_price, side_enum, fraction=1.0)
     round_trip_cost_pct = 2.0 * cost_calculator.fee_rate
     profitable = bool((raw_pct_return - round_trip_cost_pct) > 0.0)
     # cast: exit_index is always set on every path that reaches here (either

--- a/src/ml/training_pipeline/models.py
+++ b/src/ml/training_pipeline/models.py
@@ -315,11 +315,23 @@ def create_model(
         sequence_length, num_features = input_shape
         return build_price_only_model(sequence_length, num_features)
 
+    # LightGBM directional classifier. Reachable from this factory (per
+    # Phase 2b item 3 -- "models_lightgbm.py's classifier isn't reachable
+    # from create_model or the CLI"), but lightgbm is NOT an installed or
+    # declared dependency in this repo -- _ensure_lightgbm_available() raises
+    # ImportError here, same as it always has. input_shape/variant are
+    # unused (LightGBM is tabular, not sequence-shaped); ONNX export for
+    # this architecture is an explicit follow-up, not built here.
+    elif model_type_lower == "lightgbm":
+        from src.ml.training_pipeline.models_lightgbm import create_directional_classifier
+
+        return create_directional_classifier(**kwargs)
+
     else:
         raise ValueError(
             f"Unknown model_type: {model_type}. "
             f"Supported types: 'cnn_lstm', 'attention_lstm', 'tcn', 'tcn_attention', "
-            f"'tft', 'tft_ternary', 'lstm'"
+            f"'tft', 'tft_ternary', 'lstm', 'lightgbm'"
         )
 
 
@@ -378,6 +390,7 @@ AVAILABLE_MODELS = {
     "tft": "Temporal Fusion Transformer (interpretable, attention-based)",
     "tft_ternary": "TFT with 3-class softmax head (triple-barrier target)",
     "lstm": "Simple LSTM baseline",
+    "lightgbm": "LightGBM directional classifier (requires optional lightgbm dependency)",
 }
 
 # Model variants

--- a/src/ml/training_pipeline/models.py
+++ b/src/ml/training_pipeline/models.py
@@ -280,6 +280,36 @@ def create_model(
             return create_tft_model(input_shape, **variant_params)
         return create_tft_model(input_shape, **kwargs)
 
+    # Temporal Fusion Transformer, ternary (3-class) head -- entrant (c) of
+    # the TARGET-REDESIGN tournament (triple_barrier target). Same backbone
+    # as 'tft', softmax(3)/sparse_categorical_crossentropy head instead of
+    # sigmoid/BCE. Deliberately reuses TFT's variant hyperparameter presets
+    # (batch_size/epochs/patience excluded exactly like the 'tft' branch
+    # above) since the two share every layer except the output head.
+    elif model_type_lower == "tft_ternary":
+        try:
+            from src.ml.training_pipeline.models_tft import (
+                RECOMMENDED_HYPERPARAMETERS as TFT_HYPERPARAMS,
+            )
+            from src.ml.training_pipeline.models_tft import (
+                create_tft_ternary_model,
+            )
+        except ImportError:
+            raise ImportError(
+                "tft_ternary model requires models_tft module. "
+                "Ensure the file exists in src/ml/training_pipeline/"
+            ) from None
+
+        if variant != "default" and variant in TFT_HYPERPARAMS:
+            variant_params = {
+                k: v
+                for k, v in TFT_HYPERPARAMS[variant].items()
+                if k not in ("batch_size", "epochs", "patience")
+            }
+            variant_params.update(kwargs)
+            return create_tft_ternary_model(input_shape, **variant_params)
+        return create_tft_ternary_model(input_shape, **kwargs)
+
     # Price-only LSTM (simple baseline)
     elif model_type_lower == "lstm":
         sequence_length, num_features = input_shape
@@ -288,7 +318,8 @@ def create_model(
     else:
         raise ValueError(
             f"Unknown model_type: {model_type}. "
-            f"Supported types: 'cnn_lstm', 'attention_lstm', 'tcn', 'tcn_attention', 'tft', 'lstm'"
+            f"Supported types: 'cnn_lstm', 'attention_lstm', 'tcn', 'tcn_attention', "
+            f"'tft', 'tft_ternary', 'lstm'"
         )
 
 
@@ -326,7 +357,7 @@ def get_model_callbacks(model_type: str, patience: int = 15) -> list[Any]:
         except ImportError:
             pass
 
-    elif model_type_lower == "tft":
+    elif model_type_lower in ("tft", "tft_ternary"):
         try:
             from src.ml.training_pipeline.models_tft import tft_callbacks
 
@@ -345,6 +376,7 @@ AVAILABLE_MODELS = {
     "tcn": "Temporal Convolutional Network (fast training, competitive accuracy)",
     "tcn_attention": "TCN with multi-head attention",
     "tft": "Temporal Fusion Transformer (interpretable, attention-based)",
+    "tft_ternary": "TFT with 3-class softmax head (triple-barrier target)",
     "lstm": "Simple LSTM baseline",
 }
 

--- a/src/ml/training_pipeline/models_tft.py
+++ b/src/ml/training_pipeline/models_tft.py
@@ -474,6 +474,113 @@ def create_tft_model(
     return model
 
 
+def create_tft_ternary_model(
+    input_shape: tuple[int, int],
+    n_heads: int = 4,
+    hidden_size: int = 64,
+    dropout: float = 0.1,
+    num_lstm_layers: int = 1,
+    learning_rate: float = 1e-3,
+) -> Any:
+    """Create a Temporal Fusion Transformer model for ternary (3-class) prediction.
+
+    Entrant (c) of the TARGET-REDESIGN tournament (triple-barrier labels:
+    {-1, 0, 1} for down/no-touch/up). Reuses the exact same VSN / LSTM
+    encoder / attention decoder backbone as create_tft_model -- tft was
+    already the only classification-capable architecture in this codebase,
+    so the ternary head is a sibling rather than a new architecture family.
+    Only the output head and loss differ: softmax over 3 classes trained
+    with sparse categorical cross-entropy instead of a single sigmoid unit.
+
+    Args:
+        input_shape: Shape of input sequences (sequence_length, n_features)
+        n_heads: Number of attention heads in the decoder
+        hidden_size: Hidden dimension for GRN and attention layers
+        dropout: Dropout rate for regularization (0.0-0.5)
+        num_lstm_layers: Number of stacked LSTM layers (1-3)
+        learning_rate: Adam optimizer learning rate
+
+    Returns:
+        Compiled Keras model with a 3-unit softmax output, class order
+        matching src.ml.training_pipeline.labels' triple-barrier encoding
+        (index 0 = down/-1, index 1 = no-touch/0, index 2 = up/1).
+
+    Raises:
+        ValueError: If input parameters are invalid
+
+    Example:
+        >>> model = create_tft_ternary_model((60, 15), n_heads=4, hidden_size=64)
+        >>> model.fit(train_ds, validation_data=val_ds, epochs=50)
+    """
+    _ensure_tensorflow_available()
+
+    sequence_length, n_features = input_shape
+
+    # Validate parameters (mirrors create_tft_model)
+    if n_features <= 0:
+        raise ValueError(f"n_features must be positive, got {n_features}")
+    if n_heads <= 0:
+        raise ValueError(f"n_heads must be positive, got {n_heads}")
+    if hidden_size <= 0:
+        raise ValueError(f"hidden_size must be positive, got {hidden_size}")
+    if hidden_size % n_heads != 0:
+        raise ValueError(f"hidden_size ({hidden_size}) must be divisible by n_heads ({n_heads})")
+    if not 0.0 <= dropout < 1.0:
+        raise ValueError(f"dropout must be in [0.0, 1.0), got {dropout}")
+    if num_lstm_layers <= 0:
+        raise ValueError(f"num_lstm_layers must be positive, got {num_lstm_layers}")
+
+    inputs = layers.Input(shape=input_shape, name="sequence_input")
+
+    # 1. Variable Selection Network - select important features
+    x = VariableSelectionNetwork(
+        n_features=n_features,
+        hidden_size=hidden_size,
+        dropout=dropout,
+        name="variable_selection",
+    )(inputs)
+
+    # 2. LSTM encoder for temporal processing
+    for i in range(num_lstm_layers):
+        x = layers.LSTM(
+            hidden_size,
+            return_sequences=True,
+            dropout=dropout,
+            name=f"lstm_encoder_{i + 1}",
+        )(x)
+
+    # 3. Multi-head self-attention decoder
+    x = TemporalFusionDecoder(
+        n_heads=n_heads,
+        hidden_size=hidden_size,
+        dropout=dropout,
+        name="temporal_decoder",
+    )(x)
+
+    # 4. Global pooling and output
+    avg_pool = layers.GlobalAveragePooling1D(name="global_avg_pool")(x)
+    max_pool = layers.GlobalMaxPooling1D(name="global_max_pool")(x)
+    pooled = layers.Concatenate(name="pooling_concat")([avg_pool, max_pool])
+
+    x = layers.Dense(hidden_size, activation="relu", name="dense_1")(pooled)
+    x = layers.Dropout(dropout, name="dropout_dense")(x)
+
+    # Softmax over 3 classes for triple-barrier prediction (down/no-touch/up)
+    outputs = layers.Dense(3, activation="softmax", name="direction_prediction")(x)
+
+    model = Model(inputs=inputs, outputs=outputs, name="tft_ternary")
+
+    model.compile(
+        optimizer=tf.keras.optimizers.Adam(learning_rate=learning_rate),
+        loss="sparse_categorical_crossentropy",
+        metrics=[
+            tf.keras.metrics.SparseCategoricalAccuracy(name="accuracy"),
+        ],
+    )
+
+    return model
+
+
 def tft_callbacks(patience: int = 20, min_delta: float = 1e-4) -> list[Any]:
     """Get optimized callbacks for TFT training.
 

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -312,6 +312,12 @@ def _run_meta_label_pipeline(ctx: TrainingContext) -> TrainingResult:
         metadata = {
             "symbol": ctx.config.symbol,
             "model_type": registry_model_type,
+            # registry.py::_load_bundle reads this TOP-LEVEL key
+            # (md.get("timeframe", ...)) to populate StrategyModel.timeframe
+            # -- without it every bundle registers as timeframe="unknown"
+            # and becomes unfindable by any symbol/timeframe/model_type
+            # lookup (select_bundle, get_bundle_by_key).
+            "timeframe": ctx.config.timeframe,
             "training_date": pd.Timestamp.now(tz="UTC").isoformat(),
             "feature_names": list(META_LABEL_FEATURE_ORDER),
             "sequence_length": 1,  # tabular features, not sequence-shaped
@@ -622,6 +628,14 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
         metadata = {
             "symbol": ctx.config.symbol,
             "model_type": "sentiment" if has_sentiment else "price",
+            # registry.py::_load_bundle reads this TOP-LEVEL key
+            # (md.get("timeframe", ...)) to populate StrategyModel.timeframe
+            # -- without it every bundle registers as timeframe="unknown"
+            # and becomes unfindable by any symbol/timeframe/model_type
+            # lookup (select_bundle, get_bundle_by_key, and every
+            # MLBasicSignalGenerator/exam signal generator that depends on
+            # them). Was previously only nested under training_params.
+            "timeframe": ctx.config.timeframe,
             "training_date": pd.Timestamp.now(tz="UTC").isoformat(),
             "feature_names": feature_names,
             "sequence_length": ctx.config.sequence_length,

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -190,6 +190,23 @@ def _build_alt_target(
             # other timeframes is out of scope for this scaffolding.
             max_holding_bars=DEFAULT_MAX_HOLDING_HOURS,
         )
+        # triple_barrier_labels() returns raw direction values {-1, 0, 1}
+        # (the same convention get_target_class_labels("triple_barrier")
+        # documents for INFERENCE-time decoding: argmax index -> class_labels
+        # [index] is the direction). sparse_categorical_crossentropy, which
+        # tft_ternary is compiled with, requires integer class INDICES in
+        # [0, num_classes) instead -- feeding raw -1 would be an invalid
+        # class index. Remap through the same class_labels list used at
+        # inference time so training encoding and inference decoding can
+        # never drift apart.
+        class_labels = get_target_class_labels(target_type)
+        assert class_labels is not None  # triple_barrier always has class_labels
+        label_to_index = {direction: index for index, direction in enumerate(class_labels)}
+        label = LabelResult(
+            values=np.array([label_to_index[int(v)] for v in label.values], dtype=np.int64),
+            valid_mask=label.valid_mask,
+            horizon_bars=label.horizon_bars,
+        )
     else:
         raise ValueError(f"No label generator wired for target_type={target_type!r}")
 

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -51,14 +52,24 @@ from src.ml.training_pipeline.labels import (
     smoothed_forward_return_labels,
     triple_barrier_labels,
 )
+from src.ml.training_pipeline.meta_labels import (
+    META_LABEL_FEATURE_ORDER,
+    build_meta_label_features,
+    encode_meta_label_features_for_training,
+    resolve_fired_trade,
+    run_primary_signal_forward,
+)
 from src.ml.training_pipeline.models import create_model, get_model_callbacks
+from src.ml.training_pipeline.sklearn_onnx_export import export_logistic_regression_to_onnx
 from src.ml.training_pipeline.task_types import (
+    TaskType,
     get_model_task_type,
     get_target_class_labels,
     validate_target_head_compatibility,
 )
 from src.prediction.distribution_stats import FrozenDistribution
 from src.prediction.features.price_only import PriceOnlyFeatureExtractor
+from src.strategies.components.ml_signal_generator import MLBasicSignalGenerator
 
 logger = logging.getLogger(__name__)
 
@@ -219,8 +230,198 @@ def _build_alt_target(
     return aligned_values, aligned_valid
 
 
+def _run_meta_label_pipeline(ctx: TrainingContext) -> TrainingResult:
+    """Train entrant (a)'s meta-labeling classifier (TARGET-REDESIGN
+    tournament preregistration §2a).
+
+    A separate, sklearn-only data/training flow from the TF architectures
+    above -- ``ctx.config.model_type`` is irrelevant here (always trains a
+    ``sklearn.linear_model.LogisticRegression`` regardless of --model-type;
+    see train.py's --model-type help text). Steps: (1) download price data,
+    (2) run the ALREADY-TRAINED primary signal (``primary_model_type``)
+    forward to find its fire points, (3) resolve each fire's trade outcome
+    through the exam-harness exit geometry, (4) build + encode the
+    meta-label feature set, (5) fit LogisticRegression, (6) hand-roll an
+    ONNX export (sklearn_onnx_export.py), (7) save artifacts under
+    ``{symbol}/meta_label/{version}/`` with an atomic ``latest`` symlink,
+    mirroring artifacts.py's save_artifacts pattern.
+    """
+    start_time = perf_counter()
+    try:
+        price_df = download_price_data(ctx)
+
+        primary_signal_generator = MLBasicSignalGenerator(
+            model_type=ctx.config.primary_model_type,
+            timeframe=ctx.config.timeframe,
+            symbol=ctx.config.symbol,
+        )
+
+        fired = run_primary_signal_forward(primary_signal_generator, price_df)
+        if not fired:
+            raise ValueError(
+                f"Primary signal (model_type={ctx.config.primary_model_type!r}) produced "
+                f"zero fires over {ctx.config.start_date} to {ctx.config.end_date} -- "
+                f"nothing to meta-label. Try a longer window or a different primary model."
+            )
+
+        resolved_fires = []
+        resolutions = []
+        for fire in fired:
+            resolution = resolve_fired_trade(
+                price_df,
+                fire.index,
+                fire.direction,
+                take_profit_pct=DEFAULT_TAKE_PROFIT_PCT,
+                stop_loss_pct=DEFAULT_STOP_LOSS_PCT,
+                max_holding_bars=DEFAULT_MAX_HOLDING_HOURS,
+            )
+            # Unresolved (truncated at series end) fires are dropped, never
+            # treated as unprofitable -- see resolve_fired_trade's contract.
+            if resolution is not None:
+                resolved_fires.append(fire)
+                resolutions.append(resolution)
+
+        if not resolved_fires:
+            raise ValueError(
+                f"{len(fired)} primary signal fire(s) found, but none resolved within "
+                f"the training window (all truncated at series end) -- nothing to "
+                f"meta-label. Try a longer window."
+            )
+
+        features_df = build_meta_label_features(price_df, resolved_fires, resolutions)
+        X, y = encode_meta_label_features_for_training(features_df)
+
+        if len(np.unique(y)) < 2:
+            raise ValueError(
+                f"Meta-label training data has only one class present across "
+                f"{len(resolved_fires)} resolved fire(s) (all profitable or all "
+                f"unprofitable) -- LogisticRegression cannot fit a decision boundary. "
+                f"Try a longer/different training window."
+            )
+
+        from sklearn.linear_model import LogisticRegression
+
+        model = LogisticRegression(max_iter=1000)
+        model.fit(X, y)
+        train_accuracy = float(model.score(X, y))
+
+        # meta_label_logistic is the model_type task_types.py declares for
+        # this classifier (see its docstring: not create_model()-dispatched,
+        # but still declared for #947-guard/metadata-convention uniformity).
+        registry_model_type = "meta_label"
+        metadata = {
+            "symbol": ctx.config.symbol,
+            "model_type": registry_model_type,
+            "training_date": pd.Timestamp.now(tz="UTC").isoformat(),
+            "feature_names": list(META_LABEL_FEATURE_ORDER),
+            "sequence_length": 1,  # tabular features, not sequence-shaped
+            "task_type": TaskType.BINARY_CLASSIFICATION.value,
+            # meta_label's classifier output is P(primary signal's fired
+            # trade profitable), NOT a direction prediction -- class_labels=
+            # [0, 1] here means "not profitable"/"profitable". Consumers
+            # must read probabilities[1] (P(profitable)) directly, never
+            # `direction`/`confidence` the way direction-value classifiers
+            # (binary_direction/triple_barrier) are interpreted -- see
+            # task_types.py's TARGET_CLASS_LABELS docstring and
+            # MetaLabelExamSignalGenerator.
+            "class_labels": [0, 1],
+            "primary_model_type": ctx.config.primary_model_type,
+            "training_params": {
+                "target_type": "meta_label",
+                "timeframe": ctx.config.timeframe,
+                "start_date": ctx.config.start_date.isoformat(),
+                "end_date": ctx.config.end_date.isoformat(),
+                "primary_model_type": ctx.config.primary_model_type,
+                "n_fires": len(fired),
+                "n_resolved": len(resolved_fires),
+            },
+            "evaluation_results": {"train_accuracy": train_accuracy},
+        }
+
+        output_dir = ctx.paths.models_dir
+        version_id = _generate_version_id(output_dir, ctx.config.symbol, registry_model_type)
+        metadata["version_id"] = version_id
+
+        type_dir = output_dir / ctx.config.symbol.upper() / registry_model_type
+        version_dir = type_dir / version_id
+        version_dir.mkdir(parents=True, exist_ok=True)
+
+        model_path = version_dir / "model.pkl"
+        import joblib
+
+        joblib.dump(model, model_path)
+
+        onnx_path = version_dir / "model.onnx"
+        export_logistic_regression_to_onnx(
+            model, n_features=len(META_LABEL_FEATURE_ORDER), output_path=onnx_path
+        )
+
+        metadata_path = version_dir / "metadata.json"
+        with open(metadata_path, "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=2, default=str)
+
+        feature_schema = {
+            "sequence_length": 1,
+            "features": [{"name": name, "required": True} for name in META_LABEL_FEATURE_ORDER],
+        }
+        feature_schema_path = version_dir / "feature_schema.json"
+        with open(feature_schema_path, "w", encoding="utf-8") as f:
+            json.dump(feature_schema, f, indent=2)
+
+        # Atomic latest symlink update -- mirrors save_artifacts' TOCTOU-safe
+        # temp-symlink-then-replace pattern.
+        latest_link = type_dir / "latest"
+        temp_link = type_dir / f".latest.{version_dir.name}.tmp"
+        try:
+            if temp_link.exists() or temp_link.is_symlink():
+                temp_link.unlink()
+            temp_link.symlink_to(version_dir.name)
+            temp_link.replace(latest_link)
+        except OSError as e:
+            logger.warning("Failed to update latest symlink for meta_label bundle: %s", e)
+
+        artifact_paths = ArtifactPaths(
+            directory=version_dir,
+            keras_path=model_path,  # native (non-ONNX) artifact; sklearn, not Keras
+            onnx_path=onnx_path,
+            metadata_path=metadata_path,
+            plot_path=None,
+        )
+
+        duration = perf_counter() - start_time
+        logger.info(
+            "Meta-label training complete: %d fires, %d resolved, train_accuracy=%.3f",
+            len(fired),
+            len(resolved_fires),
+            train_accuracy,
+        )
+        return TrainingResult(
+            success=True,
+            metadata=metadata,
+            artifact_paths=artifact_paths,
+            duration_seconds=duration,
+        )
+
+    except Exception as exc:
+        duration = perf_counter() - start_time
+        logger.error("Meta-label training failed: %s", exc, exc_info=True)
+        return TrainingResult(
+            success=False,
+            metadata={"error": str(exc)},
+            artifact_paths=None,
+            duration_seconds=duration,
+        )
+
+
 def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
     """Run the training pipeline."""
+    if ctx.config.target_type == "meta_label":
+        # Sklearn-only path -- dispatched BEFORE the TensorFlow availability
+        # check (meta_label needs no TF at all) and BEFORE
+        # validate_target_head_compatibility (ctx.config.model_type is
+        # irrelevant for meta_label; the #947 guard's model_type/target_type
+        # cross-check doesn't apply to this separate training flow).
+        return _run_meta_label_pipeline(ctx)
     if not _TENSORFLOW_AVAILABLE:
         raise ImportError(
             "tensorflow is required for model training but is not installed. "

--- a/src/ml/training_pipeline/sklearn_onnx_export.py
+++ b/src/ml/training_pipeline/sklearn_onnx_export.py
@@ -1,0 +1,122 @@
+"""Hand-rolled ONNX export for a fitted sklearn LogisticRegression.
+
+entrant (a) (meta-labeling) of the TARGET-REDESIGN tournament trains a
+sklearn LogisticRegression as its working classifier -- `lightgbm`,
+`onnxmltools`, and `skl2onnx` are not installed or declared dependencies in
+this repo (checked pyproject.toml/requirements*.txt), so this module builds
+the ONNX graph directly via the `onnx` package (already a declared
+dependency: `onnx>=1.14.0`) instead of pulling in a new dependency for a
+single binary classifier.
+
+The graph is the minimal equivalent of
+``LogisticRegression.predict_proba(X)[:, 1]``: Reshape (squeeze the
+sequence axis OnnxRunner._prepare_input always adds) -> MatMul -> Add ->
+Sigmoid. Matches this repo's existing tf2onnx convention of opset 13
+(artifacts.py's convert_to_onnx); ir_version is pinned to 9 for
+onnxruntime 1.17.0 compatibility (onnx's own default IR_VERSION at the time
+of writing is ahead of what onnxruntime 1.17.0 declares support for).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from sklearn.linear_model import LogisticRegression
+
+_OPSET_VERSION = 13
+_IR_VERSION = 9
+
+
+def export_logistic_regression_to_onnx(
+    model: LogisticRegression,
+    n_features: int,
+    output_path: Path,
+) -> None:
+    """Export a fitted BINARY sklearn LogisticRegression to an ONNX file.
+
+    Args:
+        model: A fitted sklearn LogisticRegression. Must be binary
+            (``model.coef_.shape == (1, n_features)``) -- multi-class
+            (one-vs-rest/multinomial) models are not supported.
+        n_features: Number of input features; must match
+            ``model.coef_.shape[1]``.
+        output_path: Destination ``.onnx`` file path.
+
+    Raises:
+        ValueError: ``model`` is not a fitted binary LogisticRegression, or
+            ``n_features`` doesn't match ``model.coef_``.
+    """
+    import onnx
+    from onnx import TensorProto, helper
+
+    coef = np.asarray(model.coef_, dtype=np.float32)
+    intercept = np.asarray(model.intercept_, dtype=np.float32)
+
+    if coef.ndim != 2 or coef.shape[0] != 1:
+        raise ValueError(
+            f"export_logistic_regression_to_onnx only supports a binary "
+            f"LogisticRegression (coef_.shape == (1, n_features)), got coef_ "
+            f"shape {coef.shape} -- multi-class models are not supported."
+        )
+    if coef.shape[1] != n_features:
+        raise ValueError(
+            f"model.coef_ has {coef.shape[1]} features but n_features={n_features} "
+            f"was requested -- these must match."
+        )
+    if intercept.shape != (1,):
+        raise ValueError(f"Expected intercept_ shape (1,), got {intercept.shape}")
+
+    # Weight matrix for MatMul: (n_features, 1) so a (batch, n_features)
+    # input produces a (batch, 1) output.
+    weight = np.ascontiguousarray(coef.T)
+
+    # OnnxRunner._prepare_input always reshapes a flat feature vector to
+    # (1, 1, n_features) (the (batch, sequence, features) convention every
+    # other model in this registry uses) -- meta-label features are NOT
+    # sequence-shaped, so the graph itself squeezes the size-1 sequence axis
+    # back out via Reshape before the MatMul, rather than requiring a
+    # special-cased caller.
+    input_tensor = helper.make_tensor_value_info(
+        "input", TensorProto.FLOAT, ["batch", "sequence", n_features]
+    )
+    output_tensor = helper.make_tensor_value_info("output", TensorProto.FLOAT, ["batch", 1])
+
+    weight_initializer = helper.make_tensor(
+        "weight", TensorProto.FLOAT, list(weight.shape), weight.flatten().tolist()
+    )
+    bias_initializer = helper.make_tensor(
+        "bias", TensorProto.FLOAT, list(intercept.shape), intercept.tolist()
+    )
+    reshape_shape_initializer = helper.make_tensor(
+        "reshape_shape", TensorProto.INT64, [2], [-1, n_features]
+    )
+
+    reshape_node = helper.make_node(
+        "Reshape", inputs=["input", "reshape_shape"], outputs=["flattened"]
+    )
+    matmul_node = helper.make_node("MatMul", inputs=["flattened", "weight"], outputs=["logits"])
+    add_node = helper.make_node("Add", inputs=["logits", "bias"], outputs=["biased_logits"])
+    sigmoid_node = helper.make_node("Sigmoid", inputs=["biased_logits"], outputs=["output"])
+
+    graph = helper.make_graph(
+        nodes=[reshape_node, matmul_node, add_node, sigmoid_node],
+        name="meta_label_logistic_regression",
+        inputs=[input_tensor],
+        outputs=[output_tensor],
+        initializer=[weight_initializer, bias_initializer, reshape_shape_initializer],
+    )
+
+    onnx_model = helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", _OPSET_VERSION)],
+        ir_version=_IR_VERSION,
+    )
+    onnx.checker.check_model(onnx_model)
+    onnx.save(onnx_model, str(output_path))
+
+
+__all__ = ["export_logistic_regression_to_onnx"]

--- a/src/ml/training_pipeline/task_types.py
+++ b/src/ml/training_pipeline/task_types.py
@@ -1,9 +1,11 @@
 """Model/target task-type declarations and the #947 compatibility guard.
 
 `create_model()` (`models.py`) dispatches to architectures with fixed,
-already-compiled heads: every family except `tft` compiles a regression head
-(`loss="mse"`, an `rmse` metric); `tft` compiles a binary-classification head
-(`loss="binary_crossentropy"`, sigmoid output). Before this module existed,
+already-compiled heads: every family except `tft`/`tft_ternary` compiles a
+regression head (`loss="mse"`, an `rmse` metric); `tft` compiles a
+binary-classification head (`loss="binary_crossentropy"`, sigmoid output);
+`tft_ternary` compiles a 3-class head (`loss="sparse_categorical_crossentropy"`,
+softmax output). Before this module existed,
 `pipeline.py` built the regression close/close_normalized target
 unconditionally regardless of `model_type` — training `tft` silently fit a
 classification head against a continuous price target: no crash, no
@@ -39,6 +41,7 @@ MODEL_TASK_TYPES: dict[str, TaskType] = {
     "tcn": TaskType.REGRESSION,
     "tcn_attention": TaskType.REGRESSION,
     "tft": TaskType.BINARY_CLASSIFICATION,
+    "tft_ternary": TaskType.TERNARY_CLASSIFICATION,
 }
 
 # Every target_type the training pipeline can build a label for, by task

--- a/src/ml/training_pipeline/task_types.py
+++ b/src/ml/training_pipeline/task_types.py
@@ -42,6 +42,16 @@ MODEL_TASK_TYPES: dict[str, TaskType] = {
     "tcn_attention": TaskType.REGRESSION,
     "tft": TaskType.BINARY_CLASSIFICATION,
     "tft_ternary": TaskType.TERNARY_CLASSIFICATION,
+    # Reachable from create_model() (models.py) but requires the optional
+    # lightgbm dependency, which is not installed/declared in this repo --
+    # raises ImportError at construction time (documented follow-up).
+    "lightgbm": TaskType.BINARY_CLASSIFICATION,
+    # entrant (a)'s actual working classifier (sklearn LogisticRegression) --
+    # NOT dispatched via create_model()/model.fit() like the TF/lightgbm
+    # architectures above (see pipeline.py's _run_meta_label_pipeline, a
+    # separate training path). Declared here so the #947 guard and metadata
+    # conventions (task_type, class_labels) still apply uniformly.
+    "meta_label_logistic": TaskType.BINARY_CLASSIFICATION,
 }
 
 # Every target_type the training pipeline can build a label for, by task

--- a/src/prediction/engine.py
+++ b/src/prediction/engine.py
@@ -700,6 +700,20 @@ class PredictionEngine:
                     "loaded": True,
                     "inference_time_avg": self._get_model_avg_inference_time(bundle.key),
                 }
+        # list_bundles() only exposes "latest" per (symbol, timeframe,
+        # model_type) -- a caller pinning to a SPECIFIC, non-latest version
+        # (e.g. the TARGET-REDESIGN exam harness's fold-runner) passes that
+        # version's exact bundle.key, which won't appear above. Mirrors
+        # _resolve_bundle's identical fallback.
+        versioned_bundle = self.model_registry.get_bundle_by_key(model_name)
+        if versioned_bundle is not None:
+            return {
+                "name": versioned_bundle.key,
+                "path": getattr(versioned_bundle.runner, "model_path", None),
+                "metadata": versioned_bundle.metadata,
+                "loaded": True,
+                "inference_time_avg": self._get_model_avg_inference_time(versioned_bundle.key),
+            }
         return {}
 
     def get_performance_stats(self) -> dict[str, Any]:

--- a/src/prediction/engine.py
+++ b/src/prediction/engine.py
@@ -1017,6 +1017,14 @@ class PredictionEngine:
             for bundle in bundles:
                 if bundle.key == model_name:
                     return bundle
+            # list_bundles() only exposes "latest" per (symbol, timeframe,
+            # model_type) -- a caller pinning to a SPECIFIC, non-latest
+            # version (e.g. the TARGET-REDESIGN exam harness's fold-runner)
+            # passes that version's exact bundle.key, which won't appear
+            # above. get_bundle_by_key searches every loaded version.
+            versioned_bundle = self.model_registry.get_bundle_by_key(model_name)
+            if versioned_bundle is not None:
+                return versioned_bundle
             raise ModelNotFoundError(f"Model '{model_name}' not found")
 
         if bundles:

--- a/src/prediction/models/registry.py
+++ b/src/prediction/models/registry.py
@@ -78,11 +78,22 @@ class PredictionModelRegistry:
         self._bundles: dict[tuple[str, str, str], StrategyModel] = {}
         # Optional production selections: (symbol, timeframe, model_type) -> version_id
         self._production_index: dict[tuple[str, str, str], str] = {}
-        # Every loaded bundle, keyed by its EXACT version_id --
-        # (symbol, timeframe, model_type, version_id) -> StrategyModel. Lets
-        # get_bundle_by_key() find a specific non-latest version by its full
-        # key, unlike select_bundle()/list_bundles() (latest-wins).
+        # LOADED bundles only, keyed by their EXACT
+        # (symbol, timeframe, model_type, version_id). Seeded from _bundles
+        # (the "latest"/fallback bundle per key -- already loaded, zero
+        # extra cost) and grown lazily by get_bundle_by_key() the first time
+        # a caller pins a specific non-latest version. Deliberately NOT
+        # populated for every version on disk at scan time -- opening an
+        # ONNX InferenceSession per version would make the live 24/7
+        # process's memory grow unbounded as versions accumulate (PR #950
+        # review finding). See _versioned_bundle_paths for the lightweight
+        # (no-session) index of what's available to lazily load.
         self._versioned_bundles: dict[tuple[str, str, str, str], StrategyModel] = {}
+        # Every on-disk version's key -> directory, indexed cheaply (metadata
+        # JSON parse only, no OnnxRunner/InferenceSession) at scan time.
+        # get_bundle_by_key() consults this to lazily load a version nobody
+        # has pinned yet.
+        self._versioned_bundle_paths: dict[tuple[str, str, str, str], Path] = {}
         # RLock for thread-safe atomic swaps during reload. RLock (re-entrant) is used
         # rather than Lock because _load and reload_models share traversal logic, and a
         # future refactoring to consolidate them could call locked methods internally.
@@ -95,19 +106,27 @@ class PredictionModelRegistry:
     ) -> tuple[
         dict[tuple[str, str, str], StrategyModel],
         dict[tuple[str, str, str], str],
-        dict[tuple[str, str, str, str], StrategyModel],
+        dict[tuple[str, str, str, str], Path],
     ]:
-        """Scan the registry directory and load all bundles.
+        """Scan the registry directory, eagerly loading only "latest" bundles.
+
+        Every concrete version directory is indexed by its
+        (symbol, timeframe, model_type, version_id) key -> Path (a cheap
+        metadata.json parse, no ONNX session opened) so a non-latest
+        version stays discoverable for get_bundle_by_key() without paying
+        the InferenceSession-per-version cost at scan time -- steady-state
+        live memory must stay O(latest), not O(every version ever trained).
 
         Returns:
-            Tuple of (bundles dict, production index dict, versioned bundles dict).
+            Tuple of (bundles dict, production index dict, versioned bundle
+            PATHS dict -- not loaded StrategyModel instances).
         """
         bundles: dict[tuple[str, str, str], StrategyModel] = {}
         production_index: dict[tuple[str, str, str], str] = {}
-        versioned_bundles: dict[tuple[str, str, str, str], StrategyModel] = {}
+        versioned_paths: dict[tuple[str, str, str, str], Path] = {}
         base = Path(self.config.model_registry_path)
         if not base.exists():
-            return bundles, production_index, versioned_bundles
+            return bundles, production_index, versioned_paths
         # Expect structure: base/{symbol}/{model_type}/{version_id}/model.onnx
         for symbol_dir in base.iterdir():
             if not symbol_dir.is_dir():
@@ -117,33 +136,94 @@ class PredictionModelRegistry:
                 if not mtype_dir.is_dir():
                     continue
                 model_type = mtype_dir.name
-                # Load concrete versions first so the latest symlink assignment wins
                 latest = mtype_dir / "latest"
                 version_dirs = [p for p in mtype_dir.iterdir() if p.is_dir() and p.name != "latest"]
-                # Deterministic order keeps logging/tests stable; latest applied afterwards
+                # Deterministic order keeps logging/tests stable
                 version_dirs.sort()
+
+                # Index every concrete version's key -> path WITHOUT opening
+                # its ONNX InferenceSession -- see get_bundle_by_key for the
+                # lazy load this enables.
                 for vdir in version_dirs:
                     try:
-                        bundle = self._load_bundle(symbol, model_type, vdir)
+                        key4 = self._peek_version_key(symbol, model_type, vdir)
+                    except Exception as e:  # pragma: no cover - aggregated logging
+                        logger.error("Failed to index version at %s: %s", vdir, e)
+                        continue
+                    if key4 is not None:
+                        versioned_paths[key4] = vdir
+
+                # Eagerly load a fallback bundle (the highest-sorted version)
+                # only when no `latest` symlink exists yet -- preserves prior
+                # behavior for a mid-training/symlink-missing model_type dir
+                # without eagerly loading every OTHER version too.
+                if not latest.exists() and version_dirs:
+                    fallback_dir = version_dirs[-1]
+                    try:
+                        bundle = self._load_bundle(symbol, model_type, fallback_dir)
                         key = (bundle.symbol, bundle.timeframe, bundle.model_type)
                         bundles[key] = bundle
-                        versioned_bundles[(*key, bundle.version_id)] = bundle
                     except Exception as e:  # pragma: no cover - aggregated logging
-                        logger.error("Failed to load bundle at %s: %s", vdir, e)
+                        logger.error("Failed to load bundle at %s: %s", fallback_dir, e)
                 if latest.exists():
                     try:
                         bundle = self._load_bundle(symbol, model_type, latest)
                         key = (bundle.symbol, bundle.timeframe, bundle.model_type)
                         bundles[key] = bundle
                         production_index[key] = bundle.version_id
-                        versioned_bundles[(*key, bundle.version_id)] = bundle
                     except Exception as e:  # pragma: no cover - aggregated logging
                         logger.error("Failed to load bundle at %s: %s", latest, e)
-        return bundles, production_index, versioned_bundles
+        return bundles, production_index, versioned_paths
+
+    def _peek_version_key(
+        self, symbol: str, model_type: str, vdir: Path
+    ) -> tuple[str, str, str, str] | None:
+        """Cheaply resolve a version directory's full StrategyModel key
+        (symbol, timeframe, model_type, version_id) WITHOUT constructing an
+        OnnxRunner -- indexing every on-disk version must not open an ONNX
+        InferenceSession for versions nobody has pinned yet.
+
+        Mirrors _load_bundle's timeframe-resolution logic (metadata.json's
+        "timeframe" field, falling back to parsing the version_id) so the
+        key matches exactly what a real (lazy) load would later produce.
+        Best-effort: returns None on any error (path traversal, missing/
+        corrupt directory) and lets get_bundle_by_key's actual load raise a
+        proper error if that specific version is ever requested.
+        """
+        try:
+            real_dir = vdir.resolve()
+            registry_base = Path(self.config.model_registry_path).resolve()
+            real_dir.relative_to(registry_base)
+        except (OSError, ValueError):
+            return None
+
+        version_id = real_dir.name
+        timeframe = "unknown"
+        metadata_path = real_dir / "metadata.json"
+        if metadata_path.exists():
+            import json
+
+            try:
+                with open(metadata_path, encoding="utf-8") as f:
+                    md = json.load(f)
+                if isinstance(md, dict):
+                    timeframe = str(md.get("timeframe", timeframe))
+            except (json.JSONDecodeError, OSError):
+                pass
+        else:
+            parts = version_id.split("_")
+            if len(parts) >= 2:
+                timeframe = parts[1]
+        return (symbol, timeframe, model_type, version_id)
 
     def _load(self) -> None:
         """Load structured bundles from the configured registry path."""
-        self._bundles, self._production_index, self._versioned_bundles = self._scan_registry()
+        self._bundles, self._production_index, self._versioned_bundle_paths = self._scan_registry()
+        # Seed _versioned_bundles from the already-loaded "latest"/fallback
+        # bundles only -- zero extra cost, no new sessions opened.
+        self._versioned_bundles = {
+            (b.symbol, b.timeframe, b.model_type, b.version_id): b for b in self._bundles.values()
+        }
 
     def _load_bundle(self, symbol: str, model_type: str, vdir: Path) -> StrategyModel:
         """Load a single bundle directory into a ModelBundle."""
@@ -312,16 +392,23 @@ class PredictionModelRegistry:
             return bundle
 
     def get_bundle_by_key(self, key: str) -> StrategyModel | None:
-        """Look up any loaded bundle -- including a non-latest version -- by
-        its exact ``StrategyModel.key`` string.
+        """Look up any bundle -- including a non-latest version -- by its
+        exact ``StrategyModel.key`` string, loading it on first use.
 
         Unlike ``select_bundle``/``list_bundles`` (latest-wins, one entry
-        per symbol/timeframe/model_type), this searches every version ever
-        loaded (``_versioned_bundles``). Used by
-        ``PredictionEngine._resolve_bundle`` as a fallback when a
-        ``model_name`` doesn't match any currently-latest bundle -- e.g. the
-        TARGET-REDESIGN exam harness's fold-runner pinning a specific
-        version via ``f"{symbol}:{timeframe}:{model_type}:{version_id}"``.
+        per symbol/timeframe/model_type), this can find every version ever
+        trained. Used by ``PredictionEngine._resolve_bundle`` as a fallback
+        when a ``model_name`` doesn't match any currently-latest bundle --
+        e.g. the TARGET-REDESIGN exam harness's fold-runner pinning a
+        specific version via ``f"{symbol}:{timeframe}:{model_type}:{version_id}"``.
+
+        A non-latest version's ONNX InferenceSession is opened LAZILY, the
+        first time it's actually requested here -- not at registry-scan
+        time. This method is exam-only (never called on the live trading
+        path, which only ever calls ``select_bundle``), so live steady-state
+        memory stays O(latest) regardless of how many versions accumulate
+        on disk; the lazily-loaded session is cached in ``_versioned_bundles``
+        so a repeated pin for the same version doesn't reopen it.
 
         Thread-safe: Acquires lock so the result is from the current
         generation.
@@ -330,6 +417,17 @@ class PredictionModelRegistry:
             for bundle in self._versioned_bundles.values():
                 if bundle.key == key:
                     return bundle
+            for key4, vdir in self._versioned_bundle_paths.items():
+                symbol, timeframe, model_type, version_id = key4
+                if f"{symbol}:{timeframe}:{model_type}:{version_id}" != key:
+                    continue
+                try:
+                    bundle = self._load_bundle(symbol, model_type, vdir)
+                except Exception as e:
+                    logger.error("Failed to lazily load pinned version at %s: %s", vdir, e)
+                    return None
+                self._versioned_bundles[key4] = bundle
+                return bundle
             return None
 
     def select_many(
@@ -387,13 +485,18 @@ class PredictionModelRegistry:
         predictions continue working with the previous model versions.
         """
         # Load new bundles in background (outside lock to avoid blocking)
-        new_bundles, new_production_index, new_versioned_bundles = self._scan_registry()
+        new_bundles, new_production_index, new_versioned_paths = self._scan_registry()
 
         # Preserve existing bundles when reload produces empty results (e.g., transient
         # filesystem issue, NFS timeout, Docker volume unmount). This prevents a full
         # prediction outage from a temporary registry path unavailability.
         with self._lock:
             old_bundles = self._bundles
+            # Everything actually LOADED under the old generation: the
+            # latest/fallback bundles plus any version a caller had pinned
+            # via get_bundle_by_key during this generation's lifetime (both
+            # must be closed below; versions never pinned were never opened
+            # in the first place, so there's nothing to close for them).
             old_versioned_bundles = self._versioned_bundles
             if not new_bundles and old_bundles:
                 logger.warning(
@@ -405,7 +508,14 @@ class PredictionModelRegistry:
                 return
             self._bundles = new_bundles
             self._production_index = new_production_index
-            self._versioned_bundles = new_versioned_bundles
+            self._versioned_bundle_paths = new_versioned_paths
+            # Re-seed from the newly-loaded latest/fallback bundles only --
+            # any previously-pinned non-latest version must be re-requested
+            # (and re-loaded) through get_bundle_by_key against the new
+            # generation; it is not carried forward.
+            self._versioned_bundles = {
+                (b.symbol, b.timeframe, b.model_type, b.version_id): b for b in new_bundles.values()
+            }
 
         # Invalidate prediction caches after model swap to prevent stale
         # features from being served with the new model weights.
@@ -425,11 +535,12 @@ class PredictionModelRegistry:
             )
 
         # Close old runners outside lock to avoid blocking other threads.
-        # old_versioned_bundles holds strictly more StrategyModel instances
-        # than old_bundles (every concrete version, not just "latest") --
-        # the latest-resolved bundle is the SAME object in both dicts, so
-        # dedup by identity to close each distinct runner exactly once
-        # (never double-close, never leak a version-pinned session).
+        # old_versioned_bundles may hold MORE StrategyModel instances than
+        # old_bundles (the latest/fallback bundles plus any version a caller
+        # lazily pinned via get_bundle_by_key during this generation) -- the
+        # latest-resolved bundle is the SAME object in both dicts, so dedup
+        # by identity to close each distinct runner exactly once (never
+        # double-close, never leak a version-pinned session).
         seen_ids: set[int] = set()
         old_all_bundles: list[StrategyModel] = []
         for bundle in (*old_bundles.values(), *old_versioned_bundles.values()):

--- a/src/prediction/models/registry.py
+++ b/src/prediction/models/registry.py
@@ -74,9 +74,15 @@ class PredictionModelRegistry:
         self.config = config
         self.cache_manager = cache_manager
         # Structured bundles keyed by (symbol, timeframe, model_type) -> StrategyModel
+        # ("latest wins" -- see _scan_registry)
         self._bundles: dict[tuple[str, str, str], StrategyModel] = {}
         # Optional production selections: (symbol, timeframe, model_type) -> version_id
         self._production_index: dict[tuple[str, str, str], str] = {}
+        # Every loaded bundle, keyed by its EXACT version_id --
+        # (symbol, timeframe, model_type, version_id) -> StrategyModel. Lets
+        # get_bundle_by_key() find a specific non-latest version by its full
+        # key, unlike select_bundle()/list_bundles() (latest-wins).
+        self._versioned_bundles: dict[tuple[str, str, str, str], StrategyModel] = {}
         # RLock for thread-safe atomic swaps during reload. RLock (re-entrant) is used
         # rather than Lock because _load and reload_models share traversal logic, and a
         # future refactoring to consolidate them could call locked methods internally.
@@ -86,17 +92,22 @@ class PredictionModelRegistry:
 
     def _scan_registry(
         self,
-    ) -> tuple[dict[tuple[str, str, str], StrategyModel], dict[tuple[str, str, str], str]]:
+    ) -> tuple[
+        dict[tuple[str, str, str], StrategyModel],
+        dict[tuple[str, str, str], str],
+        dict[tuple[str, str, str, str], StrategyModel],
+    ]:
         """Scan the registry directory and load all bundles.
 
         Returns:
-            Tuple of (bundles dict, production index dict).
+            Tuple of (bundles dict, production index dict, versioned bundles dict).
         """
         bundles: dict[tuple[str, str, str], StrategyModel] = {}
         production_index: dict[tuple[str, str, str], str] = {}
+        versioned_bundles: dict[tuple[str, str, str, str], StrategyModel] = {}
         base = Path(self.config.model_registry_path)
         if not base.exists():
-            return bundles, production_index
+            return bundles, production_index, versioned_bundles
         # Expect structure: base/{symbol}/{model_type}/{version_id}/model.onnx
         for symbol_dir in base.iterdir():
             if not symbol_dir.is_dir():
@@ -116,6 +127,7 @@ class PredictionModelRegistry:
                         bundle = self._load_bundle(symbol, model_type, vdir)
                         key = (bundle.symbol, bundle.timeframe, bundle.model_type)
                         bundles[key] = bundle
+                        versioned_bundles[(*key, bundle.version_id)] = bundle
                     except Exception as e:  # pragma: no cover - aggregated logging
                         logger.error("Failed to load bundle at %s: %s", vdir, e)
                 if latest.exists():
@@ -124,13 +136,14 @@ class PredictionModelRegistry:
                         key = (bundle.symbol, bundle.timeframe, bundle.model_type)
                         bundles[key] = bundle
                         production_index[key] = bundle.version_id
+                        versioned_bundles[(*key, bundle.version_id)] = bundle
                     except Exception as e:  # pragma: no cover - aggregated logging
                         logger.error("Failed to load bundle at %s: %s", latest, e)
-        return bundles, production_index
+        return bundles, production_index, versioned_bundles
 
     def _load(self) -> None:
         """Load structured bundles from the configured registry path."""
-        self._bundles, self._production_index = self._scan_registry()
+        self._bundles, self._production_index, self._versioned_bundles = self._scan_registry()
 
     def _load_bundle(self, symbol: str, model_type: str, vdir: Path) -> StrategyModel:
         """Load a single bundle directory into a ModelBundle."""
@@ -279,6 +292,14 @@ class PredictionModelRegistry:
 
         If stage is provided and a production index exists, use it. Otherwise, use the
         most recently loaded bundle for that key (latest symlink is preferred by _load()).
+
+        Deliberately NOT version-pinnable: this method is also called
+        unconditionally on the LIVE trading path (ml_signal_generator.py),
+        so it always resolves "latest" with no override. Version pinning
+        (e.g. the exam harness pinning a specific fold's model) goes
+        through ``get_bundle_by_key`` instead, which only activates when a
+        caller explicitly passes a full bundle key -- exam-only code never
+        imported by the live runner.
         """
         with self._lock:
             key = (symbol, timeframe, model_type)
@@ -289,6 +310,27 @@ class PredictionModelRegistry:
                 )
             # Stage currently informational; production_index ensures latest symlink dominance
             return bundle
+
+    def get_bundle_by_key(self, key: str) -> StrategyModel | None:
+        """Look up any loaded bundle -- including a non-latest version -- by
+        its exact ``StrategyModel.key`` string.
+
+        Unlike ``select_bundle``/``list_bundles`` (latest-wins, one entry
+        per symbol/timeframe/model_type), this searches every version ever
+        loaded (``_versioned_bundles``). Used by
+        ``PredictionEngine._resolve_bundle`` as a fallback when a
+        ``model_name`` doesn't match any currently-latest bundle -- e.g. the
+        TARGET-REDESIGN exam harness's fold-runner pinning a specific
+        version via ``f"{symbol}:{timeframe}:{model_type}:{version_id}"``.
+
+        Thread-safe: Acquires lock so the result is from the current
+        generation.
+        """
+        with self._lock:
+            for bundle in self._versioned_bundles.values():
+                if bundle.key == key:
+                    return bundle
+            return None
 
     def select_many(
         self,
@@ -345,13 +387,14 @@ class PredictionModelRegistry:
         predictions continue working with the previous model versions.
         """
         # Load new bundles in background (outside lock to avoid blocking)
-        new_bundles, new_production_index = self._scan_registry()
+        new_bundles, new_production_index, new_versioned_bundles = self._scan_registry()
 
         # Preserve existing bundles when reload produces empty results (e.g., transient
         # filesystem issue, NFS timeout, Docker volume unmount). This prevents a full
         # prediction outage from a temporary registry path unavailability.
         with self._lock:
             old_bundles = self._bundles
+            old_versioned_bundles = self._versioned_bundles
             if not new_bundles and old_bundles:
                 logger.warning(
                     "reload_models produced 0 bundles (had %d) — keeping existing bundles. "
@@ -362,6 +405,7 @@ class PredictionModelRegistry:
                 return
             self._bundles = new_bundles
             self._production_index = new_production_index
+            self._versioned_bundles = new_versioned_bundles
 
         # Invalidate prediction caches after model swap to prevent stale
         # features from being served with the new model weights.
@@ -380,8 +424,20 @@ class PredictionModelRegistry:
                 "after model reload to avoid stale predictions"
             )
 
-        # Close old runners outside lock to avoid blocking other threads
-        for bundle in old_bundles.values():
+        # Close old runners outside lock to avoid blocking other threads.
+        # old_versioned_bundles holds strictly more StrategyModel instances
+        # than old_bundles (every concrete version, not just "latest") --
+        # the latest-resolved bundle is the SAME object in both dicts, so
+        # dedup by identity to close each distinct runner exactly once
+        # (never double-close, never leak a version-pinned session).
+        seen_ids: set[int] = set()
+        old_all_bundles: list[StrategyModel] = []
+        for bundle in (*old_bundles.values(), *old_versioned_bundles.values()):
+            if id(bundle) not in seen_ids:
+                seen_ids.add(id(bundle))
+                old_all_bundles.append(bundle)
+
+        for bundle in old_all_bundles:
             if hasattr(bundle.runner, "close"):
                 try:
                     bundle.runner.close()

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -235,8 +235,19 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
             )
 
         current_price = df["close"].iloc[index]
-        prediction = result.price
-        if not (math.isfinite(prediction) and math.isfinite(current_price) and current_price > 0):
+        # result.price for a smoothed_return-target model IS the predicted
+        # return already (the model was trained on
+        # smoothed_forward_return_labels, a return-scale target -- see
+        # labels.py). It is NOT a price level: smoothed_return metadata
+        # carries no price_normalization, so OnnxRunner never denormalizes
+        # it, and re-deriving (prediction-current_price)/current_price here
+        # would treat a ~0.002-scale return as if it were a ~60000-scale
+        # price, saturating to ~-1.0 (all-SELL, confidence clamped to 1.0)
+        # on virtually every bar. current_price is still validated as a
+        # basic data-sanity check (a non-finite/non-positive close means
+        # something upstream is broken), just no longer used arithmetically.
+        predicted_return = result.price
+        if not (math.isfinite(predicted_return) and math.isfinite(current_price) and current_price > 0):
             return Signal(
                 direction=SignalDirection.HOLD,
                 strength=0.0,
@@ -244,13 +255,11 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
                 metadata={
                     "generator": self.name,
                     "reason": "invalid_prediction_or_price",
-                    "prediction": prediction,
+                    "prediction": predicted_return,
                     "current_price": current_price,
                     "index": index,
                 },
             )
-
-        predicted_return = (prediction - current_price) / current_price
 
         distribution = self._distribution_for(result)
         if distribution is None:
@@ -277,7 +286,7 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
 
         metadata: dict[str, Any] = {
             "generator": self.name,
-            "prediction": prediction,
+            "prediction": predicted_return,
             "current_price": current_price,
             "predicted_return": predicted_return,
             "index": index,
@@ -299,10 +308,10 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
         if result is None or result.error is not None:
             return 0.0
         current_price = df["close"].iloc[index]
-        prediction = result.price
-        if not (math.isfinite(prediction) and math.isfinite(current_price) and current_price > 0):
+        # See generate_signal: result.price IS the predicted return already.
+        predicted_return = result.price
+        if not (math.isfinite(predicted_return) and math.isfinite(current_price) and current_price > 0):
             return 0.0
-        predicted_return = (prediction - current_price) / current_price
         distribution = self._distribution_for(result)
         if distribution is None:
             return 0.0

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -247,7 +247,9 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
         # basic data-sanity check (a non-finite/non-positive close means
         # something upstream is broken), just no longer used arithmetically.
         predicted_return = result.price
-        if not (math.isfinite(predicted_return) and math.isfinite(current_price) and current_price > 0):
+        if not (
+            math.isfinite(predicted_return) and math.isfinite(current_price) and current_price > 0
+        ):
             return Signal(
                 direction=SignalDirection.HOLD,
                 strength=0.0,
@@ -310,7 +312,9 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
         current_price = df["close"].iloc[index]
         # See generate_signal: result.price IS the predicted return already.
         predicted_return = result.price
-        if not (math.isfinite(predicted_return) and math.isfinite(current_price) and current_price > 0):
+        if not (
+            math.isfinite(predicted_return) and math.isfinite(current_price) and current_price > 0
+        ):
             return 0.0
         distribution = self._distribution_for(result)
         if distribution is None:

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -21,12 +21,33 @@ from __future__ import annotations
 
 import logging
 import math
+from collections import deque
+from dataclasses import dataclass
 from typing import Any
 
+import numpy as np
+import pandas as pd
+
+from src.config.constants import (
+    DEFAULT_MAX_HOLDING_HOURS,
+    DEFAULT_STOP_LOSS_PCT,
+    DEFAULT_TAKE_PROFIT_PCT,
+)
+from src.engines.shared.barrier_touch import check_barrier_touch
+from src.engines.shared.cost_calculator import CostCalculator
+from src.ml.training_pipeline.meta_labels import (
+    HIT_RATE_LOOKBACK_FIRES,
+    REALIZED_VOL_WINDOW_BARS,
+    _session_cyclical_encoding,
+    encode_meta_label_feature_row,
+)
+from src.performance.metrics import Side, pnl_percent
 from src.prediction import PredictionConfig, PredictionEngine, PredictionResult
 from src.prediction.distribution_stats import FrozenDistribution, percentile_rank_confidence
 from src.prediction.features.pipeline import FeaturePipeline
 from src.prediction.features.price_only import PriceOnlyFeatureExtractor
+from src.prediction.models.registry import PredictionModelRegistry
+from src.regime.enhanced_detector import EnhancedRegimeDetector
 from src.strategies.components.regime_context import RegimeContext
 from src.strategies.components.signal_generator import Signal, SignalDirection, SignalGenerator
 
@@ -371,4 +392,333 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
         return params
 
 
-__all__ = ["ClassificationExamSignalGenerator", "SmoothedReturnExamSignalGenerator"]
+@dataclass
+class _OpenFire:
+    """A primary signal fire whose trade outcome hasn't resolved yet."""
+
+    fire_index: int
+    direction: int  # 1 (long) or -1 (short)
+    entry_price: float
+    stop_loss_price: float
+    take_profit_price: float
+    vertical_exit_index: int
+
+
+class MetaLabelExamSignalGenerator(SignalGenerator):
+    """Entrant (a): gates a wrapped primary SignalGenerator by P(profitable).
+
+    Unlike ``ClassificationExamSignalGenerator``, this classifier's output
+    is NOT a direction prediction -- it's P(the primary signal's fired trade
+    is profitable). The primary signal supplies direction; this generator
+    only decides whether to act on it.
+
+    STATEFUL and causal BY CONSTRUCTION, which is the entire point:
+    ``resolve_fired_trade``/``build_meta_label_features``
+    (``src/ml/training_pipeline/meta_labels.py``) are TRAINING-TIME-ONLY --
+    they read forward bars deliberately, which is fine for labeling a
+    COMPLETE historical corpus but would be a genuine lookahead bug if
+    called from inside ``generate_signal()`` for the CURRENT bar (it would
+    read bars strictly after "now" in a live/backtest loop). This class
+    instead resolves open fires bar-by-bar via ``check_barrier_touch`` (the
+    same intrabar high/low logic ``ExitHandler``/``triple_barrier_labels``
+    use) as later bars naturally arrive, reconstructing the training-time
+    ``rolling_hit_rate_20`` feature online. ``generate_signal`` MUST be
+    called in strictly increasing ``index`` order -- the same contract every
+    backtest/live engine in this codebase already guarantees.
+    """
+
+    def __init__(
+        self,
+        primary_signal_generator: SignalGenerator,
+        name: str = "meta_label_exam_signal_generator",
+        model_name: str | None = None,
+        symbol: str = "BTCUSDT",
+        timeframe: str = "1h",
+        min_confidence: float = 0.5,
+        take_profit_pct: float = DEFAULT_TAKE_PROFIT_PCT,
+        stop_loss_pct: float = DEFAULT_STOP_LOSS_PCT,
+        max_holding_bars: int = DEFAULT_MAX_HOLDING_HOURS,
+        resolved_history_maxlen: int = 500,
+    ) -> None:
+        super().__init__(name)
+        self.primary_signal_generator = primary_signal_generator
+        self.model_name = model_name
+        self.symbol = symbol
+        self.timeframe = timeframe
+        self.min_confidence = min_confidence
+        self.take_profit_pct = take_profit_pct
+        self.stop_loss_pct = stop_loss_pct
+        self.max_holding_bars = max_holding_bars
+        self._open_fires: list[_OpenFire] = []
+        self._resolved_history: deque[bool] = deque(maxlen=resolved_history_maxlen)
+        self._regime_detector = EnhancedRegimeDetector()
+        self._cost_calculator = CostCalculator()
+        self._bundle = self._load_bundle()
+        # generate_signal has side effects (fire registration/resolution);
+        # cache the last (index, Signal) pair so a same-index re-call (e.g.
+        # get_confidence(df, index) after generate_signal(df, index)) never
+        # double-registers or double-resolves.
+        self._last_signal_index: int | None = None
+        self._last_signal: Signal | None = None
+
+    def _load_bundle(self) -> Any:
+        """Resolve the meta_label registry bundle once at construction.
+
+        Bypasses PredictionEngine/FeaturePipeline entirely -- meta-label
+        features are pre-computed tabular values (encode_meta_label_feature_row),
+        not something a generic OHLCV feature pipeline should re-derive.
+        Calls the ONNX runner directly, same as PredictionEngine does
+        internally after its own bundle resolution.
+        """
+        try:
+            config = PredictionConfig.from_config_manager()
+            registry = PredictionModelRegistry(config)
+            if self.model_name:
+                bundle = registry.get_bundle_by_key(self.model_name)
+                if bundle is not None:
+                    return bundle
+                logger.warning(
+                    "MetaLabelExamSignalGenerator: pinned model_name=%r not found, "
+                    "falling back to latest meta_label bundle",
+                    self.model_name,
+                )
+            return registry.select_bundle(
+                symbol=self.symbol, model_type="meta_label", timeframe=self.timeframe
+            )
+        except Exception:
+            logger.exception("MetaLabelExamSignalGenerator: failed to load meta_label bundle")
+            return None
+
+    def _resolve_open_fires(self, df: Any, index: int) -> None:
+        """Resolve any open fires against bar `index`'s OHLC, causally.
+
+        Only ever looks at df.iloc[index] (the bar that just "arrived") --
+        never forward. Fires that resolve are appended to
+        _resolved_history; fires that don't stay open for a later call.
+        """
+        high = float(df["high"].iloc[index])
+        low = float(df["low"].iloc[index])
+        still_open: list[_OpenFire] = []
+        for fire in self._open_fires:
+            side = "long" if fire.direction == 1 else "short"
+            touch = check_barrier_touch(
+                side=side,
+                candle_high=high,
+                candle_low=low,
+                stop_loss_price=fire.stop_loss_price,
+                take_profit_price=fire.take_profit_price,
+            )
+            exit_price: float | None = None
+            if touch.hit_stop_loss:
+                exit_price = touch.stop_loss_exit_price
+            elif touch.hit_take_profit:
+                exit_price = touch.take_profit_exit_price
+            elif index >= fire.vertical_exit_index:
+                exit_price = float(df["close"].iloc[index])
+
+            if exit_price is None:
+                still_open.append(fire)
+                continue
+
+            side_enum = Side.LONG if fire.direction == 1 else Side.SHORT
+            raw_pct_return = pnl_percent(fire.entry_price, exit_price, side_enum, fraction=1.0)
+            round_trip_cost_pct = 2.0 * self._cost_calculator.fee_rate
+            profitable = bool((raw_pct_return - round_trip_cost_pct) > 0.0)
+            self._resolved_history.append(profitable)
+
+        self._open_fires = still_open
+
+    def _register_fire(self, df: Any, index: int, direction: int) -> None:
+        entry_price = float(df["close"].iloc[index])
+        if direction == 1:
+            stop_loss_price = entry_price * (1.0 - self.stop_loss_pct)
+            take_profit_price = entry_price * (1.0 + self.take_profit_pct)
+        else:
+            stop_loss_price = entry_price * (1.0 + self.stop_loss_pct)
+            take_profit_price = entry_price * (1.0 - self.take_profit_pct)
+        self._open_fires.append(
+            _OpenFire(
+                fire_index=index,
+                direction=direction,
+                entry_price=entry_price,
+                stop_loss_price=stop_loss_price,
+                take_profit_price=take_profit_price,
+                vertical_exit_index=index + self.max_holding_bars,
+            )
+        )
+
+    def _rolling_hit_rate(self) -> float:
+        if not self._resolved_history:
+            return float("nan")
+        recent = list(self._resolved_history)[-HIT_RATE_LOOKBACK_FIRES:]
+        return float(np.mean(recent))
+
+    def _realized_volatility(self, df: Any, index: int) -> float:
+        """Causal 48-bar trailing realized volatility, ending at `index`."""
+        window_start = max(0, index - REALIZED_VOL_WINDOW_BARS)
+        close_window = df["close"].iloc[window_start : index + 1]
+        returns = close_window.pct_change()
+        return float(returns.std())
+
+    def generate_signal(self, df: Any, index: int, regime: RegimeContext | None = None) -> Signal:
+        """Caching wrapper: generate_signal has side effects (fire
+        registration/resolution), so a same-index re-call (e.g. a caller's
+        own get_confidence(df, index) after generate_signal(df, index))
+        must return the CACHED result rather than double-registering the
+        fire or double-resolving open fires against the same bar."""
+        if index == self._last_signal_index and self._last_signal is not None:
+            return self._last_signal
+        signal = self._generate_signal_impl(df, index, regime)
+        self._last_signal_index = index
+        self._last_signal = signal
+        return signal
+
+    def _generate_signal_impl(
+        self, df: Any, index: int, regime: RegimeContext | None = None
+    ) -> Signal:
+        self.validate_inputs(df, index)
+        self._resolve_open_fires(df, index)
+
+        primary_signal = self.primary_signal_generator.generate_signal(df, index, regime)
+        if primary_signal.direction == SignalDirection.HOLD:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={"generator": self.name, "reason": "primary_hold", "index": index},
+            )
+
+        direction = 1 if primary_signal.direction == SignalDirection.BUY else -1
+        # Register the fire unconditionally (regardless of the meta-gate's
+        # eventual verdict) -- rolling_hit_rate_20 tracks the PRIMARY
+        # signal's own track record, matching training-time semantics
+        # (run_primary_signal_forward records every fire, not just ones a
+        # meta-classifier would later approve).
+        self._register_fire(df, index, direction)
+
+        if self._bundle is None:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={"generator": self.name, "reason": "no_meta_label_bundle", "index": index},
+            )
+
+        timestamp = df.index[index]
+        session_sin, session_cos = _session_cyclical_encoding(pd.Timestamp(timestamp))
+        regime_ctx = self._regime_detector.detect_regime(df, index)
+        predicted_return_magnitude = abs(
+            float(primary_signal.metadata.get("predicted_return", 0.0))
+        )
+
+        feature_row = encode_meta_label_feature_row(
+            realized_vol_48=self._realized_volatility(df, index),
+            rolling_hit_rate_20=self._rolling_hit_rate(),
+            session_sin=session_sin,
+            session_cos=session_cos,
+            regime_trend=regime_ctx.trend.value,
+            regime_volatility=regime_ctx.volatility.value,
+            regime_confidence=float(regime_ctx.confidence),
+            predicted_return_magnitude=predicted_return_magnitude,
+        )
+
+        try:
+            prediction = self._bundle.runner.predict(feature_row)
+        except Exception:
+            logger.exception("MetaLabelExamSignalGenerator: prediction error at index %d", index)
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={"generator": self.name, "reason": "prediction_failed", "index": index},
+            )
+
+        probabilities = getattr(prediction, "probabilities", None)
+        if probabilities is None or len(probabilities) != 2:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=0.0,
+                metadata={
+                    "generator": self.name,
+                    "reason": "invalid_meta_label_output",
+                    "index": index,
+                },
+            )
+
+        # class_labels=[0, 1] ("not profitable", "profitable") -- probabilities[1]
+        # IS P(profitable) directly, regardless of which class argmax picked
+        # (see pipeline.py::_run_meta_label_pipeline's metadata comment and
+        # task_types.py's TARGET_CLASS_LABELS docstring: meta_label's output
+        # is a profitability GATE, not a direction-value classifier).
+        p_profitable = float(probabilities[1])
+
+        if p_profitable < self.min_confidence:
+            return Signal(
+                direction=SignalDirection.HOLD,
+                strength=0.0,
+                confidence=p_profitable,
+                metadata={
+                    "generator": self.name,
+                    "reason": "meta_label_gate",
+                    "p_profitable": p_profitable,
+                    "primary_direction": direction,
+                    "index": index,
+                },
+            )
+
+        metadata: dict[str, Any] = {
+            "generator": self.name,
+            "p_profitable": p_profitable,
+            "primary_direction": direction,
+            "predicted_return": primary_signal.metadata.get("predicted_return", 0.0),
+            "index": index,
+        }
+        if primary_signal.direction == SignalDirection.SELL:
+            metadata["enter_short"] = True
+
+        return Signal(
+            direction=primary_signal.direction,
+            strength=p_profitable,
+            confidence=p_profitable,
+            metadata=metadata,
+        )
+
+    def get_confidence(self, df: Any, index: int) -> float:
+        """Passive accessor -- never re-runs generate_signal's side effects.
+
+        Unlike ClassificationExamSignalGenerator/SmoothedReturnExamSignalGenerator
+        (stateless, safe to recompute), this generator is STATEFUL: calling
+        generate_signal for a bar it hasn't seen yet from get_confidence
+        would register/resolve fires out of the caller's control. Returns
+        the cached confidence from the most recent generate_signal(df, index)
+        call for this exact index, or 0.0 if that bar hasn't been processed
+        via generate_signal yet.
+        """
+        if index == self._last_signal_index and self._last_signal is not None:
+            return self._last_signal.confidence
+        return 0.0
+
+    @property
+    def warmup_period(self) -> int:
+        return max(self.primary_signal_generator.warmup_period, REALIZED_VOL_WINDOW_BARS)
+
+    def get_parameters(self) -> dict[str, Any]:
+        params = super().get_parameters()
+        params.update(
+            {
+                "model_name": self.model_name,
+                "symbol": self.symbol,
+                "timeframe": self.timeframe,
+                "min_confidence": self.min_confidence,
+                "primary_signal_generator": type(self.primary_signal_generator).__name__,
+            }
+        )
+        return params
+
+
+__all__ = [
+    "ClassificationExamSignalGenerator",
+    "MetaLabelExamSignalGenerator",
+    "SmoothedReturnExamSignalGenerator",
+]

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -25,7 +25,6 @@ from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
-import numpy as np
 import pandas as pd
 
 from src.config.constants import (
@@ -40,6 +39,7 @@ from src.ml.training_pipeline.meta_labels import (
     REALIZED_VOL_WINDOW_BARS,
     _session_cyclical_encoding,
     encode_meta_label_feature_row,
+    resolution_ordered_hit_rate,
 )
 from src.performance.metrics import Side, pnl_percent
 from src.prediction import PredictionConfig, PredictionEngine, PredictionResult
@@ -202,6 +202,22 @@ class ClassificationExamSignalGenerator(SignalGenerator):
         return params
 
 
+class TargetDistributionUnavailableError(RuntimeError):
+    """Raised when SmoothedReturnExamSignalGenerator cannot resolve ANY
+    bundle for its configured model_name/result.model_name at all -- fail
+    loud rather than silently HOLDing every bar forever (the #927 pattern:
+    a plumbing bug -- e.g. running unpinned, where PredictionResult.model_name
+    is just the ONNX file's basename and can never match a registry key --
+    reads indistinguishably from "the model legitimately never signals",
+    producing a backtest that finishes with zero trades and no error).
+
+    Deliberately NOT raised when a bundle IS found but simply predates the
+    target_distribution metadata field -- that is the class's documented,
+    intentional graceful-degrade case (a real bundle with no hardcoded-
+    formula fallback), not a plumbing failure.
+    """
+
+
 class SmoothedReturnExamSignalGenerator(SignalGenerator):
     """Entrant (d): regression output, confidence via percentile-rank.
 
@@ -360,7 +376,10 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
 
     def _distribution_for(self, result: PredictionResult) -> FrozenDistribution | None:
         if self.prediction_engine is None:
-            return None
+            raise TargetDistributionUnavailableError(
+                "SmoothedReturnExamSignalGenerator has no prediction_engine -- "
+                "cannot resolve any bundle, let alone its target_distribution."
+            )
         # Prefer this generator's OWN model_name (the registry key a caller
         # pinned, e.g. exam_target_redesign.py's ATB_MODEL_VERSION_OVERRIDE
         # support) over result.model_name -- PredictionResult.model_name is
@@ -372,9 +391,29 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
         # None), matching prior behavior for the registry-default-bundle case.
         lookup_name = self.model_name or result.model_name
         info = self.prediction_engine.get_model_info(lookup_name)
+        if not info:
+            # The bundle itself could not be resolved AT ALL -- e.g. running
+            # unpinned, where result.model_name is just the ONNX basename
+            # and can never match a registry key. This is a plumbing bug,
+            # not "this model has no target_distribution yet": fail loud
+            # (the #927 pattern) rather than silently HOLDing every bar,
+            # which reads identically to "entrant (d) never signals" with no
+            # error anywhere in the run.
+            raise TargetDistributionUnavailableError(
+                f"SmoothedReturnExamSignalGenerator: no bundle resolvable for "
+                f"model_name={lookup_name!r} (self.model_name={self.model_name!r}, "
+                f"result.model_name={result.model_name!r}). If running unpinned, "
+                "set ATB_MODEL_VERSION_OVERRIDE (or pass an explicit model_name) "
+                "so target_distribution is reachable -- result.model_name alone "
+                "(the ONNX file's basename) never matches a registry key."
+            )
         bundle_metadata = info.get("metadata") or {}
         raw = bundle_metadata.get("target_distribution")
         if not raw:
+            # A real, resolved bundle that simply predates this metadata
+            # field -- the class's documented, intentional graceful-degrade
+            # case (no hardcoded-formula fallback). Distinct from the
+            # unresolvable-bundle case above, which raises.
             return None
         try:
             return FrozenDistribution.from_metadata(raw)
@@ -460,7 +499,13 @@ class MetaLabelExamSignalGenerator(SignalGenerator):
         self.stop_loss_pct = stop_loss_pct
         self.max_holding_bars = max_holding_bars
         self._open_fires: list[_OpenFire] = []
-        self._resolved_history: deque[bool] = deque(maxlen=resolved_history_maxlen)
+        # (exit_index, fire_index, profitable) tuples, appended in the order
+        # fires actually resolve (bars processed in increasing index order;
+        # same-bar resolutions append in original fire/registration order).
+        # rolling_hit_rate_20 windows this via resolution_ordered_hit_rate --
+        # the SAME function build_meta_label_features uses at training time --
+        # so the two can never diverge again (see meta_labels.py docstring).
+        self._resolved_history: deque[tuple[int, int, bool]] = deque(maxlen=resolved_history_maxlen)
         self._regime_detector = EnhancedRegimeDetector()
         self._cost_calculator = CostCalculator()
         self._bundle = self._load_bundle()
@@ -534,7 +579,7 @@ class MetaLabelExamSignalGenerator(SignalGenerator):
             raw_pct_return = pnl_percent(fire.entry_price, exit_price, side_enum, fraction=1.0)
             round_trip_cost_pct = 2.0 * self._cost_calculator.fee_rate
             profitable = bool((raw_pct_return - round_trip_cost_pct) > 0.0)
-            self._resolved_history.append(profitable)
+            self._resolved_history.append((index, fire.fire_index, profitable))
 
         self._open_fires = still_open
 
@@ -558,10 +603,7 @@ class MetaLabelExamSignalGenerator(SignalGenerator):
         )
 
     def _rolling_hit_rate(self) -> float:
-        if not self._resolved_history:
-            return float("nan")
-        recent = list(self._resolved_history)[-HIT_RATE_LOOKBACK_FIRES:]
-        return float(np.mean(recent))
+        return resolution_ordered_hit_rate(list(self._resolved_history), HIT_RATE_LOOKBACK_FIRES)
 
     def _realized_volatility(self, df: Any, index: int) -> float:
         """Causal 48-bar trailing realized volatility, ending at `index`."""

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -361,7 +361,17 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
     def _distribution_for(self, result: PredictionResult) -> FrozenDistribution | None:
         if self.prediction_engine is None:
             return None
-        info = self.prediction_engine.get_model_info(result.model_name)
+        # Prefer this generator's OWN model_name (the registry key a caller
+        # pinned, e.g. exam_target_redesign.py's ATB_MODEL_VERSION_OVERRIDE
+        # support) over result.model_name -- PredictionResult.model_name is
+        # the ONNX file's basename (OnnxRunner.predict() sets it from
+        # os.path.basename(self.model_path), e.g. "model.onnx"), which never
+        # matches a registry bundle.key and made target_distribution
+        # permanently unreachable whenever a specific version was pinned.
+        # Falls back to result.model_name when unpinned (self.model_name is
+        # None), matching prior behavior for the registry-default-bundle case.
+        lookup_name = self.model_name or result.model_name
+        info = self.prediction_engine.get_model_info(lookup_name)
         bundle_metadata = info.get("metadata") or {}
         raw = bundle_metadata.get("target_distribution")
         if not raw:
@@ -371,7 +381,7 @@ class SmoothedReturnExamSignalGenerator(SignalGenerator):
         except (KeyError, ValueError, TypeError):
             logger.warning(
                 "SmoothedReturnExamSignalGenerator: invalid target_distribution metadata for %s",
-                result.model_name,
+                lookup_name,
             )
             return None
 

--- a/src/strategies/exam_target_redesign.py
+++ b/src/strategies/exam_target_redesign.py
@@ -166,20 +166,26 @@ def create_exam_strategy(
 def create_exam_binary_direction_strategy(
     symbol: str = "BTCUSDT",
     timeframe: str = "1h",
-    model_type: str = "tft",
+    registry_model_type: str = "price",
     sequence_length: int = 120,
     **strategy_kwargs: Any,
 ) -> Strategy:
     """Entrant (b): binary fixed-horizon direction classification.
 
-    ``model_type`` defaults to "tft" -- the only binary-classification
-    architecture (sigmoid/BCE head) in this codebase (see
-    task_types.MODEL_TASK_TYPES).
+    ``registry_model_type`` is the REGISTRY namespace a trained bundle
+    lives under -- ``pipeline.py``'s ``run_training_pipeline`` writes
+    "price" or "sentiment" depending on ``has_sentiment``
+    (``--force-price-only`` -> "price"), NOT the ``--model-type``
+    architecture selector (tft/cnn_lstm/...) used to train it. Defaults to
+    "price" -- the namespace a ``--force-price-only`` training run (the
+    exam harness's own convention, see the preregistration) writes to. The
+    architecture itself is irrelevant at backtest time: the ONNX bundle is
+    self-describing via its metadata (task_type/class_labels).
     """
     signal_generator = ClassificationExamSignalGenerator(
         name="exam_binary_direction_signal_generator",
         sequence_length=sequence_length,
-        model_name=_exam_model_name(symbol, timeframe, model_type),
+        model_name=_exam_model_name(symbol, timeframe, registry_model_type),
     )
     return create_exam_strategy(
         signal_generator, name="EntrantB_BinaryDirection", **strategy_kwargs
@@ -189,21 +195,22 @@ def create_exam_binary_direction_strategy(
 def create_exam_triple_barrier_strategy(
     symbol: str = "BTCUSDT",
     timeframe: str = "1h",
-    model_type: str = "tft_ternary",
+    registry_model_type: str = "price",
     sequence_length: int = 120,
     **strategy_kwargs: Any,
 ) -> Strategy:
     """Entrant (c): triple-barrier ternary classification.
 
-    ``model_type`` defaults to "tft_ternary" -- the 3-class softmax sibling
-    of "tft" (see models_tft.py::create_tft_ternary_model). Same consuming
+    ``registry_model_type`` is the REGISTRY namespace (see
+    create_exam_binary_direction_strategy's docstring) -- NOT the
+    ``--model-type tft_ternary`` architecture selector. Same consuming
     SignalGenerator as entrant (b): both read a classifier bundle's
     probabilities directly via ``result.probabilities``/``result.direction``.
     """
     signal_generator = ClassificationExamSignalGenerator(
         name="exam_triple_barrier_signal_generator",
         sequence_length=sequence_length,
-        model_name=_exam_model_name(symbol, timeframe, model_type),
+        model_name=_exam_model_name(symbol, timeframe, registry_model_type),
     )
     return create_exam_strategy(signal_generator, name="EntrantC_TripleBarrier", **strategy_kwargs)
 
@@ -211,7 +218,7 @@ def create_exam_triple_barrier_strategy(
 def create_exam_smoothed_return_strategy(
     symbol: str = "BTCUSDT",
     timeframe: str = "1h",
-    model_type: str = "cnn_lstm",
+    registry_model_type: str = "price",
     sequence_length: int = 120,
     long_entry_threshold: float = 0.0,
     short_entry_threshold: float = 0.0,
@@ -219,16 +226,17 @@ def create_exam_smoothed_return_strategy(
 ) -> Strategy:
     """Entrant (d): smoothed forward return (Board directive).
 
-    ``model_type`` defaults to "cnn_lstm" -- the incumbent's own regression
-    architecture, so the (d) vs. incumbent comparison isolates the target
-    reformulation (label semantics) rather than also varying architecture
-    (preregistration principle: same architecture, different target where
-    the target's task type allows it).
+    ``registry_model_type`` is the REGISTRY namespace (see
+    create_exam_binary_direction_strategy's docstring) -- NOT the
+    ``--model-type`` architecture selector (defaults to "cnn_lstm", the
+    incumbent's own regression architecture, so the (d) vs. incumbent
+    comparison isolates the target reformulation rather than also varying
+    architecture).
     """
     signal_generator = SmoothedReturnExamSignalGenerator(
         name="exam_smoothed_return_signal_generator",
         sequence_length=sequence_length,
-        model_name=_exam_model_name(symbol, timeframe, model_type),
+        model_name=_exam_model_name(symbol, timeframe, registry_model_type),
         long_entry_threshold=long_entry_threshold,
         short_entry_threshold=short_entry_threshold,
     )

--- a/src/strategies/exam_target_redesign.py
+++ b/src/strategies/exam_target_redesign.py
@@ -128,7 +128,21 @@ def create_exam_strategy(
     risk_manager = CoreRiskAdapter(core_risk_manager)
 
     risk_overrides = {
-        "position_sizer": "confidence_weighted",
+        # "fixed_fraction", NOT "confidence_weighted" -- this string selects
+        # the CORE risk manager's OWN, unrelated position-fraction
+        # calculator (src/risk/risk_manager.py::_calculate_raw_fraction),
+        # which for "confidence_weighted" reads a "prediction_confidence"
+        # indicator that NOTHING in this codebase ever populates (it always
+        # defaults to confidence=0.0 -> fraction=0.0). That fraction becomes
+        # risk_amount, which ConfidenceWeightedSizer.calculate_size treats
+        # as a hard veto (risk_amount <= 0 -> position size 0) -- silently
+        # zeroing every trade regardless of signal confidence or direction.
+        # The REAL confidence-weighted sizing happens one layer up, via the
+        # ConfidenceWeightedSizer OBJECT below (position_sizer=...),
+        # unaffected by this string. Matches ml_basic.py's
+        # create_ml_basic_strategy, which this function mirrors and which
+        # correctly uses "fixed_fraction" here.
+        "position_sizer": "fixed_fraction",
         "base_fraction": base_fraction,
         "max_fraction": base_fraction,
         "stop_loss_pct": stop_loss_pct,

--- a/src/strategies/exam_target_redesign.py
+++ b/src/strategies/exam_target_redesign.py
@@ -246,6 +246,15 @@ def create_exam_smoothed_return_strategy(
     incumbent's own regression architecture, so the (d) vs. incumbent
     comparison isolates the target reformulation rather than also varying
     architecture).
+
+    Unlike the other three entrants, this one requires
+    ``ATB_MODEL_VERSION_OVERRIDE`` to be set (i.e. always pin a specific
+    version) -- ``SmoothedReturnExamSignalGenerator`` needs its bundle's
+    ``target_distribution`` metadata, looked up by registry key, and
+    ``PredictionResult.model_name`` (the ONNX file's basename) can never
+    serve as that key when unpinned. Running unpinned raises
+    ``TargetDistributionUnavailableError`` immediately rather than silently
+    producing a zero-trade backtest (PR #950 review item 4).
     """
     signal_generator = SmoothedReturnExamSignalGenerator(
         name="exam_smoothed_return_signal_generator",

--- a/src/strategies/exam_target_redesign.py
+++ b/src/strategies/exam_target_redesign.py
@@ -24,6 +24,9 @@ four TARGET-REDESIGN entrants: ``ClassificationExamSignalGenerator`` for
 
 from __future__ import annotations
 
+import os
+from typing import Any
+
 from src.config.constants import (
     DEFAULT_MAX_HOLDING_HOURS,
     DEFAULT_STOP_LOSS_PCT,
@@ -40,8 +43,39 @@ from src.strategies.components import (
     SignalGenerator,
     Strategy,
 )
+from src.strategies.components.exam_signal_generator import (
+    ClassificationExamSignalGenerator,
+    SmoothedReturnExamSignalGenerator,
+)
 
 DEFAULT_EXAM_STRATEGY_NAME = "TargetRedesignExam"
+
+# Escape hatch letting the exam harness's fold-runner pin a SPECIFIC
+# (non-latest) model version per fold -- PredictionModelRegistry's
+# select_bundle()/list_bundles() always resolve "latest", with no override
+# (deliberately: select_bundle is also called unconditionally on the LIVE
+# trading path in ml_signal_generator.py, so it must never be pinnable via
+# ambient env var). This module is exam-only and never imported by the live
+# runner, so reading the override here has zero live blast radius. Resolved
+# into a full StrategyModel.key string
+# (f"{symbol}:{timeframe}:{model_type}:{version}"), which
+# PredictionEngine._resolve_bundle finds via PredictionModelRegistry.
+# get_bundle_by_key -- the one place a non-latest version is reachable by
+# exact key.
+_MODEL_VERSION_OVERRIDE_ENV_VAR = "ATB_MODEL_VERSION_OVERRIDE"
+
+
+def _exam_model_name(symbol: str, timeframe: str, model_type: str) -> str | None:
+    """Resolve the model_name to pass an exam SignalGenerator.
+
+    Returns a full bundle key (pinning to a specific version) when
+    ``_MODEL_VERSION_OVERRIDE_ENV_VAR`` is set, else None (registry
+    default: latest).
+    """
+    version = os.environ.get(_MODEL_VERSION_OVERRIDE_ENV_VAR)
+    if not version:
+        return None
+    return f"{symbol}:{timeframe}:{model_type}:{version}"
 
 
 def create_exam_strategy(
@@ -127,4 +161,82 @@ def create_exam_strategy(
     return strategy
 
 
-__all__ = ["DEFAULT_EXAM_STRATEGY_NAME", "create_exam_strategy"]
+def create_exam_binary_direction_strategy(
+    symbol: str = "BTCUSDT",
+    timeframe: str = "1h",
+    model_type: str = "tft",
+    sequence_length: int = 120,
+    **strategy_kwargs: Any,
+) -> Strategy:
+    """Entrant (b): binary fixed-horizon direction classification.
+
+    ``model_type`` defaults to "tft" -- the only binary-classification
+    architecture (sigmoid/BCE head) in this codebase (see
+    task_types.MODEL_TASK_TYPES).
+    """
+    signal_generator = ClassificationExamSignalGenerator(
+        name="exam_binary_direction_signal_generator",
+        sequence_length=sequence_length,
+        model_name=_exam_model_name(symbol, timeframe, model_type),
+    )
+    return create_exam_strategy(
+        signal_generator, name="EntrantB_BinaryDirection", **strategy_kwargs
+    )
+
+
+def create_exam_triple_barrier_strategy(
+    symbol: str = "BTCUSDT",
+    timeframe: str = "1h",
+    model_type: str = "tft_ternary",
+    sequence_length: int = 120,
+    **strategy_kwargs: Any,
+) -> Strategy:
+    """Entrant (c): triple-barrier ternary classification.
+
+    ``model_type`` defaults to "tft_ternary" -- the 3-class softmax sibling
+    of "tft" (see models_tft.py::create_tft_ternary_model). Same consuming
+    SignalGenerator as entrant (b): both read a classifier bundle's
+    probabilities directly via ``result.probabilities``/``result.direction``.
+    """
+    signal_generator = ClassificationExamSignalGenerator(
+        name="exam_triple_barrier_signal_generator",
+        sequence_length=sequence_length,
+        model_name=_exam_model_name(symbol, timeframe, model_type),
+    )
+    return create_exam_strategy(signal_generator, name="EntrantC_TripleBarrier", **strategy_kwargs)
+
+
+def create_exam_smoothed_return_strategy(
+    symbol: str = "BTCUSDT",
+    timeframe: str = "1h",
+    model_type: str = "cnn_lstm",
+    sequence_length: int = 120,
+    long_entry_threshold: float = 0.0,
+    short_entry_threshold: float = 0.0,
+    **strategy_kwargs: Any,
+) -> Strategy:
+    """Entrant (d): smoothed forward return (Board directive).
+
+    ``model_type`` defaults to "cnn_lstm" -- the incumbent's own regression
+    architecture, so the (d) vs. incumbent comparison isolates the target
+    reformulation (label semantics) rather than also varying architecture
+    (preregistration principle: same architecture, different target where
+    the target's task type allows it).
+    """
+    signal_generator = SmoothedReturnExamSignalGenerator(
+        name="exam_smoothed_return_signal_generator",
+        sequence_length=sequence_length,
+        model_name=_exam_model_name(symbol, timeframe, model_type),
+        long_entry_threshold=long_entry_threshold,
+        short_entry_threshold=short_entry_threshold,
+    )
+    return create_exam_strategy(signal_generator, name="EntrantD_SmoothedReturn", **strategy_kwargs)
+
+
+__all__ = [
+    "DEFAULT_EXAM_STRATEGY_NAME",
+    "create_exam_binary_direction_strategy",
+    "create_exam_smoothed_return_strategy",
+    "create_exam_strategy",
+    "create_exam_triple_barrier_strategy",
+]

--- a/src/strategies/exam_target_redesign.py
+++ b/src/strategies/exam_target_redesign.py
@@ -45,8 +45,10 @@ from src.strategies.components import (
 )
 from src.strategies.components.exam_signal_generator import (
     ClassificationExamSignalGenerator,
+    MetaLabelExamSignalGenerator,
     SmoothedReturnExamSignalGenerator,
 )
+from src.strategies.components.ml_signal_generator import MLBasicSignalGenerator
 
 DEFAULT_EXAM_STRATEGY_NAME = "TargetRedesignExam"
 
@@ -233,9 +235,45 @@ def create_exam_smoothed_return_strategy(
     return create_exam_strategy(signal_generator, name="EntrantD_SmoothedReturn", **strategy_kwargs)
 
 
+def create_exam_meta_label_strategy(
+    symbol: str = "BTCUSDT",
+    timeframe: str = "1h",
+    primary_model_type: str = "basic",
+    min_confidence: float = 0.5,
+    **strategy_kwargs: Any,
+) -> Strategy:
+    """Entrant (a): meta-labeling secondary classifier.
+
+    Wraps a live ``MLBasicSignalGenerator`` (pointed at
+    ``primary_model_type``, e.g. "basic" -- an ALREADY-TRAINED primary
+    bundle) with ``MetaLabelExamSignalGenerator``, which gates the
+    primary's direction by P(profitable) from the meta_label classifier
+    (see ``pipeline.py::_run_meta_label_pipeline`` for how that classifier
+    is trained). ``min_confidence`` here is the meta-label gate's own
+    threshold (P(profitable) >= min_confidence to act) -- NOT
+    create_exam_strategy's ConfidenceWeightedSizer min_confidence (still
+    applied on top via **strategy_kwargs, unrelated stage).
+    """
+    primary_signal_generator = MLBasicSignalGenerator(
+        model_type=primary_model_type,
+        timeframe=timeframe,
+        symbol=symbol,
+    )
+    signal_generator = MetaLabelExamSignalGenerator(
+        primary_signal_generator=primary_signal_generator,
+        name="exam_meta_label_signal_generator",
+        model_name=_exam_model_name(symbol, timeframe, "meta_label"),
+        symbol=symbol,
+        timeframe=timeframe,
+        min_confidence=min_confidence,
+    )
+    return create_exam_strategy(signal_generator, name="EntrantA_MetaLabel", **strategy_kwargs)
+
+
 __all__ = [
     "DEFAULT_EXAM_STRATEGY_NAME",
     "create_exam_binary_direction_strategy",
+    "create_exam_meta_label_strategy",
     "create_exam_smoothed_return_strategy",
     "create_exam_strategy",
     "create_exam_triple_barrier_strategy",

--- a/tests/integration/tournament/__init__.py
+++ b/tests/integration/tournament/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the TARGET-REDESIGN tournament (GH #933)."""

--- a/tests/integration/tournament/test_entrant_dry_runs.py
+++ b/tests/integration/tournament/test_entrant_dry_runs.py
@@ -1,0 +1,435 @@
+"""End-to-end acceptance tests for the TARGET-REDESIGN tournament (GH #933).
+
+Phase 2b item 6: one dry-run per entrant, each proving the FULL path works,
+not just its individual pieces in isolation: tiny synthetic OHLCV -> train
+via the REAL CLI entrypoint (`atb train cloud --provider local`, 1-2
+epochs) -> artifact with correct metadata -> exam backtest via the REAL
+backtest CLI path (`atb backtest exam_<entrant>`) -> completes with >=1
+trade and sane outputs.
+
+Run in a genuinely separate PROCESS, not in-process via pytest function
+calls -- two independent reasons force this:
+
+1. tests/conftest.py unconditionally stubs the entire onnxruntime module
+   for the whole pytest session (InferenceSession.run always returns a
+   fixed [[[0.0]]] constant, installed once at collection time before any
+   test runs). Under that stub, entrant (c)'s ternary output (3 values
+   expected, the stub returns 1) always raises inside
+   OnnxRunner._process_classification_output -> the exam signal generator's
+   own try/except swallows it -> permanent HOLD -> zero trades. Entrant
+   (d)'s regression path reads a constant predicted_return=0.0 -> never
+   crosses either entry threshold -> permanent HOLD. Entrant (a)'s gate
+   sees P(profitable)=0.0 always -> below any sane min_confidence ->
+   permanent HOLD. Only a genuinely separate process, where the real
+   onnxruntime (a declared, actually-installed dependency) loads, exercises
+   real inference and can produce a real, non-degenerate trade count.
+2. "train via the REAL CLI entrypoint" / "backtest via the REAL backtest
+   CLI path" -- these tests invoke `python -m cli.__main__ train cloud ...`
+   / `python -m cli.__main__ backtest ...` as actual subprocesses, not
+   `_handle_cloud`/`_handle` called directly, so the tests exercise argparse
+   parsing, env var handling, and process exit codes exactly as a human
+   operator running the tournament for real would.
+
+Why `python -m cli.__main__` and not the installed `atb` console script:
+`atb`'s entry point resolves `cli.__main__` via whatever is importable from
+sys.path, which for an editable install can point at a DIFFERENT checkout
+entirely (verified empirically while building this file: `atb` in this
+worktree's venv silently ran a stale `cli` package and rejected every new
+flag these tests depend on). `python -m cli.__main__` with `cwd=REPO_ROOT`
+guarantees this worktree's own `cli/` package is what actually runs.
+
+Each test cleans up its own `src/ml/models/{SYMBOL}/` directory in
+teardown -- these are real, if small, artifacts written into the actual
+registry path (TrainingPaths.default() is not overridable via any CLI flag
+today), so a distinctive ACCT<letter> symbol per entrant keeps them from
+ever colliding with real BTCUSDT/ETHUSDT data.
+
+Bugs found and fixed by actually running this suite against the wiring
+(Phase 2b): a registry-namespace mismatch in the exam strategy factories
+(exam_target_redesign.py, "registry_model_type" fix), a non-numeric-metric
+crash in `atb train cloud`'s completion summary (train_cloud.py), a missing
+top-level "timeframe" key in every bundle's metadata.json (pipeline.py --
+made EVERY trained bundle unfindable by symbol/timeframe/model_type lookup,
+not just target-redesign ones), and a risk_overrides["position_sizer"]
+string collision that silently zeroed every trade regardless of signal
+confidence or direction (exam_target_redesign.py, "fixed_fraction" fix).
+None of these would have been caught by unit tests mocking the pieces in
+isolation -- this is why the coordinator called these tests first-class.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MODELS_ROOT = REPO_ROOT / "src" / "ml" / "models"
+
+TRAIN_TIMEOUT_SECONDS = 240
+BACKTEST_TIMEOUT_SECONDS = 120
+PROMOTE_TIMEOUT_SECONDS = 60
+
+# Common to every entrant's training run: --provider local (in-process,
+# synchronous, no real AWS), --mock-data (deterministic synthetic OHLCV, no
+# network -- see ingestion.py::load_training_corpus's use_mock_data branch),
+# --force-price-only (skips sentiment entirely, the simplest/fastest path;
+# also what determines the "price" registry namespace these tests resolve
+# artifacts from), --input-data-s3 (a placeholder that makes orchestrator.py
+# skip its own real-S3 upload step entirely -- local provider never reads
+# this URI, see providers/local.py).
+_COMMON_TRAIN_ARGS = [
+    "--provider",
+    "local",
+    "--mock-data",
+    "--days",
+    "20",
+    "--sequence-length",
+    "120",
+    "--force-price-only",
+    "--input-data-s3",
+    "s3://acceptance-test-dummy/dummy.csv",
+]
+
+
+def _run_cli(
+    args: list[str], *, extra_env: dict[str, str] | None = None, timeout: int
+) -> subprocess.CompletedProcess[str]:
+    """Invoke `python -m cli.__main__ <args>` as a real subprocess."""
+    env = os.environ.copy()
+    # CloudTrainingConfig.from_env requires this even for --provider local
+    # (LocalProvider treats output_s3_path as a local path, never actually
+    # touches S3) -- any non-empty value satisfies the check.
+    env.setdefault("SAGEMAKER_S3_BUCKET", "acceptance-test-dummy-bucket")
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-m", "cli.__main__", *args],
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _cleanup_symbol(symbol: str) -> None:
+    path = MODELS_ROOT / symbol.upper()
+    if path.exists():
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _latest_version_id(symbol: str, registry_model_type: str) -> str:
+    latest = MODELS_ROOT / symbol.upper() / registry_model_type / "latest"
+    assert latest.is_symlink(), (
+        f"No 'latest' symlink at {latest} -- training did not produce a "
+        f"registered artifact. Check the training subprocess's stdout/stderr."
+    )
+    return latest.resolve().name
+
+
+def _read_metadata(symbol: str, registry_model_type: str, version_id: str) -> dict:
+    metadata_path = (
+        MODELS_ROOT / symbol.upper() / registry_model_type / version_id / "metadata.json"
+    )
+    assert metadata_path.exists(), f"metadata.json missing at {metadata_path}"
+    return json.loads(metadata_path.read_text())
+
+
+def _parse_total_trades(stdout: str) -> int:
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Total Trades:"):
+            return int(stripped.split(":", 1)[1].strip())
+    raise AssertionError(f"Could not find 'Total Trades:' line in backtest output:\n{stdout}")
+
+
+class TestEntrantBinaryDirectionDryRun:
+    """Entrant (b): binary fixed-horizon direction classification (tft)."""
+
+    SYMBOL = "ACCTB"
+
+    def teardown_method(self) -> None:
+        _cleanup_symbol(self.SYMBOL)
+
+    def test_train_and_backtest_end_to_end(self) -> None:
+        train = _run_cli(
+            [
+                "train",
+                "cloud",
+                self.SYMBOL,
+                *_COMMON_TRAIN_ARGS,
+                "--epochs",
+                "2",
+                "--model-type",
+                "tft",
+                "--target-type",
+                "binary_direction",
+                "--target-horizon",
+                "1",
+            ],
+            timeout=TRAIN_TIMEOUT_SECONDS,
+        )
+        assert train.returncode == 0, train.stdout + train.stderr
+
+        version_id = _latest_version_id(self.SYMBOL, "price")
+        metadata = _read_metadata(self.SYMBOL, "price", version_id)
+        assert metadata["task_type"] == "binary_classification"
+        assert metadata["class_labels"] == [-1, 1]
+        assert metadata["timeframe"] == "1h"
+
+        backtest = _run_cli(
+            [
+                "backtest",
+                "exam_binary_direction",
+                "--symbol",
+                self.SYMBOL,
+                "--mock-data",
+                "--days",
+                "20",
+                "--timeframe",
+                "1h",
+                "--no-cache",
+            ],
+            extra_env={"ATB_MODEL_VERSION_OVERRIDE": version_id},
+            timeout=BACKTEST_TIMEOUT_SECONDS,
+        )
+        assert backtest.returncode == 0, backtest.stdout + backtest.stderr
+        assert _parse_total_trades(backtest.stdout) >= 1
+
+
+class TestEntrantTripleBarrierDryRun:
+    """Entrant (c): triple-barrier ternary classification (tft_ternary)."""
+
+    SYMBOL = "ACCTC"
+
+    def teardown_method(self) -> None:
+        _cleanup_symbol(self.SYMBOL)
+
+    def test_train_and_backtest_end_to_end(self) -> None:
+        train = _run_cli(
+            [
+                "train",
+                "cloud",
+                self.SYMBOL,
+                *_COMMON_TRAIN_ARGS,
+                "--epochs",
+                "2",
+                "--model-type",
+                "tft_ternary",
+                "--target-type",
+                "triple_barrier",
+            ],
+            timeout=TRAIN_TIMEOUT_SECONDS,
+        )
+        assert train.returncode == 0, train.stdout + train.stderr
+
+        version_id = _latest_version_id(self.SYMBOL, "price")
+        metadata = _read_metadata(self.SYMBOL, "price", version_id)
+        assert metadata["task_type"] == "ternary_classification"
+        assert metadata["class_labels"] == [-1, 0, 1]
+        assert metadata["timeframe"] == "1h"
+
+        backtest = _run_cli(
+            [
+                "backtest",
+                "exam_triple_barrier",
+                "--symbol",
+                self.SYMBOL,
+                "--mock-data",
+                "--days",
+                "20",
+                "--timeframe",
+                "1h",
+                "--no-cache",
+            ],
+            extra_env={"ATB_MODEL_VERSION_OVERRIDE": version_id},
+            timeout=BACKTEST_TIMEOUT_SECONDS,
+        )
+        assert backtest.returncode == 0, backtest.stdout + backtest.stderr
+        assert _parse_total_trades(backtest.stdout) >= 1
+
+
+class TestEntrantSmoothedReturnDryRun:
+    """Entrant (d): smoothed forward return (cnn_lstm -- the incumbent's own
+    regression architecture, isolating the target reformulation)."""
+
+    SYMBOL = "ACCTD"
+
+    def teardown_method(self) -> None:
+        _cleanup_symbol(self.SYMBOL)
+
+    def test_train_and_backtest_end_to_end(self) -> None:
+        train = _run_cli(
+            [
+                "train",
+                "cloud",
+                self.SYMBOL,
+                *_COMMON_TRAIN_ARGS,
+                "--epochs",
+                "2",
+                "--model-type",
+                "cnn_lstm",
+                "--target-type",
+                "smoothed_return",
+                "--target-horizon",
+                "6",
+            ],
+            timeout=TRAIN_TIMEOUT_SECONDS,
+        )
+        assert train.returncode == 0, train.stdout + train.stderr
+
+        version_id = _latest_version_id(self.SYMBOL, "price")
+        metadata = _read_metadata(self.SYMBOL, "price", version_id)
+        assert metadata["task_type"] == "regression"
+        assert "target_distribution" in metadata
+
+        backtest = _run_cli(
+            [
+                "backtest",
+                "exam_smoothed_return",
+                "--symbol",
+                self.SYMBOL,
+                "--mock-data",
+                "--days",
+                "20",
+                "--timeframe",
+                "1h",
+                "--no-cache",
+            ],
+            extra_env={"ATB_MODEL_VERSION_OVERRIDE": version_id},
+            timeout=BACKTEST_TIMEOUT_SECONDS,
+        )
+        assert backtest.returncode == 0, backtest.stdout + backtest.stderr
+        assert _parse_total_trades(backtest.stdout) >= 1
+
+
+@pytest.mark.timeout(420)
+class TestEntrantMetaLabelDryRun:
+    """Entrant (a): meta-labeling secondary classifier.
+
+    Two-stage, unlike the other three: (1) train a PRIMARY regression model
+    (lands under the "price" namespace, same as any other --force-price-only
+    run), (2) promote it into the "basic" namespace via `atb train
+    cloud-promote` (create_exam_meta_label_strategy's primary_model_type
+    defaults to "basic", matching MLBasicSignalGenerator's own default --
+    call_strategy_factory only threads `symbol` through _load_strategy, so
+    there is no CLI way to override it for a backtest-CLI-driven test; the
+    fix is to land the primary bundle in the default namespace rather than
+    fight that), (3) train the meta_label classifier, which runs the
+    promoted primary forward to find its fire points.
+
+    Overrides pytest.ini's global 120s per-test timeout (pytest-timeout) --
+    unlike the other three entrants' single train+backtest pair, this test
+    makes THREE sequential subprocess calls (primary train, promote, meta
+    train) plus the backtest, each paying its own ~10-20s Python/TF import
+    overhead on top of actual work.
+    """
+
+    SYMBOL = "ACCTA"
+
+    def teardown_method(self) -> None:
+        _cleanup_symbol(self.SYMBOL)
+
+    def test_train_and_backtest_end_to_end(self) -> None:
+        primary_train = _run_cli(
+            [
+                "train",
+                "cloud",
+                self.SYMBOL,
+                *_COMMON_TRAIN_ARGS,
+                "--epochs",
+                "2",
+                "--model-type",
+                "cnn_lstm",
+                "--target-type",
+                "regression",
+            ],
+            timeout=TRAIN_TIMEOUT_SECONDS,
+        )
+        assert primary_train.returncode == 0, primary_train.stdout + primary_train.stderr
+
+        primary_version = _latest_version_id(self.SYMBOL, "price")
+
+        promote = _run_cli(
+            [
+                "train",
+                "cloud-promote",
+                self.SYMBOL,
+                primary_version,
+                "--from",
+                "price",
+                "--to",
+                "basic",
+                "--set-latest",
+            ],
+            timeout=PROMOTE_TIMEOUT_SECONDS,
+        )
+        assert promote.returncode == 0, promote.stdout + promote.stderr
+
+        # A wider window than the other three entrants' 20 days: the
+        # primary's fires need to span enough of the (seed=42, deterministic
+        # for every --mock-data run) synthetic walk's up/down phases for
+        # BOTH profitable and unprofitable outcomes to appear -- with only
+        # 20 days, every fire in this corpus happened to resolve the same
+        # way, and _run_meta_label_pipeline correctly refuses to fit
+        # LogisticRegression on a single-class corpus (see pipeline.py's
+        # own guard, added in Phase 2b item 3).
+        meta_train = _run_cli(
+            [
+                "train",
+                "cloud",
+                self.SYMBOL,
+                "--provider",
+                "local",
+                "--mock-data",
+                "--days",
+                "60",
+                "--sequence-length",
+                "120",
+                "--force-price-only",
+                "--input-data-s3",
+                "s3://acceptance-test-dummy/dummy.csv",
+                "--epochs",
+                "1",
+                "--target-type",
+                "meta_label",
+                "--primary-model-type",
+                "basic",
+            ],
+            timeout=TRAIN_TIMEOUT_SECONDS,
+        )
+        assert meta_train.returncode == 0, meta_train.stdout + meta_train.stderr
+
+        meta_version = _latest_version_id(self.SYMBOL, "meta_label")
+        metadata = _read_metadata(self.SYMBOL, "meta_label", meta_version)
+        assert metadata["task_type"] == "binary_classification"
+        assert metadata["class_labels"] == [0, 1]
+        assert metadata["primary_model_type"] == "basic"
+        assert metadata["timeframe"] == "1h"
+
+        backtest = _run_cli(
+            [
+                "backtest",
+                "exam_meta_label",
+                "--symbol",
+                self.SYMBOL,
+                "--mock-data",
+                "--days",
+                "60",
+                "--timeframe",
+                "1h",
+                "--no-cache",
+            ],
+            extra_env={"ATB_MODEL_VERSION_OVERRIDE": meta_version},
+            timeout=BACKTEST_TIMEOUT_SECONDS,
+        )
+        assert backtest.returncode == 0, backtest.stdout + backtest.stderr
+        assert _parse_total_trades(backtest.stdout) >= 1

--- a/tests/integration/tournament/test_entrant_dry_runs.py
+++ b/tests/integration/tournament/test_entrant_dry_runs.py
@@ -38,11 +38,15 @@ worktree's venv silently ran a stale `cli` package and rejected every new
 flag these tests depend on). `python -m cli.__main__` with `cwd=REPO_ROOT`
 guarantees this worktree's own `cli/` package is what actually runs.
 
-Each test cleans up its own `src/ml/models/{SYMBOL}/` directory in
-teardown -- these are real, if small, artifacts written into the actual
-registry path (TrainingPaths.default() is not overridable via any CLI flag
-today), so a distinctive ACCT<letter> symbol per entrant keeps them from
-ever colliding with real BTCUSDT/ETHUSDT data.
+Every test runs against an isolated, per-test registry: MODEL_REGISTRY_PATH
+(the same env var PredictionConfig.model_registry_path reads on the
+backtest-lookup side) is pinned to a pytest tmp_path directory for BOTH the
+train and backtest subprocess calls (PR #950 review item 5 --
+TrainingPaths.default()/promote_model_version's default now honor it too).
+No test writes into the real src/ml/models/ registry at all, and pytest's
+own tmp_path cleanup means there is nothing to tear down manually. The
+distinctive ACCT<letter> symbol per entrant is kept anyway for readable
+failure output, not for collision-avoidance (no longer load-bearing).
 
 Bugs found and fixed by actually running this suite against the wiring
 (Phase 2b): a registry-namespace mismatch in the exam strategy factories
@@ -61,7 +65,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -71,7 +74,6 @@ import pytest
 pytestmark = [pytest.mark.integration, pytest.mark.slow]
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-MODELS_ROOT = REPO_ROOT / "src" / "ml" / "models"
 
 TRAIN_TIMEOUT_SECONDS = 240
 BACKTEST_TIMEOUT_SECONDS = 120
@@ -100,14 +102,27 @@ _COMMON_TRAIN_ARGS = [
 
 
 def _run_cli(
-    args: list[str], *, extra_env: dict[str, str] | None = None, timeout: int
+    args: list[str],
+    *,
+    registry_root: Path,
+    extra_env: dict[str, str] | None = None,
+    timeout: int,
 ) -> subprocess.CompletedProcess[str]:
-    """Invoke `python -m cli.__main__ <args>` as a real subprocess."""
+    """Invoke `python -m cli.__main__ <args>` as a real subprocess.
+
+    ``registry_root`` is always pinned via MODEL_REGISTRY_PATH -- the same
+    env var PredictionConfig.model_registry_path reads on the backtest
+    lookup side, and that TrainingPaths.default()/promote_model_version's
+    default now also honor (PR #950 review item 5) -- so every train/
+    promote/backtest call in a test resolves the SAME isolated, per-test
+    directory, never the real src/ml/models/ registry.
+    """
     env = os.environ.copy()
     # CloudTrainingConfig.from_env requires this even for --provider local
     # (LocalProvider treats output_s3_path as a local path, never actually
     # touches S3) -- any non-empty value satisfies the check.
     env.setdefault("SAGEMAKER_S3_BUCKET", "acceptance-test-dummy-bucket")
+    env["MODEL_REGISTRY_PATH"] = str(registry_root)
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -120,14 +135,8 @@ def _run_cli(
     )
 
 
-def _cleanup_symbol(symbol: str) -> None:
-    path = MODELS_ROOT / symbol.upper()
-    if path.exists():
-        shutil.rmtree(path, ignore_errors=True)
-
-
-def _latest_version_id(symbol: str, registry_model_type: str) -> str:
-    latest = MODELS_ROOT / symbol.upper() / registry_model_type / "latest"
+def _latest_version_id(registry_root: Path, symbol: str, registry_model_type: str) -> str:
+    latest = registry_root / symbol.upper() / registry_model_type / "latest"
     assert latest.is_symlink(), (
         f"No 'latest' symlink at {latest} -- training did not produce a "
         f"registered artifact. Check the training subprocess's stdout/stderr."
@@ -135,9 +144,11 @@ def _latest_version_id(symbol: str, registry_model_type: str) -> str:
     return latest.resolve().name
 
 
-def _read_metadata(symbol: str, registry_model_type: str, version_id: str) -> dict:
+def _read_metadata(
+    registry_root: Path, symbol: str, registry_model_type: str, version_id: str
+) -> dict:
     metadata_path = (
-        MODELS_ROOT / symbol.upper() / registry_model_type / version_id / "metadata.json"
+        registry_root / symbol.upper() / registry_model_type / version_id / "metadata.json"
     )
     assert metadata_path.exists(), f"metadata.json missing at {metadata_path}"
     return json.loads(metadata_path.read_text())
@@ -156,10 +167,8 @@ class TestEntrantBinaryDirectionDryRun:
 
     SYMBOL = "ACCTB"
 
-    def teardown_method(self) -> None:
-        _cleanup_symbol(self.SYMBOL)
-
-    def test_train_and_backtest_end_to_end(self) -> None:
+    def test_train_and_backtest_end_to_end(self, tmp_path: Path) -> None:
+        registry_root = tmp_path / "models"
         train = _run_cli(
             [
                 "train",
@@ -175,12 +184,13 @@ class TestEntrantBinaryDirectionDryRun:
                 "--target-horizon",
                 "1",
             ],
+            registry_root=registry_root,
             timeout=TRAIN_TIMEOUT_SECONDS,
         )
         assert train.returncode == 0, train.stdout + train.stderr
 
-        version_id = _latest_version_id(self.SYMBOL, "price")
-        metadata = _read_metadata(self.SYMBOL, "price", version_id)
+        version_id = _latest_version_id(registry_root, self.SYMBOL, "price")
+        metadata = _read_metadata(registry_root, self.SYMBOL, "price", version_id)
         assert metadata["task_type"] == "binary_classification"
         assert metadata["class_labels"] == [-1, 1]
         assert metadata["timeframe"] == "1h"
@@ -198,6 +208,7 @@ class TestEntrantBinaryDirectionDryRun:
                 "1h",
                 "--no-cache",
             ],
+            registry_root=registry_root,
             extra_env={"ATB_MODEL_VERSION_OVERRIDE": version_id},
             timeout=BACKTEST_TIMEOUT_SECONDS,
         )
@@ -210,10 +221,8 @@ class TestEntrantTripleBarrierDryRun:
 
     SYMBOL = "ACCTC"
 
-    def teardown_method(self) -> None:
-        _cleanup_symbol(self.SYMBOL)
-
-    def test_train_and_backtest_end_to_end(self) -> None:
+    def test_train_and_backtest_end_to_end(self, tmp_path: Path) -> None:
+        registry_root = tmp_path / "models"
         train = _run_cli(
             [
                 "train",
@@ -227,12 +236,13 @@ class TestEntrantTripleBarrierDryRun:
                 "--target-type",
                 "triple_barrier",
             ],
+            registry_root=registry_root,
             timeout=TRAIN_TIMEOUT_SECONDS,
         )
         assert train.returncode == 0, train.stdout + train.stderr
 
-        version_id = _latest_version_id(self.SYMBOL, "price")
-        metadata = _read_metadata(self.SYMBOL, "price", version_id)
+        version_id = _latest_version_id(registry_root, self.SYMBOL, "price")
+        metadata = _read_metadata(registry_root, self.SYMBOL, "price", version_id)
         assert metadata["task_type"] == "ternary_classification"
         assert metadata["class_labels"] == [-1, 0, 1]
         assert metadata["timeframe"] == "1h"
@@ -250,6 +260,7 @@ class TestEntrantTripleBarrierDryRun:
                 "1h",
                 "--no-cache",
             ],
+            registry_root=registry_root,
             extra_env={"ATB_MODEL_VERSION_OVERRIDE": version_id},
             timeout=BACKTEST_TIMEOUT_SECONDS,
         )
@@ -263,10 +274,8 @@ class TestEntrantSmoothedReturnDryRun:
 
     SYMBOL = "ACCTD"
 
-    def teardown_method(self) -> None:
-        _cleanup_symbol(self.SYMBOL)
-
-    def test_train_and_backtest_end_to_end(self) -> None:
+    def test_train_and_backtest_end_to_end(self, tmp_path: Path) -> None:
+        registry_root = tmp_path / "models"
         train = _run_cli(
             [
                 "train",
@@ -282,12 +291,13 @@ class TestEntrantSmoothedReturnDryRun:
                 "--target-horizon",
                 "6",
             ],
+            registry_root=registry_root,
             timeout=TRAIN_TIMEOUT_SECONDS,
         )
         assert train.returncode == 0, train.stdout + train.stderr
 
-        version_id = _latest_version_id(self.SYMBOL, "price")
-        metadata = _read_metadata(self.SYMBOL, "price", version_id)
+        version_id = _latest_version_id(registry_root, self.SYMBOL, "price")
+        metadata = _read_metadata(registry_root, self.SYMBOL, "price", version_id)
         assert metadata["task_type"] == "regression"
         assert "target_distribution" in metadata
 
@@ -304,6 +314,7 @@ class TestEntrantSmoothedReturnDryRun:
                 "1h",
                 "--no-cache",
             ],
+            registry_root=registry_root,
             extra_env={"ATB_MODEL_VERSION_OVERRIDE": version_id},
             timeout=BACKTEST_TIMEOUT_SECONDS,
         )
@@ -335,10 +346,8 @@ class TestEntrantMetaLabelDryRun:
 
     SYMBOL = "ACCTA"
 
-    def teardown_method(self) -> None:
-        _cleanup_symbol(self.SYMBOL)
-
-    def test_train_and_backtest_end_to_end(self) -> None:
+    def test_train_and_backtest_end_to_end(self, tmp_path: Path) -> None:
+        registry_root = tmp_path / "models"
         primary_train = _run_cli(
             [
                 "train",
@@ -352,11 +361,12 @@ class TestEntrantMetaLabelDryRun:
                 "--target-type",
                 "regression",
             ],
+            registry_root=registry_root,
             timeout=TRAIN_TIMEOUT_SECONDS,
         )
         assert primary_train.returncode == 0, primary_train.stdout + primary_train.stderr
 
-        primary_version = _latest_version_id(self.SYMBOL, "price")
+        primary_version = _latest_version_id(registry_root, self.SYMBOL, "price")
 
         promote = _run_cli(
             [
@@ -370,6 +380,7 @@ class TestEntrantMetaLabelDryRun:
                 "basic",
                 "--set-latest",
             ],
+            registry_root=registry_root,
             timeout=PROMOTE_TIMEOUT_SECONDS,
         )
         assert promote.returncode == 0, promote.stdout + promote.stderr
@@ -404,12 +415,13 @@ class TestEntrantMetaLabelDryRun:
                 "--primary-model-type",
                 "basic",
             ],
+            registry_root=registry_root,
             timeout=TRAIN_TIMEOUT_SECONDS,
         )
         assert meta_train.returncode == 0, meta_train.stdout + meta_train.stderr
 
-        meta_version = _latest_version_id(self.SYMBOL, "meta_label")
-        metadata = _read_metadata(self.SYMBOL, "meta_label", meta_version)
+        meta_version = _latest_version_id(registry_root, self.SYMBOL, "meta_label")
+        metadata = _read_metadata(registry_root, self.SYMBOL, "meta_label", meta_version)
         assert metadata["task_type"] == "binary_classification"
         assert metadata["class_labels"] == [0, 1]
         assert metadata["primary_model_type"] == "basic"
@@ -428,6 +440,7 @@ class TestEntrantMetaLabelDryRun:
                 "1h",
                 "--no-cache",
             ],
+            registry_root=registry_root,
             extra_env={"ATB_MODEL_VERSION_OVERRIDE": meta_version},
             timeout=BACKTEST_TIMEOUT_SECONDS,
         )

--- a/tests/unit/cli/test_backtest.py
+++ b/tests/unit/cli/test_backtest.py
@@ -63,6 +63,7 @@ class TestLoadStrategy:
             ),
             ("exam_triple_barrier", "cli.commands.backtest.create_exam_triple_barrier_strategy"),
             ("exam_smoothed_return", "cli.commands.backtest.create_exam_smoothed_return_strategy"),
+            ("exam_meta_label", "cli.commands.backtest.create_exam_meta_label_strategy"),
         ],
     )
     def test_loads_exam_target_redesign_strategies(self, strategy_name, patch_target):

--- a/tests/unit/cli/test_backtest.py
+++ b/tests/unit/cli/test_backtest.py
@@ -54,6 +54,44 @@ class TestLoadStrategy:
             with pytest.raises(Exception, match="Model not found"):
                 _load_strategy("ml_basic")
 
+    @pytest.mark.parametrize(
+        ("strategy_name", "patch_target"),
+        [
+            (
+                "exam_binary_direction",
+                "cli.commands.backtest.create_exam_binary_direction_strategy",
+            ),
+            ("exam_triple_barrier", "cli.commands.backtest.create_exam_triple_barrier_strategy"),
+            ("exam_smoothed_return", "cli.commands.backtest.create_exam_smoothed_return_strategy"),
+        ],
+    )
+    def test_loads_exam_target_redesign_strategies(self, strategy_name, patch_target):
+        """TARGET-REDESIGN tournament exam-only strategies (Phase 2b item 4)
+        must be selectable via the backtest CLI -- this is the fold-runner's
+        only entry point for entrants (b)/(c)/(d)."""
+        with patch(patch_target) as mock_create:
+            mock_strategy = Mock(name=strategy_name)
+            mock_create.return_value = mock_strategy
+
+            result = _load_strategy(strategy_name)
+
+            assert result == mock_strategy
+            mock_create.assert_called_once()
+
+    def test_exam_target_redesign_strategies_are_not_selectable_by_live_runner(self):
+        """Arch-review requirement: the exam harness (ConfidenceWeightedSizer
+        + ratified risk-limits defaults, deliberately different from
+        HyperGrowth's live wiring) must never be reachable from a live/paper
+        trading session. src/engines/live/runner.py's strategy dict must not
+        import or reference any exam_target_redesign factory."""
+        import inspect
+
+        from src.engines.live import runner as live_runner
+
+        source = inspect.getsource(live_runner)
+        assert "exam_target_redesign" not in source
+        assert "create_exam_" not in source
+
 
 class TestGetDateRange:
     """Tests for the _get_date_range function."""

--- a/tests/unit/cli/test_backtest.py
+++ b/tests/unit/cli/test_backtest.py
@@ -185,6 +185,7 @@ class TestHandleBacktest:
             cache_ttl=24,
             log_to_db=False,
             provider="binance",
+            mock_data=False,
         )
 
     @pytest.fixture
@@ -381,6 +382,39 @@ class TestHandleBacktest:
             # Assert
             assert result == 0
             mock_create_provider.assert_called_once_with(provider_type="coinbase")
+
+    def test_backtest_with_mock_data_bypasses_real_providers_entirely(
+        self, default_args, mock_backtester
+    ):
+        """--mock-data (mirrors `atb live --mock-data`) must never construct
+        a real network-backed provider or the disk cache -- this is what
+        acceptance/integration tests rely on to exercise the REAL backtest
+        CLI path with zero network dependency (Phase 2b item 6)."""
+        default_args.mock_data = True
+
+        with (
+            patch("src.engines.backtest.engine.Backtester", return_value=mock_backtester),
+            patch("cli.commands.backtest._load_strategy") as mock_load_strategy,
+            patch("cli.commands.backtest.configure_logging"),
+            patch(
+                "src.data_providers.provider_factory.create_data_provider"
+            ) as mock_create_provider,
+            patch(
+                "src.data_providers.cached_data_provider.CachedDataProvider"
+            ) as mock_cached_provider,
+            patch("cli.commands.backtest.SymbolFactory.to_exchange_symbol", return_value="BTCUSDT"),
+            patch("builtins.open", create=True),
+            patch("cli.commands.backtest.PROJECT_ROOT", Path("/tmp/test")),
+        ):
+            mock_strategy = Mock(name="ml_basic")
+            mock_strategy.get_trading_pair.return_value = "BTCUSDT"
+            mock_load_strategy.return_value = mock_strategy
+
+            result = _handle(default_args)
+
+            assert result == 0
+            mock_create_provider.assert_not_called()
+            mock_cached_provider.assert_not_called()
 
     def test_returns_error_on_invalid_strategy(self, default_args):
         """Test that error is returned when strategy loading fails."""

--- a/tests/unit/cli/test_train.py
+++ b/tests/unit/cli/test_train.py
@@ -107,3 +107,34 @@ class TestTrainModelCommand:
         with patch("cli.commands.train._TRAINING_AVAILABLE", True):
             with pytest.raises(SystemExit):
                 _handle_model(args)
+
+    def test_model_type_accepts_tft(self):
+        """--model-type was missing 'tft' entirely (pre-existing gap found
+        while wiring entrant (c)); tft must be selectable via the local
+        (non-cloud) train CLI same as cloud's."""
+        args = argparse.Namespace(args=["BTCUSDT", "--model-type", "tft"])
+
+        with (
+            patch("cli.commands.train._TRAINING_AVAILABLE", True),
+            patch("cli.commands.train.train_model_main") as mock_train,
+        ):
+            mock_train.return_value = 0
+            _handle_model(args)
+
+            parsed_args = mock_train.call_args.args[0]
+            assert parsed_args.model_type == "tft"
+
+    def test_model_type_accepts_tft_ternary(self):
+        """tft_ternary (entrant (c)'s 3-class head) must be selectable via
+        the local train CLI, not just train cloud."""
+        args = argparse.Namespace(args=["BTCUSDT", "--model-type", "tft_ternary"])
+
+        with (
+            patch("cli.commands.train._TRAINING_AVAILABLE", True),
+            patch("cli.commands.train.train_model_main") as mock_train,
+        ):
+            mock_train.return_value = 0
+            _handle_model(args)
+
+            parsed_args = mock_train.call_args.args[0]
+            assert parsed_args.model_type == "tft_ternary"

--- a/tests/unit/cli/test_train.py
+++ b/tests/unit/cli/test_train.py
@@ -3,6 +3,8 @@
 import argparse
 from unittest.mock import patch
 
+import pytest
+
 from cli.commands.train import _handle_model
 
 
@@ -59,3 +61,49 @@ class TestTrainModelCommand:
             # Assert
             # Should return error when training not available
             assert result is not None
+
+    def test_target_type_and_horizon_reach_train_model_main(self):
+        """Phase 2b item 1: --target-type/--target-horizon must reach
+        train_model_main's args namespace (TrainingConfig construction is
+        train_model_main's own responsibility, tested separately)."""
+        args = argparse.Namespace(
+            args=[
+                "BTCUSDT",
+                "--target-type",
+                "binary_direction",
+                "--target-horizon",
+                "6",
+            ]
+        )
+
+        with (
+            patch("cli.commands.train._TRAINING_AVAILABLE", True),
+            patch("cli.commands.train.train_model_main") as mock_train,
+        ):
+            mock_train.return_value = 0
+            _handle_model(args)
+
+            parsed_args = mock_train.call_args.args[0]
+            assert parsed_args.target_type == "binary_direction"
+            assert parsed_args.target_horizon == 6
+
+    def test_target_type_defaults_preserve_current_behavior(self):
+        args = argparse.Namespace(args=["BTCUSDT"])
+
+        with (
+            patch("cli.commands.train._TRAINING_AVAILABLE", True),
+            patch("cli.commands.train.train_model_main") as mock_train,
+        ):
+            mock_train.return_value = 0
+            _handle_model(args)
+
+            parsed_args = mock_train.call_args.args[0]
+            assert parsed_args.target_type == "regression"
+            assert parsed_args.target_horizon == 1
+
+    def test_unknown_target_type_rejected_by_argparse(self):
+        args = argparse.Namespace(args=["BTCUSDT", "--target-type", "not_a_real_target"])
+
+        with patch("cli.commands.train._TRAINING_AVAILABLE", True):
+            with pytest.raises(SystemExit):
+                _handle_model(args)

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -8,7 +8,6 @@ run_training_pipeline, not just be accepted by argparse.
 from __future__ import annotations
 
 import argparse
-from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -1,0 +1,83 @@
+"""Tests for cli/commands/train_commands.py::train_model_main.
+
+Focused on Phase 2b item 1 (CLI/config threading): --target-type/
+--target-horizon must actually reach the TrainingConfig passed into
+run_training_pipeline, not just be accepted by argparse.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _base_args(**overrides) -> argparse.Namespace:
+    defaults = dict(
+        symbol="BTCUSDT",
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+        timeframe="1h",
+        epochs=1,
+        batch_size=32,
+        sequence_length=10,
+        force_sentiment=False,
+        force_price_only=False,
+        skip_plots=True,
+        skip_robustness=True,
+        skip_onnx=True,
+        disable_mixed_precision=True,
+        model_type="cnn_lstm",
+        model_variant="default",
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+@pytest.mark.fast
+class TestTrainModelMainTargetType:
+    @patch("cli.commands.train_commands.run_training_pipeline")
+    @patch("cli.commands.train_commands._TENSORFLOW_AVAILABLE", True)
+    def test_target_type_and_horizon_reach_training_config(self, mock_run):
+        from cli.commands.train_commands import train_model_main
+
+        mock_run.return_value = MagicMock(
+            success=True, duration_seconds=1.0, metadata={"evaluation_results": {}}
+        )
+        args = _base_args(target_type="binary_direction", target_horizon=6)
+
+        train_model_main(args)
+
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.target_type == "binary_direction"
+        assert ctx.config.target_horizon == 6
+
+    @patch("cli.commands.train_commands.run_training_pipeline")
+    @patch("cli.commands.train_commands._TENSORFLOW_AVAILABLE", True)
+    def test_missing_target_type_defaults_to_regression(self, mock_run):
+        """args without target_type/target_horizon at all (e.g. an older
+        caller not yet updated) must still work -- getattr fallback."""
+        from cli.commands.train_commands import train_model_main
+
+        mock_run.return_value = MagicMock(
+            success=True, duration_seconds=1.0, metadata={"evaluation_results": {}}
+        )
+        args = argparse.Namespace(
+            symbol="BTCUSDT",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+            timeframe="1h",
+            epochs=1,
+            batch_size=32,
+            sequence_length=10,
+            force_sentiment=False,
+            force_price_only=False,
+        )
+
+        train_model_main(args)
+
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.target_type == "regression"
+        assert ctx.config.target_horizon == 1

--- a/tests/unit/cli/test_train_commands.py
+++ b/tests/unit/cli/test_train_commands.py
@@ -80,3 +80,36 @@ class TestTrainModelMainTargetType:
         ctx = mock_run.call_args.args[0]
         assert ctx.config.target_type == "regression"
         assert ctx.config.target_horizon == 1
+
+    @patch("cli.commands.train_commands.run_training_pipeline")
+    @patch("cli.commands.train_commands._TENSORFLOW_AVAILABLE", True)
+    def test_primary_model_type_reaches_training_config(self, mock_run):
+        """Phase 2b item 3: --primary-model-type must reach TrainingConfig
+        for --target-type meta_label to be trainable at all."""
+        from cli.commands.train_commands import train_model_main
+
+        mock_run.return_value = MagicMock(
+            success=True, duration_seconds=1.0, metadata={"evaluation_results": {}}
+        )
+        args = _base_args(target_type="meta_label", primary_model_type="basic")
+
+        train_model_main(args)
+
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.target_type == "meta_label"
+        assert ctx.config.primary_model_type == "basic"
+
+    @patch("cli.commands.train_commands.run_training_pipeline")
+    @patch("cli.commands.train_commands._TENSORFLOW_AVAILABLE", True)
+    def test_missing_primary_model_type_defaults_to_none(self, mock_run):
+        from cli.commands.train_commands import train_model_main
+
+        mock_run.return_value = MagicMock(
+            success=True, duration_seconds=1.0, metadata={"evaluation_results": {}}
+        )
+        args = _base_args()
+
+        train_model_main(args)
+
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.primary_model_type is None

--- a/tests/unit/cloud/test_entrypoint.py
+++ b/tests/unit/cloud/test_entrypoint.py
@@ -54,6 +54,21 @@ class TestParseHyperparameters:
         assert parsed["target_type"] == "binary_direction"
         assert parsed["target_horizon"] == 6
 
+    def test_primary_model_type_defaults_to_none(self) -> None:
+        parsed = parse_hyperparameters({})
+        assert parsed["primary_model_type"] is None
+
+    def test_primary_model_type_empty_string_parses_to_none(self) -> None:
+        """orchestrator.py's _build_job_spec sends "" for an unset
+        primary_model_type (SageMaker hyperparameters must be strings) --
+        must round-trip back to None, not the literal empty string."""
+        parsed = parse_hyperparameters({"primary_model_type": ""})
+        assert parsed["primary_model_type"] is None
+
+    def test_primary_model_type_is_parsed(self) -> None:
+        parsed = parse_hyperparameters({"primary_model_type": "basic"})
+        assert parsed["primary_model_type"] == "basic"
+
 
 @pytest.mark.fast
 class TestRunTrainingThreading:
@@ -130,6 +145,25 @@ class TestRunTrainingThreading:
         ctx = mock_run.call_args.args[0]
         assert ctx.config.target_type == "regression"
         assert ctx.config.target_horizon == 1
+
+    def test_primary_model_type_reaches_training_config(self) -> None:
+        params = self._base_params(target_type="meta_label", primary_model_type="basic")
+
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.target_type == "meta_label"
+        assert ctx.config.primary_model_type == "basic"
+
+    def test_primary_model_type_default_reaches_training_config_as_none(self) -> None:
+        params = self._base_params()
+
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.primary_model_type is None
 
     def test_invalid_model_type_fails_before_training(self) -> None:
         # Arrange - TrainingConfig validation must reject unknown architectures

--- a/tests/unit/cloud/test_entrypoint.py
+++ b/tests/unit/cloud/test_entrypoint.py
@@ -207,3 +207,44 @@ class TestRunTrainingThreading:
         assert rc == 1
         fake_pipeline.run_training_pipeline.assert_not_called()
         mock_failure.assert_called_once()
+
+    def test_target_type_mismatch_after_construction_fails_before_training(self) -> None:
+        """PR #950 review item 3: a future bug that silently constructs a
+        TrainingConfig with a different target_type/target_horizon than
+        hyperparameters.json requested (e.g. a copy-paste error in the
+        constructor call, or a key-name desync from orchestrator.py) must
+        be caught HERE -- before run_training_pipeline spends any paid
+        SageMaker GPU time -- not silently train the wrong target."""
+        params = self._base_params(target_type="triple_barrier", target_horizon=6)
+        fake_pipeline = MagicMock()
+
+        class _MismatchedConfig:
+            """Stands in for TrainingConfig but ignores the requested
+            target_type/target_horizon -- simulates the exact drift class
+            this check exists to catch."""
+
+            def __init__(self, **kwargs) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+                # Simulate the bug: silently defaults instead of honoring
+                # what was actually requested.
+                self.target_type = "regression"
+                self.target_horizon = 1
+
+        with (
+            patch.dict(sys.modules, {"src.ml.training_pipeline.pipeline": fake_pipeline}),
+            patch(
+                "src.ml.training_pipeline.config.TrainingConfig",
+                _MismatchedConfig,
+            ),
+            patch("src.ml.cloud.entrypoint.write_failure_file") as mock_failure,
+        ):
+            rc = run_training(params)
+
+        assert rc == 1
+        fake_pipeline.run_training_pipeline.assert_not_called()
+        mock_failure.assert_called_once()
+        (failure_message,) = mock_failure.call_args.args
+        assert "mismatch" in failure_message
+        assert "triple_barrier" in failure_message
+        assert "regression" in failure_message

--- a/tests/unit/cloud/test_entrypoint.py
+++ b/tests/unit/cloud/test_entrypoint.py
@@ -44,6 +44,16 @@ class TestParseHyperparameters:
         assert parsed["epochs"] == 50
         assert parsed["batch_size"] == 64
 
+    def test_target_type_defaults_preserve_current_behavior(self) -> None:
+        parsed = parse_hyperparameters({})
+        assert parsed["target_type"] == "regression"
+        assert parsed["target_horizon"] == 1
+
+    def test_target_type_and_horizon_are_parsed(self) -> None:
+        parsed = parse_hyperparameters({"target_type": "binary_direction", "target_horizon": "6"})
+        assert parsed["target_type"] == "binary_direction"
+        assert parsed["target_horizon"] == 6
+
 
 @pytest.mark.fast
 class TestRunTrainingThreading:
@@ -95,6 +105,31 @@ class TestRunTrainingThreading:
         ctx = mock_run.call_args.args[0]
         assert ctx.config.model_type == "cnn_lstm"
         assert ctx.config.model_variant == "default"
+
+    def test_target_type_and_horizon_reach_training_config(self) -> None:
+        # Arrange
+        params = self._base_params(
+            model_type="tft", target_type="binary_direction", target_horizon=6
+        )
+
+        # Act
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        # Assert
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.target_type == "binary_direction"
+        assert ctx.config.target_horizon == 6
+
+    def test_target_type_defaults_reach_training_config(self) -> None:
+        params = self._base_params()
+
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.target_type == "regression"
+        assert ctx.config.target_horizon == 1
 
     def test_invalid_model_type_fails_before_training(self) -> None:
         # Arrange - TrainingConfig validation must reject unknown architectures

--- a/tests/unit/cloud/test_entrypoint.py
+++ b/tests/unit/cloud/test_entrypoint.py
@@ -69,6 +69,14 @@ class TestParseHyperparameters:
         parsed = parse_hyperparameters({"primary_model_type": "basic"})
         assert parsed["primary_model_type"] == "basic"
 
+    def test_use_mock_data_defaults_to_false(self) -> None:
+        parsed = parse_hyperparameters({})
+        assert parsed["use_mock_data"] is False
+
+    def test_use_mock_data_is_parsed(self) -> None:
+        parsed = parse_hyperparameters({"use_mock_data": "true"})
+        assert parsed["use_mock_data"] is True
+
 
 @pytest.mark.fast
 class TestRunTrainingThreading:
@@ -164,6 +172,24 @@ class TestRunTrainingThreading:
         assert rc == 0
         ctx = mock_run.call_args.args[0]
         assert ctx.config.primary_model_type is None
+
+    def test_use_mock_data_reaches_training_config(self) -> None:
+        params = self._base_params(use_mock_data=True)
+
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.use_mock_data is True
+
+    def test_use_mock_data_default_reaches_training_config_as_false(self) -> None:
+        params = self._base_params()
+
+        rc, mock_run = self._run_with_stub_pipeline(params)
+
+        assert rc == 0
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.use_mock_data is False
 
     def test_invalid_model_type_fails_before_training(self) -> None:
         # Arrange - TrainingConfig validation must reject unknown architectures

--- a/tests/unit/cloud/test_orchestrator.py
+++ b/tests/unit/cloud/test_orchestrator.py
@@ -223,6 +223,30 @@ class TestBuildJobSpec:
         assert spec.hyperparameters["target_type"] == "meta_label"
         assert spec.hyperparameters["primary_model_type"] == "basic"
 
+    def test_build_job_spec_default_use_mock_data_hyperparameters(
+        self, orchestrator: CloudTrainingOrchestrator
+    ) -> None:
+        spec = orchestrator._build_job_spec()
+        assert spec.hyperparameters["use_mock_data"] == "false"
+
+    def test_build_job_spec_custom_use_mock_data_hyperparameters(self) -> None:
+        training_config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 1),
+            use_mock_data=True,
+        )
+        cloud_config = CloudTrainingConfig(
+            training_config=training_config,
+            storage_config=CloudStorageConfig(s3_bucket="test-bucket"),
+        )
+        orchestrator = CloudTrainingOrchestrator(cloud_config, MagicMock())
+
+        spec = orchestrator._build_job_spec()
+
+        assert spec.hyperparameters["use_mock_data"] == "true"
+
 
 class TestSubmitJob:
     """Tests for submit_job method."""

--- a/tests/unit/cloud/test_orchestrator.py
+++ b/tests/unit/cloud/test_orchestrator.py
@@ -159,6 +159,40 @@ class TestBuildJobSpec:
         assert spec.to_hyperparameters()["model_type"] == "tcn_attention"
         assert spec.to_hyperparameters()["model_variant"] == "deep"
 
+    def test_build_job_spec_default_target_type_hyperparameters(
+        self, orchestrator: CloudTrainingOrchestrator
+    ) -> None:
+        """Phase 2b item 1: default target_type/target_horizon must reach
+        the job hyperparameters too (regression/1, preserving current
+        behavior for every job submitted before --target-type existed)."""
+        spec = orchestrator._build_job_spec()
+        assert spec.hyperparameters["target_type"] == "regression"
+        assert spec.hyperparameters["target_horizon"] == "1"
+
+    def test_build_job_spec_custom_target_type_hyperparameters(self) -> None:
+        training_config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 1),
+            model_type="tft",
+            target_type="binary_direction",
+            target_horizon=6,
+        )
+        cloud_config = CloudTrainingConfig(
+            training_config=training_config,
+            storage_config=CloudStorageConfig(s3_bucket="test-bucket"),
+        )
+        orchestrator = CloudTrainingOrchestrator(cloud_config, MagicMock())
+
+        spec = orchestrator._build_job_spec()
+
+        assert spec.hyperparameters["target_type"] == "binary_direction"
+        assert spec.hyperparameters["target_horizon"] == "6"
+        # SageMaker requires string hyperparameter values end-to-end
+        assert spec.to_hyperparameters()["target_type"] == "binary_direction"
+        assert spec.to_hyperparameters()["target_horizon"] == "6"
+
 
 class TestSubmitJob:
     """Tests for submit_job method."""

--- a/tests/unit/cloud/test_orchestrator.py
+++ b/tests/unit/cloud/test_orchestrator.py
@@ -877,12 +877,14 @@ class TestSyncArtifactsUsesMetadataSymbol:
 
         orchestrator.provider.download_artifacts.side_effect = fake_download
 
-        with patch("src.ml.cloud.orchestrator.get_project_root", return_value=tmp_path):
+        # get_model_registry_root() (PR #950 review item 5) returns the
+        # FULL registry root directly -- unlike the old get_project_root(),
+        # nothing appends "src/ml/models" on top of it here anymore.
+        registry_root = tmp_path / "src" / "ml" / "models"
+        with patch("src.ml.cloud.orchestrator.get_model_registry_root", return_value=registry_root):
             result = orchestrator._sync_artifacts("job-1", "s3://bucket/out/model.tar.gz")
 
-        expected = (
-            tmp_path / "src" / "ml" / "models" / "ETHUSDT" / "price" / "2026-07-05_10h00m00s_v1"
-        )
+        expected = registry_root / "ETHUSDT" / "price" / "2026-07-05_10h00m00s_v1"
         assert result == expected
         assert (expected / "model.onnx").exists()
 
@@ -896,10 +898,42 @@ class TestSyncArtifactsUsesMetadataSymbol:
 
         orchestrator.provider.download_artifacts.side_effect = fake_download
 
-        with patch("src.ml.cloud.orchestrator.get_project_root", return_value=tmp_path):
+        registry_root = tmp_path / "src" / "ml" / "models"
+        with patch("src.ml.cloud.orchestrator.get_model_registry_root", return_value=registry_root):
             result = orchestrator._sync_artifacts("job-2", "s3://bucket/out/model.tar.gz")
 
         assert result.parent.parent.name == "BTCUSDT"
+
+    def test_default_registry_honors_model_registry_path_override(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """PR #950 review item 5: without patching get_model_registry_root
+        at all, MODEL_REGISTRY_PATH alone must redirect where _sync_artifacts
+        lands a trained bundle -- this is the FINAL destination every
+        trained model (cloud or local provider) reaches, so it's the one
+        code path that actually determines whether an acceptance test's
+        MODEL_REGISTRY_PATH override keeps artifacts out of the real
+        src/ml/models/ registry."""
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(tmp_path / "isolated-registry"))
+        orchestrator = _make_orchestrator(symbol="BTCUSDT")
+
+        def fake_download(job_id: str, temp_dir: Path) -> Path:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+            metadata = {
+                "symbol": "BTCUSDT",
+                "model_type": "price",
+                "version_id": "2026-07-05_10h00m00s_v1",
+            }
+            (temp_dir / "metadata.json").write_text(json.dumps(metadata))
+            (temp_dir / "model.onnx").write_text("model-bytes")
+            return temp_dir
+
+        orchestrator.provider.download_artifacts.side_effect = fake_download
+
+        result = orchestrator._sync_artifacts("job-3", "s3://bucket/out/model.tar.gz")
+
+        assert str(result).startswith(str(tmp_path / "isolated-registry"))
+        assert (result / "model.onnx").exists()
 
 
 @pytest.mark.fast

--- a/tests/unit/cloud/test_orchestrator.py
+++ b/tests/unit/cloud/test_orchestrator.py
@@ -193,6 +193,36 @@ class TestBuildJobSpec:
         assert spec.to_hyperparameters()["target_type"] == "binary_direction"
         assert spec.to_hyperparameters()["target_horizon"] == "6"
 
+    def test_build_job_spec_default_primary_model_type_hyperparameters(
+        self, orchestrator: CloudTrainingOrchestrator
+    ) -> None:
+        """Phase 2b item 3: primary_model_type=None must round-trip through
+        the string-only hyperparameters dict as "" (SageMaker requires
+        string values; entrypoint.py::parse_hyperparameters treats "" as
+        unset)."""
+        spec = orchestrator._build_job_spec()
+        assert spec.hyperparameters["primary_model_type"] == ""
+
+    def test_build_job_spec_custom_primary_model_type_hyperparameters(self) -> None:
+        training_config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 1),
+            target_type="meta_label",
+            primary_model_type="basic",
+        )
+        cloud_config = CloudTrainingConfig(
+            training_config=training_config,
+            storage_config=CloudStorageConfig(s3_bucket="test-bucket"),
+        )
+        orchestrator = CloudTrainingOrchestrator(cloud_config, MagicMock())
+
+        spec = orchestrator._build_job_spec()
+
+        assert spec.hyperparameters["target_type"] == "meta_label"
+        assert spec.hyperparameters["primary_model_type"] == "basic"
+
 
 class TestSubmitJob:
     """Tests for submit_job method."""

--- a/tests/unit/cloud/test_promotion.py
+++ b/tests/unit/cloud/test_promotion.py
@@ -129,3 +129,19 @@ class TestPromoteModelVersion:
 
         assert target == registry / "BTCUSDT" / "scratch" / VERSION
         assert (target / "model.onnx").exists()
+
+    def test_default_registry_root_honors_model_registry_path_override(
+        self, registry: Path, monkeypatch
+    ) -> None:
+        """PR #950 review item 5: when registry_root isn't passed explicitly
+        (the real CLI's _handle_cloud_promote never passes it), the default
+        must still honor MODEL_REGISTRY_PATH -- the same env var
+        PredictionConfig.model_registry_path reads -- so an acceptance test
+        pinning that env var redirects promotion too, not just training."""
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        target = promote_model_version("BTCUSDT", VERSION)  # no registry_root kwarg
+
+        assert target == registry / "BTCUSDT" / "basic" / VERSION
+        assert (target / "model.onnx").exists()
+        assert (target / "model.onnx").exists()

--- a/tests/unit/cloud/test_providers.py
+++ b/tests/unit/cloud/test_providers.py
@@ -91,6 +91,125 @@ class TestLocalProvider:
         assert status.start_time is not None
         assert status.end_time is None
 
+    def test_run_local_training_threads_hyperparameters_into_training_config(
+        self, provider: LocalProvider
+    ) -> None:
+        """Phase 2b item 1 regression guard: _run_local_training previously
+        built TrainingConfig straight from TrainingJobSpec's typed fields
+        and NEVER read model_type/model_variant/target_type/target_horizon/
+        force_sentiment/force_price_only/mixed_precision from
+        spec.hyperparameters at all -- `atb train cloud --provider local`
+        silently trained cnn_lstm/regression regardless of what CLI flags
+        were passed. Every hyperparameter must actually reach
+        TrainingConfig."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+
+        from src.ml.cloud.providers.base import TrainingJobStatus
+
+        spec = TrainingJobSpec(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date="2024-01-01T00:00:00",
+            end_date="2024-01-31T00:00:00",
+            epochs=1,
+            batch_size=32,
+            sequence_length=10,
+            instance_type="ml.g4dn.xlarge",
+            use_spot_instances=True,
+            max_runtime_seconds=3600,
+            output_s3_path="s3://test-bucket/models/",
+            hyperparameters={
+                "model_type": "tft",
+                "model_variant": "lightweight",
+                "target_type": "binary_direction",
+                "target_horizon": "6",
+                "force_sentiment": "false",
+                "force_price_only": "true",
+                "mixed_precision": "false",
+            },
+        )
+        job_id = "local-test1234"
+        provider._jobs[job_id] = TrainingJobStatus(
+            job_name=job_id,
+            status="InProgress",
+            start_time=datetime.now(UTC),
+            end_time=None,
+            failure_reason=None,
+            output_s3_path=None,
+            metrics={},
+        )
+
+        mock_result = MagicMock(success=True)
+        mock_result.artifact_paths.directory = Path("/tmp/fake-artifacts")
+        mock_result.metadata = {"evaluation_results": {}}
+
+        with patch(
+            "src.ml.training_pipeline.pipeline.run_training_pipeline",
+            return_value=mock_result,
+        ) as mock_run:
+            provider._run_local_training(job_id, spec)
+
+        assert mock_run.call_args is not None, "run_training_pipeline was never called"
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.model_type == "tft"
+        assert ctx.config.model_variant == "lightweight"
+        assert ctx.config.target_type == "binary_direction"
+        assert ctx.config.target_horizon == 6
+        assert ctx.config.force_sentiment is False
+        assert ctx.config.force_price_only is True
+        assert ctx.config.mixed_precision is False
+
+    def test_run_local_training_defaults_preserve_current_behavior(
+        self, provider: LocalProvider
+    ) -> None:
+        """No hyperparameters set (e.g. an older orchestrator) must still
+        default to cnn_lstm/regression -- byte-identical to before this fix."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+
+        from src.ml.cloud.providers.base import TrainingJobStatus
+
+        spec = TrainingJobSpec(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date="2024-01-01T00:00:00",
+            end_date="2024-01-31T00:00:00",
+            epochs=1,
+            batch_size=32,
+            sequence_length=10,
+            instance_type="ml.g4dn.xlarge",
+            use_spot_instances=True,
+            max_runtime_seconds=3600,
+            output_s3_path="s3://test-bucket/models/",
+        )
+        job_id = "local-test5678"
+        provider._jobs[job_id] = TrainingJobStatus(
+            job_name=job_id,
+            status="InProgress",
+            start_time=datetime.now(UTC),
+            end_time=None,
+            failure_reason=None,
+            output_s3_path=None,
+            metrics={},
+        )
+
+        mock_result = MagicMock(success=True)
+        mock_result.artifact_paths.directory = Path("/tmp/fake-artifacts")
+        mock_result.metadata = {"evaluation_results": {}}
+
+        with patch(
+            "src.ml.training_pipeline.pipeline.run_training_pipeline",
+            return_value=mock_result,
+        ) as mock_run:
+            provider._run_local_training(job_id, spec)
+
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.model_type == "cnn_lstm"
+        assert ctx.config.model_variant == "default"
+        assert ctx.config.target_type == "regression"
+        assert ctx.config.target_horizon == 1
+
     def test_get_job_status_unknown_job(self, provider: LocalProvider) -> None:
         """Verify get_job_status raises for unknown job."""
         with pytest.raises(ValueError, match="Job not found"):

--- a/tests/unit/cloud/test_providers.py
+++ b/tests/unit/cloud/test_providers.py
@@ -263,6 +263,50 @@ class TestLocalProvider:
         assert ctx.config.target_type == "meta_label"
         assert ctx.config.primary_model_type == "basic"
 
+    def test_run_local_training_threads_use_mock_data(self, provider: LocalProvider) -> None:
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+
+        from src.ml.cloud.providers.base import TrainingJobStatus
+
+        spec = TrainingJobSpec(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date="2024-01-01T00:00:00",
+            end_date="2024-01-31T00:00:00",
+            epochs=1,
+            batch_size=32,
+            sequence_length=10,
+            instance_type="ml.g4dn.xlarge",
+            use_spot_instances=True,
+            max_runtime_seconds=3600,
+            output_s3_path="s3://test-bucket/models/",
+            hyperparameters={"use_mock_data": "true"},
+        )
+        job_id = "local-test3456"
+        provider._jobs[job_id] = TrainingJobStatus(
+            job_name=job_id,
+            status="InProgress",
+            start_time=datetime.now(UTC),
+            end_time=None,
+            failure_reason=None,
+            output_s3_path=None,
+            metrics={},
+        )
+
+        mock_result = MagicMock(success=True)
+        mock_result.artifact_paths.directory = Path("/tmp/fake-artifacts")
+        mock_result.metadata = {"evaluation_results": {}}
+
+        with patch(
+            "src.ml.training_pipeline.pipeline.run_training_pipeline",
+            return_value=mock_result,
+        ) as mock_run:
+            provider._run_local_training(job_id, spec)
+
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.use_mock_data is True
+
     def test_get_job_status_unknown_job(self, provider: LocalProvider) -> None:
         """Verify get_job_status raises for unknown job."""
         with pytest.raises(ValueError, match="Job not found"):

--- a/tests/unit/cloud/test_providers.py
+++ b/tests/unit/cloud/test_providers.py
@@ -209,6 +209,59 @@ class TestLocalProvider:
         assert ctx.config.model_variant == "default"
         assert ctx.config.target_type == "regression"
         assert ctx.config.target_horizon == 1
+        assert ctx.config.primary_model_type is None
+
+    def test_run_local_training_threads_primary_model_type(self, provider: LocalProvider) -> None:
+        """Phase 2b item 3: primary_model_type must reach TrainingConfig via
+        the local provider too -- the acceptance test for entrant (a) trains
+        via `atb train cloud --provider local --target-type meta_label
+        --primary-model-type <bundle>`."""
+        from datetime import UTC, datetime
+        from unittest.mock import MagicMock, patch
+
+        from src.ml.cloud.providers.base import TrainingJobStatus
+
+        spec = TrainingJobSpec(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date="2024-01-01T00:00:00",
+            end_date="2024-01-31T00:00:00",
+            epochs=1,
+            batch_size=32,
+            sequence_length=10,
+            instance_type="ml.g4dn.xlarge",
+            use_spot_instances=True,
+            max_runtime_seconds=3600,
+            output_s3_path="s3://test-bucket/models/",
+            hyperparameters={
+                "target_type": "meta_label",
+                "primary_model_type": "basic",
+            },
+        )
+        job_id = "local-test9012"
+        provider._jobs[job_id] = TrainingJobStatus(
+            job_name=job_id,
+            status="InProgress",
+            start_time=datetime.now(UTC),
+            end_time=None,
+            failure_reason=None,
+            output_s3_path=None,
+            metrics={},
+        )
+
+        mock_result = MagicMock(success=True)
+        mock_result.artifact_paths.directory = Path("/tmp/fake-artifacts")
+        mock_result.metadata = {"evaluation_results": {}}
+
+        with patch(
+            "src.ml.training_pipeline.pipeline.run_training_pipeline",
+            return_value=mock_result,
+        ) as mock_run:
+            provider._run_local_training(job_id, spec)
+
+        ctx = mock_run.call_args.args[0]
+        assert ctx.config.target_type == "meta_label"
+        assert ctx.config.primary_model_type == "basic"
 
     def test_get_job_status_unknown_job(self, provider: LocalProvider) -> None:
         """Verify get_job_status raises for unknown job."""

--- a/tests/unit/cloud/test_train_cloud_cli.py
+++ b/tests/unit/cloud/test_train_cloud_cli.py
@@ -171,6 +171,15 @@ class TestHandleCloudArchitectureSelection:
         training_config = mock_cls.call_args.args[0].training_config
         assert training_config.model_type == "tft_ternary"
 
+    def test_lightgbm_is_accepted(self) -> None:
+        """Reachable from the CLI (Phase 2b item 3), even though it will
+        raise ImportError once create_model() actually dispatches --
+        lightgbm isn't an installed/declared dependency."""
+        mock_cls = self._submit(["BTCUSDT", "--no-wait", "--model-type", "lightgbm"])
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.model_type == "lightgbm"
+
     def test_unknown_model_type_rejected_by_argparse(self) -> None:
         with pytest.raises(SystemExit):
             _handle_cloud(_ns(["BTCUSDT", "--no-wait", "--model-type", "transformer"]))
@@ -232,6 +241,31 @@ class TestHandleCloudTargetTypeSelection:
     def test_unknown_target_type_rejected_by_argparse(self) -> None:
         with pytest.raises(SystemExit):
             _handle_cloud(_ns(["BTCUSDT", "--no-wait", "--target-type", "not_a_real_target"]))
+
+    def test_meta_label_with_primary_model_type_reaches_training_config(self) -> None:
+        """Phase 2b item 3: --target-type meta_label + --primary-model-type
+        must both reach TrainingConfig -- meta_label raises in
+        TrainingConfig.__post_init__ without a primary_model_type."""
+        mock_cls = self._submit(
+            [
+                "BTCUSDT",
+                "--no-wait",
+                "--target-type",
+                "meta_label",
+                "--primary-model-type",
+                "basic",
+            ]
+        )
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.target_type == "meta_label"
+        assert training_config.primary_model_type == "basic"
+
+    def test_primary_model_type_defaults_to_none(self) -> None:
+        mock_cls = self._submit(["BTCUSDT", "--no-wait"])
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.primary_model_type is None
 
 
 @pytest.mark.fast

--- a/tests/unit/cloud/test_train_cloud_cli.py
+++ b/tests/unit/cloud/test_train_cloud_cli.py
@@ -163,6 +163,14 @@ class TestHandleCloudArchitectureSelection:
         training_config = mock_cls.call_args.args[0].training_config
         assert training_config.model_type == "tft"
 
+    def test_tft_ternary_is_accepted(self) -> None:
+        """entrant (c)'s 3-class head must be CLI-selectable on the cloud
+        train path (used by --provider local for its acceptance test)."""
+        mock_cls = self._submit(["BTCUSDT", "--no-wait", "--model-type", "tft_ternary"])
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.model_type == "tft_ternary"
+
     def test_unknown_model_type_rejected_by_argparse(self) -> None:
         with pytest.raises(SystemExit):
             _handle_cloud(_ns(["BTCUSDT", "--no-wait", "--model-type", "transformer"]))

--- a/tests/unit/cloud/test_train_cloud_cli.py
+++ b/tests/unit/cloud/test_train_cloud_cli.py
@@ -269,6 +269,61 @@ class TestHandleCloudTargetTypeSelection:
 
 
 @pytest.mark.fast
+class TestHandleCloudWaitCompletionSummary:
+    """Regression guard: found while running the Phase 2b item 6 acceptance
+    tests for real -- a successful `atb train cloud` run (no --no-wait)
+    crashed AFTER training/registry-sync succeeded while printing the final
+    metrics summary, because result.metrics can contain non-numeric values
+    (e.g. {"error": "..."} -- pipeline.py's own diagnostics-failure
+    degradation path, see evaluate_model_performance's KeyError('rmse') for
+    a tft/binary_classification bundle, a real, reproducible case) and the
+    print loop blindly formatted every value with :.4f. A crash here made
+    the CLI process exit non-zero despite training having actually
+    succeeded -- exactly what an acceptance test's `returncode == 0` check
+    would (correctly) flag as a failure."""
+
+    def _run_to_completion(self, metrics: dict) -> tuple[int, object]:
+        from src.ml.cloud.orchestrator import CloudTrainingResult
+
+        provider = MagicMock()
+        provider.is_available.return_value = True
+        provider.provider_name = "local"
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.run_training.return_value = CloudTrainingResult(
+            success=True,
+            job_id="local-test",
+            job_status="Completed",
+            provider="local",
+            artifact_path=Path("/tmp/fake-artifacts"),
+            metrics=metrics,
+            duration_seconds=12.3,
+        )
+
+        with (
+            patch.dict("os.environ", {"SAGEMAKER_S3_BUCKET": "test-bucket"}),
+            patch("src.ml.cloud.providers.get_provider", return_value=provider),
+            patch(
+                "src.ml.cloud.orchestrator.CloudTrainingOrchestrator",
+                return_value=mock_orchestrator,
+            ),
+        ):
+            rc = _handle_cloud(_ns(["BTCUSDT", "--provider", "local"]))
+        return rc, mock_orchestrator
+
+    def test_non_numeric_metric_value_does_not_crash(self) -> None:
+        rc, _ = self._run_to_completion({"error": "diagnostics failed: KeyError('rmse')"})
+        assert rc == 0
+
+    def test_numeric_metrics_still_format_as_before(self) -> None:
+        rc, _ = self._run_to_completion({"train_accuracy": 0.512345})
+        assert rc == 0
+
+    def test_mixed_numeric_and_non_numeric_metrics(self) -> None:
+        rc, _ = self._run_to_completion({"train_accuracy": 0.5, "note": "partial"})
+        assert rc == 0
+
+
+@pytest.mark.fast
 class TestHandleCloudPromote:
     """Tests for the cloud-promote CLI handler."""
 

--- a/tests/unit/cloud/test_train_cloud_cli.py
+++ b/tests/unit/cloud/test_train_cloud_cli.py
@@ -173,6 +173,60 @@ class TestHandleCloudArchitectureSelection:
 
 
 @pytest.mark.fast
+class TestHandleCloudTargetTypeSelection:
+    """Phase 2b item 1: --target-type/--target-horizon threading on `atb train cloud`."""
+
+    def _submit(self, cli_args: list[str]) -> MagicMock:
+        provider = MagicMock()
+        provider.is_available.return_value = True
+        provider.provider_name = "sagemaker"
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.submit_job.return_value = "job-1"
+
+        with (
+            patch.dict("os.environ", {"SAGEMAKER_S3_BUCKET": "test-bucket"}),
+            patch("src.ml.cloud.providers.get_provider", return_value=provider),
+            patch(
+                "src.ml.cloud.orchestrator.CloudTrainingOrchestrator",
+                return_value=mock_orchestrator,
+            ) as mock_cls,
+        ):
+            rc = _handle_cloud(_ns(cli_args))
+
+        assert rc == 0
+        return mock_cls
+
+    def test_target_type_and_horizon_reach_training_config(self) -> None:
+        mock_cls = self._submit(
+            [
+                "BTCUSDT",
+                "--no-wait",
+                "--model-type",
+                "tft",
+                "--target-type",
+                "binary_direction",
+                "--target-horizon",
+                "6",
+            ]
+        )
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.target_type == "binary_direction"
+        assert training_config.target_horizon == 6
+
+    def test_defaults_preserve_current_behavior(self) -> None:
+        mock_cls = self._submit(["BTCUSDT", "--no-wait"])
+
+        training_config = mock_cls.call_args.args[0].training_config
+        assert training_config.target_type == "regression"
+        assert training_config.target_horizon == 1
+
+    def test_unknown_target_type_rejected_by_argparse(self) -> None:
+        with pytest.raises(SystemExit):
+            _handle_cloud(_ns(["BTCUSDT", "--no-wait", "--target-type", "not_a_real_target"]))
+
+
+@pytest.mark.fast
 class TestHandleCloudPromote:
     """Tests for the cloud-promote CLI handler."""
 

--- a/tests/unit/ml/training_pipeline/test_models_tft.py
+++ b/tests/unit/ml/training_pipeline/test_models_tft.py
@@ -246,6 +246,62 @@ class TestCreateTFTModel:
         assert model.loss is not None
 
 
+class TestCreateTFTTernaryModel:
+    """Tests for the ternary (3-class) TFT variant -- entrant (c) architecture
+    (TARGET-REDESIGN tournament, triple-barrier {-1,0,1} labels). Reuses the
+    same VSN/LSTM/attention backbone as create_tft_model with a 3-class
+    softmax head instead of the binary sigmoid head, since tft was already
+    the only classification-capable architecture in this codebase."""
+
+    def test_default_params(self, input_shape):
+        from src.ml.training_pipeline.models_tft import create_tft_ternary_model
+
+        model = create_tft_ternary_model(input_shape)
+        assert model is not None
+        assert model.name == "tft_ternary"
+
+    def test_forward_pass_output_shape(self, input_shape, sample_input):
+        from src.ml.training_pipeline.models_tft import create_tft_ternary_model
+
+        model = create_tft_ternary_model(input_shape)
+        output = model.predict(sample_input, verbose=0)
+
+        # Output: (batch_size, 3) -- one probability per class {-1, 0, 1}.
+        assert output.shape == (4, 3)
+
+    def test_output_is_a_probability_distribution(self, input_shape, sample_input):
+        """Softmax output: each row sums to ~1, every value in [0, 1]."""
+        from src.ml.training_pipeline.models_tft import create_tft_ternary_model
+
+        model = create_tft_ternary_model(input_shape)
+        output = model.predict(sample_input, verbose=0)
+
+        assert np.all(output >= 0.0)
+        assert np.all(output <= 1.0)
+        np.testing.assert_allclose(output.sum(axis=1), 1.0, atol=1e-5)
+
+    def test_model_is_compiled_with_categorical_loss(self, input_shape):
+        from src.ml.training_pipeline.models_tft import create_tft_ternary_model
+
+        model = create_tft_ternary_model(input_shape)
+        assert model.optimizer is not None
+        assert "categorical_crossentropy" in str(model.loss).lower()
+
+    def test_invalid_n_features_raises(self):
+        from src.ml.training_pipeline.models_tft import create_tft_ternary_model
+
+        with pytest.raises(ValueError, match="n_features must be positive"):
+            create_tft_ternary_model((30, 0))
+
+    def test_custom_params(self):
+        from src.ml.training_pipeline.models_tft import create_tft_ternary_model
+
+        model = create_tft_ternary_model(
+            input_shape=(20, 8), n_heads=2, hidden_size=32, dropout=0.2, num_lstm_layers=2
+        )
+        assert model is not None
+
+
 class TestModelFactoryIntegration:
     """Test TFT integration with the model factory."""
 
@@ -275,6 +331,35 @@ class TestModelFactoryIntegration:
         from src.ml.training_pipeline.models import get_model_callbacks
 
         cbs = get_model_callbacks("tft", patience=15)
+        assert len(cbs) == 2  # EarlyStopping + ReduceLROnPlateau
+
+    def test_create_model_tft_ternary(self, input_shape):
+        """tft_ternary (entrant (c)'s 3-class head) is accessible through
+        create_model factory, same as tft."""
+        from src.ml.training_pipeline.models import create_model
+
+        model = create_model("tft_ternary", input_shape)
+        assert model is not None
+        assert model.name == "tft_ternary"
+        assert model.output_shape == (None, 3)
+
+    def test_create_model_tft_ternary_case_insensitive(self, input_shape):
+        from src.ml.training_pipeline.models import create_model
+
+        model = create_model("TFT_TERNARY", input_shape)
+        assert model is not None
+
+    def test_available_models_includes_tft_ternary(self):
+        from src.ml.training_pipeline.models import AVAILABLE_MODELS
+
+        assert "tft_ternary" in AVAILABLE_MODELS
+
+    def test_get_model_callbacks_tft_ternary_reuses_tft_callbacks(self):
+        """tft_ternary shares tft's backbone, so it reuses tft_callbacks
+        rather than needing its own callback set."""
+        from src.ml.training_pipeline.models import get_model_callbacks
+
+        cbs = get_model_callbacks("tft_ternary", patience=15)
         assert len(cbs) == 2  # EarlyStopping + ReduceLROnPlateau
 
 

--- a/tests/unit/ml/training_pipeline/test_models_tft.py
+++ b/tests/unit/ml/training_pipeline/test_models_tft.py
@@ -354,6 +354,20 @@ class TestModelFactoryIntegration:
 
         assert "tft_ternary" in AVAILABLE_MODELS
 
+    def test_create_model_lightgbm_dispatches_to_directional_classifier(self, input_shape):
+        """lightgbm is reachable from create_model() but raises ImportError
+        at construction time since lightgbm isn't an installed/declared
+        dependency in this repo (documented follow-up, Phase 2b item 3)."""
+        from src.ml.training_pipeline.models import create_model
+
+        with pytest.raises(ImportError, match="lightgbm"):
+            create_model("lightgbm", input_shape, has_sentiment=False)
+
+    def test_available_models_includes_lightgbm(self):
+        from src.ml.training_pipeline.models import AVAILABLE_MODELS
+
+        assert "lightgbm" in AVAILABLE_MODELS
+
     def test_get_model_callbacks_tft_ternary_reuses_tft_callbacks(self):
         """tft_ternary shares tft's backbone, so it reuses tft_callbacks
         rather than needing its own callback set."""

--- a/tests/unit/predictions/test_engine_prediction.py
+++ b/tests/unit/predictions/test_engine_prediction.py
@@ -168,6 +168,11 @@ class TestPredictionEnginePredict:
         bundle = _make_bundle(Mock())
         engine.model_registry.list_bundles.return_value = [bundle]
         engine.model_registry.get_default_bundle.return_value = bundle
+        # Also miss on the versioned-bundle fallback (Phase 2b item 4) --
+        # otherwise the mocked registry's auto-generated Mock return would
+        # be treated as a real bundle and this test would stop exercising
+        # the not-found path at all.
+        engine.model_registry.get_bundle_by_key.return_value = None
 
         mock_features = np.random.random((1, 10))
         engine.feature_pipeline.transform.return_value = mock_features
@@ -177,6 +182,44 @@ class TestPredictionEnginePredict:
 
         assert result.error is not None
         assert "not found" in result.error
+
+    @patch("src.prediction.engine.PredictionModelRegistry")
+    @patch("src.prediction.engine.FeaturePipeline")
+    def test_predict_falls_back_to_versioned_bundle_by_key(self, mock_pipeline, mock_registry):
+        """A model_name that doesn't match any currently-latest bundle
+        (list_bundles()) but does match a specific, non-latest version's
+        exact key must still resolve -- the TARGET-REDESIGN exam harness's
+        fold-runner pins a specific version this way (Phase 2b item 4)."""
+        engine = PredictionEngine()
+
+        mock_model = Mock()
+        mock_prediction = ModelPrediction(
+            price=101.0,
+            confidence=0.6,
+            direction=1,
+            model_name="pinned_model",
+            inference_time=0.01,
+        )
+        mock_model.predict.return_value = mock_prediction
+
+        latest_bundle = _make_bundle(Mock(), version="v2")
+        pinned_bundle = _make_bundle(mock_model, version="v1")
+        engine.model_registry.list_bundles.return_value = [latest_bundle]
+        engine.model_registry.get_default_bundle.return_value = latest_bundle
+        # list_bundles() only exposes "latest" (v2); the pinned version (v1)
+        # is only reachable through get_bundle_by_key.
+        engine.model_registry.get_bundle_by_key.return_value = pinned_bundle
+
+        mock_features = np.random.random((1, 10))
+        engine.feature_pipeline.transform.return_value = mock_features
+
+        data = self.create_test_data()
+        result = engine.predict(data, model_name=pinned_bundle.key)
+
+        engine.model_registry.get_bundle_by_key.assert_called_once_with(pinned_bundle.key)
+        assert result.error is None
+        assert mock_model.predict.call_count == 1
+        assert result.model_name == "pinned_model"
 
     @patch("src.prediction.engine.PredictionModelRegistry")
     @patch("src.prediction.engine.FeaturePipeline")

--- a/tests/unit/predictions/test_engine_utilities.py
+++ b/tests/unit/predictions/test_engine_utilities.py
@@ -77,9 +77,44 @@ class TestPredictionEngineUtilities:
         """Test getting info for non-existent model"""
         engine = PredictionEngine()
         engine.model_registry.list_bundles.return_value = []
+        # Also miss on the versioned-bundle fallback (see
+        # test_get_model_info_finds_pinned_non_latest_version) -- otherwise
+        # the mocked registry's auto-generated Mock return would be treated
+        # as a real bundle.
+        engine.model_registry.get_bundle_by_key.return_value = None
 
         info = engine.get_model_info("nonexistent")
         assert info == {}
+
+    @patch("src.prediction.engine.PredictionModelRegistry")
+    @patch("src.prediction.engine.FeaturePipeline")
+    def test_get_model_info_finds_pinned_non_latest_version(self, mock_pipeline, mock_registry):
+        """A model_name that doesn't match any currently-latest bundle
+        (list_bundles()) but does match a specific, non-latest version's
+        exact key must still resolve -- mirrors _resolve_bundle's fallback
+        (Phase 2b item 4/6): the exam harness's fold-runner pins a specific
+        version this way, and SmoothedReturnExamSignalGenerator._distribution_for
+        depends on get_model_info finding a pinned version to read
+        target_distribution metadata from."""
+        engine = PredictionEngine()
+
+        mock_runner = Mock()
+        mock_runner.model_path = "/path/to/model.onnx"
+        latest_bundle = _make_bundle(Mock(), version="v2")
+        pinned_bundle = _make_bundle(
+            mock_runner, version="v1", metadata={"target_distribution": {"foo": "bar"}}
+        )
+        engine.model_registry.list_bundles.return_value = [latest_bundle]
+        # list_bundles() only exposes "latest" (v2); the pinned version (v1)
+        # is only reachable through get_bundle_by_key.
+        engine.model_registry.get_bundle_by_key.return_value = pinned_bundle
+
+        info = engine.get_model_info(pinned_bundle.key)
+
+        engine.model_registry.get_bundle_by_key.assert_called_once_with(pinned_bundle.key)
+        assert info["name"] == pinned_bundle.key
+        assert info["metadata"] == {"target_distribution": {"foo": "bar"}}
+        assert info["loaded"] is True
 
     def test_get_performance_stats(self):
         """Test getting performance statistics"""

--- a/tests/unit/strategies/components/test_exam_signal_generator.py
+++ b/tests/unit/strategies/components/test_exam_signal_generator.py
@@ -215,8 +215,10 @@ class TestSmoothedReturnExamSignalGenerator:
 
         generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
         df = _make_df(150)
-        current_price = float(df["close"].iloc[130])
-        mock_result.price = current_price * 1.03  # controlled +3% predicted return
+        # result.price IS the predicted return directly (the model was
+        # trained on smoothed_forward_return_labels, a return-scale target)
+        # -- NOT a price level to re-derive a return from.
+        mock_result.price = 0.03  # controlled +3% predicted return
         mock_engine.predict.return_value = mock_result
 
         signal = generator.generate_signal(df, 130)
@@ -230,11 +232,43 @@ class TestSmoothedReturnExamSignalGenerator:
         assert signal.confidence != pytest.approx(naive_multiplier_confidence)
         assert signal.confidence == pytest.approx(0.6333, abs=0.01)
 
+    def test_units_bug_regression_small_return_does_not_saturate_all_sell(
+        self, mock_config_class, mock_engine_class
+    ):
+        """#948 fix-round bug (flagged by claude[bot] PR review, missed in
+        the first fix round): treating result.price as a PRICE and
+        re-deriving (prediction-current_price)/current_price produced
+        ~-0.9999 on virtually every bar (saturated all-SELL, confidence
+        clamped to 1.0), since a return-scale value (~0.002) is ~4 orders
+        of magnitude smaller than a real price (~60000). A typical small
+        predicted return must produce a typical small predicted_return in
+        the signal metadata, not a near -1.0 value."""
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.model_name = "BTCUSDT:1h:smoothed_return:v1"
+        mock_engine.get_model_info.return_value = {
+            "metadata": {"target_distribution": self._distribution_metadata()}
+        }
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
+        df = _make_df(150)
+        mock_result.price = 0.002  # a typical small smoothed-return prediction
+        mock_engine.predict.return_value = mock_result
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.metadata["predicted_return"] == pytest.approx(0.002, abs=1e-9)
+        assert signal.direction == SignalDirection.BUY
+        assert signal.confidence < 1.0
+
     def test_missing_target_distribution_holds(self, mock_config_class, mock_engine_class):
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
         mock_result.error = None
-        mock_result.price = 51000.0
+        mock_result.price = 0.02
         mock_result.model_name = "BTCUSDT:1h:smoothed_return:v1"
         mock_engine.predict.return_value = mock_result
         mock_engine.get_model_info.return_value = {"metadata": {}}
@@ -291,8 +325,7 @@ class TestSmoothedReturnExamSignalGenerator:
 
         generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
         df = _make_df(150)
-        current_price = float(df["close"].iloc[130])
-        mock_result.price = current_price * 1.05  # +5% predicted move
+        mock_result.price = 0.05  # +5% predicted return, consumed directly
         mock_engine.predict.return_value = mock_result
 
         signal = generator.generate_signal(df, 130)
@@ -315,8 +348,7 @@ class TestSmoothedReturnExamSignalGenerator:
 
         generator = SmoothedReturnExamSignalGenerator(sequence_length=120)
         df = _make_df(150)
-        current_price = float(df["close"].iloc[130])
-        mock_result.price = current_price * 0.95  # -5% predicted move
+        mock_result.price = -0.05  # -5% predicted return, consumed directly
         mock_engine.predict.return_value = mock_result
 
         signal = generator.generate_signal(df, 130)

--- a/tests/unit/strategies/components/test_exam_signal_generator.py
+++ b/tests/unit/strategies/components/test_exam_signal_generator.py
@@ -305,6 +305,45 @@ class TestSmoothedReturnExamSignalGenerator:
 
         assert signal.direction == SignalDirection.HOLD
 
+    def test_distribution_lookup_uses_own_model_name_not_result_model_name(
+        self, mock_config_class, mock_engine_class
+    ):
+        """Regression guard found via Phase 2b item 6's real end-to-end
+        acceptance run: PredictionResult.model_name is the ONNX file's
+        basename (OnnxRunner.predict() sets it from
+        os.path.basename(self.model_path), e.g. "model.onnx") -- it NEVER
+        matches a registry bundle.key (format
+        "{symbol}:{timeframe}:{model_type}:{version}"), so
+        get_model_info(result.model_name) could never find target_distribution
+        for a PINNED (ATB_MODEL_VERSION_OVERRIDE) bundle in real production
+        code -- only in unit tests whose mocks don't distinguish the two
+        strings. This generator's own self.model_name (set at construction,
+        e.g. by exam_target_redesign.py's _exam_model_name) IS the correct
+        registry key and must be preferred when set."""
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        # Deliberately NOT a valid registry key -- exactly what
+        # OnnxRunner.predict() actually produces in real code.
+        mock_result.model_name = "model.onnx"
+        mock_engine.get_model_info.return_value = {
+            "metadata": {"target_distribution": self._distribution_metadata()}
+        }
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        pinned_key = "BTCUSDT:1h:price:2026-01-01_1h_v1"
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120, model_name=pinned_key)
+        df = _make_df(150)
+        mock_result.price = 0.05
+        mock_engine.predict.return_value = mock_result
+
+        signal = generator.generate_signal(df, 130)
+
+        mock_engine.get_model_info.assert_called_once_with(pinned_key)
+        assert signal.direction == SignalDirection.BUY
+        assert signal.confidence > 0.0
+
     def test_insufficient_history_holds(self, mock_config_class, mock_engine_class):
         mock_engine = MagicMock()
         mock_engine.health_check.return_value = {"status": "healthy"}

--- a/tests/unit/strategies/components/test_exam_signal_generator.py
+++ b/tests/unit/strategies/components/test_exam_signal_generator.py
@@ -13,6 +13,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from src.engines.shared.barrier_touch import BarrierTouchResult
+from src.ml.training_pipeline.meta_labels import (
+    HIT_RATE_LOOKBACK_FIRES,
+    PrimarySignalRecord,
+    TradeResolution,
+    build_meta_label_features,
+)
 from src.prediction import PredictionResult
 from src.prediction.distribution_stats import FrozenDistribution
 from src.prediction.models.onnx_runner import ModelPrediction
@@ -20,6 +27,7 @@ from src.strategies.components.exam_signal_generator import (
     ClassificationExamSignalGenerator,
     MetaLabelExamSignalGenerator,
     SmoothedReturnExamSignalGenerator,
+    TargetDistributionUnavailableError,
 )
 from src.strategies.components.signal_generator import (
     Signal,
@@ -270,7 +278,39 @@ class TestSmoothedReturnExamSignalGenerator:
         assert signal.direction == SignalDirection.BUY
         assert signal.confidence < 1.0
 
+    def test_unresolvable_bundle_raises_instead_of_silent_hold(
+        self, mock_config_class, mock_engine_class
+    ):
+        """PR #950 review item 4: when running UNPINNED (self.model_name is
+        None), lookup falls back to result.model_name -- the ONNX file's
+        basename (e.g. "model.onnx") -- which can never match a registry
+        key, so get_model_info returns {} (nothing resolvable at all). This
+        must fail loud (TargetDistributionUnavailableError), not silently
+        HOLD every bar forever -- a full backtest finishing with zero
+        trades and no error is indistinguishable from "the model
+        legitimately never signals" (the #927 silent-failure pattern)."""
+        mock_engine = MagicMock()
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.price = 0.02
+        mock_result.model_name = "model.onnx"  # unpinned: the ONNX basename
+        mock_engine.predict.return_value = mock_result
+        mock_engine.get_model_info.return_value = {}  # nothing resolvable at all
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = SmoothedReturnExamSignalGenerator(sequence_length=120)  # no model_name pinned
+        df = _make_df(150)
+
+        with pytest.raises(TargetDistributionUnavailableError):
+            generator.generate_signal(df, 130)
+
     def test_missing_target_distribution_holds(self, mock_config_class, mock_engine_class):
+        """Distinct from the unresolvable-bundle case above: a REAL,
+        resolved bundle (get_model_info returns non-empty) that simply
+        predates the target_distribution metadata field is the class's
+        documented, intentional graceful-degrade case (no hardcoded-formula
+        fallback) -- must still HOLD, not raise."""
         mock_engine = MagicMock()
         mock_result = Mock(spec=PredictionResult)
         mock_result.error = None
@@ -569,3 +609,162 @@ class TestMetaLabelExamSignalGenerator:
 
         assert len(generator._resolved_history) == 1
         assert len(generator._open_fires) == 1  # the second fire, still open
+
+
+@patch("src.strategies.components.exam_signal_generator.check_barrier_touch")
+@patch("src.strategies.components.exam_signal_generator.PredictionModelRegistry")
+@patch("src.strategies.components.exam_signal_generator.PredictionConfig")
+class TestMetaLabelHitRateTrainServeParity:
+    """PR #950 review finding: rolling_hit_rate_20 windowed in FIRE order at
+    training time (build_meta_label_features) but RESOLUTION order at
+    serve time (MetaLabelExamSignalGenerator) selected different trailing-20
+    subsets once >20 fires had resolved, silently skewing entrant (a)'s
+    features relative to what it was trained on. Both sites now delegate to
+    the single shared ``resolution_ordered_hit_rate`` -- this test drives
+    BOTH real code paths (training's build_meta_label_features and the
+    serving generator's actual bar-by-bar state machine, real
+    check_barrier_touch calls only stubbed at the OHLC-touch boundary) over
+    an IDENTICAL, deliberately overlapping fire/resolution history (>20
+    resolved fires, fire-order and resolution-order genuinely diverging)
+    and asserts they compute the identical rolling_hit_rate_20 for the same
+    final fire."""
+
+    _N_FIRES = 30
+    _FIRE_SPACING = 2
+    _WARMUP = 60
+    _MAX_HOLDING_BARS = 20
+    _TAKE_PROFIT_PCT = 0.04
+    _STOP_LOSS_PCT = 0.05
+
+    @classmethod
+    def _fire_index(cls, position: int) -> int:
+        return cls._WARMUP + cls._FIRE_SPACING * position
+
+    @classmethod
+    def _is_fast(cls, position: int) -> bool:
+        """Even positions resolve almost immediately (barrier touch, 1 bar
+        after firing); odd positions resolve only after the full
+        max_holding_bars vertical exit -- with fire spacing (2) far smaller
+        than the slow holding period (20), many slow fires stay open
+        concurrently while later fast fires fire AND resolve, producing the
+        overlapping-trades divergence this test targets."""
+        return position % 2 == 0
+
+    @classmethod
+    def _make_df(cls, periods: int = 250) -> pd.DataFrame:
+        # Tiny strictly-increasing drift so every fire's entry price (and
+        # therefore its derived stop-loss/take-profit price pair) is unique
+        # -- lets the check_barrier_touch stub identify which fire a given
+        # call belongs to by its (stop_loss_price, take_profit_price) pair,
+        # without needing real, mutually-interfering OHLC price action for
+        # 25 overlapping trades.
+        closes = 100.0 + np.arange(periods) * 1e-4
+        return pd.DataFrame(
+            {
+                "open": closes,
+                "high": closes,
+                "low": closes,
+                "close": closes,
+                "volume": np.full(periods, 1000.0),
+            },
+            index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+        )
+
+    @classmethod
+    def _expected_resolutions(cls) -> list[TradeResolution]:
+        resolutions = []
+        for position in range(cls._N_FIRES):
+            fire_index = cls._fire_index(position)
+            if cls._is_fast(position):
+                resolutions.append(TradeResolution(profitable=True, exit_index=fire_index + 1))
+            else:
+                resolutions.append(
+                    TradeResolution(profitable=False, exit_index=fire_index + cls._MAX_HOLDING_BARS)
+                )
+        return resolutions
+
+    def test_training_and_serving_agree_on_overlapping_trailing_window(
+        self, mock_config_class, mock_registry_class, mock_check_barrier_touch
+    ):
+        df = self._make_df()
+
+        # --- Training side: hand-built fires/resolutions matching exactly
+        # what the (real, unmocked) check_barrier_touch-driven serving path
+        # below will independently produce (verified by construction: fast
+        # fires touch take-profit at fire_index+1 for a net gain of
+        # take_profit_pct minus round-trip fees, well above zero; slow
+        # fires vertical-exit after max_holding_bars at a ~0.002% price
+        # drift, well below round-trip fees) -- see _is_fast's docstring.
+        fires = [
+            PrimarySignalRecord(index=self._fire_index(p), direction=1, predicted_return=0.01)
+            for p in range(self._N_FIRES)
+        ]
+        resolutions = self._expected_resolutions()
+        features = build_meta_label_features(
+            df, fires, resolutions, hit_rate_lookback=HIT_RATE_LOOKBACK_FIRES
+        )
+        training_hit_rate = features["rolling_hit_rate_20"].iloc[-1]
+
+        # Sanity check this scenario is actually a meaningful regression
+        # guard: resolution-order and fire-order windowing must disagree
+        # here, or this test would pass even without the fix.
+        buggy_fire_ordered = [
+            resolutions[i].profitable
+            for i in range(self._N_FIRES - 1)
+            if resolutions[i].exit_index <= fires[-1].index
+        ][-HIT_RATE_LOOKBACK_FIRES:]
+        assert training_hit_rate != pytest.approx(float(np.mean(buggy_fire_ordered)))
+
+        # --- Serving side: drive the REAL MetaLabelExamSignalGenerator
+        # bar-by-bar. Only check_barrier_touch (the OHLC-touch primitive) is
+        # stubbed, keyed by each fire's own (stop_loss_price,
+        # take_profit_price) pair (unique per fire thanks to the drifting
+        # entry prices) -- everything else (fire registration, resolution
+        # bookkeeping, _rolling_hit_rate, encode_meta_label_feature_row) is
+        # the actual production code.
+        fast_signatures: set[tuple[float, float]] = set()
+        for position in range(self._N_FIRES):
+            if not self._is_fast(position):
+                continue
+            entry_price = float(df["close"].iloc[self._fire_index(position)])
+            sl = entry_price * (1.0 - self._STOP_LOSS_PCT)
+            tp = entry_price * (1.0 + self._TAKE_PROFIT_PCT)
+            fast_signatures.add((round(sl, 8), round(tp, 8)))
+
+        def fake_touch(side, candle_high, candle_low, stop_loss_price, take_profit_price):
+            key = (round(stop_loss_price, 8), round(take_profit_price, 8))
+            hit_take_profit = key in fast_signatures
+            return BarrierTouchResult(
+                hit_stop_loss=False,
+                hit_take_profit=hit_take_profit,
+                stop_loss_exit_price=stop_loss_price,
+                take_profit_exit_price=take_profit_price,
+            )
+
+        mock_check_barrier_touch.side_effect = fake_touch
+
+        mock_bundle = MagicMock()
+        mock_bundle.runner.predict.side_effect = [
+            _make_meta_label_prediction(0.9) for _ in range(self._N_FIRES)
+        ]
+        mock_registry = MagicMock()
+        mock_registry.select_bundle.return_value = mock_bundle
+        mock_registry_class.return_value = mock_registry
+
+        fire_at = {self._fire_index(p): (SignalDirection.BUY, 0.01) for p in range(self._N_FIRES)}
+        primary = _CannedPrimarySignalGenerator(fire_at=fire_at, warmup=self._WARMUP)
+        generator = MetaLabelExamSignalGenerator(
+            primary_signal_generator=primary,
+            min_confidence=0.0,
+            take_profit_pct=self._TAKE_PROFIT_PCT,
+            stop_loss_pct=self._STOP_LOSS_PCT,
+            max_holding_bars=self._MAX_HOLDING_BARS,
+        )
+
+        last_fire_index = self._fire_index(self._N_FIRES - 1)
+        for index in range(self._WARMUP, last_fire_index + 1):
+            generator.generate_signal(df, index)
+
+        serving_hit_rate = generator._rolling_hit_rate()
+
+        assert serving_hit_rate == pytest.approx(training_hit_rate)

--- a/tests/unit/strategies/components/test_exam_signal_generator.py
+++ b/tests/unit/strategies/components/test_exam_signal_generator.py
@@ -15,11 +15,17 @@ import pytest
 
 from src.prediction import PredictionResult
 from src.prediction.distribution_stats import FrozenDistribution
+from src.prediction.models.onnx_runner import ModelPrediction
 from src.strategies.components.exam_signal_generator import (
     ClassificationExamSignalGenerator,
+    MetaLabelExamSignalGenerator,
     SmoothedReturnExamSignalGenerator,
 )
-from src.strategies.components.signal_generator import SignalDirection
+from src.strategies.components.signal_generator import (
+    Signal,
+    SignalDirection,
+    SignalGenerator,
+)
 
 
 def _make_df(length=150):
@@ -355,3 +361,172 @@ class TestSmoothedReturnExamSignalGenerator:
 
         assert signal.direction == SignalDirection.SELL
         assert signal.metadata["enter_short"] is True
+
+
+class _CannedPrimarySignalGenerator(SignalGenerator):
+    """Fires exactly at the configured indices with a fixed direction/
+    predicted_return; HOLD everywhere else."""
+
+    def __init__(self, fire_at: dict[int, tuple[SignalDirection, float]], warmup: int = 5):
+        super().__init__("canned_primary")
+        self._fire_at = fire_at
+        self._warmup = warmup
+
+    def generate_signal(self, df, index, regime=None) -> Signal:
+        if index in self._fire_at:
+            direction, predicted_return = self._fire_at[index]
+            return Signal(
+                direction=direction,
+                strength=0.5,
+                confidence=0.5,
+                metadata={"predicted_return": predicted_return},
+            )
+        return Signal(direction=SignalDirection.HOLD, strength=0.0, confidence=0.0, metadata={})
+
+    def get_confidence(self, df, index) -> float:
+        return 0.5
+
+    @property
+    def warmup_period(self) -> int:
+        return self._warmup
+
+
+def _make_meta_label_prediction(p_profitable: float) -> ModelPrediction:
+    """A ModelPrediction shaped like OnnxRunner's binary_classification
+    output for meta_label's class_labels=[0,1] convention: probabilities is
+    (P(not profitable), P(profitable))."""
+    return ModelPrediction(
+        price=float("nan"),
+        confidence=max(p_profitable, 1.0 - p_profitable),
+        direction=1 if p_profitable >= 0.5 else 0,
+        model_name="BTCUSDT:1h:meta_label:v1",
+        inference_time=0.001,
+        probabilities=(1.0 - p_profitable, p_profitable),
+    )
+
+
+@patch("src.strategies.components.exam_signal_generator.PredictionModelRegistry")
+@patch("src.strategies.components.exam_signal_generator.PredictionConfig")
+class TestMetaLabelExamSignalGenerator:
+    """entrant (a): gates a wrapped primary SignalGenerator by P(profitable).
+    STATEFUL and causal -- resolves fires bar-by-bar via check_barrier_touch,
+    never by scanning forward (that would leak future bars into the CURRENT
+    bar's signal, the exact bug class resolve_fired_trade/
+    build_meta_label_features are training-time-only to avoid)."""
+
+    def _mock_bundle(self, mock_registry_class, predictions: list[float]):
+        """predictions: queue of P(profitable) values, consumed in order,
+        one per generate_signal call that reaches meta-label prediction."""
+        mock_bundle = MagicMock()
+        mock_bundle.runner.predict.side_effect = [
+            _make_meta_label_prediction(p) for p in predictions
+        ]
+        mock_registry = MagicMock()
+        mock_registry.select_bundle.return_value = mock_bundle
+        mock_registry_class.return_value = mock_registry
+        return mock_bundle
+
+    def test_hold_when_primary_holds(self, mock_config_class, mock_registry_class):
+        self._mock_bundle(mock_registry_class, [])
+        primary = _CannedPrimarySignalGenerator(fire_at={})
+        generator = MetaLabelExamSignalGenerator(primary_signal_generator=primary)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 100)
+
+        assert signal.direction == SignalDirection.HOLD
+
+    def test_passes_through_primary_direction_when_confident(
+        self, mock_config_class, mock_registry_class
+    ):
+        self._mock_bundle(mock_registry_class, [0.9])
+        primary = _CannedPrimarySignalGenerator(fire_at={100: (SignalDirection.BUY, 0.02)})
+        generator = MetaLabelExamSignalGenerator(
+            primary_signal_generator=primary, min_confidence=0.5
+        )
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 100)
+
+        assert signal.direction == SignalDirection.BUY
+        assert signal.confidence == pytest.approx(0.9)
+
+    def test_gates_to_hold_when_not_confident(self, mock_config_class, mock_registry_class):
+        self._mock_bundle(mock_registry_class, [0.2])
+        primary = _CannedPrimarySignalGenerator(fire_at={100: (SignalDirection.BUY, 0.02)})
+        generator = MetaLabelExamSignalGenerator(
+            primary_signal_generator=primary, min_confidence=0.5
+        )
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 100)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.metadata["reason"] == "meta_label_gate"
+
+    def test_mutating_a_future_bar_does_not_change_the_current_signal(
+        self, mock_config_class, mock_registry_class
+    ):
+        """The core leak-safety property: generate_signal(df, index) must be
+        identical whether or not bars strictly after `index` are mutated."""
+        self._mock_bundle(mock_registry_class, [0.9, 0.9])
+        primary = _CannedPrimarySignalGenerator(fire_at={100: (SignalDirection.BUY, 0.02)})
+
+        df_orig = _make_df(150)
+        df_mutated = df_orig.copy()
+        df_mutated.loc[df_mutated.index[105:], ["open", "high", "low", "close"]] *= 5.0
+
+        gen_a = MetaLabelExamSignalGenerator(primary_signal_generator=primary, min_confidence=0.5)
+        signal_orig = gen_a.generate_signal(df_orig, 100)
+
+        gen_b = MetaLabelExamSignalGenerator(
+            primary_signal_generator=_CannedPrimarySignalGenerator(
+                fire_at={100: (SignalDirection.BUY, 0.02)}
+            ),
+            min_confidence=0.5,
+        )
+        signal_mutated = gen_b.generate_signal(df_mutated, 100)
+
+        assert signal_orig.direction == signal_mutated.direction
+        assert signal_orig.confidence == pytest.approx(signal_mutated.confidence)
+
+    def test_no_bundle_available_holds(self, mock_config_class, mock_registry_class):
+        mock_registry = MagicMock()
+        mock_registry.select_bundle.side_effect = RuntimeError("no meta_label bundle")
+        mock_registry_class.return_value = mock_registry
+        primary = _CannedPrimarySignalGenerator(fire_at={100: (SignalDirection.BUY, 0.02)})
+
+        generator = MetaLabelExamSignalGenerator(primary_signal_generator=primary)
+        df = _make_df(150)
+
+        signal = generator.generate_signal(df, 100)
+
+        assert signal.direction == SignalDirection.HOLD
+        assert signal.metadata["reason"] == "no_meta_label_bundle"
+
+    def test_open_fire_resolves_and_feeds_rolling_hit_rate(
+        self, mock_config_class, mock_registry_class
+    ):
+        """A fire registered at bar 100 must resolve (via barrier touch or
+        vertical exit) as later bars are processed, and the resolved
+        outcome must feed rolling_hit_rate_20 for a LATER fire's feature
+        row -- never influencing the fire's own decision retroactively."""
+        self._mock_bundle(mock_registry_class, [0.9, 0.9])
+        primary = _CannedPrimarySignalGenerator(
+            fire_at={100: (SignalDirection.BUY, 0.02), 110: (SignalDirection.BUY, 0.01)}
+        )
+        generator = MetaLabelExamSignalGenerator(
+            primary_signal_generator=primary, min_confidence=0.5
+        )
+        df = _make_df(150)
+        # Force a take-profit touch shortly after the first fire so it
+        # resolves well before the second fire at index 110.
+        df.loc[df.index[102], "high"] = df["close"].iloc[100] * 1.10
+
+        generator.generate_signal(df, 100)
+        for i in range(101, 110):
+            generator.generate_signal(df, i)
+        generator.generate_signal(df, 110)
+
+        assert len(generator._resolved_history) == 1
+        assert len(generator._open_fires) == 1  # the second fire, still open

--- a/tests/unit/strategies/test_exam_target_redesign.py
+++ b/tests/unit/strategies/test_exam_target_redesign.py
@@ -24,7 +24,17 @@ from src.strategies.components import (
     HoldSignalGenerator,
     Strategy,
 )
-from src.strategies.exam_target_redesign import create_exam_strategy
+from src.strategies.components.exam_signal_generator import (
+    ClassificationExamSignalGenerator,
+    SmoothedReturnExamSignalGenerator,
+)
+from src.strategies.exam_target_redesign import (
+    _MODEL_VERSION_OVERRIDE_ENV_VAR,
+    create_exam_binary_direction_strategy,
+    create_exam_smoothed_return_strategy,
+    create_exam_strategy,
+    create_exam_triple_barrier_strategy,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -144,3 +154,85 @@ class TestCreateExamStrategy:
     def test_default_name(self):
         strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
         assert strategy.name
+
+
+class TestPerEntrantExamStrategyFactories:
+    """Per-entrant factory functions -- CLI-selectable via backtest.py's
+    exam-only strategy registration (Phase 2b item 4). Each wires the
+    entrant's SignalGenerator into create_exam_strategy's shared harness
+    wiring, and each supports pinning to a SPECIFIC (non-latest) model
+    version per fold via ATB_MODEL_VERSION_OVERRIDE -- exam-only, read
+    inside this module rather than the shared registry, so it can never
+    affect live trading (PredictionModelRegistry.select_bundle always
+    resolves latest regardless)."""
+
+    def test_binary_direction_uses_classification_signal_generator(self):
+        strategy = create_exam_binary_direction_strategy()
+
+        assert isinstance(strategy, Strategy)
+        assert isinstance(strategy.signal_generator, ClassificationExamSignalGenerator)
+        assert strategy.signal_generator.model_name is None
+
+    def test_triple_barrier_uses_classification_signal_generator(self):
+        strategy = create_exam_triple_barrier_strategy()
+
+        assert isinstance(strategy.signal_generator, ClassificationExamSignalGenerator)
+        assert strategy.signal_generator.model_name is None
+
+    def test_smoothed_return_uses_smoothed_return_signal_generator(self):
+        strategy = create_exam_smoothed_return_strategy()
+
+        assert isinstance(strategy.signal_generator, SmoothedReturnExamSignalGenerator)
+        assert strategy.signal_generator.model_name is None
+
+    def test_binary_direction_pins_model_version_via_env_var(self, monkeypatch):
+        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+
+        strategy = create_exam_binary_direction_strategy(symbol="ETHUSDT", timeframe="4h")
+
+        assert strategy.signal_generator.model_name == "ETHUSDT:4h:tft:2026-01-01_1h_v1"
+
+    def test_triple_barrier_pins_model_version_via_env_var(self, monkeypatch):
+        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+
+        strategy = create_exam_triple_barrier_strategy(symbol="BTCUSDT", timeframe="1h")
+
+        assert strategy.signal_generator.model_name == "BTCUSDT:1h:tft_ternary:2026-01-01_1h_v1"
+
+    def test_smoothed_return_pins_model_version_via_env_var(self, monkeypatch):
+        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+
+        strategy = create_exam_smoothed_return_strategy(symbol="BTCUSDT", timeframe="1h")
+
+        assert strategy.signal_generator.model_name == "BTCUSDT:1h:cnn_lstm:2026-01-01_1h_v1"
+
+    def test_env_var_unset_leaves_model_name_none(self, monkeypatch):
+        monkeypatch.delenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, raising=False)
+
+        strategy = create_exam_binary_direction_strategy()
+
+        assert strategy.signal_generator.model_name is None
+
+    def test_each_entrant_gets_a_distinct_strategy_name(self):
+        names = {
+            create_exam_binary_direction_strategy().name,
+            create_exam_triple_barrier_strategy().name,
+            create_exam_smoothed_return_strategy().name,
+        }
+        assert len(names) == 3
+
+    def test_model_type_and_sequence_length_are_overridable(self):
+        strategy = create_exam_binary_direction_strategy(model_type="tft", sequence_length=60)
+
+        assert strategy.signal_generator.sequence_length == 60
+
+    def test_uses_confidence_weighted_sizer_not_fixed_fraction(self):
+        """Same #938 requirement as create_exam_strategy -- verified end-to-
+        end through the per-entrant factories, not just the shared helper."""
+        for strategy in (
+            create_exam_binary_direction_strategy(),
+            create_exam_triple_barrier_strategy(),
+            create_exam_smoothed_return_strategy(),
+        ):
+            assert isinstance(strategy.position_sizer, ConfidenceWeightedSizer)
+            assert type(strategy.risk_manager).__name__ != "FlatRiskManager"

--- a/tests/unit/strategies/test_exam_target_redesign.py
+++ b/tests/unit/strategies/test_exam_target_redesign.py
@@ -8,6 +8,8 @@ base_fraction=0.2, min_confidence=0.3)) -- NOT HyperGrowth's FlatRiskManager
 express confidence/magnitude differences at all.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from src.config.constants import (
@@ -26,11 +28,13 @@ from src.strategies.components import (
 )
 from src.strategies.components.exam_signal_generator import (
     ClassificationExamSignalGenerator,
+    MetaLabelExamSignalGenerator,
     SmoothedReturnExamSignalGenerator,
 )
 from src.strategies.exam_target_redesign import (
     _MODEL_VERSION_OVERRIDE_ENV_VAR,
     create_exam_binary_direction_strategy,
+    create_exam_meta_label_strategy,
     create_exam_smoothed_return_strategy,
     create_exam_strategy,
     create_exam_triple_barrier_strategy,
@@ -236,3 +240,57 @@ class TestPerEntrantExamStrategyFactories:
         ):
             assert isinstance(strategy.position_sizer, ConfidenceWeightedSizer)
             assert type(strategy.risk_manager).__name__ != "FlatRiskManager"
+
+
+class TestCreateExamMetaLabelStrategy:
+    """Entrant (a): wraps a live MLBasicSignalGenerator (the primary) with
+    MetaLabelExamSignalGenerator (the profitability gate). Mocks
+    MLBasicSignalGenerator's construction -- it raises hard when no bundle
+    exists for the requested symbol/model_type/timeframe (unlike the other
+    three entrants' generators, which degrade gracefully to a None
+    prediction_engine), so these tests must not depend on the dev
+    registry's live contents."""
+
+    def test_wires_meta_label_signal_generator_wrapping_the_primary(self):
+        with patch("src.strategies.exam_target_redesign.MLBasicSignalGenerator") as mock_primary:
+            mock_primary_instance = mock_primary.return_value
+            strategy = create_exam_meta_label_strategy()
+
+        assert isinstance(strategy, Strategy)
+        assert isinstance(strategy.signal_generator, MetaLabelExamSignalGenerator)
+        assert strategy.signal_generator.primary_signal_generator is mock_primary_instance
+
+    def test_primary_model_type_threaded_to_ml_basic_signal_generator(self):
+        with patch("src.strategies.exam_target_redesign.MLBasicSignalGenerator") as mock_primary:
+            create_exam_meta_label_strategy(
+                symbol="ETHUSDT", timeframe="4h", primary_model_type="sentiment"
+            )
+
+        mock_primary.assert_called_once_with(
+            model_type="sentiment", timeframe="4h", symbol="ETHUSDT"
+        )
+
+    def test_min_confidence_threaded_to_meta_label_gate(self):
+        with patch("src.strategies.exam_target_redesign.MLBasicSignalGenerator"):
+            strategy = create_exam_meta_label_strategy(min_confidence=0.7)
+
+        assert strategy.signal_generator.min_confidence == pytest.approx(0.7)
+
+    def test_pins_model_version_via_env_var(self, monkeypatch):
+        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+        with patch("src.strategies.exam_target_redesign.MLBasicSignalGenerator"):
+            strategy = create_exam_meta_label_strategy(symbol="BTCUSDT", timeframe="1h")
+
+        assert strategy.signal_generator.model_name == "BTCUSDT:1h:meta_label:2026-01-01_1h_v1"
+
+    def test_strategy_name(self):
+        with patch("src.strategies.exam_target_redesign.MLBasicSignalGenerator"):
+            strategy = create_exam_meta_label_strategy()
+        assert strategy.name == "EntrantA_MetaLabel"
+
+    def test_uses_confidence_weighted_sizer_not_fixed_fraction(self):
+        with patch("src.strategies.exam_target_redesign.MLBasicSignalGenerator"):
+            strategy = create_exam_meta_label_strategy()
+
+        assert isinstance(strategy.position_sizer, ConfidenceWeightedSizer)
+        assert type(strategy.risk_manager).__name__ != "FlatRiskManager"

--- a/tests/unit/strategies/test_exam_target_redesign.py
+++ b/tests/unit/strategies/test_exam_target_redesign.py
@@ -53,6 +53,55 @@ class TestCreateExamStrategy:
         assert strategy.position_sizer is not None
         assert strategy.regime_detector is not None
 
+    def test_risk_overrides_position_sizer_is_fixed_fraction_not_confidence_weighted(self):
+        """Regression guard found via Phase 2b item 6's real end-to-end
+        acceptance run: risk_overrides["position_sizer"] is a STRING key
+        consumed by the CORE risk manager's OWN, unrelated
+        "confidence_weighted" fraction calculator
+        (src/risk/risk_manager.py::_calculate_raw_fraction), which reads a
+        "prediction_confidence" indicator that NOTHING in this codebase ever
+        populates (grep confirms risk_manager.py is the only reference) --
+        it silently returns fraction=0.0 always, which
+        ConfidenceWeightedSizer.calculate_size then treats as a hard veto
+        (risk_amount <= 0 -> position size 0), producing PERMANENT ZERO
+        TRADES regardless of signal confidence or direction. The REAL
+        confidence-weighting happens one layer up, via the
+        ConfidenceWeightedSizer OBJECT assigned to Strategy.position_sizer
+        (unaffected by this string) -- ml_basic.py's create_ml_basic_strategy
+        (which this function mirrors) correctly uses "fixed_fraction" here;
+        this exam scaffolding had drifted from that pattern."""
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+
+        overrides = strategy.get_risk_overrides()
+        assert overrides["position_sizer"] == "fixed_fraction"
+
+    def test_risk_manager_actually_sizes_a_confident_signal_nonzero(self):
+        """End-to-end guard for the same bug: calculate_position_size (the
+        risk_amount Stage-1 cap ConfidenceWeightedSizer's veto depends on)
+        must return a positive value for a real, confident signal -- not
+        just check the override string in isolation."""
+        import pandas as pd
+
+        from src.strategies.components.signal_generator import Signal, SignalDirection
+
+        strategy = create_exam_strategy(signal_generator=HoldSignalGenerator())
+        df = pd.DataFrame(
+            {
+                "open": [100.0] * 150,
+                "high": [101.0] * 150,
+                "low": [99.0] * 150,
+                "close": [100.0] * 150,
+                "volume": [1000.0] * 150,
+            }
+        )
+        signal = Signal(direction=SignalDirection.BUY, strength=0.6, confidence=0.6, metadata={})
+
+        risk_amount = strategy.risk_manager.calculate_position_size(
+            signal, 1000.0, None, df=df, index=100, price=100.0
+        )
+
+        assert risk_amount > 0.0
+
     def test_uses_the_supplied_signal_generator(self):
         signal_generator = HoldSignalGenerator()
         strategy = create_exam_strategy(signal_generator=signal_generator)

--- a/tests/unit/strategies/test_exam_target_redesign.py
+++ b/tests/unit/strategies/test_exam_target_redesign.py
@@ -194,21 +194,21 @@ class TestPerEntrantExamStrategyFactories:
 
         strategy = create_exam_binary_direction_strategy(symbol="ETHUSDT", timeframe="4h")
 
-        assert strategy.signal_generator.model_name == "ETHUSDT:4h:tft:2026-01-01_1h_v1"
+        assert strategy.signal_generator.model_name == "ETHUSDT:4h:price:2026-01-01_1h_v1"
 
     def test_triple_barrier_pins_model_version_via_env_var(self, monkeypatch):
         monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
 
         strategy = create_exam_triple_barrier_strategy(symbol="BTCUSDT", timeframe="1h")
 
-        assert strategy.signal_generator.model_name == "BTCUSDT:1h:tft_ternary:2026-01-01_1h_v1"
+        assert strategy.signal_generator.model_name == "BTCUSDT:1h:price:2026-01-01_1h_v1"
 
     def test_smoothed_return_pins_model_version_via_env_var(self, monkeypatch):
         monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
 
         strategy = create_exam_smoothed_return_strategy(symbol="BTCUSDT", timeframe="1h")
 
-        assert strategy.signal_generator.model_name == "BTCUSDT:1h:cnn_lstm:2026-01-01_1h_v1"
+        assert strategy.signal_generator.model_name == "BTCUSDT:1h:price:2026-01-01_1h_v1"
 
     def test_env_var_unset_leaves_model_name_none(self, monkeypatch):
         monkeypatch.delenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, raising=False)
@@ -225,8 +225,10 @@ class TestPerEntrantExamStrategyFactories:
         }
         assert len(names) == 3
 
-    def test_model_type_and_sequence_length_are_overridable(self):
-        strategy = create_exam_binary_direction_strategy(model_type="tft", sequence_length=60)
+    def test_registry_model_type_and_sequence_length_are_overridable(self):
+        strategy = create_exam_binary_direction_strategy(
+            registry_model_type="sentiment", sequence_length=60
+        )
 
         assert strategy.signal_generator.sequence_length == 60
 

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -280,7 +280,7 @@ def test_reload_models_clears_cache_on_success(tmp_path: Path, monkeypatch):
     # Patch _scan_registry to return a valid bundle so reload doesn't early-return
     fake_bundle = _make_fake_bundle("BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
     fake_bundles = {("BTCUSDT", "1h", "basic"): fake_bundle}
-    with patch.object(reg, "_scan_registry", return_value=(fake_bundles, {})):
+    with patch.object(reg, "_scan_registry", return_value=(fake_bundles, {}, {})):
         # Act
         reg.reload_models()
 
@@ -310,7 +310,7 @@ def test_reload_models_warns_when_no_cache_manager(tmp_path: Path, monkeypatch, 
 
     with (
         caplog.at_level(logging.WARNING),
-        patch.object(reg, "_scan_registry", return_value=(fake_bundles, {})),
+        patch.object(reg, "_scan_registry", return_value=(fake_bundles, {}, {})),
     ):
         reg.reload_models()
 
@@ -345,7 +345,7 @@ def test_reload_models_handles_cache_clear_exception(tmp_path: Path, monkeypatch
 
     with (
         caplog.at_level(logging.WARNING),
-        patch.object(reg, "_scan_registry", return_value=(fake_bundles, {})),
+        patch.object(reg, "_scan_registry", return_value=(fake_bundles, {}, {})),
     ):
         reg.reload_models()
 
@@ -375,9 +375,136 @@ def test_reload_models_cache_clear_returns_none(tmp_path: Path, monkeypatch):
     fake_bundle = _make_fake_bundle("BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
     fake_bundles = {("BTCUSDT", "1h", "basic"): fake_bundle}
 
-    with patch.object(reg, "_scan_registry", return_value=(fake_bundles, {})):
+    with patch.object(reg, "_scan_registry", return_value=(fake_bundles, {}, {})):
         # Act -- should not raise despite None return value
         reg.reload_models()
 
     # Assert
     mock_cache_manager.clear.assert_called_once()
+
+
+# ---- Model-version pinning tests (Phase 2b item 4) ----
+#
+# The exam harness fold-runner needs to pin a SPECIFIC model version per
+# fold; select_bundle()/list_bundles() always resolve "latest" with no way
+# to override it, and select_bundle() is ALSO called unconditionally on the
+# live trading path (ml_signal_generator.py) -- so pinning must not touch
+# it. get_bundle_by_key() is the opt-in escape hatch instead: it searches
+# every loaded version, not just "latest", and only activates when a caller
+# explicitly passes a full bundle key (PredictionEngine._resolve_bundle's
+# model_name fallback) -- never on select_bundle()'s live-trading callers.
+
+
+def _make_bundle_with_latest_symlink(
+    tmpdir: Path, symbol: str, model_type: str, timeframe: str, version: str
+) -> Path:
+    """Like _make_bundle, but also points a `latest` symlink at the version."""
+    base = _make_bundle(tmpdir, symbol, model_type, timeframe, version)
+    latest = base.parent / "latest"
+    if latest.exists() or latest.is_symlink():
+        latest.unlink()
+    latest.symlink_to(base, target_is_directory=True)
+    return base
+
+
+@pytest.mark.fast
+def test_versioned_bundles_populated_for_every_loaded_version(tmp_path: Path, monkeypatch):
+    reg_root = tmp_path / "models"
+    _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
+    _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
+
+    cfg = PredictionConfig.from_config_manager()
+    monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
+    reg = PredictionModelRegistry(cfg)
+
+    assert ("BTCUSDT", "1h", "basic", "2025-01-01_1h_v1") in reg._versioned_bundles
+    assert ("BTCUSDT", "1h", "basic", "2025-02-01_1h_v2") in reg._versioned_bundles
+
+
+@pytest.mark.fast
+def test_get_bundle_by_key_finds_non_latest_version(tmp_path: Path, monkeypatch):
+    reg_root = tmp_path / "models"
+    _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
+    _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
+
+    cfg = PredictionConfig.from_config_manager()
+    monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
+    reg = PredictionModelRegistry(cfg)
+
+    bundle = reg.get_bundle_by_key("BTCUSDT:1h:basic:2025-01-01_1h_v1")
+
+    assert bundle is not None
+    assert bundle.version_id == "2025-01-01_1h_v1"
+
+
+@pytest.mark.fast
+def test_get_bundle_by_key_also_finds_latest_version(tmp_path: Path, monkeypatch):
+    reg_root = tmp_path / "models"
+    _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
+
+    cfg = PredictionConfig.from_config_manager()
+    monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
+    reg = PredictionModelRegistry(cfg)
+
+    bundle = reg.get_bundle_by_key("BTCUSDT:1h:basic:2025-02-01_1h_v2")
+
+    assert bundle is not None
+    assert bundle.version_id == "2025-02-01_1h_v2"
+
+
+@pytest.mark.fast
+def test_get_bundle_by_key_returns_none_for_unknown_key(tmp_path: Path, monkeypatch):
+    reg_root = tmp_path / "models"
+    _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
+
+    cfg = PredictionConfig.from_config_manager()
+    monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
+    reg = PredictionModelRegistry(cfg)
+
+    assert reg.get_bundle_by_key("BTCUSDT:1h:basic:does-not-exist_1h_v9") is None
+
+
+@pytest.mark.fast
+def test_select_bundle_always_resolves_latest_regardless_of_other_versions(
+    tmp_path: Path, monkeypatch
+):
+    """select_bundle() is also called unconditionally on the live trading
+    path (ml_signal_generator.py) -- it must always resolve latest, with no
+    pinning mechanism reachable through it."""
+    reg_root = tmp_path / "models"
+    _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
+    _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
+
+    cfg = PredictionConfig.from_config_manager()
+    monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
+    reg = PredictionModelRegistry(cfg)
+
+    bundle = reg.select_bundle(symbol="BTCUSDT", model_type="basic", timeframe="1h")
+
+    assert bundle.version_id == "2025-02-01_1h_v2"
+
+
+@pytest.mark.fast
+def test_reload_models_closes_versioned_runners_without_double_close(tmp_path: Path, monkeypatch):
+    """reload_models must close every distinct runner across both _bundles
+    and _versioned_bundles exactly once -- ONNX sessions must be cleaned up
+    (CODE.md Resource Management); double-closing or leaking either is a
+    live-crash risk."""
+    reg_root = tmp_path / "models"
+    _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
+    _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
+
+    cfg = PredictionConfig.from_config_manager()
+    monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
+    reg = PredictionModelRegistry(cfg)
+
+    old_bundle_runner = reg._bundles[("BTCUSDT", "1h", "basic")].runner
+    old_v1_runner = reg._versioned_bundles[("BTCUSDT", "1h", "basic", "2025-01-01_1h_v1")].runner
+    close_calls = {"bundle": 0, "v1": 0}
+    old_bundle_runner.close = lambda: close_calls.__setitem__("bundle", close_calls["bundle"] + 1)
+    old_v1_runner.close = lambda: close_calls.__setitem__("v1", close_calls["v1"] + 1)
+
+    reg.reload_models()
+
+    assert close_calls["bundle"] == 1
+    assert close_calls["v1"] == 1

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -408,7 +408,12 @@ def _make_bundle_with_latest_symlink(
 
 
 @pytest.mark.fast
-def test_versioned_bundles_populated_for_every_loaded_version(tmp_path: Path, monkeypatch):
+def test_non_latest_version_indexed_but_not_eagerly_loaded(tmp_path: Path, monkeypatch):
+    """Item 2 fix (PR #950 review): a non-latest version must be
+    DISCOVERABLE (its path indexed) without its ONNX InferenceSession being
+    opened at scan time -- live steady-state memory must stay O(latest),
+    not O(every version ever trained). Only get_bundle_by_key (exam-only,
+    never called on the live trading path) triggers the lazy load."""
     reg_root = tmp_path / "models"
     _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
     _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
@@ -417,8 +422,48 @@ def test_versioned_bundles_populated_for_every_loaded_version(tmp_path: Path, mo
     monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
     reg = PredictionModelRegistry(cfg)
 
-    assert ("BTCUSDT", "1h", "basic", "2025-01-01_1h_v1") in reg._versioned_bundles
+    # latest IS eagerly loaded (unchanged live behavior/cost).
     assert ("BTCUSDT", "1h", "basic", "2025-02-01_1h_v2") in reg._versioned_bundles
+    # The non-latest version is only INDEXED (path recorded), not loaded.
+    assert ("BTCUSDT", "1h", "basic", "2025-01-01_1h_v1") not in reg._versioned_bundles
+    assert ("BTCUSDT", "1h", "basic", "2025-01-01_1h_v1") in reg._versioned_bundle_paths
+
+    # Pinning it via get_bundle_by_key lazily loads and caches it.
+    bundle = reg.get_bundle_by_key("BTCUSDT:1h:basic:2025-01-01_1h_v1")
+    assert bundle is not None
+    assert ("BTCUSDT", "1h", "basic", "2025-01-01_1h_v1") in reg._versioned_bundles
+
+
+@pytest.mark.fast
+def test_no_non_latest_sessions_constructed_when_no_override_set(tmp_path: Path, monkeypatch):
+    """Item 2 fix (PR #950 review), explicit regression guard: constructing
+    the registry with several non-latest versions on disk must not
+    construct an OnnxRunner/InferenceSession for ANY of them -- only the
+    `latest` symlink target gets loaded."""
+    reg_root = tmp_path / "models"
+    _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2024-01-01_1h_v1")
+    _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2024-06-01_1h_v2")
+    _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2024-11-01_1h_v3")
+    _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v4")
+
+    cfg = PredictionConfig.from_config_manager()
+    monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
+
+    load_calls: list[str] = []
+    original_load_bundle = PredictionModelRegistry._load_bundle
+
+    def spy_load_bundle(self, symbol, model_type, vdir):
+        load_calls.append(Path(vdir).name)
+        return original_load_bundle(self, symbol, model_type, vdir)
+
+    with patch.object(PredictionModelRegistry, "_load_bundle", spy_load_bundle):
+        reg = PredictionModelRegistry(cfg)
+
+    # Only the `latest` symlink target is ever given an OnnxRunner -- the 3
+    # non-latest versions are indexed by path only.
+    assert load_calls == ["latest"]
+    assert len(reg._versioned_bundles) == 1
+    assert len(reg._versioned_bundle_paths) == 4  # all 4 concrete versions indexed
 
 
 @pytest.mark.fast
@@ -486,10 +531,13 @@ def test_select_bundle_always_resolves_latest_regardless_of_other_versions(
 
 @pytest.mark.fast
 def test_reload_models_closes_versioned_runners_without_double_close(tmp_path: Path, monkeypatch):
-    """reload_models must close every distinct runner across both _bundles
-    and _versioned_bundles exactly once -- ONNX sessions must be cleaned up
-    (CODE.md Resource Management); double-closing or leaking either is a
-    live-crash risk."""
+    """reload_models must close every distinct LOADED runner across both
+    _bundles and _versioned_bundles exactly once -- ONNX sessions must be
+    cleaned up (CODE.md Resource Management); double-closing or leaking
+    either is a live-crash risk. v1 is only loaded here because we pin it
+    via get_bundle_by_key first (the lazy-loading fix, item 2) -- a version
+    nobody ever pins is never opened in the first place, so there is
+    nothing to close for it."""
     reg_root = tmp_path / "models"
     _make_bundle(reg_root, "BTCUSDT", "basic", "1h", "2025-01-01_1h_v1")
     _make_bundle_with_latest_symlink(reg_root, "BTCUSDT", "basic", "1h", "2025-02-01_1h_v2")
@@ -497,6 +545,9 @@ def test_reload_models_closes_versioned_runners_without_double_close(tmp_path: P
     cfg = PredictionConfig.from_config_manager()
     monkeypatch.setattr(cfg, "model_registry_path", str(reg_root))
     reg = PredictionModelRegistry(cfg)
+
+    pinned = reg.get_bundle_by_key("BTCUSDT:1h:basic:2025-01-01_1h_v1")
+    assert pinned is not None
 
     old_bundle_runner = reg._bundles[("BTCUSDT", "1h", "basic")].runner
     old_v1_runner = reg._versioned_bundles[("BTCUSDT", "1h", "basic", "2025-01-01_1h_v1")].runner

--- a/tests/unit/training_pipeline/test_config_paths.py
+++ b/tests/unit/training_pipeline/test_config_paths.py
@@ -5,6 +5,29 @@ import src.ml.training_pipeline.config as cfg
 
 def test_training_paths_default_points_to_model_registry(tmp_path, monkeypatch):
     monkeypatch.setattr(cfg, "get_project_root", lambda: Path(tmp_path))
+    # models_dir is resolved by get_model_registry_root() (shared with
+    # promote_model_version and PredictionConfig.model_registry_path, PR
+    # #950 review item 5) -- also monkeypatch its own get_project_root()
+    # call so the default (no MODEL_REGISTRY_PATH override) case matches.
+    monkeypatch.setattr("src.infrastructure.runtime.paths.get_project_root", lambda: Path(tmp_path))
+    monkeypatch.delenv("MODEL_REGISTRY_PATH", raising=False)
+
     paths = cfg.TrainingPaths.default()
+
     assert paths.models_dir == Path(tmp_path) / "src" / "ml" / "models"
     assert paths.data_dir == Path(tmp_path) / "data"
+
+
+def test_training_paths_default_honors_model_registry_path_override(tmp_path, monkeypatch):
+    """PR #950 review item 5: MODEL_REGISTRY_PATH (the same key
+    PredictionConfig.model_registry_path reads) must redirect models_dir --
+    the lever acceptance tests use to keep trained artifacts out of the
+    real src/ml/models/ registry."""
+    monkeypatch.setattr(cfg, "get_project_root", lambda: Path(tmp_path))
+    override_dir = tmp_path / "isolated-registry"
+    monkeypatch.setenv("MODEL_REGISTRY_PATH", str(override_dir))
+
+    paths = cfg.TrainingPaths.default()
+
+    assert paths.models_dir == override_dir
+    assert override_dir.is_dir()

--- a/tests/unit/training_pipeline/test_ml_training_config.py
+++ b/tests/unit/training_pipeline/test_ml_training_config.py
@@ -282,6 +282,25 @@ class TestTrainingConfig:
                 target_type="meta_label",
             )
 
+    def test_use_mock_data_defaults_to_false(self):
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+        )
+        assert config.use_mock_data is False
+
+    def test_use_mock_data_is_settable(self):
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+            use_mock_data=True,
+        )
+        assert config.use_mock_data is True
+
     def test_primary_model_type_defaults_to_none(self):
         config = TrainingConfig(
             symbol="BTCUSDT",

--- a/tests/unit/training_pipeline/test_ml_training_config.py
+++ b/tests/unit/training_pipeline/test_ml_training_config.py
@@ -156,6 +156,19 @@ class TestTrainingConfig:
         # Assert
         assert config.model_type == "tft"
 
+    def test_accepts_tft_ternary_model_type(self):
+        # Arrange & Act
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+            model_type="tft_ternary",
+        )
+
+        # Assert
+        assert config.model_type == "tft_ternary"
+
     def test_rejects_unknown_model_type(self):
         # Act & Assert
         with pytest.raises(ValueError, match="model_type"):

--- a/tests/unit/training_pipeline/test_ml_training_config.py
+++ b/tests/unit/training_pipeline/test_ml_training_config.py
@@ -62,9 +62,17 @@ class TestTrainingPaths:
         assert paths.models_dir == models_dir
 
     @patch("src.ml.training_pipeline.config.get_project_root")
-    def test_default_factory(self, mock_get_root, tmp_path):
+    def test_default_factory(self, mock_get_root, tmp_path, monkeypatch):
         # Arrange
         mock_get_root.return_value = tmp_path
+        # models_dir is resolved by get_model_registry_root() (shared with
+        # promote_model_version and PredictionConfig.model_registry_path,
+        # PR #950 review item 5) -- it calls its OWN get_project_root()
+        # (src.infrastructure.runtime.paths), unaffected by the patch
+        # above, so it must be patched too for the default (no
+        # MODEL_REGISTRY_PATH override) case to resolve under tmp_path.
+        monkeypatch.setattr("src.infrastructure.runtime.paths.get_project_root", lambda: tmp_path)
+        monkeypatch.delenv("MODEL_REGISTRY_PATH", raising=False)
 
         # Act
         paths = TrainingPaths.default()

--- a/tests/unit/training_pipeline/test_ml_training_config.py
+++ b/tests/unit/training_pipeline/test_ml_training_config.py
@@ -247,6 +247,50 @@ class TestTrainingConfig:
         assert config.model_type == "tft"
         assert config.target_type == "regression"
 
+    def test_accepts_lightgbm_model_type(self):
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+            model_type="lightgbm",
+        )
+        assert config.model_type == "lightgbm"
+
+    def test_accepts_meta_label_target_type_with_primary_model_type(self):
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+            target_type="meta_label",
+            primary_model_type="basic",
+        )
+        assert config.target_type == "meta_label"
+        assert config.primary_model_type == "basic"
+
+    def test_meta_label_without_primary_model_type_raises(self):
+        """meta_label needs a primary signal to run forward first --
+        primary_model_type names its registry model_type. Required, per
+        train.py's --primary-model-type help text."""
+        with pytest.raises(ValueError, match="primary_model_type"):
+            TrainingConfig(
+                symbol="BTCUSDT",
+                timeframe="1h",
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 12, 31),
+                target_type="meta_label",
+            )
+
+    def test_primary_model_type_defaults_to_none(self):
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 12, 31),
+        )
+        assert config.primary_model_type is None
+
     def test_days_requested(self):
         # Arrange
         start = datetime(2024, 1, 1)

--- a/tests/unit/training_pipeline/test_ml_training_ingestion.py
+++ b/tests/unit/training_pipeline/test_ml_training_ingestion.py
@@ -209,6 +209,39 @@ class TestLoadTrainingCorpus:
         assert result.index.tz is not None
         assert len(result) == len(df)
 
+    def test_use_mock_data_bypasses_binance_entirely(self, tmp_path):
+        """Test-only escape hatch (mirrors `atb live --mock-data`): when
+        ctx.config.use_mock_data is set, BinanceProvider must never be
+        constructed at all -- acceptance/integration tests rely on this to
+        exercise the real training pipeline with zero network dependency."""
+        ctx = _make_ctx(tmp_path)
+        ctx.config.use_mock_data = True
+
+        with (
+            patch("src.data_providers.binance_provider.BinanceProvider") as binance_cls,
+            patch("src.data_providers.cached_data_provider.CachedDataProvider") as cached_cls,
+        ):
+            result = load_training_corpus(ctx)
+
+        binance_cls.assert_not_called()
+        cached_cls.assert_not_called()
+        assert not result.empty
+        assert result.index.min() >= pd.Timestamp(ctx.start_iso)
+        assert result.index.max() <= pd.Timestamp(ctx.end_iso)
+
+    def test_use_mock_data_produces_deterministic_dense_coverage(self, tmp_path):
+        """MockDataProvider must produce a corpus that passes the SAME
+        coverage validation a real Binance-backed corpus would (dense,
+        fixed-frequency, no gaps) -- otherwise use_mock_data would fail the
+        exact guard it's meant to route around."""
+        ctx = _make_ctx(tmp_path, start=datetime(2024, 1, 1), end=datetime(2024, 1, 5))
+        ctx.config.use_mock_data = True
+
+        result = load_training_corpus(ctx)
+
+        expected_bars = len(pd.date_range(ctx.start_iso, ctx.end_iso, freq="1h", tz="UTC"))
+        assert len(result) == pytest.approx(expected_bars, abs=1)
+
 
 @pytest.mark.fast
 class TestValidateDataCoverage:

--- a/tests/unit/training_pipeline/test_ml_training_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_labels.py
@@ -98,6 +98,56 @@ class TestSmoothedForwardReturnLabels:
         assert np.isnan(result.values[1])
         assert np.isnan(result.values[2])
 
+    def test_zero_divisor_marks_row_invalid_not_zero_or_inf(self):
+        """PR #948 review finding (claude[bot]): close_arr[idx]==0 at the
+        divisor must not silently produce inf/nan written into the label
+        array as if it were a valid, fully-realized row -- the row must be
+        marked invalid (valid_mask=False), matching this module's own
+        'unresolved is not the same as zero' convention used everywhere else."""
+        close = pd.Series([0.0, 101.0, 103.0])
+        result = smoothed_forward_return_labels(close, horizon=1)
+        assert result.valid_mask[0] == False  # noqa: E712 -- explicit bool check
+        assert np.isnan(result.values[0])
+
+    def test_negative_divisor_marks_row_invalid(self):
+        close = pd.Series([-5.0, 101.0, 103.0])
+        result = smoothed_forward_return_labels(close, horizon=1)
+        assert result.valid_mask[0] == False  # noqa: E712
+        assert np.isnan(result.values[0])
+
+    def test_nan_divisor_marks_row_invalid(self):
+        close = pd.Series([float("nan"), 101.0, 103.0])
+        result = smoothed_forward_return_labels(close, horizon=1)
+        assert result.valid_mask[0] == False  # noqa: E712
+        assert np.isnan(result.values[0])
+
+    def test_bad_divisor_does_not_affect_other_rows(self):
+        """A single corrupted close must not poison neighboring rows -- only
+        the row whose OWN entry price is the bad divisor is marked invalid."""
+        close = pd.Series([100.0, 0.0, 103.0, 105.0])
+        result = smoothed_forward_return_labels(close, horizon=1)
+        # t=0: divisor is close[0]=100 (fine) -- valid even though the
+        # FUTURE close it reads happens to be zero (a legitimate, if
+        # unusual, forward value -- only the divisor, close[t] itself, is
+        # guarded).
+        assert result.valid_mask[0]
+        # t=1: divisor is close[1]=0.0 -- invalid.
+        assert result.valid_mask[1] == False  # noqa: E712
+        # t=2: divisor is close[2]=103.0 -- valid, unaffected by t=1's bad row.
+        assert result.valid_mask[2]
+        assert result.values[2] == pytest.approx(105.0 / 103.0 - 1.0, abs=1e-9)
+
+    def test_no_runtime_warning_on_zero_divisor(self):
+        """Guards against a numpy RuntimeWarning (divide by zero / invalid
+        value) leaking from the vectorized computation -- the fix must
+        avoid dividing by the bad values at all, not divide-then-discard."""
+        import warnings
+
+        close = pd.Series([0.0, 101.0, 103.0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            smoothed_forward_return_labels(close, horizon=1)
+
 
 class TestTripleBarrierLabels:
     """Hand-computable fixture (per task instructions): a tiny synthetic OHLC

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -345,7 +345,11 @@ class TestResolveFiredTradeEntryPriceValidation:
         )
         with pytest.raises(ValueError, match="entry_price"):
             resolve_fired_trade(
-                df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+                df,
+                fire_index=0,
+                direction=1,
+                take_profit_pct=0.05,
+                stop_loss_pct=0.03,
                 max_holding_bars=1,
             )
 
@@ -359,7 +363,11 @@ class TestResolveFiredTradeEntryPriceValidation:
         )
         with pytest.raises(ValueError, match="entry_price"):
             resolve_fired_trade(
-                df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+                df,
+                fire_index=0,
+                direction=1,
+                take_profit_pct=0.05,
+                stop_loss_pct=0.03,
                 max_holding_bars=1,
             )
 
@@ -373,7 +381,11 @@ class TestResolveFiredTradeEntryPriceValidation:
         )
         with pytest.raises(ValueError, match="entry_price"):
             resolve_fired_trade(
-                df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+                df,
+                fire_index=0,
+                direction=1,
+                take_profit_pct=0.05,
+                stop_loss_pct=0.03,
                 max_holding_bars=1,
             )
 
@@ -392,7 +404,11 @@ class TestResolveFiredTradeEntryPriceValidation:
             }
         )
         resolution = resolve_fired_trade(
-            df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            df,
+            fire_index=0,
+            direction=1,
+            take_profit_pct=0.05,
+            stop_loss_pct=0.03,
             max_holding_bars=3,
         )
         assert resolution is not None

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -22,9 +22,12 @@ import pytest
 
 from src.engines.shared.cost_calculator import CostCalculator
 from src.ml.training_pipeline.meta_labels import (
+    META_LABEL_FEATURE_ORDER,
     PrimarySignalRecord,
     TradeResolution,
     build_meta_label_features,
+    encode_meta_label_feature_row,
+    encode_meta_label_features_for_training,
     resolve_fired_trade,
     run_primary_signal_forward,
     simulate_fired_trade_profitability,
@@ -606,3 +609,153 @@ class TestBuildMetaLabelFeatures:
         ]
         with pytest.raises(ValueError, match="length"):
             build_meta_label_features(df, fires, resolutions)
+
+
+class TestEncodeMetaLabelFeaturesForTraining:
+    """encode_meta_label_features_for_training turns build_meta_label_features'
+    DataFrame (with string regime enum columns) into numeric (X, y) arrays a
+    sklearn LogisticRegression can fit on."""
+
+    @staticmethod
+    def _synthetic_df(periods=300):
+        rng = np.random.default_rng(11)
+        closes = 100.0 + np.cumsum(rng.normal(0, 0.3, periods))
+        return pd.DataFrame(
+            {
+                "open": closes - 0.1,
+                "high": closes + 0.5,
+                "low": closes - 0.5,
+                "close": closes,
+                "volume": 1000.0 + rng.uniform(0, 50, periods),
+            },
+            index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+        )
+
+    def test_shape_matches_feature_order(self):
+        df = self._synthetic_df()
+        fires = [
+            PrimarySignalRecord(index=100, direction=1, predicted_return=0.01),
+            PrimarySignalRecord(index=120, direction=-1, predicted_return=-0.02),
+        ]
+        resolutions = [
+            TradeResolution(profitable=True, exit_index=101),
+            TradeResolution(profitable=False, exit_index=121),
+        ]
+        features_df = build_meta_label_features(df, fires, resolutions)
+
+        X, y = encode_meta_label_features_for_training(features_df)
+
+        assert X.shape == (2, len(META_LABEL_FEATURE_ORDER))
+        assert y.shape == (2,)
+        assert X.dtype == np.float32
+        assert list(y) == [1, 0]
+
+    def test_nan_rolling_hit_rate_filled_with_neutral_prior(self):
+        """The first fire has no eligible prior resolved fires -- its
+        rolling_hit_rate_20 is NaN in build_meta_label_features' output and
+        must be filled with a documented neutral prior (0.5), not left as
+        NaN (sklearn cannot fit on NaN)."""
+        df = self._synthetic_df()
+        fires = [PrimarySignalRecord(index=100, direction=1, predicted_return=0.01)]
+        resolutions = [TradeResolution(profitable=True, exit_index=101)]
+        features_df = build_meta_label_features(df, fires, resolutions)
+        assert np.isnan(features_df["rolling_hit_rate_20"].iloc[0])  # sanity check
+
+        X, _y = encode_meta_label_features_for_training(features_df)
+
+        assert np.all(np.isfinite(X))
+        hit_rate_idx = META_LABEL_FEATURE_ORDER.index("rolling_hit_rate_20")
+        assert X[0, hit_rate_idx] == pytest.approx(0.5)
+
+    def test_regime_columns_are_numeric_encoded(self):
+        df = self._synthetic_df()
+        fires = [PrimarySignalRecord(index=150, direction=1, predicted_return=0.01)]
+        resolutions = [TradeResolution(profitable=True, exit_index=151)]
+        features_df = build_meta_label_features(df, fires, resolutions)
+
+        X, _y = encode_meta_label_features_for_training(features_df)
+
+        # Every value must be finite and numeric -- no string enum values leaked through.
+        assert np.all(np.isfinite(X))
+
+    def test_empty_features_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            encode_meta_label_features_for_training(pd.DataFrame())
+
+
+class TestEncodeMetaLabelFeatureRow:
+    """encode_meta_label_feature_row is the INFERENCE-time counterpart --
+    one row at a time (the exam signal generator computes features
+    incrementally, not as a batch DataFrame) -- sharing the exact same
+    encoding as encode_meta_label_features_for_training so training and
+    inference can never drift apart."""
+
+    def test_returns_array_in_feature_order(self):
+        row = encode_meta_label_feature_row(
+            realized_vol_48=0.01,
+            rolling_hit_rate_20=0.6,
+            session_sin=0.5,
+            session_cos=0.86,
+            regime_trend="trend_up",
+            regime_volatility="high_vol",
+            regime_confidence=0.7,
+            predicted_return_magnitude=0.02,
+        )
+
+        assert row.shape == (len(META_LABEL_FEATURE_ORDER),)
+        assert row.dtype == np.float32
+        assert np.all(np.isfinite(row))
+
+    def test_nan_rolling_hit_rate_filled_with_neutral_prior(self):
+        row = encode_meta_label_feature_row(
+            realized_vol_48=0.01,
+            rolling_hit_rate_20=float("nan"),
+            session_sin=0.5,
+            session_cos=0.86,
+            regime_trend="range",
+            regime_volatility="low_vol",
+            regime_confidence=0.5,
+            predicted_return_magnitude=0.01,
+        )
+
+        hit_rate_idx = META_LABEL_FEATURE_ORDER.index("rolling_hit_rate_20")
+        assert row[hit_rate_idx] == pytest.approx(0.5)
+
+    def test_matches_batch_encoding_for_the_same_logical_row(self):
+        """Training-time (batch) and inference-time (row) encoders must
+        agree bit-for-bit on the same input -- this is the leak/drift guard
+        the whole split exists to prevent."""
+        df = self._synthetic_df_helper()
+        fires = [PrimarySignalRecord(index=150, direction=1, predicted_return=0.02)]
+        resolutions = [TradeResolution(profitable=True, exit_index=151)]
+        features_df = build_meta_label_features(df, fires, resolutions)
+        batch_X, _y = encode_meta_label_features_for_training(features_df)
+
+        row = features_df.iloc[0]
+        row_X = encode_meta_label_feature_row(
+            realized_vol_48=row["realized_vol_48"],
+            rolling_hit_rate_20=row["rolling_hit_rate_20"],
+            session_sin=row["session_sin"],
+            session_cos=row["session_cos"],
+            regime_trend=row["regime_trend"],
+            regime_volatility=row["regime_volatility"],
+            regime_confidence=row["regime_confidence"],
+            predicted_return_magnitude=row["predicted_return_magnitude"],
+        )
+
+        np.testing.assert_allclose(batch_X[0], row_X)
+
+    @staticmethod
+    def _synthetic_df_helper(periods=300):
+        rng = np.random.default_rng(13)
+        closes = 100.0 + np.cumsum(rng.normal(0, 0.3, periods))
+        return pd.DataFrame(
+            {
+                "open": closes - 0.1,
+                "high": closes + 0.5,
+                "low": closes - 0.5,
+                "close": closes,
+                "volume": 1000.0 + rng.uniform(0, 50, periods),
+            },
+            index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+        )

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -28,6 +28,7 @@ from src.ml.training_pipeline.meta_labels import (
     build_meta_label_features,
     encode_meta_label_feature_row,
     encode_meta_label_features_for_training,
+    resolution_ordered_hit_rate,
     resolve_fired_trade,
     run_primary_signal_forward,
     simulate_fired_trade_profitability,
@@ -419,6 +420,70 @@ class TestResolveFiredTradeEntryPriceValidation:
         expected_raw_return = pnl_percent(100.0, 105.0, Side.LONG)
         round_trip_cost = 2.0 * CostCalculator().fee_rate
         assert resolution.profitable == ((expected_raw_return - round_trip_cost) > 0.0)
+
+
+class TestResolutionOrderedHitRate:
+    """resolution_ordered_hit_rate is the single shared windowing function
+    both build_meta_label_features (training) and
+    MetaLabelExamSignalGenerator._rolling_hit_rate (serving) now call --
+    the fix for the fire-order-vs-resolution-order train/serve skew found
+    in PR #950 review."""
+
+    def test_empty_history_is_nan(self):
+        assert np.isnan(resolution_ordered_hit_rate([], 20))
+
+    def test_windows_by_resolution_order_not_input_order(self):
+        """Passing entries in FIRE order (not resolution order) must not
+        change the result -- the function re-sorts internally."""
+        # fire_index 0 resolves LAST (exit_index=100); fire_index 1 resolves
+        # FIRST (exit_index=10). "Last 1 by resolution order" must be
+        # fire_index 0 (True), not fire_index 1 (False), even though
+        # fire_index 1 comes second in fire/input order.
+        fire_order_input = [(100, 0, True), (10, 1, False)]
+        assert resolution_ordered_hit_rate(fire_order_input, 1) == pytest.approx(1.0)
+
+    def test_ties_on_exit_index_break_by_fire_index(self):
+        """Same-bar resolutions must order by fire_index ascending (matching
+        the online path: _resolve_open_fires iterates still-open fires in
+        their original registration order within one bar)."""
+        tied = [(50, 2, False), (50, 1, True)]
+        # Sorted by (exit_index, fire_index): (50,1,True) then (50,2,False).
+        # Last 1 -> fire_index 2 -> False.
+        assert resolution_ordered_hit_rate(tied, 1) == pytest.approx(0.0)
+
+    def test_overlapping_trades_past_lookback_selects_resolution_ordered_subset(self):
+        """With >20 resolved fires whose fire-order and resolution-order
+        diverge, the correct (resolution-ordered) trailing-20 window must
+        differ from the old, buggy fire-ordered trailing-20 window -- this
+        is the regression this fix closes."""
+        # 25 fires, alternating: even fire_index positions resolve almost
+        # immediately (fast, profitable=True); odd positions resolve much
+        # later (slow, profitable=False) -- classic overlapping-trades
+        # pattern (an early slow fire resolves after several later fast
+        # fires have already resolved).
+        history = []
+        for i in range(25):
+            fire_index = i
+            if i % 2 == 0:
+                exit_index = fire_index + 1  # fast
+                profitable = True
+            else:
+                exit_index = fire_index + 40  # slow, overlaps many fast fires
+                profitable = False
+            history.append((exit_index, fire_index, profitable))
+
+        correct = resolution_ordered_hit_rate(history, 20)
+
+        # The old (buggy) fire-order windowing: sort by fire_index only,
+        # take the last 20 by FIRE order (i.e. fires 5..24).
+        fire_ordered = sorted(history, key=lambda item: item[1])
+        buggy_last_20 = [profitable for _, _, profitable in fire_ordered[-20:]]
+        buggy = float(np.mean(buggy_last_20))
+
+        # The two windowing conventions must select genuinely different
+        # subsets for this scenario (proving the test is a meaningful
+        # regression guard, not a no-op).
+        assert correct != pytest.approx(buggy)
 
 
 class TestBuildMetaLabelFeatures:

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from src.engines.shared.cost_calculator import CostCalculator
 from src.ml.training_pipeline.meta_labels import (
     PrimarySignalRecord,
     TradeResolution,
@@ -329,6 +330,76 @@ class TestResolveFiredTrade:
             )
             expected = resolution.profitable if resolution is not None else None
             assert simple == expected
+
+
+class TestResolveFiredTradeEntryPriceValidation:
+    """PR #948 review finding (claude[bot]): entry_price (close[fire_index],
+    raw market data) was used as a P&L divisor with no zero/positive/finite
+    check -- CODE.md#L133 'Validate entry_price > 0 before any P&L or
+    stop-loss calculation.' A zero/NaN close at fire_index must raise, not
+    silently compute NaN and mislabel the row as unprofitable."""
+
+    def test_zero_entry_price_raises(self):
+        df = pd.DataFrame(
+            {"close": [0.0, 101.0, 103.0], "high": [0.0, 102.0, 104.0], "low": [0.0, 100.0, 102.0]}
+        )
+        with pytest.raises(ValueError, match="entry_price"):
+            resolve_fired_trade(
+                df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+                max_holding_bars=1,
+            )
+
+    def test_negative_entry_price_raises(self):
+        df = pd.DataFrame(
+            {
+                "close": [-5.0, 101.0, 103.0],
+                "high": [-5.0, 102.0, 104.0],
+                "low": [-5.0, 100.0, 102.0],
+            }
+        )
+        with pytest.raises(ValueError, match="entry_price"):
+            resolve_fired_trade(
+                df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+                max_holding_bars=1,
+            )
+
+    def test_nan_entry_price_raises(self):
+        df = pd.DataFrame(
+            {
+                "close": [float("nan"), 101.0, 103.0],
+                "high": [float("nan"), 102.0, 104.0],
+                "low": [float("nan"), 100.0, 102.0],
+            }
+        )
+        with pytest.raises(ValueError, match="entry_price"):
+            resolve_fired_trade(
+                df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+                max_holding_bars=1,
+            )
+
+    def test_pnl_calculation_matches_shared_pnl_percent(self):
+        """The P&L math itself must be src.performance.metrics.pnl_percent,
+        not a hand-rolled duplicate (CODE.md#L331 'never duplicate financial
+        logic') -- verified by cross-checking a hand-computed fixture
+        against pnl_percent's own output directly."""
+        from src.performance.metrics import Side, pnl_percent
+
+        df = pd.DataFrame(
+            {
+                "close": [100.0, 101.0, 103.0, 106.0],
+                "high": [100.0, 102.0, 104.0, 107.0],
+                "low": [99.0, 100.0, 102.0, 105.0],
+            }
+        )
+        resolution = resolve_fired_trade(
+            df, fire_index=0, direction=1, take_profit_pct=0.05, stop_loss_pct=0.03,
+            max_holding_bars=3,
+        )
+        assert resolution is not None
+        # bar3 high=107 >= entry(100)*1.05=105 -> TP hit, exit_price=105 (exact level).
+        expected_raw_return = pnl_percent(100.0, 105.0, Side.LONG)
+        round_trip_cost = 2.0 * CostCalculator().fee_rate
+        assert resolution.profitable == ((expected_raw_return - round_trip_cost) > 0.0)
 
 
 class TestBuildMetaLabelFeatures:

--- a/tests/unit/training_pipeline/test_ml_training_models.py
+++ b/tests/unit/training_pipeline/test_ml_training_models.py
@@ -413,6 +413,24 @@ class TestCreateModelTrainerContract:
         assert model.input_shape == (None, 120, 5)
         assert model.output_shape == (None, 1)
 
+    @pytest.mark.parametrize("variant", ["default", "lightweight", "deep"])
+    def test_constructs_tft_ternary_with_trainer_kwargs(self, variant):
+        """tft_ternary is excluded from TRAINER_MODEL_MATRIX because it has a
+        3-class output_shape, not the (None, 1) all other architectures
+        share -- tested separately with the correct expected shape."""
+        input_shape = (120, 5)
+
+        model = create_model(
+            model_type="tft_ternary",
+            input_shape=input_shape,
+            variant=variant,
+            has_sentiment=False,
+        )
+
+        assert isinstance(model, tf.keras.Model)
+        assert model.input_shape == (None, 120, 5)
+        assert model.output_shape == (None, 3)
+
 
 # lstm/cnn_lstm compile with a single metric ([rmse]); attention_lstm/tcn/tcn_attention
 # compile with two ([rmse, mae]). tft is excluded: it's a binary direction-classification
@@ -465,12 +483,15 @@ class TestCreateModelEvaluationContract:
 def _infer_actual_task_type(model) -> TaskType:
     """Ground-truth task type inferred from a REAL compiled model's loss.
 
-    Every architecture in this codebase today compiles either "mse"
-    (regression) or "binary_crossentropy" (binary classification, currently
-    only tft) -- if a future architecture compiles something else, this
-    helper intentionally has no silent fallback for it.
+    Every architecture in this codebase today compiles "mse" (regression),
+    "binary_crossentropy" (binary classification, tft), or
+    "sparse_categorical_crossentropy" (ternary classification, tft_ternary)
+    -- if a future architecture compiles something else, this helper
+    intentionally has no silent fallback for it.
     """
     loss_name = str(model.loss).lower()
+    if "sparse_categorical_crossentropy" in loss_name:
+        return TaskType.TERNARY_CLASSIFICATION
     if "binary_crossentropy" in loss_name or "bce" in loss_name:
         return TaskType.BINARY_CLASSIFICATION
     if "mse" in loss_name or "mean_squared_error" in loss_name:
@@ -516,6 +537,26 @@ class TestModelTaskTypeMatchesRealCompiledHead:
             f"update MODEL_TASK_TYPES in task_types.py to match."
         )
 
+    def test_tft_ternary_declared_task_type_matches_compiled_loss(self):
+        """tft_ternary excluded from TRAINER_MODEL_MATRIX (different output
+        contract, see TestCreateModelTrainerContract) but still needs this
+        same drift guard."""
+        model = create_model(
+            model_type="tft_ternary",
+            input_shape=(120, 5),
+            variant="default",
+            has_sentiment=False,
+        )
+
+        declared = get_model_task_type("tft_ternary")
+        actual = _infer_actual_task_type(model)
+
+        assert declared == actual, (
+            f"task_types.MODEL_TASK_TYPES['tft_ternary'] = {declared} but the "
+            f"real compiled model's loss ({model.loss!r}) implies {actual} -- "
+            f"update MODEL_TASK_TYPES in task_types.py to match."
+        )
+
 
 # Every model_type x target_type pairing the training pipeline could be
 # asked to run. Extends the #937 15-pair smoke matrix's spirit -- assert
@@ -523,19 +564,23 @@ class TestModelTaskTypeMatchesRealCompiledHead:
 # compatibility (the #947 guard, task_types.validate_target_head_compatibility).
 TARGET_COMPATIBILITY_MATRIX = [
     (model_type, target_type)
-    for model_type in ["lstm", "cnn_lstm", "attention_lstm", "tcn", "tcn_attention", "tft"]
+    for model_type in [
+        "lstm",
+        "cnn_lstm",
+        "attention_lstm",
+        "tcn",
+        "tcn_attention",
+        "tft",
+        "tft_ternary",
+    ]
     for target_type in ["regression", "binary_direction", "triple_barrier", "smoothed_return"]
 ]
 
 # Compatible pairs: regression-headed architectures need a REGRESSION-task
 # target (regression or smoothed_return, both continuous); tft's binary
-# sigmoid/BCE head needs binary_direction. triple_barrier is
-# TERNARY_CLASSIFICATION and has no compatible architecture yet (the
-# per-entrant ternary-head model factory is explicitly deferred by the
-# TARGET-REDESIGN preregistration §8/Next-steps -- shared label/signal
-# infrastructure ships first) -- every triple_barrier pairing must be
-# rejected today, and this set is the single place that needs updating
-# once a ternary architecture exists.
+# sigmoid/BCE head needs binary_direction; tft_ternary's 3-class softmax
+# head needs triple_barrier (TERNARY_CLASSIFICATION) -- entrant (c) of the
+# TARGET-REDESIGN tournament. Every other pairing must be rejected.
 _COMPATIBLE_MODEL_TARGET_PAIRS = {
     ("lstm", "regression"),
     ("lstm", "smoothed_return"),
@@ -548,6 +593,7 @@ _COMPATIBLE_MODEL_TARGET_PAIRS = {
     ("tcn_attention", "regression"),
     ("tcn_attention", "smoothed_return"),
     ("tft", "binary_direction"),
+    ("tft_ternary", "triple_barrier"),
 }
 
 

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -11,8 +11,10 @@ import pytest
 _TENSORFLOW_AVAILABLE = find_spec("tensorflow") is not None
 
 from src.ml.training_pipeline.config import TrainingConfig, TrainingContext, TrainingPaths
+from src.ml.training_pipeline.labels import LabelResult
 from src.ml.training_pipeline.pipeline import (
     TrainingResult,
+    _build_alt_target,
     _generate_version_id,
     enable_mixed_precision,
     run_training_pipeline,
@@ -205,6 +207,72 @@ class TestEnableMixedPrecision:
         enable_mixed_precision(enabled=True)
 
         # Assert - no exception should be raised
+
+
+@pytest.mark.fast
+class TestBuildAltTarget:
+    """_build_alt_target's triple_barrier branch must emit class INDICES
+    {0, 1, 2} for sparse_categorical_crossentropy, not the raw direction
+    values {-1, 0, 1} triple_barrier_labels() returns -- an #838-class units
+    bug (raw values fed straight into a loss that requires indices in
+    [0, num_classes) would crash or silently corrupt every tft_ternary
+    training run). class_labels=[-1, 0, 1] (task_types.py) is the single
+    source of truth for both this training-side encoding and OnnxRunner's
+    inference-side decoding -- they must never drift apart.
+    """
+
+    def test_triple_barrier_values_are_class_indices_not_raw_directions(self):
+        idx = pd.date_range("2024-01-01", periods=5, freq="1h")
+        merged_df = pd.DataFrame(
+            {"close": [100.0] * 5, "high": [100.0] * 5, "low": [100.0] * 5}, index=idx
+        )
+        feature_data = pd.DataFrame({"dummy": [0.0] * 5}, index=idx)
+
+        raw_label = LabelResult(
+            values=np.array([-1, 0, 1, -1, 1], dtype=np.int64),
+            valid_mask=np.array([True, True, True, True, True]),
+            horizon_bars=336,
+        )
+
+        with patch(
+            "src.ml.training_pipeline.pipeline.triple_barrier_labels",
+            return_value=raw_label,
+        ):
+            target_array, valid_mask = _build_alt_target(
+                "triple_barrier", 1, merged_df, feature_data
+            )
+
+        # class_labels = [-1, 0, 1] -> index 0 is direction -1, index 1 is
+        # direction 0, index 2 is direction 1.
+        assert list(target_array) == [0.0, 1.0, 2.0, 0.0, 2.0]
+        assert list(valid_mask) == [True, True, True, True, True]
+
+    def test_triple_barrier_invalid_rows_stay_masked_out(self):
+        """Invalid (unresolved) rows carry the LabelResult placeholder value
+        0 (see LabelResult docstring); they must remain excluded via
+        valid_mask regardless of how the placeholder maps through the
+        class_labels encoding."""
+        idx = pd.date_range("2024-01-01", periods=3, freq="1h")
+        merged_df = pd.DataFrame(
+            {"close": [100.0] * 3, "high": [100.0] * 3, "low": [100.0] * 3}, index=idx
+        )
+        feature_data = pd.DataFrame({"dummy": [0.0] * 3}, index=idx)
+
+        raw_label = LabelResult(
+            values=np.array([1, 0, 0], dtype=np.int64),
+            valid_mask=np.array([True, True, False]),
+            horizon_bars=336,
+        )
+
+        with patch(
+            "src.ml.training_pipeline.pipeline.triple_barrier_labels",
+            return_value=raw_label,
+        ):
+            _target_array, valid_mask = _build_alt_target(
+                "triple_barrier", 1, merged_df, feature_data
+            )
+
+        assert list(valid_mask) == [True, True, False]
 
 
 @pytest.mark.fast

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -375,6 +375,11 @@ class TestRunMetaLabelPipeline:
         assert metadata["class_labels"] == [0, 1]
         assert metadata["primary_model_type"] == "basic"
         assert metadata["feature_names"] == list(META_LABEL_FEATURE_ORDER)
+        # Same top-level "timeframe" regression guard as
+        # TestRunTrainingPipeline::test_successful_training_price_only --
+        # registry.py::_load_bundle reads it at the top level, not nested
+        # under training_params.
+        assert metadata.get("timeframe") == "1h"
 
         latest_link = result.artifact_paths.directory.parent / "latest"
         assert latest_link.is_symlink()
@@ -531,6 +536,16 @@ class TestRunTrainingPipeline:
         assert result.duration_seconds > 0
         assert "symbol" in result.metadata
         assert result.metadata["symbol"] == "BTCUSDT"
+        # Regression guard: found while running Phase 2b item 6's
+        # acceptance tests for real -- registry.py::_load_bundle reads a
+        # TOP-LEVEL "timeframe" key (md.get("timeframe", ...)), but this
+        # metadata dict only ever set it nested under "training_params".
+        # Every bundle trained via this pipeline registered with
+        # StrategyModel.timeframe == "unknown", making it unfindable by any
+        # symbol/timeframe/model_type lookup (select_bundle,
+        # get_bundle_by_key) -- the exact mechanism every exam signal
+        # generator and MLBasicSignalGenerator depend on.
+        assert result.metadata.get("timeframe") == "1h"
 
     def _make_price_df(self, periods=200):
         """Build a deterministic OHLCV frame with varying prices."""

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -1,5 +1,6 @@
 """Unit tests for ML training pipeline orchestration module."""
 
+import json
 from datetime import datetime
 from importlib.util import find_spec
 from unittest.mock import MagicMock, patch
@@ -12,6 +13,7 @@ _TENSORFLOW_AVAILABLE = find_spec("tensorflow") is not None
 
 from src.ml.training_pipeline.config import TrainingConfig, TrainingContext, TrainingPaths
 from src.ml.training_pipeline.labels import LabelResult
+from src.ml.training_pipeline.meta_labels import META_LABEL_FEATURE_ORDER
 from src.ml.training_pipeline.pipeline import (
     TrainingResult,
     _build_alt_target,
@@ -273,6 +275,146 @@ class TestBuildAltTarget:
             )
 
         assert list(valid_mask) == [True, True, False]
+
+
+@pytest.mark.fast
+class TestRunMetaLabelPipeline:
+    """entrant (a): the sklearn-only training path (target_type="meta_label"),
+    which run_training_pipeline dispatches to BEFORE the TensorFlow
+    availability check and BEFORE validate_target_head_compatibility (model_type
+    is irrelevant for meta_label -- it always trains a LogisticRegression
+    regardless of --model-type, see train.py's help text)."""
+
+    @staticmethod
+    def _synthetic_price_df(periods=400):
+        rng = np.random.default_rng(21)
+        closes = 100.0 + np.cumsum(rng.normal(0, 0.3, periods))
+        return pd.DataFrame(
+            {
+                "open": closes - 0.1,
+                "high": closes + 0.5,
+                "low": closes - 0.5,
+                "close": closes,
+                "volume": 1000.0 + rng.uniform(0, 50, periods),
+            },
+            index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+        )
+
+    class _StubPrimarySignalGenerator:
+        """Fires a deterministic long/short pattern with predicted_return
+        metadata -- mirrors MLBasicSignalGenerator's generate_signal
+        contract without needing a real ONNX bundle."""
+
+        warmup_period = 60
+
+        def generate_signal(self, df, index, regime=None):
+            from src.strategies.components.signal_generator import Signal, SignalDirection
+
+            if index % 15 != 0:
+                return Signal(
+                    direction=SignalDirection.HOLD, strength=0.0, confidence=0.0, metadata={}
+                )
+            direction = SignalDirection.BUY if (index // 15) % 2 == 0 else SignalDirection.SELL
+            return Signal(
+                direction=direction,
+                strength=0.5,
+                confidence=0.5,
+                metadata={"predicted_return": 0.01 if direction == SignalDirection.BUY else -0.01},
+            )
+
+    def _make_ctx(self, tmp_path, **overrides):
+        defaults = dict(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            target_type="meta_label",
+            primary_model_type="basic",
+        )
+        defaults.update(overrides)
+        config = TrainingConfig(**defaults)
+        paths = TrainingPaths(
+            project_root=tmp_path, data_dir=tmp_path / "data", models_dir=tmp_path / "models"
+        )
+        return TrainingContext(config=config, paths=paths)
+
+    @patch("src.ml.training_pipeline.pipeline.MLBasicSignalGenerator")
+    @patch("src.ml.training_pipeline.pipeline.download_price_data")
+    def test_dispatches_before_tensorflow_check(self, mock_download, mock_signal_cls, tmp_path):
+        """Must not raise ImportError even when _TENSORFLOW_AVAILABLE is
+        False -- meta_label training is sklearn-only."""
+        mock_download.return_value = self._synthetic_price_df()
+        mock_signal_cls.return_value = self._StubPrimarySignalGenerator()
+        ctx = self._make_ctx(tmp_path)
+
+        with patch("src.ml.training_pipeline.pipeline._TENSORFLOW_AVAILABLE", False):
+            result = run_training_pipeline(ctx)
+
+        assert result.success is True
+
+    @patch("src.ml.training_pipeline.pipeline.MLBasicSignalGenerator")
+    @patch("src.ml.training_pipeline.pipeline.download_price_data")
+    def test_successful_training_writes_artifacts(self, mock_download, mock_signal_cls, tmp_path):
+        mock_download.return_value = self._synthetic_price_df()
+        mock_signal_cls.return_value = self._StubPrimarySignalGenerator()
+        ctx = self._make_ctx(tmp_path)
+
+        result = run_training_pipeline(ctx)
+
+        assert result.success is True
+        assert result.artifact_paths is not None
+        assert result.artifact_paths.directory.exists()
+        onnx_path = result.artifact_paths.directory / "model.onnx"
+        assert onnx_path.exists()
+        metadata_path = result.artifact_paths.directory / "metadata.json"
+        assert metadata_path.exists()
+
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+        assert metadata["task_type"] == "binary_classification"
+        assert metadata["class_labels"] == [0, 1]
+        assert metadata["primary_model_type"] == "basic"
+        assert metadata["feature_names"] == list(META_LABEL_FEATURE_ORDER)
+
+        latest_link = result.artifact_paths.directory.parent / "latest"
+        assert latest_link.is_symlink()
+        assert latest_link.resolve() == result.artifact_paths.directory.resolve()
+
+    @patch("src.ml.training_pipeline.pipeline.MLBasicSignalGenerator")
+    @patch("src.ml.training_pipeline.pipeline.download_price_data")
+    def test_primary_signal_generator_constructed_with_config_fields(
+        self, mock_download, mock_signal_cls, tmp_path
+    ):
+        mock_download.return_value = self._synthetic_price_df()
+        mock_signal_cls.return_value = self._StubPrimarySignalGenerator()
+        ctx = self._make_ctx(
+            tmp_path, symbol="ETHUSDT", timeframe="4h", primary_model_type="sentiment"
+        )
+
+        run_training_pipeline(ctx)
+
+        mock_signal_cls.assert_called_once_with(
+            model_type="sentiment", timeframe="4h", symbol="ETHUSDT"
+        )
+
+    @patch("src.ml.training_pipeline.pipeline.MLBasicSignalGenerator")
+    @patch("src.ml.training_pipeline.pipeline.download_price_data")
+    def test_zero_fires_fails_gracefully(self, mock_download, mock_signal_cls, tmp_path):
+        from src.strategies.components.signal_generator import Signal, SignalDirection
+
+        mock_download.return_value = self._synthetic_price_df()
+        always_hold = MagicMock()
+        always_hold.warmup_period = 5
+        always_hold.generate_signal.return_value = Signal(
+            direction=SignalDirection.HOLD, strength=0.0, confidence=0.0, metadata={}
+        )
+        mock_signal_cls.return_value = always_hold
+        ctx = self._make_ctx(tmp_path)
+
+        result = run_training_pipeline(ctx)
+
+        assert result.success is False
+        assert "fire" in result.metadata.get("error", "").lower()
 
 
 @pytest.mark.fast

--- a/tests/unit/training_pipeline/test_ml_training_task_types.py
+++ b/tests/unit/training_pipeline/test_ml_training_task_types.py
@@ -36,6 +36,16 @@ class TestGetModelTaskType:
         accepts it against triple_barrier."""
         assert get_model_task_type("tft_ternary") is TaskType.TERNARY_CLASSIFICATION
 
+    def test_lightgbm_is_binary_classification(self):
+        assert get_model_task_type("lightgbm") is TaskType.BINARY_CLASSIFICATION
+
+    def test_meta_label_logistic_is_binary_classification(self):
+        """The sklearn LogisticRegression classifier entrant (a) actually
+        trains with -- not dispatched via create_model() (a different,
+        non-Keras training path), but still declared here so the #947 guard
+        and metadata conventions apply uniformly."""
+        assert get_model_task_type("meta_label_logistic") is TaskType.BINARY_CLASSIFICATION
+
     def test_case_insensitive(self):
         assert get_model_task_type("TFT") is TaskType.BINARY_CLASSIFICATION
         assert get_model_task_type("CNN_LSTM") is TaskType.REGRESSION

--- a/tests/unit/training_pipeline/test_ml_training_task_types.py
+++ b/tests/unit/training_pipeline/test_ml_training_task_types.py
@@ -30,6 +30,12 @@ class TestGetModelTaskType:
     def test_tft_is_binary_classification(self):
         assert get_model_task_type("tft") is TaskType.BINARY_CLASSIFICATION
 
+    def test_tft_ternary_is_ternary_classification(self):
+        """tft_ternary (entrant (c)'s 3-class softmax sibling to tft) must
+        declare TERNARY_CLASSIFICATION so validate_target_head_compatibility
+        accepts it against triple_barrier."""
+        assert get_model_task_type("tft_ternary") is TaskType.TERNARY_CLASSIFICATION
+
     def test_case_insensitive(self):
         assert get_model_task_type("TFT") is TaskType.BINARY_CLASSIFICATION
         assert get_model_task_type("CNN_LSTM") is TaskType.REGRESSION
@@ -93,10 +99,17 @@ class TestValidateTargetHeadCompatibility:
             validate_target_head_compatibility("lstm", "triple_barrier")
 
     def test_tft_with_triple_barrier_raises(self):
-        """tft is a binary head; ternary triple-barrier needs a 3-class head
-        that doesn't exist among the current architectures yet."""
+        """tft is a binary head; triple_barrier needs a 3-class head, which
+        is tft_ternary, not tft."""
         with pytest.raises(ValueError, match="incompatible"):
             validate_target_head_compatibility("tft", "triple_barrier")
+
+    def test_tft_ternary_with_triple_barrier_is_compatible(self):
+        validate_target_head_compatibility("tft_ternary", "triple_barrier")  # no raise
+
+    def test_tft_ternary_with_regression_raises(self):
+        with pytest.raises(ValueError, match="incompatible"):
+            validate_target_head_compatibility("tft_ternary", "regression")
 
     def test_unknown_model_type_raises(self):
         with pytest.raises(ValueError, match="model_type"):

--- a/tests/unit/training_pipeline/test_sklearn_onnx_export.py
+++ b/tests/unit/training_pipeline/test_sklearn_onnx_export.py
@@ -1,0 +1,127 @@
+"""Unit tests for the hand-rolled sklearn LogisticRegression -> ONNX exporter.
+
+entrant (a) (meta-labeling)'s working classifier is a plain sklearn
+LogisticRegression (lightgbm/onnxmltools/skl2onnx are not installed or
+declared dependencies in this repo -- see Phase 2b item 3's plan). This
+exporter builds the minimal ONNX equivalent (MatMul + Add + Sigmoid) by
+hand via the `onnx` package directly, which IS a declared dependency.
+
+Round-trip numerical correctness is verified via onnx.reference.
+ReferenceEvaluator (part of the `onnx` package itself, pure Python) rather
+than onnxruntime.InferenceSession -- tests/conftest.py stubs the entire
+onnxruntime module for the whole suite (always returns a fixed constant),
+so it cannot verify real inference. ReferenceEvaluator sidesteps that stub
+entirely and gives a genuine correctness check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from sklearn.linear_model import LogisticRegression
+
+from src.ml.training_pipeline.sklearn_onnx_export import export_logistic_regression_to_onnx
+
+pytestmark = pytest.mark.fast
+
+
+def _fit_toy_model(n_features: int = 4) -> LogisticRegression:
+    rng = np.random.default_rng(42)
+    X = rng.normal(size=(200, n_features))
+    # A separable-ish rule so the fitted model has real, non-degenerate weights.
+    y = (X[:, 0] + 0.5 * X[:, 1] - 0.3 * X[:, 2] > 0).astype(int)
+    model = LogisticRegression()
+    model.fit(X, y)
+    return model
+
+
+class TestExportLogisticRegressionToOnnx:
+    def test_writes_a_valid_onnx_file(self, tmp_path: Path):
+        import onnx
+
+        model = _fit_toy_model(n_features=4)
+        output_path = tmp_path / "model.onnx"
+
+        export_logistic_regression_to_onnx(model, n_features=4, output_path=output_path)
+
+        assert output_path.exists()
+        onnx_model = onnx.load(str(output_path))
+        onnx.checker.check_model(onnx_model)
+
+    def test_output_matches_sklearn_predict_proba(self, tmp_path: Path):
+        """Round-trip: ONNX graph's sigmoid(Wx+b) must equal sklearn's own
+        predict_proba(...)[:, 1] (P(class=1)) for the same input, within
+        float32 tolerance."""
+        from onnx.reference import ReferenceEvaluator
+
+        n_features = 5
+        model = _fit_toy_model(n_features=n_features)
+        output_path = tmp_path / "model.onnx"
+        export_logistic_regression_to_onnx(model, n_features=n_features, output_path=output_path)
+
+        rng = np.random.default_rng(7)
+        # OnnxRunner._prepare_input reshapes a flat (n_features,) array to
+        # (1, 1, n_features) -- feed exactly that shape here.
+        sample = rng.normal(size=(1, 1, n_features)).astype(np.float32)
+
+        evaluator = ReferenceEvaluator(str(output_path))
+        (onnx_output,) = evaluator.run(None, {"input": sample})
+
+        expected = model.predict_proba(sample.reshape(1, n_features))[:, 1]
+
+        np.testing.assert_allclose(onnx_output.flatten(), expected, atol=1e-5)
+
+    def test_output_is_a_single_scalar_matching_binary_classification_contract(
+        self, tmp_path: Path
+    ):
+        """OnnxRunner._process_classification_output's binary_classification
+        branch requires flattened.size == 1 -- a 2-column probability
+        vector (sklearn's predict_proba shape) would violate that contract."""
+        from onnx.reference import ReferenceEvaluator
+
+        n_features = 3
+        model = _fit_toy_model(n_features=n_features)
+        output_path = tmp_path / "model.onnx"
+        export_logistic_regression_to_onnx(model, n_features=n_features, output_path=output_path)
+
+        sample = np.random.default_rng(1).normal(size=(1, 1, n_features)).astype(np.float32)
+        evaluator = ReferenceEvaluator(str(output_path))
+        (onnx_output,) = evaluator.run(None, {"input": sample})
+
+        assert np.asarray(onnx_output).flatten().size == 1
+
+    def test_output_bounded_in_unit_interval(self, tmp_path: Path):
+        from onnx.reference import ReferenceEvaluator
+
+        n_features = 4
+        model = _fit_toy_model(n_features=n_features)
+        output_path = tmp_path / "model.onnx"
+        export_logistic_regression_to_onnx(model, n_features=n_features, output_path=output_path)
+
+        rng = np.random.default_rng(3)
+        evaluator = ReferenceEvaluator(str(output_path))
+        for _ in range(10):
+            sample = rng.normal(size=(1, 1, n_features)).astype(np.float32) * 10
+            (onnx_output,) = evaluator.run(None, {"input": sample})
+            value = float(np.asarray(onnx_output).flatten()[0])
+            assert 0.0 <= value <= 1.0
+
+    def test_rejects_feature_count_mismatch(self, tmp_path: Path):
+        model = _fit_toy_model(n_features=4)
+        output_path = tmp_path / "model.onnx"
+
+        with pytest.raises(ValueError, match="coef_"):
+            export_logistic_regression_to_onnx(model, n_features=5, output_path=output_path)
+
+    def test_rejects_multiclass_model(self, tmp_path: Path):
+        rng = np.random.default_rng(0)
+        X = rng.normal(size=(60, 3))
+        y = rng.integers(0, 3, size=60)  # 3 classes -- not binary
+        model = LogisticRegression()
+        model.fit(X, y)
+        output_path = tmp_path / "model.onnx"
+
+        with pytest.raises(ValueError, match="binary"):
+            export_logistic_regression_to_onnx(model, n_features=3, output_path=output_path)


### PR DESCRIPTION
## Summary

Closes the gap an execution agent found in PR #948: the TARGET-REDESIGN tournament's (GH #933) Phase 2 scaffolding was unit-tested but **not reachable end-to-end via any CLI entry point** — no entrant could actually be trained-and-exam-backtested through `atb train` / `atb backtest`. This PR wires all 4 entrants through the real CLI paths and adds one genuine (non-mocked, subprocess) end-to-end acceptance test per entrant. Tracking issue: #949.

**No training runs, tournament results, or model promotions are part of this PR** — it is wiring/scaffolding only, same class of change as #948.

### 6-item scope

1. **CLI/config threading** — `--target-type`/`--target-horizon` on both `atb train` (local) and `atb train cloud` (SageMaker container-side env/hyperparameter plumbing too). Unblocked entrants (b) binary-direction and (d) smoothed-return.
2. **Ternary support** — `create_tft_ternary_model()` (3-class softmax) + `MODEL_TASK_TYPES["tft_ternary"] = TERNARY_CLASSIFICATION`. Unblocked entrant (c) triple-barrier. Also fixed a raw `{-1,0,1}` → class-index `{0,1,2}` remap bug in `pipeline.py::_build_alt_target`.
3. **Meta-label pipeline integration** — `meta_labels.py` was standalone; wired a full sklearn-only training driver (`_run_meta_label_pipeline`, dispatched before the TF path when `target_type == "meta_label"`), a hand-rolled ONNX export for a fitted `LogisticRegression` (`sklearn_onnx_export.py`, opset 13), and a causal, stateful exam-time consumer (`MetaLabelExamSignalGenerator`, calls `bundle.runner.predict()` directly, bypassing `PredictionEngine`/`FeaturePipeline`). Unblocked entrant (a).
4. **Exam harness CLI path** — registered `exam_binary_direction`/`exam_triple_barrier`/`exam_smoothed_return`/`exam_meta_label` in `backtest.py`'s `_load_strategy` dict, explicitly commented "exam-only, never add to the live runner" (not added to `src/strategies/__init__.py`). Added `PredictionModelRegistry.get_bundle_by_key(key)` (indexes every loaded bundle by full key, not just latest) and `ATB_MODEL_VERSION_OVERRIDE` env-var pinning, read only in exam-only code (`exam_target_redesign.py::_exam_model_name`) — deliberately **not** read inside `select_bundle()`, which is also on the live trading path.
5. **Bug fixes** — disposed of all 3 outstanding claude[bot] PR #948 inline review comments (units bug, zero-divisor guard in `labels.py`), plus 5 more bugs found only by actually running the full path end-to-end (see "Bugs found by running it" below).
6. **Acceptance tests** — `tests/integration/tournament/test_entrant_dry_runs.py`: one real dry-run per entrant. Tiny synthetic OHLCV (`--mock-data`, deterministic seed) → train via the real CLI entrypoint (`python -m cli.__main__ train cloud --provider local`, genuine subprocess) → artifact with correct metadata → exam backtest via the real `atb backtest exam_<entrant>` CLI path with version pinning → completes with ≥1 real trade. Explicitly the deliverable that turns "components exist" into "tournament can run."

### Bugs found by running it (not catchable by unit tests mocking pieces in isolation)

- **`train_cloud.py`'s completion summary crashed on a non-numeric metric value** (e.g. `evaluate_model_performance`'s own diagnostics-failure placeholder `{"error": "..."}`), turning an already-successful, already-registered training run into a non-zero exit. Fixed with an `isinstance` guard.
- **`pipeline.py`'s metadata never set a top-level `"timeframe"` key** (only nested under `training_params`) — `registry.py::_load_bundle` reads `md.get("timeframe", ...)` at the top level, so every bundle trained via this pipeline (not just target-redesign ones) registered with `timeframe == "unknown"`, unfindable by any symbol/timeframe/model_type lookup, including this PR's own version-pinning path.
- **The critical one**: `exam_target_redesign.py::create_exam_strategy` set `risk_overrides["position_sizer"] = "confidence_weighted"` — a string that selects the CORE risk manager's *own*, unrelated fraction calculator (`risk_manager.py::_calculate_raw_fraction`), which for that name reads a `"prediction_confidence"` indicator that **nothing in this codebase ever populates**. It always returned `fraction=0.0`, which `ConfidenceWeightedSizer.calculate_size` then treated as a hard veto (`risk_amount <= 0` → size `0`) — silently zeroing every trade for all four entrants regardless of signal direction or confidence. `ml_basic.py::create_ml_basic_strategy` (which this function claims to mirror) correctly uses `"fixed_fraction"` here; fixed to match. Confirmed via a real CLI backtest going from `Total Trades: 0` → `Total Trades: 48`.
- **`SmoothedReturnExamSignalGenerator._distribution_for` looked up `target_distribution` metadata via `result.model_name`** — the ONNX file's basename (e.g. `"model.onnx"`, set by `OnnxRunner.predict()`), which can never match a registry `bundle.key`. Fixed to prefer `self.model_name` (the generator's own pinned registry key), with `PredictionEngine.get_model_info` extended with the same `get_bundle_by_key` fallback `_resolve_bundle` already had.
- Entrant-specific test-parameter issues (not code bugs): sequence length mismatch (fixed to `120` to match the exam factories' hardcoded value), a 120s global pytest-timeout killing the 3-subprocess meta-label test (fixed with a per-class `@pytest.mark.timeout(420)`), and a `--days 20` corpus producing a degenerate single-class meta-label training set under the deterministic mock provider (fixed by widening to `--days 60` for regime diversity).

## Test plan

- [x] TDD throughout — every fix above has a failing-first unit/integration test.
- [x] `atb dev quality --changed --branch origin/develop` — Black/Ruff/MyPy all green (including the new untracked test file, verified directly).
- [x] `atb test unit` — 4273 passed, 1 skipped, clean.
- [x] `pytest tests/integration/tournament/test_entrant_dry_runs.py -v` — all 4 entrant acceptance tests pass, individually and together (406.28s combined), confirmed via real (non-mocked) subprocess CLI execution end-to-end.
- [x] Test artifact cleanup verified clean (`git status --short src/ml/models/` empty after the run; no leftover `ACCT*` directories).

## Related

- GH #933 — tournament tracking issue / preregistration
- GH #949 — this round's tracking issue
- GH #947 — the tft/regression-target silent-mismatch bug this wiring's task-type guard extends
- PR #948 — Phase 2 scaffolding (predecessor, build-only)

Not merging — same two-reviewer gauntlet (architecture-reviewer + code-reviewer) as prior rounds before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)