### PR TITLE
fix: seed smoothed_return target_distribution from model predictions, not labels

### DIFF
--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -597,8 +597,14 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
         # ctx.config.target_type by the #947 guard at the top of this
         # function, so it never raises here). class_labels only applies to
         # classification target types. target_distribution is computed ONCE
-        # from y_train ONLY (never X_val/y_val) -- the harness-wide rule
-        # that the confidence mapping must never see eval-window data.
+        # from the model's PREDICTIONS on the training split ONLY (never
+        # X_val/y_val) -- the harness-wide rule that the confidence mapping
+        # must never see eval-window data. Predictions, not labels: the
+        # consumer (SmoothedReturnExamSignalGenerator) percentile-ranks
+        # |predicted_return| against this table, and a regression model's
+        # predictions run far smaller in magnitude than its labels
+        # (regression to the mean), so a label-seeded table pins confidence
+        # near zero on every window and the entrant can never trade.
         # Diagnostics-only: a failure here degrades gracefully (same
         # pattern as the evaluation/robustness block above) rather than
         # discarding an already-trained model.
@@ -610,10 +616,13 @@ def run_training_pipeline(ctx: TrainingContext) -> TrainingResult:
             target_type_metadata["class_labels"] = class_labels
         if ctx.config.target_type == "smoothed_return":
             try:
+                train_predictions = np.asarray(
+                    model.predict(X_train, verbose=0), dtype=np.float64
+                ).reshape(-1)
                 target_type_metadata["target_distribution"] = FrozenDistribution.from_samples(
-                    np.abs(y_train)
+                    np.abs(train_predictions)
                 ).to_metadata()
-            except ValueError as exc:
+            except (ValueError, RuntimeError, TypeError) as exc:
                 logger.warning(
                     "Failed to compute target_distribution metadata for smoothed_return: "
                     "%s. Entrant (d)'s percentile-rank confidence will be unavailable for "

--- a/tests/unit/training_pipeline/test_metadata_contract_round_trip.py
+++ b/tests/unit/training_pipeline/test_metadata_contract_round_trip.py
@@ -227,6 +227,13 @@ class TestPipelineWritesClassificationMetadata:
             mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
             model = MagicMock()
             model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
+            # A weak-signal regression model predicts on a much smaller scale
+            # than its labels (targets above span +/-0.05); the persisted
+            # distribution must be seeded from THESE predictions.
+            train_predictions = (
+                np.random.default_rng(3).normal(0.0, 0.002, (40, 1)).astype(np.float32)
+            )
+            model.predict.return_value = train_predictions
             mocks["create_model"].return_value = model
             mocks["validate_model_robustness"].return_value = {}
             mocks["evaluate_model_performance"].return_value = {
@@ -243,6 +250,10 @@ class TestPipelineWritesClassificationMetadata:
         assert "class_labels" not in on_disk
         assert "target_distribution" in on_disk
         dist = FrozenDistribution.from_metadata(on_disk["target_distribution"])
+        # Seeded from the model's |predictions| on the training split, not
+        # the |labels|: every table value must sit within the prediction
+        # range, far below the ~0.05 label scale.
+        assert max(dist.values) <= float(np.abs(train_predictions).max()) + 1e-9
         # Round-trips into a usable distribution (doesn't raise, produces a
         # bounded confidence for a representative value).
         confidence = percentile_rank_confidence(0.02, dist)
@@ -304,6 +315,140 @@ class TestPipelineWritesClassificationMetadata:
         assert on_disk["task_type"] == "regression"
         assert "class_labels" not in on_disk
         assert "target_distribution" not in on_disk
+
+
+class TestTargetDistributionSeededFromModelPredictions:
+    """The persisted target_distribution must be on the scale of the MODEL'S
+    |predictions| on the training split -- what
+    SmoothedReturnExamSignalGenerator percentile-ranks at inference time
+    (exam_signal_generator.py, distribution_stats.py docstring) -- NOT the
+    scale of the |labels|. A regression model's predictions are far smaller
+    in magnitude than its labels (regression to the mean), so a label-seeded
+    table pins percentile-rank confidence near zero on every window,
+    in-sample included, and the entrant can never clear the sizer's
+    confidence gate.
+
+    Trains a REAL (tiny) keras model through the real pipeline (real
+    model.fit, real build_tf_datasets, real save_artifacts) so the persisted
+    distribution can be checked against |predictions| recomputed from the
+    saved model.keras artifact."""
+
+    def test_distribution_scale_matches_saved_model_predictions(self, tmp_path):
+        import tensorflow as tf
+
+        tf.keras.utils.set_random_seed(7)
+        rng = np.random.default_rng(7)
+
+        sequence_length, num_features, num_sequences = 10, 1, 50
+        sequences = rng.normal(0.0, 1.0, (num_sequences, sequence_length, num_features)).astype(
+            np.float32
+        )
+        # Labels: large-magnitude, near-zero-mean; features are pure noise.
+        # A briefly-trained zero-initialized regression head therefore
+        # predicts near the label mean (~0), guaranteeing
+        # median|label| >> median|prediction| -- the gap that lets this test
+        # discriminate a prediction-seeded table from a label-seeded one.
+        magnitudes = rng.uniform(0.5, 1.0, num_sequences)
+        signs = rng.choice([-1.0, 1.0], num_sequences)
+        targets = (magnitudes * signs).astype(np.float32)
+
+        X_train, y_train = sequences[:40], targets[:40]
+
+        config = TrainingConfig(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 31),
+            epochs=2,
+            sequence_length=sequence_length,
+            target_type="smoothed_return",
+            target_horizon=3,
+            diagnostics=DiagnosticsOptions(
+                generate_plots=False, evaluate_robustness=False, convert_to_onnx=False
+            ),
+        )
+        paths = TrainingPaths(
+            project_root=tmp_path, data_dir=tmp_path / "data", models_dir=tmp_path / "models"
+        )
+        ctx = TrainingContext(config=config, paths=paths)
+
+        inputs = tf.keras.Input(shape=(sequence_length, num_features))
+        outputs = tf.keras.layers.Dense(1, kernel_initializer="zeros", bias_initializer="zeros")(
+            tf.keras.layers.Flatten()(inputs)
+        )
+        tiny_model = tf.keras.Model(inputs=inputs, outputs=outputs)
+        tiny_model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3), loss="mse")
+
+        # Same producer-half setup as TestPipelineWritesClassificationMetadata,
+        # except build_tf_datasets/save_artifacts run for real and create_model
+        # returns a real trainable model instead of a MagicMock.
+        names = [
+            "configure_gpu",
+            "download_price_data",
+            "load_sentiment_data",
+            "create_robust_features",
+            "create_sequences",
+            "split_sequences",
+            "create_model",
+            "validate_model_robustness",
+            "evaluate_model_performance",
+            "create_training_plots",
+            "enable_mixed_precision",
+        ]
+        with ExitStack() as stack:
+            mocks = {
+                name: stack.enter_context(patch(f"src.ml.training_pipeline.pipeline.{name}"))
+                for name in names
+            }
+            mocks["configure_gpu"].return_value = None
+            price_df = _make_ohlcv_df()
+            mocks["download_price_data"].return_value = price_df
+            mocks["load_sentiment_data"].return_value = None
+            feature_df = price_df.copy()
+            feature_df["close_scaled"] = 0.5
+            mocks["create_robust_features"].return_value = (
+                feature_df,
+                {"close": MagicMock()},
+                ["close_scaled"],
+            )
+            mocks["create_sequences"].return_value = (sequences, targets)
+            mocks["split_sequences"].return_value = (
+                X_train,
+                y_train,
+                sequences[40:],
+                targets[40:],
+            )
+            mocks["create_model"].return_value = tiny_model
+            mocks["validate_model_robustness"].return_value = {}
+            mocks["evaluate_model_performance"].return_value = {
+                "error": "diagnostics skipped in test"
+            }
+            mocks["create_training_plots"].return_value = None
+
+            result = run_training_pipeline(ctx)
+
+        assert result.success is True, result.metadata
+        on_disk = json.loads(result.artifact_paths.metadata_path.read_text())
+        assert "target_distribution" in on_disk
+        dist = FrozenDistribution.from_metadata(on_disk["target_distribution"])
+
+        saved_model = tf.keras.models.load_model(result.artifact_paths.keras_path)
+        abs_predictions = np.abs(
+            np.asarray(saved_model.predict(X_train, verbose=0), dtype=np.float64).reshape(-1)
+        )
+        median_abs_prediction = float(np.median(abs_predictions))
+        median_abs_label = float(np.median(np.abs(np.asarray(y_train, dtype=np.float64))))
+        distribution_median = float(np.interp(50.0, dist.percentiles, dist.values))
+
+        # Setup validity: the discriminating gap must actually exist, or this
+        # test has lost its power to tell the two seedings apart.
+        assert median_abs_prediction > 0.0
+        assert median_abs_label > 10.0 * median_abs_prediction
+
+        # The contract under test: the persisted table's median must sit on
+        # the model's own |prediction| scale. A label-seeded table lands an
+        # order of magnitude higher and fails the upper bound.
+        assert 0.2 * median_abs_prediction <= distribution_median <= 5.0 * median_abs_prediction
 
 
 class TestRealRegistryLoadedOnnxRunnerConsumesMetadata:

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -576,6 +576,9 @@ class TestRunTrainingPipeline:
         mocks["build_tf_datasets"].return_value = (MagicMock(), MagicMock())
         model = MagicMock()
         model.fit.return_value = MagicMock(history={"loss": [0.1], "val_loss": [0.2]})
+        # smoothed_return seeds target_distribution from model.predict on the
+        # training split -- a bare MagicMock isn't array-convertible there.
+        model.predict.return_value = np.full((40, 1), 0.001, dtype=np.float32)
         mocks["create_model"].return_value = model
         mocks["validate_model_robustness"].return_value = {}
         mocks["evaluate_model_performance"].return_value = {"test_rmse": 0.1}


### PR DESCRIPTION
# fix: seed smoothed_return target_distribution from model predictions, not labels

## Bug

`run_training_pipeline` seeded the `smoothed_return` confidence distribution from the training **labels** (`FrozenDistribution.from_samples(np.abs(y_train))`), but the consumer (`SmoothedReturnExamSignalGenerator.generate_signal`, per the prereg spec §2d and `distribution_stats.py`'s own module docstring) percentile-ranks the model's **predictions** against it.

**Evidence one-liner:** label-seeded distribution vs prediction ranking — regression to the mean puts |prediction| ~27x below |label| for a weak-signal model, so percentile-rank confidence is permanently pinned near zero (max observed 0.067 vs the 0.30 sizer gate) on ANY window, in-sample included — entrant (d) can never trade.

## Fix

Seed the distribution from the model's own predictions on the training split: `np.abs(model.predict(X_train, verbose=0))` (batched, flattened, float64). This stays leak-free — predictions on training data touch no eval-window data — and keeps the "computed ONCE from the training split ONLY" property; only the seeded array is corrected.

The `except` also now catches `RuntimeError`/`TypeError` (a real `model.predict` can fail in ways `np.abs(y_train)` never could), preserving the block's graceful-degradation contract.

## Existing bundles

All existing `smoothed_return` bundles carry a wrong (label-scaled) `target_distribution`. They are being metadata-patched by the tournament — **no retrain needed**, model weights are unaffected; only the metadata.json table is stale.

## Testing performed

- **Failing-first regression test** (`TestTargetDistributionSeededFromModelPredictions`): trains a real tiny keras model through the real pipeline (real `model.fit`/`build_tf_datasets`/`save_artifacts`), reloads the persisted `model.keras`, and asserts the persisted distribution's median sits within [0.2x, 5x] of median |prediction| recomputed from the saved model. Synthetic data guarantees median|label| > 10x median|prediction| (zero-init head, noise features, large zero-mean labels), so a label-seeded table fails by an order of magnitude — confirmed failing before the fix (0.730 vs 0.0067, ~110x) and passing after.
- Updated the #948/#950 metadata round-trip test to configure `model.predict` and assert the persisted table sits within the prediction range (below the label scale); updated `test_ml_training_pipeline.py`'s shared mock helper likewise.
- `atb dev quality --changed` green (black, ruff, mypy).
- Full unit suite green.

## References

- TARGET-REDESIGN tournament: #933
- Producer/consumer metadata contract: #948, #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)
