### PR TITLE
docs(research): TARGET-REDESIGN prereg Amendment 2 - correct F3 incumbent-control artifact

### DIFF
--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -430,3 +430,30 @@ Recorded as "Amendment 1" appended to the prereg doc (original §2a text left un
 append-only convention) — decided and logged BEFORE any entrant-(a) training job existed,
 pre-data and validity-strengthening, not results-driven.
 Ref: GH #933, docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md (Amendment 1)
+
+## 2026-07-11 12:25 · track-record · ml-engineer
+TARGET-REDESIGN tournament (GH #933) · event: preregistration amended (Amendment 2, pre-data,
+corrects a factual error inherited by an earlier PM ruling)
+While preparing entrant (a)/F3 (which the prereg's own baseline text, and a same-day PM ruling
+built on it, said should reuse the live artifact basic/2026-07-04_22h_v1 rather than retrain),
+checked that artifact's actual training_params.end_date directly instead of trusting the prereg's
+prose claim of a 2025-12-31 cutoff. The real cutoff is 2026-07-04 — the live artifact's training
+data entirely covers F3's eval window (2025-01-03→2025-06-30) and extends over a year beyond it.
+This is the identical lookahead-contamination class Amendment 1 fixed for entrant (a) at F1/F2,
+here applying to BOTH the F3 incumbent-control baseline itself and entrant (a)/F3's intended
+primary signal. Flagged to PM rather than proceeding on the earlier ruling (which had just been
+made that same day, based on the same unverified premise) — paused entrant (a)/F3 entirely rather
+than running it against either artifact until this was resolved.
+PM ruling (reversing the earlier same-day one): the fold-matched F3 incumbent-control retrain
+already trained this session (price/2026-07-11_11h17m33s_v1, cutoff 2024-12-31, exactly matching
+F3's fold definition) is the authoritative F3 baseline for its L1 row, L2 exam, and as entrant
+(a)/F3's primary signal. The live artifact is excluded from F3 entirely — not even as a
+supplementary cross-check. Zero additional training cost: this retrain was already logged earlier
+as an "unnecessary" accidental job (a minor budget deviation from the since-corrected assumption);
+that characterization now reverses -- it was the correct call all along, and its prior existence
+is why this correction is free. Recorded as "Amendment 2" appended to the prereg doc (original
+text and Amendment 1 both left unedited) — decided and logged before any F3-control-dependent
+result existed, pre-data and validity-strengthening, not results-driven. The superseded ruling is
+named explicitly in the amendment text as inheriting the same wrong premise, not as an independent
+error.
+Ref: GH #933, docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md (Amendment 2)

--- a/docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md
+++ b/docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md
@@ -557,3 +557,58 @@ This amendment changes only which trained artifact plays the role of "primary si
 §3/§4/§6/§7's frozen run-book sections), decided by the PM before any entrant-(a) data existed.
 The original §2a text above is left unedited per the append-only amendment convention — this
 section is the authoritative statement of what entrant (a) actually runs against, going forward.
+
+---
+
+## Amendment 2 (2026-07-11, PM ruling — pre-data, corrects a factual error in the original baseline description)
+
+**Status**: Decided and recorded before any F3-control-dependent evaluation had run. At the time
+this amendment was written, F3's incumbent-control L2 exam had not been executed and entrant
+(a)/F3's training had not been executed — no result of any kind existed for either. Pre-data,
+validity-strengthening, not results-driven.
+
+**What the original baselines section (§2, "Incumbent control") claimed**: "Because this
+tournament's primary fold set (§3) is entirely pre-2026, and the incumbent's actual training
+cutoff is 2025-12-31, the incumbent's own already-trained artifact can be reused directly as the
+fold-3 control without retraining (its training window predates every fold's eval start by
+construction)." This same claim was the basis for a PM ruling on 2026-07-11 ("control_F3
+confirmed: basic/2026-07-04_22h_v1 is the authoritative F3 incumbent-control baseline") made
+earlier the same day, and for an instruction to use that same artifact as entrant (a)/F3's primary
+signal.
+
+**The error this amendment corrects**: neither the prereg's claim nor the PM ruling built on it
+was verified against the artifact's own metadata before being acted on. Direct inspection of
+`ETHUSDT/basic/2026-07-04_22h_v1/metadata.json`'s `training_params.end_date` shows the actual
+training cutoff is **2026-07-04**, not 2025-12-31. F3's eval window is 2025-01-03→2025-06-30 — the
+live artifact's real training data entirely covers that window and extends more than a year
+beyond it. This is the identical lookahead-contamination pattern Amendment 1 was written to
+eliminate for entrant (a) at F1/F2, and it applies with equal force here to (a) the F3
+incumbent-control baseline itself, and (b) entrant (a)/F3's intended primary signal, both of which
+were about to consume the contaminated artifact under the pre-correction ruling.
+
+**Ruling**: the fold-matched F3 incumbent-control retrain trained earlier in Phase 3 execution
+(registry version `price/2026-07-11_11h17m33s_v1`, training cutoff 2024-12-31 — exactly matching
+F3's own fold definition, the same treatment already given to F1 and F2's incumbent-control rows)
+is the **authoritative F3 incumbent-control baseline**, for its L1 row, its L2 exam, and as
+entrant (a)/F3's primary signal. The live artifact (`basic/2026-07-04_22h_v1`) is **excluded from
+F3 entirely** — not retained even as a supplementary cross-check, since a contaminated
+cross-check figure sitting next to the authoritative one invites exactly the kind of accidental
+anchoring a tournament report should avoid.
+
+**Superseded ruling, named explicitly**: the PM's earlier same-day ruling endorsing the live
+artifact for F3 is superseded by this amendment. It is not being treated as a separate error in
+its own right — it inherited the same unverified factual premise this amendment corrects, and
+falls with it.
+
+**Note on process, stated for the record**: the F3 incumbent-control retrain now ruled
+authoritative was originally logged, at the time it was trained, as an "unnecessary" job — a
+minor accidental budget deviation from a design that (per the since-corrected assumption) called
+for reusing the live artifact instead. That characterization is now reversed: this was the
+correct call all along, and its existence is why this correction costs zero additional training
+jobs. Logged here for an honest record of how the tournament actually arrived at a valid F3
+baseline.
+
+**Everything else in the prereg, including Amendment 1, stands unchanged.** This amendment is
+scoped narrowly to which trained artifact is authoritative for fold F3's incumbent-control role
+(baseline and entrant-(a)-primary-signal alike) — no other fold, entrant specification, metric,
+or decision-table entry is affected.


### PR DESCRIPTION
## Summary

Appends **Amendment 2** to the TARGET-REDESIGN tournament preregistration
(`docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md`), correcting a
factual error in the original baselines section — and in a same-day PM ruling that inherited it —
**before any F3-control-dependent evaluation had run**. Pre-data, validity-strengthening, not
results-driven.

**The error**: the prereg's baselines section claims the live incumbent artifact
(`basic/2026-07-04_22h_v1`) has a training cutoff of 2025-12-31, predating F3's eval window
(2025-01-03→2025-06-30), and can therefore be reused directly as F3's control without retraining.
Direct inspection of the artifact's own `metadata.json` (`training_params.end_date`) shows the
real cutoff is **2026-07-04** — the artifact's training data entirely covers F3's eval window plus
over a year beyond it. This is the identical lookahead-contamination class Amendment 1 fixed for
entrant (a) at F1/F2, here applying to both the F3 incumbent-control baseline itself and entrant
(a)/F3's intended primary signal.

**The ruling**: the fold-matched F3 incumbent-control retrain already trained this session
(`price/2026-07-11_11h17m33s_v1`, cutoff 2024-12-31 — matching F3's own fold definition, same
treatment as F1/F2) is the authoritative F3 baseline for its L1 row, L2 exam, and entrant
(a)/F3's primary signal. The live artifact is excluded from F3 entirely, not retained even as a
supplementary cross-check. Zero additional training cost — the retrain already existed
(previously logged as an "unnecessary" accidental job; that characterization now reverses, since
it turns out to have been the correct call all along).

An earlier same-day PM ruling endorsing the live artifact for F3 is explicitly named as
superseded — it inherited the same unverified premise this amendment corrects, not a separate
error in its own right.

The original prereg text and Amendment 1 are both left unedited per the append-only convention.
Also appends the corresponding `.claude/state/log.md` track-record entry.

## Testing performed

Docs-only change (prose append to a markdown file + a log append). No code touched. `git status`
confirms only the two intended files are staged.

## Test plan

- [x] Docs-only diff, reviewed for accuracy against the corrected artifact metadata
- [x] Append-only convention honored (original text and Amendment 1 both untouched)
- [ ] PM fast-merge (pre-agreed out of band — this documents a decision already made, not
      proposing a new one)

Ref: GH #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)