### PR TITLE
fix(config): correct July 2026 FOMC date in macro_events.json

### DIFF
--- a/config/macro_events.json
+++ b/config/macro_events.json
@@ -6,6 +6,6 @@
     {"name": "CPI May 2026", "type": "CPI", "time": "2026-05-13T12:30:00Z"},
     {"name": "FOMC June 2026", "type": "FOMC", "time": "2026-06-17T18:00:00Z", "hours_before": 18, "hours_after": 18},
     {"name": "CPI July 2026", "type": "CPI", "time": "2026-07-14T12:30:00Z"},
-    {"name": "FOMC July 2026", "type": "FOMC", "time": "2026-07-29T18:00:00Z", "hours_before": 18, "hours_after": 18}
+    {"name": "FOMC July 2026", "type": "FOMC", "time": "2026-07-08T18:00:00Z", "hours_before": 18, "hours_after": 18}
   ]
 }

--- a/tests/unit/position_management/test_macro_events.py
+++ b/tests/unit/position_management/test_macro_events.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 from src.engines.shared.execution.entry_handler_mixin import SharedEntryHandlerMixin
 from src.position_management.macro_events import (
+    DEFAULT_CALENDAR_PATH,
     MacroEvent,
     MacroEventCalendar,
     MacroEventGuard,
@@ -86,6 +87,58 @@ def test_from_config_applies_defaults_and_overrides(tmp_path):
     # Event A uses defaults: 10h before -> window opens 02:30.
     assert cal.active_event(datetime(2026, 7, 14, 2, 30, tzinfo=UTC)) is not None
     assert cal.active_event(datetime(2026, 7, 14, 2, 29, tzinfo=UTC)) is None
+
+
+# --- default config integrity (regression: #962, wrong FOMC date) ----------
+#
+# #962: config/macro_events.json listed "FOMC July 2026" as 2026-07-29 when the
+# real meeting (and the one production actually scheduled entry-pause windows
+# around) was 2026-07-08. Nothing caught the typo because the file parses fine
+# and MacroEventCalendar.from_config() fails open (silently drops malformed
+# entries, never raises) — a config typo produces no visible symptom short of
+# an empirical audit of `strategy_executions.reasons`. These tests give the
+# file itself a few load-bearing invariants.
+
+
+def test_default_config_events_have_valid_iso8601_utc_times():
+    raw = json.loads(DEFAULT_CALENDAR_PATH.read_text(encoding="utf-8"))
+    assert raw["events"], "default macro event calendar is empty"
+    for event in raw["events"]:
+        time_str = event["time"]
+        assert time_str.endswith(
+            "Z"
+        ), f"{event['name']!r} time is not UTC ('Z' suffix): {time_str!r}"
+        parsed = datetime.fromisoformat(time_str[:-1] + "+00:00")
+        assert parsed.tzinfo is not None
+
+
+def test_default_config_no_events_silently_dropped():
+    """`from_config` swallows malformed entries via try/except+log instead of raising,
+    so a schema regression would otherwise shrink the calendar with no test failure."""
+    raw = json.loads(DEFAULT_CALENDAR_PATH.read_text(encoding="utf-8"))
+    cal = MacroEventCalendar.from_config()
+    assert len(cal) == len(raw["events"])
+
+
+def test_default_config_has_upcoming_coverage():
+    """Canary: if nobody maintains this file, the guard silently stops de-risking
+    anything (fail-safe-by-design, but that's exactly how #962 went unnoticed for
+    an entire staging trial). Flag it loudly instead."""
+    raw = json.loads(DEFAULT_CALENDAR_PATH.read_text(encoding="utf-8"))
+    times = [
+        (
+            datetime.fromisoformat(e["time"][:-1] + "+00:00")
+            if e["time"].endswith("Z")
+            else datetime.fromisoformat(e["time"])
+        )
+        for e in raw["events"]
+    ]
+    most_recent = max(times)
+    now = datetime.now(UTC)
+    assert most_recent >= now - timedelta(days=14), (
+        "macro_events.json's most recent listed event is over 14 days in the past — "
+        "the calendar needs a maintenance pass to keep upcoming de-risk coverage (#962)."
+    )
 
 
 # --- guard -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #962.

`config/macro_events.json` (added in #806, single commit `2dc114b5`, 2026-07-04, never touched since) listed the July 2026 FOMC meeting as:

```json
{"name": "FOMC July 2026", "type": "FOMC", "time": "2026-07-29T18:00:00Z", "hours_before": 18, "hours_after": 18}
```

But the FOMC event the rest of the system actually treated as real was **2026-07-08** — that's the date production scheduled its `FEATURE_ENTRY_PAUSE` windows around (`.claude/state/log.md`: `fomc-pause-on (Jul 7 18:00Z)`, `fomc-pause-off (Jul 8 20:00Z)`, and multiple entries referencing "post-FOMC" activity on 2026-07-08). There is no other evidence anywhere in state/log history, docs, or ops snapshots of a genuine second FOMC meeting on 2026-07-29.

**Conclusion: this was a straight date typo (07-29 for 07-08), not a second legitimate event.** I went with the conservative fix per the issue's guidance rather than inventing a second calendar entry.

### Impact

Because of the wrong date, `MacroEventGuard` (`src/position_management/macro_events.py`) never armed a de-risking window (entry block + halved exposure caps) around the actual Jul-8 FOMC during the staging bear-market-cohort trial — confirmed empirically via zero `macro_event_block_*` tags in `strategy_executions.reasons` over the entire cohort period. The guard fails open by design (a stale/malformed calendar produces no windows, not an error), so this went unnoticed until an empirical audit surfaced it.

## Changes

- `config/macro_events.json`: corrected `"FOMC July 2026"` time from `2026-07-29T18:00:00Z` to `2026-07-08T18:00:00Z`. Kept the existing `hours_before`/`hours_after` of 18/18 — the 18h-before window opens at Jul-7 18:00Z, matching what was actually scheduled operationally.
- `tests/unit/position_management/test_macro_events.py`: added three regression tests against the default config file, following this file's existing conventions (plain pytest functions, `pytestmark = pytest.mark.unit`):
  - `test_default_config_events_have_valid_iso8601_utc_times` — every event's `time` field is a valid `Z`-suffixed ISO-8601 UTC string.
  - `test_default_config_no_events_silently_dropped` — `MacroEventCalendar.from_config()` swallows malformed entries via try/except+log rather than raising; this asserts the loaded calendar's length matches the raw JSON's event count, so a schema regression can't silently shrink the calendar without a test failure.
  - `test_default_config_has_upcoming_coverage` — freshness canary: fails if the calendar's most-recently-listed event is more than 14 days in the past, i.e. flags a calendar that's drifted stale with no upcoming de-risk coverage.

None of these tests can retroactively catch the exact typo (07-29 is itself a syntactically valid date), but together they close the class of bug where the calendar silently loses effective coverage — either through schema corruption or simple staleness — without anyone noticing until an empirical audit.

## Testing performed

```
python -m pytest tests/unit/position_management/test_macro_events.py -v   # 15 passed
python -m pytest tests/unit/position_management/ -q                       # 244 passed
atb dev quality --changed                                                 # black + ruff pass
python bin/run_mypy.py --targets src/position_management/macro_events.py  # 0 errors
```

## Notes for reviewers

- Staging-only, dry-run-adjacent feature (`enable_macro_event_guard` flag) — no live-capital or money-path risk.
- Not merging this myself; leaving open for review per standard process.

Closes #962.
