### PR TITLE
docs(research): LINEAR INPUT-SCREENING experiment (Lane A, Phase 1) — no arm graduates

### DIFF
--- a/.claude/state/log.md
+++ b/.claude/state/log.md
@@ -514,4 +514,41 @@ Ranked shortlist for next phase: (1) multi-scale realized vol/range from own cac
 calendar features, (3) BTC->ETH cross-asset (already-cached BTC data), (4) funding rate, (5) basis/
 premium proxy, (6) Fear & Greed. Deferred: OI, long/short ratio, on-chain flows, DXY/SPX/NDX macro,
 BTC dominance, social volume -- unobtainable at needed depth or weak evidence.
-Ref: GH #959 (research issue, state:researching), PR #958 (docs/input-audit -> develop).
+Ref: GH #959 (research issue, state:researching), PR #958 (docs/input-audit -> develop, merged
+9e7ea5e8).
+
+---
+
+## 2026-07-12 10:45 · track-record · quant-researcher
+Experiment #967: LINEAR INPUT-SCREENING (Lane A, Phase 1) -- does any of the input-candidates
+audit's (#959, PR #958) 6 shortlisted alternative-input classes show a linearly-detectable
+next-bar directional edge over the price-only feature contract? -> REJECTED, no arm graduates.
+Evidence: docs/research/experiments/2026-07-12_input-screening-linear.md
+Preregistered (folds/thresholds/graduation rule locked before any scoring run) then ran: logistic
+regression on next-bar direction, PriceOnlyFeatureExtractor(120) contract (same as the
+target-redesign tournament's linear baseline), F1/F2/F3 walk-forward folds identical to that
+tournament, 7 arms (price-only control + realized-vol/range, calendar, BTC cross-asset, funding
+rate, basis/premium, Fear&Greed, all-combined). Pre-committed graduation rule (McNemar-significant
+at Bonferroni alpha=0.05/7~=0.0071 on >=2/3 folds AND avg DA improvement >=0.5pp) fails for EVERY
+arm on EVERY count -- zero folds reach Bonferroni significance for any arm (best single-fold
+p=0.0384, calendar/F3, itself in the WRONG direction and still non-significant after correction);
+largest average delta is funding_rate at +0.37pp, still short of the +0.5pp bar. All CPU-only,
+seconds-per-fit, 24 fits total (~9min wall-clock once BLAS threads were capped at 4 to stop
+oversubscription against the exit-geometry lane's concurrent process -- an uncapped first attempt
+ran 29min/620%CPU with zero progress and was killed, no result from it used).
+Validity check (arm 0 vs the target-redesign tournament's reported linear-baseline DA): replicates
+within the pre-committed +/-2pp tolerance on F1 (-1.30pp) and F2 (-0.51pp), MISSES on F3 (-2.39pp)
+-- disclosed as a non-replication (method necessarily differs: logistic-on-direction vs the
+tournament's unrecoverable LinearRegression-on-continuous-target script, an explicitly
+pre-approved substitution per this experiment's own dispatch brief), does not invalidate the
+internal arm-vs-control comparisons (same control/method/run for every arm).
+Reading: converges with the four-tournament pattern (window #898, architecture #939,
+target-redesign, now this linear input screen) -- no lever tried so far moves ETHUSDT 1h
+next-bar directional accuracy meaningfully past its ~51-53% ceiling. Named risk NOT resolved here:
+a linear detector can only find linearly-separable signal; several candidates' own literature
+support (funding-rate crowding, HAR-RV volatility) is about regime/vol structure, not linear
+direction -- a nonlinear re-screen of the same 6 classes is the natural next falsification test
+before fully retiring the "new information sources" lever, cheaper than the full deep-model
+tournament. No src/ change, no live-affecting decision -- nothing for risk-officer to stress-test.
+Ref: issue #967 (closed), PR #969, docs/research/2026-07-12_input-candidates-audit.md (PR #958,
+merged 9e7ea5e8).

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ cache/*
 .claude/statusline.cjs
 .gemini-reviews/
 .agent-active
+scripts/research/.cache/

--- a/docs/research/experiments/2026-07-12_input-screening-linear.md
+++ b/docs/research/experiments/2026-07-12_input-screening-linear.md
@@ -4,9 +4,9 @@ Date: 2026-07-12
 Author: quant-researcher
 Status: **COMPLETE — no arm graduates; results appended below the locked prereg**
 Issue: GH #959 (Phase 0, input-candidates audit), this doc is Lane A Phase 1
-Related: `docs/research/2026-07-12_input-candidates-audit.md` (PR #958, open at time of
-writing — branch `docs/input-audit`, not yet merged to develop; scripts cherry-picked into
-this worktree directly since PR #958 was not blocked on), `docs/research/experiments/2026-07-10_target-redesign-tournament-results.md`
+Related: `docs/research/2026-07-12_input-candidates-audit.md` (PR #958 — open, branch
+`docs/input-audit`, when this experiment's scripts were cherry-picked; merged to develop at
+`9e7ea5e8` before this experiment's own PR landed), `docs/research/experiments/2026-07-10_target-redesign-tournament-results.md`
 (fold definitions, linear-baseline methodology, merged to develop at `25e0a202`)
 North star: the target-redesign report's conclusion, quoted verbatim: *"the feature set
 itself — not the model, not the window, not the target shape — is the ceiling... The next

--- a/docs/research/experiments/2026-07-12_input-screening-linear.md
+++ b/docs/research/experiments/2026-07-12_input-screening-linear.md
@@ -2,7 +2,7 @@
 
 Date: 2026-07-12
 Author: quant-researcher
-Status: **PLANNED — pre-registration locked before any scoring run**
+Status: **COMPLETE — no arm graduates; results appended below the locked prereg**
 Issue: GH #959 (Phase 0, input-candidates audit), this doc is Lane A Phase 1
 Related: `docs/research/2026-07-12_input-candidates-audit.md` (PR #958, open at time of
 writing — branch `docs/input-audit`, not yet merged to develop; scripts cherry-picked into
@@ -226,3 +226,184 @@ information sources" lever the target-redesign report recommended is worth GPU b
 
 *Pre-registration locked at the above wording. Results appended below after the run, never by
 editing the sections above.*
+
+---
+
+## Pre-run implementation note (added before the scoring run, not after)
+
+`max_iter=1000` (§2) produced an sklearn `ConvergenceWarning` on the arm-0 smoke test (lbfgs
+hadn't converged on ~47k rows × 600 features within 1000 iterations); raised to `max_iter=3000`
+before any fold/arm result was recorded. This is a numerical-convergence setting, not a metric,
+threshold, or graduation-rule change — noted here rather than silently edited into §2, per the
+anti-p-hacking discipline of never rewriting pre-committed sections after the fact.
+
+A first run attempt (background job `bfvf8289s`, 8 arms on F1 only, launched to smoke-test the
+full grid) ran for 29 minutes at ~620% CPU with zero output — far outside the "seconds per fit"
+budget — and was killed rather than trusted. Root cause: no BLAS thread-count cap, so `lbfgs`'s
+own thread pool oversubscribed against the exit-geometry lane's concurrent CPU-bound process
+running on the same machine (`experiments/exit_geometry_sweep.py`, confirmed still running via
+`ps aux` at the same time). Fixed by capping `OMP_NUM_THREADS`/`OPENBLAS_NUM_THREADS`/
+`MKL_NUM_THREADS`/`NUMEXPR_NUM_THREADS=4` before the real run — every fit then completed in
+10–47 seconds, matching the pre-registered compute-plan expectation. No result from the killed
+run was used; every number below comes from the capped, completed run only.
+
+---
+
+## Results
+
+**Run**: single complete pass, all 7 candidate arms × 3 folds + price-only control, `scripts/research/run_input_screening.py`,
+raw output committed at `scripts/research/input_screening_results.json` (per-bar correctness
+vectors are not included in the JSON dump — only aggregated per-fold/per-arm numbers — but are
+fully reproducible by re-running the script against the disk-cached raw data in
+`scripts/research/.cache/`, itself gitignored; re-running hits no network endpoint). 24 fits
+total, 10–47s each, ~9 minutes wall-clock with BLAS capped at 4 threads.
+
+### Validity check (arm 0 vs. the target-redesign tournament's linear baseline)
+
+| Fold | Ours (logistic-on-direction) | Tournament (LinearRegression-on-`close_normalized`) | Diff | Within ±2.0pp? |
+|---|---|---|---|---|
+| F1 | 51.94% | 53.24% | −1.30pp | **PASS** |
+| F2 | 53.10% | 53.61% | −0.51pp | **PASS** |
+| F3 | 50.79% | 53.18% | −2.39pp | **FAIL** |
+
+**Read plainly, as pre-committed in §2**: F1 and F2 replicate within tolerance; F3 does not
+(−2.39pp, 0.39pp past the ±2.0pp bar). This is reported as a **non-replication on F3**, not
+adjusted after the fact — no threshold was moved, no method was changed, after seeing this
+number. Two candidate explanations, neither chased further this session (would require rebuilding
+the tournament's unrecoverable script to confirm): (1) genuine method difference — logistic-on-
+direction and LinearRegression-on-continuous-target-then-sign are not identical estimators, and
+F3's regime (2025 H1, the most volatile/choppiest of the three per the target-redesign tournament's
+own regime notes) may be exactly where that difference bites hardest; (2) the two runs' feature
+data isn't bit-identical (this experiment re-fetched OHLCV from the live cache/API rather than
+reusing the tournament's exact frozen snapshot, which no longer exists). **This limits, but does
+not invalidate, the arm-vs-control comparisons below** — every arm in this experiment is compared
+against the SAME control, fit under the SAME method, on the SAME data, in the SAME run; the
+non-replication is specifically about the "matches the external tournament" claim for F3, not
+about internal comparability.
+
+### Per-fold, per-arm results
+
+Reported metrics only — Brier and the naive-persistence-disagreement DA are context, never used
+to rank or gate, per §5.
+
+**F1** (eval 2023-01-03→2023-06-30, n_eval=4,295, naive persistence DA=46.17%):
+
+| Arm | n_train | DA | Δ vs control (pp) | McNemar p | Brier | DA on naive-disagree subset (n) |
+|---|---|---|---|---|---|---|
+| price_only_control | 46,861 | 51.94% | — | — | 0.2502 | 54.75% (2,610) |
+| realized_vol_range | 46,812 | 52.34% | +0.40 | 0.2494 | 0.2505 | 55.14% (2,579) |
+| calendar | 46,861 | 52.08% | +0.14 | 0.7140 | 0.2504 | 54.90% (2,592) |
+| btc_cross | 46,861 | 52.06% | +0.12 | 0.7651 | 0.2503 | 54.91% (2,575) |
+| funding_rate | 27,096 | 52.41% | +0.47 | 0.5275 | 0.2529 | 55.49% (2,440) |
+| basis_premium | 26,438 | 52.36% | +0.42 | 0.5684 | 0.2532 | 55.47% (2,430) |
+| fear_greed | 42,767 | 52.22% | +0.28 | 0.6049 | 0.2507 | 55.11% (2,542) |
+| all_combined | 26,438 | 52.13% | +0.19 | 0.8225 | 0.2536 | 55.28% (2,424) |
+
+**F2** (eval 2024-01-03→2024-06-30, n_eval=4,320, naive persistence DA=46.57%):
+
+| Arm | n_train | DA | Δ vs control (pp) | McNemar p | Brier | DA on naive-disagree subset (n) |
+|---|---|---|---|---|---|---|
+| price_only_control | 55,620 | 53.10% | — | — | 0.2499 | 55.18% (2,724) |
+| realized_vol_range | 55,571 | 52.64% | −0.46 | 0.1611 | 0.2500 | 54.86% (2,694) |
+| calendar | 55,620 | 52.99% | −0.12 | 0.7700 | 0.2500 | 55.13% (2,701) |
+| btc_cross | 55,620 | 52.80% | −0.30 | 0.3974 | 0.2499 | 54.99% (2,695) |
+| funding_rate | 35,855 | 53.03% | −0.07 | 0.9422 | 0.2508 | 55.43% (2,567) |
+| basis_premium | 35,197 | 52.64% | −0.46 | 0.4831 | 0.2512 | 55.13% (2,556) |
+| fear_greed | 51,526 | 52.82% | −0.28 | 0.5736 | 0.2498 | 55.10% (2,648) |
+| all_combined | 35,197 | 53.06% | −0.05 | 0.9728 | 0.2512 | 55.53% (2,532) |
+
+**F3** (eval 2025-01-03→2025-06-30, n_eval=4,296, naive persistence DA=48.21%):
+
+| Arm | n_train | DA | Δ vs control (pp) | McNemar p | Brier | DA on naive-disagree subset (n) |
+|---|---|---|---|---|---|---|
+| price_only_control | 64,404 | 50.79% | — | — | 0.2531 | 52.02% (2,741) |
+| realized_vol_range | 64,355 | 51.00% | +0.21 | 0.5124 | 0.2531 | 52.21% (2,720) |
+| calendar | 64,404 | 50.23% | −0.56 | **0.0384** | 0.2532 | 51.59% (2,743) |
+| btc_cross | 64,404 | 50.68% | −0.12 | 0.7676 | 0.2529 | 51.95% (2,724) |
+| funding_rate | 44,639 | 51.51% | +0.72 | 0.2411 | 0.2531 | 52.74% (2,588) |
+| basis_premium | 43,981 | 51.37% | +0.58 | 0.3506 | 0.2531 | 52.61% (2,604) |
+| fear_greed | 60,310 | 51.00% | +0.21 | 0.6522 | 0.2530 | 52.22% (2,706) |
+| all_combined | 43,981 | 50.84% | +0.05 | 0.9708 | 0.2532 | 52.17% (2,601) |
+
+**One nominal-significance flag, named rather than buried**: `calendar`/F3 shows p=0.0384 —
+nominally significant at the uncorrected α=0.05, but (a) not at the pre-committed Bonferroni
+α=0.0071, and (b) in the WRONG direction (Δ=−0.56pp, calendar is *worse* than the price-only
+control on F3, not better). This is exactly the kind of result the Bonferroni correction and the
+±0.5pp practical-magnitude bar exist to filter out — a large-enough candidate set will produce an
+occasional nominal p<0.05 by chance alone, and this one doesn't even point the direction a
+"graduates" verdict would need.
+
+### Graduation verdicts (per §5's pre-committed rule, applied literally)
+
+| Arm | Avg Δ vs control (pp, F1–F3) | Folds with p < 0.0071 | Verdict |
+|---|---|---|---|
+| realized_vol_range | +0.05 | 0/3 | **does not graduate** |
+| calendar | −0.18 | 0/3 | **does not graduate** |
+| btc_cross | −0.10 | 0/3 | **does not graduate** |
+| funding_rate | +0.37 | 0/3 | **does not graduate** |
+| basis_premium | +0.18 | 0/3 | **does not graduate** |
+| fear_greed | +0.07 | 0/3 | **does not graduate** |
+| all_combined | +0.06 | 0/3 | **does not graduate** |
+
+**No arm graduates.** Zero of the seven arms clears McNemar significance at the Bonferroni bar on
+even a single fold, let alone the required two — the largest single-fold p-value below 0.05 is
+`calendar`/F3 (0.0384), which is both non-significant after correction and in the wrong direction.
+Every arm's average magnitude also sits well under the +0.5pp practical bar (`funding_rate`'s
++0.37pp is the largest, still short). Both halves of the graduation rule fail, for every arm, on
+every count — this is not a marginal or ambiguous outcome.
+
+### Reading this result honestly
+
+**This is a full, reportable negative result, not a silent gap**, per the anti-p-hacking
+discipline (§9). Read alongside the three prior tournaments (window #898, architecture #939,
+target-redesign, this doc's direct predecessor), the pattern is now four-for-four: no lever tried
+so far — training window, model architecture, target/label design, or (this experiment) a
+*linear* detector's view of six shortlisted alternative-input classes — has moved next-bar
+directional accuracy on ETHUSDT 1h meaningfully past its ~51–53% ceiling.
+
+**What this does and does not say about the input classes themselves**:
+
+- It does **not** say these inputs carry zero information at any horizon or for any model class.
+  A linear/logistic model can only detect signal that is (approximately) linearly separable in
+  the raw feature space; several of the candidates' own literature support (funding rate's
+  cross-exchange Granger evidence, HAR-RV's volatility literature for arm 1) is explicitly about
+  regime/crowding/volatility structure, not a claim that a *linear* combination of these features
+  predicts *direction* — the audit itself flagged this distinction (§4/§5 of the audit doc). A
+  nonlinear model (tree ensemble, small MLP) could in principle find structure a linear model
+  cannot; that is a real, named risk of false negative, not resolved by this experiment.
+- It **does** say that the cheapest, fastest test available found no linearly-detectable
+  directional edge from any of the six shortlisted classes, on this feature contract, on these
+  three folds, at Bonferroni-corrected significance. That is exactly what a screening gate is
+  for: it does not prove an input is worthless, but it removes the "obviously and cheaply
+  confirmed" path to the deep-model tournament for every one of these six candidates.
+- `funding_rate` (avg +0.37pp) and `basis_premium` (avg +0.18pp) are the two least-unpromising
+  candidates by raw magnitude, both missing the practical bar and nowhere near significance —
+  worth naming as the closest calls, not worth reading as "almost graduated." `calendar` is the
+  only arm with a negative average delta driven by a nominally-flagged (wrong-direction) fold,
+  making it the weakest candidate of the six by this evidence.
+
+### Recommendation
+
+**Rejected as-is — no arm graduates to the deep-model input tournament under this screen.** This
+recommendation is scoped narrowly: it says a *linear* gate finds no evidence at Bonferroni
+significance for any of the six shortlisted input classes on ETHUSDT 1h. Two honest paths forward,
+neither decided here:
+
+1. **Accept this as further evidence for the four-tournament pattern** (window/architecture/
+   target/input-linear-screen, all null) and treat "no readily-available feature addition moves
+   this system's directional-accuracy ceiling" as the standing structural finding, pending either
+   a genuinely different data modality (order-book microstructure, on-chain once a paid vendor
+   decision is made) or a nonlinear-detector re-test of the same six classes before fully retiring
+   the "new information sources" lever.
+2. **A nonlinear re-screen** (small gradient-boosted-tree or shallow-MLP version of this exact
+   experiment, same folds/arms/thresholds) is the natural next falsification test for the named
+   false-negative risk above, cheaper than jumping straight to the full deep-model tournament —
+   this would still be a screening step, not the tournament itself.
+
+This is a recommendation, not a resource commitment — the next step should go through its own
+`experiment-preregister` pass, informed by but not pre-decided by this write-up, per §9.
+
+**For risk-officer / pm**: nothing here proposes a live-affecting change; there is nothing to
+stress-test. Flagging for completeness only, per the standing convention.
+
+**Status**: COMPLETE.

--- a/docs/research/experiments/2026-07-12_input-screening-linear.md
+++ b/docs/research/experiments/2026-07-12_input-screening-linear.md
@@ -1,0 +1,228 @@
+# INPUT SCREENING (Linear) — Pre-registration
+
+Date: 2026-07-12
+Author: quant-researcher
+Status: **PLANNED — pre-registration locked before any scoring run**
+Issue: GH #959 (Phase 0, input-candidates audit), this doc is Lane A Phase 1
+Related: `docs/research/2026-07-12_input-candidates-audit.md` (PR #958, open at time of
+writing — branch `docs/input-audit`, not yet merged to develop; scripts cherry-picked into
+this worktree directly since PR #958 was not blocked on), `docs/research/experiments/2026-07-10_target-redesign-tournament-results.md`
+(fold definitions, linear-baseline methodology, merged to develop at `25e0a202`)
+North star: the target-redesign report's conclusion, quoted verbatim: *"the feature set
+itself — not the model, not the window, not the target shape — is the ceiling... The next
+research lever this implies is new information sources."*
+
+**No deep-model training accompanies this document.** This is a cheap CPU-only linear/logistic
+screening gate — seconds per fit — whose sole purpose is to decide which of the audit's
+shortlisted input classes earn a slot in the (expensive, GPU) deep-model input tournament.
+Nothing here is proposed for staging or live capital.
+
+---
+
+## 1. Hypothesis
+
+**H1 (per arm)**: Adding input class *k* to the price-only feature contract produces a linear
+classifier whose next-bar directional accuracy (DA) is higher than the price-only control's DA,
+by a margin that is both statistically significant (paired McNemar per fold) and practically
+non-trivial (≥0.5pp averaged across F1–F3), on at least 2 of the 3 primary folds.
+
+**H0 (per arm, the falsifier)**: Input class *k* adds no more OOS directional information than
+the price-only control already has — any observed DA improvement is noise (fails the McNemar +
+magnitude bar on at least 2 of 3 folds).
+
+**Why a linear gate, not a straight jump to deep models**: three independent tournaments (window
+#898, architecture #939, target-redesign, this doc's direct predecessor) each held the
+price-only feature set fixed and varied a different lever, and all three found the lever wasn't
+the binding constraint. A cheap linear/logistic screen on the SAME feature-addition question
+(does this input help at all, linearly) is the appropriate next filter before spending GPU budget
+on a deep architecture per input class — a mediocre-evidence input that a linear model can't even
+detect a linear signal from is a weak candidate for a deep model to justify testing next, though
+not proof a nonlinear model couldn't find something a linear one can't (named explicitly as a risk
+of false negative in §5).
+
+**Named risk of false positive** (per arm, generic): any of the 7 arms could show a spurious
+"win" purely from added degrees of freedom (more coefficients to fit noise with), especially arms
+whose extra features are themselves partially derived from price (Fear & Greed's known
+circularity, per the audit). The Bonferroni correction (§4) and the ≥2-of-3-folds requirement are
+the primary defenses; §5 names this explicitly per arm.
+
+---
+
+## 2. Model — same linear family as the tournament baseline
+
+**Method chosen**: `sklearn.linear_model.LogisticRegression` (L2 penalty, `C=1.0`, `lbfgs`,
+`max_iter=1000`) predicting binary next-bar direction, fit on the identical feature contract used
+by the target-redesign tournament's linear/incumbent baseline
+(`PriceOnlyFeatureExtractor(normalization_window=120)`, 5 columns — `close/volume/high/low/open`
+rolling-min-max-normalized — flattened over a 120-bar sequence = 600 base inputs), standardized
+(`StandardScaler`, fit on the training split only, applied to eval).
+
+**Why logistic-on-direction rather than byte-for-byte `LinearRegression`-on-`close_normalized`**:
+the target-redesign tournament's own linear-baseline script ran in an ephemeral worktree
+(`.claude/worktrees/target-redesign-tournament`, detached at `6fc224c0`) that was never committed
+to `develop` or to any PR — `methods.md`/`training_matrix.py` are not recoverable, only their
+prose description in the results doc. Byte-for-byte reproduction is therefore not possible.
+Logistic-on-direction is the explicitly-permitted alternative from this experiment's own dispatch
+brief ("logistic regression on next-bar direction, **or** replicate the tournament's exact linear
+method") and is the closest same-family analog: same feature contract, same
+linear-model-family assumption, direct classification instead of a continuous-target-then-sign
+reconstruction (which would have required guessing at an unrecoverable de-normalization step).
+
+**Validity check (pre-committed, arm 0 only)**: the price-only control's averaged per-fold DA
+must land within **±2.0 percentage points** of the tournament's reported linear-baseline DA
+(53.24% / 53.61% / 53.18% on F1/F2/F3, `aggregate_stats_CORRECTED`). If any fold misses by more
+than 2.0pp, this is reported as a **non-replication** in the results section, not silently
+adjusted — all arm-vs-control comparisons in this doc still stand on their own (each arm is
+compared to the SAME control run under the SAME method), but the "matches the tournament" claim
+is withdrawn for whichever fold(s) miss, and flagged as a limitation rather than fixed by
+changing the method after seeing the number (that would be exactly the post-hoc-threshold-move
+the anti-p-hacking rule prohibits).
+
+---
+
+## 3. Folds — identical to the target-redesign tournament
+
+Reused verbatim from `docs/research/experiments/2026-07-10_target-redesign-tournament-prereg.md`
+§3 (same symbol, ETHUSDT, same timeframe, 1h):
+
+| Fold | Train (cutoff) | Embargo | Eval window |
+|---|---|---|---|
+| F1 | 2017-08-17 → 2022-12-31 | 48h | 2023-01-03 → 2023-06-30 |
+| F2 | 2017-08-17 → 2023-12-31 | 48h | 2024-01-03 → 2024-06-30 |
+| F3 | 2017-08-17 → 2024-12-31 | 48h | 2025-01-03 → 2025-06-30 |
+
+Expanding-window training (not rolling), matching #898's finding that full history ties-or-beats
+shorter windows. The 48h embargo applies to every feature's lookback, not just the label: no
+rolling/z-score/percentile statistic used at eval time may be fit using any data inside the
+embargo gap or the eval window itself (§6 gives the per-input rule). F4 (the tournament's
+confirmatory-only fold) is **not** included here — this is a screening gate, not a full
+tournament, and F4 was explicitly non-deciding even there; adding a 4th fold here would only
+inflate the multiple-comparison budget for no decision-relevant benefit.
+
+---
+
+## 4. Arms (pre-committed, no post-hoc additions or removals)
+
+All arms 1–6 ADD their features to the arm-0 price-only contract; none replace it. Arm 7 adds
+all of arms 1–6's features together.
+
+| # | Arm | Extra features (beyond price-only) | Alignment rule |
+|---|---|---|---|
+| 0 | Price-only control | none (600-dim price-only contract only) | — |
+| 1 | Multi-scale realized vol + range dynamics | rolling realized vol of log returns at 6h/24h/168h; Parkinson range estimator (24h window); single-bar HL-range-%-of-close and its 24h rolling mean | All rolling windows end at bar `t-1` (the last bar in the price-only sequence); computed on the full OHLCV frame, sampled only at `t-1`, never at `t` — a bar's still-forming high/low is never used to predict its own direction |
+| 2 | Calendar/session | hour-of-day (sin/cos), day-of-week (sin/cos), hours-to-next-funding-settlement (00:00/08:00/16:00 UTC cycle) | Uses bar `t`'s OWN timestamp — a deterministic function of the exchange clock, known arbitrarily far in advance; this is the one arm with no lookahead surface by construction (per the audit) |
+| 3 | BTC→ETH cross-asset | BTC lagged return (1h/6h/24h) and 24h realized vol, joined on BTC's own closed bar at ETH's `t-1` timestamp | BTC bar joined at ETH's `t-1`, never at `t` — BTC's `t-1` bar is closed well before ETH's `t` prediction is made, per the audit's explicit alignment warning |
+| 4 | Funding rate (ETHUSDT perp) | last-settled funding rate level, rate-of-change vs previous settlement, 30-day rolling z-score (frozen: z-score mean/std fit on the training split only, applied unchanged to eval — the harness-wide no-eval-leakage rule from the target-redesign tournament), extreme-funding binary flag (|z|>2) | Forward-filled from the last **settled** print as of bar `t-1`'s timestamp — a bar at `t-1`=07:00 UTC sees the 00:00 print, never the 08:00 one; `markPrice`'s empty pre-2021 values are not coerced to 0.0 (excluded from any feature that would use them) |
+| 5 | Basis / perp-spot premium proxy | premium-index CLOSE at `t-1`, and its own 24h rolling std | Uses only the closed bar's `close`-of-premium; never that bar's own `high`/`low` (those aren't known until the bar itself closes) |
+| 6 | Fear & Greed | daily F&G value (forward-filled to hourly), lagged a full day past the print date, plus 7-day momentum and an extreme-value flag (<20 or >80) | Daily value for calendar day `D` is used only for bars on or after `D+1` — one full day of conservatism past the print, per the audit's alignment rule; tested as a marginal addition over the price/vol baseline specifically (not standalone), given F&G's own partial circularity with price |
+| 7 | All-combined | arms 1+2+3+4+5+6's features together, added to price-only | Same per-input alignment rules as above, applied jointly |
+
+**Explicitly excluded from this round** (per the audit's own recommendation, restated here so it
+is pre-committed, not a post-hoc omission): open interest / long-short ratio (no free historical
+depth past 30 days), on-chain exchange-flow/active-address metrics (no free source at the needed
+depth), DXY/SPX/NDX macro (weak short-horizon evidence + non-trivial calendar-alignment cost).
+`OnChainFeatureExtractor`, `MacroFeatureExtractor`, and the social-volume/news-sentiment parts of
+`EnhancedSentimentExtractor` are **not used anywhere in this experiment** — per the audit's
+headline finding, they are simulated no-ops and including them would silently invalidate any
+"alternative data didn't help" reading.
+
+---
+
+## 5. Metrics, thresholds, and the graduation rule (pre-committed)
+
+**Primary metric**: per-fold directional accuracy (DA) — plain classification accuracy of the
+logistic model's `argmax` direction vs. `1[close[t] > close[t-1]]`, on that fold's eval window.
+
+**Significance test**: per-fold **McNemar's test** (paired — every arm is scored on the identical
+set of eval bars within a fold, so the correct test is paired, not an independent-samples
+two-proportion z-test) comparing each arm's per-bar correctness vector against the price-only
+control's, on the same fold.
+
+**Multiple-comparison correction**: **Bonferroni, α = 0.05/7 ≈ 0.0071** across the 7 arms
+(6 candidate arms + the all-combined arm; arm 0 is the reference, not itself tested against
+itself). This is stricter than the target-redesign tournament's 6-pairwise-comparison correction
+(0.0083) because this screen deliberately tests more candidates against one fixed reference.
+
+**Graduation rule (pre-committed, exact numbers, not to move after seeing results)**: an input
+class graduates to the deep-model input tournament if and only if, versus the price-only control:
+
+1. McNemar p < 0.0071 (Bonferroni-corrected) on **≥ 2 of the 3 folds** (F1/F2/F3), AND
+2. The **average** DA improvement across F1–F3 is **≥ +0.5 percentage points**.
+
+Both conditions must hold. An arm that clears (1) but not (2) — statistically real but too small
+to matter — does not graduate. An arm that clears (2) but not (1) — a nominally large gap that
+isn't statistically distinguishable from noise at this bar count — does not graduate. This
+exact wording is locked before any scoring run.
+
+**Reported, never used to rank or gate** (per instruction 6):
+
+- **Brier score** (mean squared error of the model's `P(up)` against the actual binary outcome),
+  every arm, every fold.
+- **DA restricted to the subset of eval bars where the arm's predicted direction disagrees with
+  naive persistence** (`sign(close[t-1]-close[t-2])` continuing) — isolates whether an arm adds
+  anything beyond trivial momentum-continuation, computed only where cheap (it is, here — no
+  extra data, just a subset mask on already-computed predictions).
+
+---
+
+## 6. Leakage discipline (restated per input, all causal)
+
+Every feature is computed strictly from data available at or before the bar it is attributed to,
+with the specific rule stated per arm in §4's table. Two harness-wide rules apply across every
+arm:
+
+- **The 48h embargo gates every rolling/z-score statistic**, not just the label: any
+  frozen-statistic feature (arm 4's funding z-score) is fit on the training split only and applied
+  unchanged to the eval window — never refit or updated using eval-window data, matching the
+  target-redesign tournament's harness-wide confidence-mechanism rule.
+- **No same-bar high/low lookahead**: every range/volatility feature computed from a bar's own
+  high/low uses that bar only after it is fully closed and only for bars strictly before the
+  target bar `t` (i.e., sampled at `t-1`, never `t`) — CODE.md's top backtest-parity rule, applied
+  to every new feature in this experiment, not just the ones with an external data source.
+
+---
+
+## 7. Data
+
+- **ETHUSDT / BTCUSDT 1h OHLCV**: local cache (`cache/market_data/`, `CachedDataProvider` +
+  `BinanceProvider`), already covering 2017-08-17 → present per `atb data cache-manager info`
+  (verified this session, 34 cached files). No stale-cache concern — this experiment fetches
+  through the exact fold cutoffs directly if not already cached.
+- **ETHUSDT perp funding rate**: `fapi.binance.com/fapi/v1/fundingRate`, full history pull (not
+  the audit's 30-day sample), paginated per the audit's proof-of-obtainability script pattern.
+- **ETHUSDT perp premium index**: `fapi.binance.com/fapi/v1/premiumIndexKlines`, 1h granularity,
+  full history pull, same pagination pattern.
+- **Fear & Greed index**: `api.alternative.me/fng/?limit=0`, full history (already verified
+  3,080 daily records, 2018-02-01 to present, by the audit).
+
+All fetches are cached to disk under `scripts/research/.cache/` (gitignored) inside this
+experiment's scripts, so re-running the screen does not re-hit any network endpoint.
+
+---
+
+## 8. Compute plan
+
+Every fit is CPU-only `sklearn.LogisticRegression` on at most ~65k rows × ~610 features — seconds
+per fit, `lbfgs` solver. Total: 7 arms × 3 folds = 21 fits, plus the naive-persistence baseline
+(free, no fit). No GPU, no cloud, no SageMaker. Runs entirely inside this worktree
+(`.claude/worktrees/input-screening-linear`), sequentially, no contention with the exit-geometry
+lane's heavy-compute lock (not applicable here — nothing here is a full backtest or GPU job). If
+any step turns out to need a full `atb backtest` run, that is explicitly out of this doc's scope
+and will be coordinated with the PM before running, per the dispatch brief.
+
+---
+
+## 9. Decision this experiment feeds
+
+This is a **screening gate**, not a strategy-change proposal. Its only output is a graduation
+verdict per input class, handed to whoever scopes the next (deep-model) input tournament. No
+arm's outcome here — pass or fail — authorizes any change to a live-affecting strategy, model, or
+`risk-limits.json`. If every arm fails to graduate, that is itself a reportable, full-write-up
+result (per the anti-p-hacking rule), not a silent gap — it would mean even a linear detector
+finds no signal in any shortlisted input class, which is directly relevant to whether the "new
+information sources" lever the target-redesign report recommended is worth GPU budget at all.
+
+---
+
+*Pre-registration locked at the above wording. Results appended below after the run, never by
+editing the sections above.*

--- a/scripts/research/input_screening_results.json
+++ b/scripts/research/input_screening_results.json
@@ -1,0 +1,476 @@
+{
+  "generated_at": "2026-07-12T09:39:10.124826+00:00",
+  "results_by_fold": {
+    "F1": {
+      "price_only_control": {
+        "arm": "price_only_control",
+        "fold": "F1",
+        "n_train": 46861,
+        "n_eval": 4295,
+        "da": 51.9441210710128,
+        "brier": 0.2502479559222334,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 54.75095785440614,
+        "n_naive_disagree": 2610,
+        "mcnemar_p_vs_control": null,
+        "delta_da_vs_control_pp": 0.0
+      },
+      "realized_vol_range": {
+        "arm": "realized_vol_range",
+        "fold": "F1",
+        "n_train": 46812,
+        "n_eval": 4295,
+        "da": 52.33993015133876,
+        "brier": 0.2504985302712599,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 55.13765025203568,
+        "n_naive_disagree": 2579,
+        "n_common_with_control": 4295,
+        "mcnemar_p_vs_control": 0.24937669004363616,
+        "delta_da_vs_control_pp": 0.39580908032596085
+      },
+      "calendar": {
+        "arm": "calendar",
+        "fold": "F1",
+        "n_train": 46861,
+        "n_eval": 4295,
+        "da": 52.0838183934808,
+        "brier": 0.250359281186412,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 54.8996913580247,
+        "n_naive_disagree": 2592,
+        "n_common_with_control": 4295,
+        "mcnemar_p_vs_control": 0.7140111628842962,
+        "delta_da_vs_control_pp": 0.13969732246799538
+      },
+      "btc_cross": {
+        "arm": "btc_cross",
+        "fold": "F1",
+        "n_train": 46861,
+        "n_eval": 4295,
+        "da": 52.06053550640279,
+        "brier": 0.25034293928539003,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 54.9126213592233,
+        "n_naive_disagree": 2575,
+        "n_common_with_control": 4295,
+        "mcnemar_p_vs_control": 0.7650574199487117,
+        "delta_da_vs_control_pp": 0.11641443538999141
+      },
+      "funding_rate": {
+        "arm": "funding_rate",
+        "fold": "F1",
+        "n_train": 27096,
+        "n_eval": 4295,
+        "da": 52.40977881257276,
+        "brier": 0.25290462323427365,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 55.49180327868852,
+        "n_naive_disagree": 2440,
+        "n_common_with_control": 4295,
+        "mcnemar_p_vs_control": 0.5274551540734863,
+        "delta_da_vs_control_pp": 0.46565774155995854
+      },
+      "basis_premium": {
+        "arm": "basis_premium",
+        "fold": "F1",
+        "n_train": 26438,
+        "n_eval": 4295,
+        "da": 52.36321303841677,
+        "brier": 0.25316564709330436,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 55.47325102880658,
+        "n_naive_disagree": 2430,
+        "n_common_with_control": 4295,
+        "mcnemar_p_vs_control": 0.5683749353322357,
+        "delta_da_vs_control_pp": 0.4190919674039648
+      },
+      "fear_greed": {
+        "arm": "fear_greed",
+        "fold": "F1",
+        "n_train": 42767,
+        "n_eval": 4295,
+        "da": 52.22351571594878,
+        "brier": 0.25072451334915713,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 55.11408339889851,
+        "n_naive_disagree": 2542,
+        "n_common_with_control": 4295,
+        "mcnemar_p_vs_control": 0.6049283873869076,
+        "delta_da_vs_control_pp": 0.27939464493597654
+      },
+      "all_combined": {
+        "arm": "all_combined",
+        "fold": "F1",
+        "n_train": 26438,
+        "n_eval": 4295,
+        "da": 52.13038416763679,
+        "brier": 0.2536398279914548,
+        "naive_da": 46.16996507566938,
+        "da_on_naive_disagree_subset": 55.28052805280528,
+        "n_naive_disagree": 2424,
+        "n_common_with_control": 4295,
+        "mcnemar_p_vs_control": 0.8225423827944983,
+        "delta_da_vs_control_pp": 0.1862630966239891
+      }
+    },
+    "F2": {
+      "price_only_control": {
+        "arm": "price_only_control",
+        "fold": "F2",
+        "n_train": 55620,
+        "n_eval": 4320,
+        "da": 53.101851851851855,
+        "brier": 0.2498706152480126,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 55.17621145374449,
+        "n_naive_disagree": 2724,
+        "mcnemar_p_vs_control": null,
+        "delta_da_vs_control_pp": 0.0
+      },
+      "realized_vol_range": {
+        "arm": "realized_vol_range",
+        "fold": "F2",
+        "n_train": 55571,
+        "n_eval": 4320,
+        "da": 52.63888888888889,
+        "brier": 0.24998669801584456,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 54.86265775798069,
+        "n_naive_disagree": 2694,
+        "n_common_with_control": 4320,
+        "mcnemar_p_vs_control": 0.16112227096098028,
+        "delta_da_vs_control_pp": -0.4629629629629619
+      },
+      "calendar": {
+        "arm": "calendar",
+        "fold": "F2",
+        "n_train": 55620,
+        "n_eval": 4320,
+        "da": 52.986111111111114,
+        "brier": 0.24996944259945894,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 55.12773047019623,
+        "n_naive_disagree": 2701,
+        "n_common_with_control": 4320,
+        "mcnemar_p_vs_control": 0.7699893951857691,
+        "delta_da_vs_control_pp": -0.11574074074074048
+      },
+      "btc_cross": {
+        "arm": "btc_cross",
+        "fold": "F2",
+        "n_train": 55620,
+        "n_eval": 4320,
+        "da": 52.800925925925924,
+        "brier": 0.2499481867819307,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 54.990723562152134,
+        "n_naive_disagree": 2695,
+        "n_common_with_control": 4320,
+        "mcnemar_p_vs_control": 0.3973782900879155,
+        "delta_da_vs_control_pp": -0.3009259259259309
+      },
+      "funding_rate": {
+        "arm": "funding_rate",
+        "fold": "F2",
+        "n_train": 35855,
+        "n_eval": 4320,
+        "da": 53.03240740740741,
+        "brier": 0.25080526671339626,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 55.43435917413323,
+        "n_naive_disagree": 2567,
+        "n_common_with_control": 4320,
+        "mcnemar_p_vs_control": 0.9422103470377879,
+        "delta_da_vs_control_pp": -0.06944444444444287
+      },
+      "basis_premium": {
+        "arm": "basis_premium",
+        "fold": "F2",
+        "n_train": 35197,
+        "n_eval": 4320,
+        "da": 52.63888888888889,
+        "brier": 0.25119672879875043,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 55.12519561815337,
+        "n_naive_disagree": 2556,
+        "n_common_with_control": 4320,
+        "mcnemar_p_vs_control": 0.4831394127100678,
+        "delta_da_vs_control_pp": -0.4629629629629619
+      },
+      "fear_greed": {
+        "arm": "fear_greed",
+        "fold": "F2",
+        "n_train": 51526,
+        "n_eval": 4320,
+        "da": 52.824074074074076,
+        "brier": 0.24979712836959453,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 55.09818731117825,
+        "n_naive_disagree": 2648,
+        "n_common_with_control": 4320,
+        "mcnemar_p_vs_control": 0.5736224274247995,
+        "delta_da_vs_control_pp": -0.27777777777777857
+      },
+      "all_combined": {
+        "arm": "all_combined",
+        "fold": "F2",
+        "n_train": 35197,
+        "n_eval": 4320,
+        "da": 53.05555555555556,
+        "brier": 0.2512471297522347,
+        "naive_da": 46.574074074074076,
+        "da_on_naive_disagree_subset": 55.52922590837282,
+        "n_naive_disagree": 2532,
+        "n_common_with_control": 4320,
+        "mcnemar_p_vs_control": 0.9728318245555583,
+        "delta_da_vs_control_pp": -0.04629629629629761
+      }
+    },
+    "F3": {
+      "price_only_control": {
+        "arm": "price_only_control",
+        "fold": "F3",
+        "n_train": 64404,
+        "n_eval": 4296,
+        "da": 50.791433891992554,
+        "brier": 0.2530891482764912,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 52.02480846406421,
+        "n_naive_disagree": 2741,
+        "mcnemar_p_vs_control": null,
+        "delta_da_vs_control_pp": 0.0
+      },
+      "realized_vol_range": {
+        "arm": "realized_vol_range",
+        "fold": "F3",
+        "n_train": 64355,
+        "n_eval": 4296,
+        "da": 51.00093109869647,
+        "brier": 0.2530671459753697,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 52.20588235294118,
+        "n_naive_disagree": 2720,
+        "n_common_with_control": 4296,
+        "mcnemar_p_vs_control": 0.5123564769095189,
+        "delta_da_vs_control_pp": 0.20949720670391514
+      },
+      "calendar": {
+        "arm": "calendar",
+        "fold": "F3",
+        "n_train": 64404,
+        "n_eval": 4296,
+        "da": 50.232774674115454,
+        "brier": 0.2532017265092597,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 51.58585490339045,
+        "n_naive_disagree": 2743,
+        "n_common_with_control": 4296,
+        "mcnemar_p_vs_control": 0.03844849701100047,
+        "delta_da_vs_control_pp": -0.5586592178770999
+      },
+      "btc_cross": {
+        "arm": "btc_cross",
+        "fold": "F3",
+        "n_train": 64404,
+        "n_eval": 4296,
+        "da": 50.67504655493482,
+        "brier": 0.2529486801187605,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 51.945668135095445,
+        "n_naive_disagree": 2724,
+        "n_common_with_control": 4296,
+        "mcnemar_p_vs_control": 0.7675626320478244,
+        "delta_da_vs_control_pp": -0.11638733705773063
+      },
+      "funding_rate": {
+        "arm": "funding_rate",
+        "fold": "F3",
+        "n_train": 44639,
+        "n_eval": 4296,
+        "da": 51.51303538175046,
+        "brier": 0.25308493431277485,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 52.74343122102009,
+        "n_naive_disagree": 2588,
+        "n_common_with_control": 4296,
+        "mcnemar_p_vs_control": 0.24109568115214008,
+        "delta_da_vs_control_pp": 0.7216014897579086
+      },
+      "basis_premium": {
+        "arm": "basis_premium",
+        "fold": "F3",
+        "n_train": 43981,
+        "n_eval": 4296,
+        "da": 51.37337057728119,
+        "brier": 0.25308106773065875,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 52.61136712749616,
+        "n_naive_disagree": 2604,
+        "n_common_with_control": 4296,
+        "mcnemar_p_vs_control": 0.35057403213728394,
+        "delta_da_vs_control_pp": 0.581936685288639
+      },
+      "fear_greed": {
+        "arm": "fear_greed",
+        "fold": "F3",
+        "n_train": 60310,
+        "n_eval": 4296,
+        "da": 51.00093109869647,
+        "brier": 0.2529701706521147,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 52.21729490022173,
+        "n_naive_disagree": 2706,
+        "n_common_with_control": 4296,
+        "mcnemar_p_vs_control": 0.6522393974092942,
+        "delta_da_vs_control_pp": 0.20949720670391514
+      },
+      "all_combined": {
+        "arm": "all_combined",
+        "fold": "F3",
+        "n_train": 43981,
+        "n_eval": 4296,
+        "da": 50.83798882681564,
+        "brier": 0.25317700478702926,
+        "naive_da": 48.20763500931099,
+        "da_on_naive_disagree_subset": 52.17224144559785,
+        "n_naive_disagree": 2601,
+        "n_common_with_control": 4296,
+        "mcnemar_p_vs_control": 0.970836200037914,
+        "delta_da_vs_control_pp": 0.04655493482308515
+      }
+    }
+  },
+  "verdicts": {
+    "realized_vol_range": {
+      "per_fold_delta_pp": {
+        "F1": 0.39580908032596085,
+        "F2": -0.4629629629629619,
+        "F3": 0.20949720670391514
+      },
+      "per_fold_p": {
+        "F1": 0.24937669004363616,
+        "F2": 0.16112227096098028,
+        "F3": 0.5123564769095189
+      },
+      "n_significant_folds": 0,
+      "avg_delta_pp": 0.04744777468897136,
+      "graduates": false
+    },
+    "calendar": {
+      "per_fold_delta_pp": {
+        "F1": 0.13969732246799538,
+        "F2": -0.11574074074074048,
+        "F3": -0.5586592178770999
+      },
+      "per_fold_p": {
+        "F1": 0.7140111628842962,
+        "F2": 0.7699893951857691,
+        "F3": 0.03844849701100047
+      },
+      "n_significant_folds": 0,
+      "avg_delta_pp": -0.17823421204994835,
+      "graduates": false
+    },
+    "btc_cross": {
+      "per_fold_delta_pp": {
+        "F1": 0.11641443538999141,
+        "F2": -0.3009259259259309,
+        "F3": -0.11638733705773063
+      },
+      "per_fold_p": {
+        "F1": 0.7650574199487117,
+        "F2": 0.3973782900879155,
+        "F3": 0.7675626320478244
+      },
+      "n_significant_folds": 0,
+      "avg_delta_pp": -0.10029960919789005,
+      "graduates": false
+    },
+    "funding_rate": {
+      "per_fold_delta_pp": {
+        "F1": 0.46565774155995854,
+        "F2": -0.06944444444444287,
+        "F3": 0.7216014897579086
+      },
+      "per_fold_p": {
+        "F1": 0.5274551540734863,
+        "F2": 0.9422103470377879,
+        "F3": 0.24109568115214008
+      },
+      "n_significant_folds": 0,
+      "avg_delta_pp": 0.3726049289578081,
+      "graduates": false
+    },
+    "basis_premium": {
+      "per_fold_delta_pp": {
+        "F1": 0.4190919674039648,
+        "F2": -0.4629629629629619,
+        "F3": 0.581936685288639
+      },
+      "per_fold_p": {
+        "F1": 0.5683749353322357,
+        "F2": 0.4831394127100678,
+        "F3": 0.35057403213728394
+      },
+      "n_significant_folds": 0,
+      "avg_delta_pp": 0.17935522990988062,
+      "graduates": false
+    },
+    "fear_greed": {
+      "per_fold_delta_pp": {
+        "F1": 0.27939464493597654,
+        "F2": -0.27777777777777857,
+        "F3": 0.20949720670391514
+      },
+      "per_fold_p": {
+        "F1": 0.6049283873869076,
+        "F2": 0.5736224274247995,
+        "F3": 0.6522393974092942
+      },
+      "n_significant_folds": 0,
+      "avg_delta_pp": 0.0703713579540377,
+      "graduates": false
+    },
+    "all_combined": {
+      "per_fold_delta_pp": {
+        "F1": 0.1862630966239891,
+        "F2": -0.04629629629629761,
+        "F3": 0.04655493482308515
+      },
+      "per_fold_p": {
+        "F1": 0.8225423827944983,
+        "F2": 0.9728318245555583,
+        "F3": 0.970836200037914
+      },
+      "n_significant_folds": 0,
+      "avg_delta_pp": 0.062173911716925545,
+      "graduates": false
+    }
+  },
+  "validity_check": {
+    "F1": {
+      "ours": 51.9441210710128,
+      "tournament": 53.24,
+      "diff_pp": -1.2958789289872001,
+      "within_tolerance": true
+    },
+    "F2": {
+      "ours": 53.101851851851855,
+      "tournament": 53.61,
+      "diff_pp": -0.5081481481481447,
+      "within_tolerance": true
+    },
+    "F3": {
+      "ours": 50.791433891992554,
+      "tournament": 53.18,
+      "diff_pp": -2.3885661080074456,
+      "within_tolerance": false
+    }
+  },
+  "graduation_rule": {
+    "min_significant_folds": 2,
+    "min_avg_delta_pp": 0.5,
+    "bonferroni_alpha": 0.0071428571428571435
+  }
+}

--- a/scripts/research/is_data.py
+++ b/scripts/research/is_data.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Data loading for the LINEAR INPUT-SCREENING experiment (Lane A, Phase 1).
+
+Research script only — not wired into any DataProvider/cache-manager path, per
+CODE.md's Backtest-Live Parity rule. Fetches are disk-cached under
+scripts/research/.cache/ (gitignored) so repeat runs never re-hit the network.
+
+Sources:
+  - ETHUSDT / BTCUSDT 1h OHLCV: the repo's own CachedDataProvider(BinanceProvider())
+    (same machinery the training pipeline uses).
+  - ETHUSDT perp funding rate: fapi.binance.com/fapi/v1/fundingRate (free, no key).
+  - ETHUSDT perp premium index (basis proxy): fapi.binance.com/fapi/v1/premiumIndexKlines
+    (free, no key).
+  - Fear & Greed index: api.alternative.me/fng/ (free, no key).
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+CACHE_DIR = Path(__file__).parent / ".cache"
+CACHE_DIR.mkdir(exist_ok=True)
+
+FUNDING_URL = "https://fapi.binance.com/fapi/v1/fundingRate"
+PREMIUM_URL = "https://fapi.binance.com/fapi/v1/premiumIndexKlines"
+FNG_URL = "https://api.alternative.me/fng/"
+
+
+def _project_root() -> Path:
+    # scripts/research/is_data.py -> repo root is two parents up
+    return Path(__file__).resolve().parents[2]
+
+
+def load_ohlcv(symbol: str, timeframe: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Load OHLCV via the repo's own CachedDataProvider (reuses local cache/market_data)."""
+    import sys
+
+    root = _project_root()
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    from src.data_providers.binance_provider import BinanceProvider
+    from src.data_providers.cached_data_provider import CachedDataProvider
+
+    provider = CachedDataProvider(BinanceProvider())
+    df = provider.get_historical_data(symbol, timeframe, start, end)
+    df = df.copy()
+    if not isinstance(df.index, pd.DatetimeIndex):
+        # Normalize to a tz-aware UTC DatetimeIndex regardless of what column/index
+        # the provider returns timestamps in.
+        if "timestamp" in df.columns:
+            df = df.set_index(pd.to_datetime(df["timestamp"], utc=True))
+        elif "open_time" in df.columns:
+            df = df.set_index(pd.to_datetime(df["open_time"], utc=True))
+        else:
+            df.index = pd.to_datetime(df.index, utc=True)
+    elif df.index.tz is None:
+        df.index = df.index.tz_localize(UTC)
+    df = df.sort_index()
+    df = df[~df.index.duplicated(keep="first")]
+    return df
+
+
+def _paginate_binance(url: str, params: dict, time_key: str, start_ms: int, end_ms: int) -> list:
+    out: list = []
+    cursor = start_ms
+    while cursor < end_ms:
+        p = dict(params)
+        p["startTime"] = cursor
+        p["endTime"] = end_ms
+        p["limit"] = 1000
+        resp = requests.get(url, params=p, timeout=(5, 30))
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        out.extend(batch)
+        last_ts = batch[-1][time_key] if isinstance(batch[-1], dict) else batch[-1][0]
+        if last_ts <= cursor:
+            break
+        cursor = last_ts + 1
+        if len(batch) < 1000:
+            break
+        time.sleep(0.15)
+    return out
+
+
+def load_funding_rate(symbol: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Full ETHUSDT perp funding-rate history, disk-cached."""
+    cache_file = CACHE_DIR / f"funding_{symbol}.parquet"
+    if cache_file.exists():
+        df = pd.read_parquet(cache_file)
+    else:
+        start_ms = int(datetime(2019, 1, 1, tzinfo=UTC).timestamp() * 1000)
+        end_ms = int(datetime.now(UTC).timestamp() * 1000)
+        records = _paginate_binance(
+            FUNDING_URL, {"symbol": symbol}, "fundingTime", start_ms, end_ms
+        )
+        df = pd.DataFrame(records)
+        df["fundingTime"] = pd.to_datetime(df["fundingTime"], unit="ms", utc=True)
+        df["fundingRate"] = df["fundingRate"].astype(float)
+        # markPrice is "" in some pre-2021 records; keep as NaN, never coerce to 0.0
+        df["markPrice"] = pd.to_numeric(df["markPrice"], errors="coerce")
+        df = df.drop_duplicates(subset="fundingTime").sort_values("fundingTime")
+        df.to_parquet(cache_file)
+    df = df.set_index("fundingTime")
+    # start/end are accepted for API-shape consistency with the other loaders; this
+    # loader always returns the full cached history and lets the caller align/forward-fill,
+    # since funding-rate feature construction needs the pre-fold-cutoff tail for lookback.
+    del start, end
+    return df
+
+
+def load_premium_index(symbol: str, start: datetime, end: datetime) -> pd.DataFrame:
+    """Full ETHUSDT premium-index (basis proxy) klines, 1h, disk-cached."""
+    cache_file = CACHE_DIR / f"premium_{symbol}.parquet"
+    if cache_file.exists():
+        df = pd.read_parquet(cache_file)
+        return df
+    start_ms = int(datetime(2019, 1, 1, tzinfo=UTC).timestamp() * 1000)
+    end_ms = int(datetime.now(UTC).timestamp() * 1000)
+    out = []
+    cursor = start_ms
+    while cursor < end_ms:
+        resp = requests.get(
+            PREMIUM_URL,
+            params={
+                "symbol": symbol,
+                "interval": "1h",
+                "startTime": cursor,
+                "endTime": end_ms,
+                "limit": 1000,
+            },
+            timeout=(5, 30),
+        )
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        out.extend(batch)
+        last_open = batch[-1][0]
+        if last_open <= cursor:
+            break
+        cursor = last_open + 3600_000  # advance one hour past last open time
+        if len(batch) < 1000:
+            break
+        time.sleep(0.15)
+    cols = [
+        "open_time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "ignore1",
+        "close_time",
+        "ignore2",
+        "ignore3",
+        "ignore4",
+        "ignore5",
+        "ignore6",
+    ]
+    df = pd.DataFrame(out, columns=cols[: len(out[0])] if out else cols)
+    if df.empty:
+        raise RuntimeError(f"No premium-index data returned for {symbol}")
+    df["open_time"] = pd.to_datetime(df["open_time"], unit="ms", utc=True)
+    for c in ("open", "high", "low", "close"):
+        df[c] = df[c].astype(float)
+    df = df.drop_duplicates(subset="open_time").sort_values("open_time")
+    df = df.set_index("open_time")[["open", "high", "low", "close"]]
+    df.to_parquet(cache_file)
+    return df
+
+
+def load_fear_greed() -> pd.DataFrame:
+    """Full Fear & Greed daily history, disk-cached."""
+    cache_file = CACHE_DIR / "feargreed.parquet"
+    if cache_file.exists():
+        return pd.read_parquet(cache_file)
+    resp = requests.get(FNG_URL, params={"limit": 0, "format": "json"}, timeout=(5, 30))
+    resp.raise_for_status()
+    data = resp.json()["data"]
+    df = pd.DataFrame(data)
+    df["timestamp"] = pd.to_datetime(df["timestamp"].astype(int), unit="s", utc=True)
+    df["value"] = df["value"].astype(float)
+    df = df.drop_duplicates(subset="timestamp").sort_values("timestamp")
+    df = df.set_index("timestamp")[["value"]]
+    df.to_parquet(cache_file)
+    return df
+
+
+if __name__ == "__main__":
+    # Smoke check: pull everything once so subsequent runs hit the disk cache.
+    fr = load_funding_rate("ETHUSDT", datetime(2019, 1, 1, tzinfo=UTC), datetime.now(UTC))
+    print(f"funding rate: {len(fr)} records, {fr.index.min()} -> {fr.index.max()}")
+    pi = load_premium_index("ETHUSDT", datetime(2019, 1, 1, tzinfo=UTC), datetime.now(UTC))
+    print(f"premium index: {len(pi)} records, {pi.index.min()} -> {pi.index.max()}")
+    fg = load_fear_greed()
+    print(f"fear&greed: {len(fg)} records, {fg.index.min()} -> {fg.index.max()}")

--- a/scripts/research/is_features.py
+++ b/scripts/research/is_features.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Feature construction for the LINEAR INPUT-SCREENING experiment (Lane A, Phase 1).
+
+Research script only (CODE.md Backtest-Live Parity: nothing here counts as
+backtest-ready until it goes through src/engines/shared/). Every function's
+docstring states its own alignment rule; these match the prereg's §4/§6 tables
+verbatim — do not change the rule here without amending the prereg first.
+
+Feature-contract convention: every "extra" feature (arms 1/3/4/5/6) is computed on
+the FULL historical frame using only backward-looking rolling windows, then sampled
+at row `idx-1` (the last bar in the price-only 120-bar sequence, already closed) when
+assembling a training/eval sample for target bar `idx`. Arm 2 (calendar) is the sole
+exception — it uses bar `idx`'s own timestamp, which is a deterministic function of
+the exchange clock and carries no lookahead risk by construction.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from src.prediction.features.price_only import PriceOnlyFeatureExtractor  # noqa: E402
+
+SEQUENCE_LENGTH = 120
+PRICE_ONLY_COLS = [
+    "close_normalized",
+    "volume_normalized",
+    "high_normalized",
+    "low_normalized",
+    "open_normalized",
+]
+
+
+def build_price_only_frame(ohlcv: pd.DataFrame) -> pd.DataFrame:
+    """PriceOnlyFeatureExtractor(120) applied to the full OHLCV frame — the exact
+    feature contract the target-redesign tournament's linear baseline used."""
+    extractor = PriceOnlyFeatureExtractor(normalization_window=SEQUENCE_LENGTH)
+    return extractor.extract(ohlcv.copy())
+
+
+# ---------------------------------------------------------------------------
+# Arm 1: multi-scale realized vol + range dynamics (own OHLCV)
+# ---------------------------------------------------------------------------
+
+
+def realized_vol_frame(ohlcv: pd.DataFrame) -> pd.DataFrame:
+    """Alignment rule: every rolling window ends at the row's own index (that bar,
+    once closed). Sampled at `t-1` when scoring target `t` — this frame's row `t-1`
+    never uses bar `t`'s still-forming high/low/close."""
+    close = ohlcv["close"]
+    high = ohlcv["high"]
+    low = ohlcv["low"]
+    log_ret = np.log(close / close.shift(1))
+
+    out = pd.DataFrame(index=ohlcv.index)
+    out["rv_6h"] = log_ret.rolling(6, min_periods=6).std()
+    out["rv_24h"] = log_ret.rolling(24, min_periods=24).std()
+    out["rv_168h"] = log_ret.rolling(168, min_periods=168).std()
+    # Parkinson range-based volatility estimator, 24h rolling window.
+    log_hl2 = (np.log(high / low)) ** 2
+    out["park_vol_24h"] = np.sqrt(log_hl2.rolling(24, min_periods=24).mean() / (4 * np.log(2)))
+    out["hl_range_pct"] = (high - low) / close
+    out["hl_range_pct_ma24"] = out["hl_range_pct"].rolling(24, min_periods=24).mean()
+    return out
+
+
+REALIZED_VOL_COLS = [
+    "rv_6h",
+    "rv_24h",
+    "rv_168h",
+    "park_vol_24h",
+    "hl_range_pct",
+    "hl_range_pct_ma24",
+]
+
+
+# ---------------------------------------------------------------------------
+# Arm 2: calendar/session features
+# ---------------------------------------------------------------------------
+
+
+def calendar_features_for_timestamps(timestamps: pd.DatetimeIndex) -> pd.DataFrame:
+    """Alignment rule: uses bar `t`'s OWN timestamp directly (not `t-1`) — a
+    deterministic function of the exchange clock, known arbitrarily far in advance.
+    No lookahead surface."""
+    hour = timestamps.hour + timestamps.minute / 60.0
+    dow = timestamps.dayofweek
+    out = pd.DataFrame(index=timestamps)
+    out["hour_sin"] = np.sin(2 * np.pi * hour / 24.0)
+    out["hour_cos"] = np.cos(2 * np.pi * hour / 24.0)
+    out["dow_sin"] = np.sin(2 * np.pi * dow / 7.0)
+    out["dow_cos"] = np.cos(2 * np.pi * dow / 7.0)
+    # Funding settles at 00:00/08:00/16:00 UTC — hours until the next settlement.
+    hours_since_midnight = hour
+    hours_to_next = (8 - (hours_since_midnight % 8)) % 8
+    hours_to_next = np.where(hours_to_next == 0, 8.0, hours_to_next)
+    out["hours_to_funding"] = hours_to_next
+    return out
+
+
+CALENDAR_COLS = ["hour_sin", "hour_cos", "dow_sin", "dow_cos", "hours_to_funding"]
+
+
+# ---------------------------------------------------------------------------
+# Arm 3: BTC -> ETH cross-asset
+# ---------------------------------------------------------------------------
+
+
+def btc_cross_frame(btc_ohlcv: pd.DataFrame, eth_index: pd.DatetimeIndex) -> pd.DataFrame:
+    """Alignment rule: BTC features are computed on BTC's own closed bars, then
+    reindexed onto ETH's timeline with forward-fill only (never a future BTC bar).
+    When a sample for ETH target `t` is assembled, this frame is sampled at ETH's
+    `t-1` timestamp — i.e. BTC's bar at (or the last BTC bar at/before) ETH's `t-1`,
+    which by construction closed before ETH's `t` prediction is made."""
+    close = btc_ohlcv["close"]
+    log_ret = np.log(close / close.shift(1))
+    btc = pd.DataFrame(index=btc_ohlcv.index)
+    btc["btc_ret_1h"] = log_ret
+    btc["btc_ret_6h"] = np.log(close / close.shift(6))
+    btc["btc_ret_24h"] = np.log(close / close.shift(24))
+    btc["btc_rv_24h"] = log_ret.rolling(24, min_periods=24).std()
+    # Reindex onto ETH's own timeline; forward-fill carries the last KNOWN (past)
+    # BTC value forward across any gap — never pulls a later BTC bar backward.
+    out = btc.reindex(eth_index).ffill()
+    return out
+
+
+BTC_COLS = ["btc_ret_1h", "btc_ret_6h", "btc_ret_24h", "btc_rv_24h"]
+
+
+# ---------------------------------------------------------------------------
+# Arm 4: funding rate (ETHUSDT perp)
+# ---------------------------------------------------------------------------
+
+
+def funding_frame(
+    funding_raw: pd.DataFrame, eth_index: pd.DatetimeIndex, train_cutoff
+) -> pd.DataFrame:
+    """Alignment rule: forward-filled from the last SETTLED print as of the queried
+    timestamp (merge_asof, direction='backward' — never a settlement that hasn't
+    printed yet). `markPrice`'s empty pre-2021 values are NaN (never coerced to 0.0)
+    and excluded from anything that would use them. The 30-day z-score's mean/std are
+    fit on the TRAINING split only (rows with timestamp <= train_cutoff) and applied
+    unchanged to the eval window — the harness-wide frozen-statistic rule from the
+    target-redesign tournament, applied here so eval-window bars never leak into
+    their own normalization."""
+    fr = funding_raw.sort_index()
+    settled = fr["fundingRate"]
+
+    eth_df = pd.DataFrame(index=eth_index)
+    merged = pd.merge_asof(
+        eth_df.rename_axis("ts").reset_index(),
+        settled.rename_axis("ts").reset_index().rename(columns={"fundingRate": "funding_rate"}),
+        on="ts",
+        direction="backward",
+    ).set_index("ts")
+
+    out = pd.DataFrame(index=eth_index)
+    out["funding_rate"] = merged["funding_rate"]
+    # rate-of-change vs the previous *settlement* (not previous hourly row, which
+    # would mostly be a repeat of the same settlement between prints)
+    settled_unique = settled[~settled.index.duplicated(keep="first")]
+    roc = settled_unique.diff()
+    roc_merged = pd.merge_asof(
+        eth_df.rename_axis("ts").reset_index(),
+        roc.rename_axis("ts").reset_index().rename(columns={"fundingRate": "funding_roc"}),
+        on="ts",
+        direction="backward",
+    ).set_index("ts")
+    out["funding_roc"] = roc_merged["funding_roc"]
+
+    train_mask = out.index <= pd.Timestamp(train_cutoff)
+    train_vals = out.loc[train_mask, "funding_rate"].dropna()
+    mu, sigma = train_vals.mean(), train_vals.std()
+    if not sigma or np.isnan(sigma):
+        sigma = 1.0
+    out["funding_z"] = (out["funding_rate"] - mu) / sigma
+    out["funding_extreme"] = (out["funding_z"].abs() > 2.0).astype(float)
+    return out
+
+
+FUNDING_COLS = ["funding_rate", "funding_roc", "funding_z", "funding_extreme"]
+FUNDING_FIRST_SETTLEMENT = pd.Timestamp("2019-11-27", tz="UTC")
+
+
+# ---------------------------------------------------------------------------
+# Arm 5: basis / perp-spot premium proxy
+# ---------------------------------------------------------------------------
+
+
+def premium_frame(premium_raw: pd.DataFrame, eth_index: pd.DatetimeIndex) -> pd.DataFrame:
+    """Alignment rule: uses only the closed bar's own `close`-of-premium value —
+    never that same bar's `high`/`low` (not known until the bar itself closes)."""
+    close = premium_raw["close"].sort_index()
+    close = close[~close.index.duplicated(keep="first")]
+    out = pd.DataFrame(index=eth_index)
+    out["premium_close"] = close.reindex(eth_index).ffill()
+    out["premium_vol_24h"] = out["premium_close"].rolling(24, min_periods=24).std()
+    return out
+
+
+PREMIUM_COLS = ["premium_close", "premium_vol_24h"]
+PREMIUM_FIRST_BAR = pd.Timestamp("2019-12-24", tz="UTC")
+
+
+# ---------------------------------------------------------------------------
+# Arm 6: Fear & Greed
+# ---------------------------------------------------------------------------
+
+
+def fear_greed_frame(fng_raw: pd.DataFrame, eth_index: pd.DatetimeIndex) -> pd.DataFrame:
+    """Alignment rule: a daily value printed for calendar day D is used only for
+    bars on or after D+1 — one full day of conservatism past the print (the audit's
+    explicit lag rule; alternative.me's "today" value is a running/settling read,
+    not confirmed final until the day closes)."""
+    value = fng_raw["value"].sort_index()
+    lagged = value.copy()
+    lagged.index = lagged.index + pd.Timedelta(days=1)
+    lagged = lagged[~lagged.index.duplicated(keep="first")]
+
+    out = pd.DataFrame(index=eth_index)
+    merged = pd.merge_asof(
+        pd.DataFrame(index=eth_index).rename_axis("ts").reset_index(),
+        lagged.rename_axis("ts").reset_index().rename(columns={"value": "fng_value"}),
+        on="ts",
+        direction="backward",
+    ).set_index("ts")
+    out["fng_value"] = merged["fng_value"]
+    out["fng_momentum_7d"] = out["fng_value"] - out["fng_value"].shift(7 * 24)
+    out["fng_extreme"] = ((out["fng_value"] < 20) | (out["fng_value"] > 80)).astype(float)
+    return out
+
+
+FNG_COLS = ["fng_value", "fng_momentum_7d", "fng_extreme"]
+FNG_FIRST_DAY = pd.Timestamp("2018-02-01", tz="UTC") + pd.Timedelta(days=1)
+
+
+# ---------------------------------------------------------------------------
+# Sample assembly
+# ---------------------------------------------------------------------------
+
+
+def assemble_samples(
+    price_only: pd.DataFrame,
+    target_indices: np.ndarray,
+    extra_frame: pd.DataFrame | None,
+    extra_cols: list[str] | None,
+    calendar_for_targets: pd.DataFrame | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build (X, y) for the given target row positions (integer positions into
+    `price_only`, each >= SEQUENCE_LENGTH and >= 1).
+
+    X = flattened 120-bar price-only sequence [t-120 .. t-1] (600 dims) plus, if
+    given, `extra_frame`'s row at position `t-1` (arms 1/3/4/5) and/or
+    `calendar_for_targets`'s row at position `t` (arm 2 only).
+    y = 1 if close[t] > close[t-1] else 0.
+    """
+    values = price_only[PRICE_ONLY_COLS].to_numpy(dtype=np.float64)
+    close = price_only["close"].to_numpy(dtype=np.float64)
+
+    extra_vals = (
+        extra_frame[extra_cols].to_numpy(dtype=np.float64) if extra_frame is not None else None
+    )
+    cal_vals = (
+        calendar_for_targets.to_numpy(dtype=np.float64)
+        if calendar_for_targets is not None
+        else None
+    )
+
+    X_rows = []
+    y_rows = []
+    for i, t in enumerate(target_indices):
+        seq = values[t - SEQUENCE_LENGTH : t].reshape(-1)
+        row = [seq]
+        if extra_vals is not None:
+            row.append(extra_vals[t - 1])
+        if cal_vals is not None:
+            row.append(cal_vals[i])
+        X_rows.append(np.concatenate(row))
+        y_rows.append(1.0 if close[t] > close[t - 1] else 0.0)
+
+    return np.vstack(X_rows), np.array(y_rows)

--- a/scripts/research/run_input_screening.py
+++ b/scripts/research/run_input_screening.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""LINEAR INPUT-SCREENING experiment runner (Lane A, Phase 1).
+
+Preregistered at docs/research/experiments/2026-07-12_input-screening-linear.md —
+read that file for the hypothesis, arm definitions, thresholds, and graduation
+rule. This script implements exactly what's pre-committed there; do not add or
+remove arms/thresholds here without amending the prereg first.
+
+Usage: python scripts/research/run_input_screening.py [--out results.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.stats import binomtest
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+
+sys.path.insert(0, str(Path(__file__).parent))
+from is_data import load_fear_greed, load_funding_rate, load_ohlcv, load_premium_index  # noqa: E402
+from is_features import (  # noqa: E402
+    BTC_COLS,
+    FNG_COLS,
+    FNG_FIRST_DAY,
+    FUNDING_COLS,
+    FUNDING_FIRST_SETTLEMENT,
+    PREMIUM_COLS,
+    PREMIUM_FIRST_BAR,
+    REALIZED_VOL_COLS,
+    SEQUENCE_LENGTH,
+    assemble_samples,
+    btc_cross_frame,
+    build_price_only_frame,
+    calendar_features_for_timestamps,
+    fear_greed_frame,
+    funding_frame,
+    premium_frame,
+    realized_vol_frame,
+)
+
+SYMBOL = "ETHUSDT"
+BTC_SYMBOL = "BTCUSDT"
+TIMEFRAME = "1h"
+HISTORY_START = datetime(2017, 8, 17, tzinfo=UTC)
+HISTORY_END = datetime(2025, 7, 2, tzinfo=UTC)  # buffer past F3 eval end
+
+FOLDS = [
+    {
+        "name": "F1",
+        "train_cutoff": pd.Timestamp("2022-12-31 23:00", tz="UTC"),
+        "eval_start": pd.Timestamp("2023-01-03 00:00", tz="UTC"),
+        "eval_end": pd.Timestamp("2023-06-30 23:00", tz="UTC"),
+    },
+    {
+        "name": "F2",
+        "train_cutoff": pd.Timestamp("2023-12-31 23:00", tz="UTC"),
+        "eval_start": pd.Timestamp("2024-01-03 00:00", tz="UTC"),
+        "eval_end": pd.Timestamp("2024-06-30 23:00", tz="UTC"),
+    },
+    {
+        "name": "F3",
+        "train_cutoff": pd.Timestamp("2024-12-31 23:00", tz="UTC"),
+        "eval_start": pd.Timestamp("2025-01-03 00:00", tz="UTC"),
+        "eval_end": pd.Timestamp("2025-06-30 23:00", tz="UTC"),
+    },
+]
+
+# Tournament's reported linear-baseline DA (results.json aggregate_stats_CORRECTED),
+# used only for the arm-0 validity check (prereg §2).
+TOURNAMENT_LINEAR_BASELINE_DA = {"F1": 53.24, "F2": 53.61, "F3": 53.18}
+VALIDITY_TOLERANCE_PP = 2.0
+
+BONFERRONI_ALPHA = 0.05 / 7  # 7 arms tested against the control, prereg §5
+GRADUATION_MIN_SIGNIFICANT_FOLDS = 2
+GRADUATION_MIN_AVG_DELTA_PP = 0.5
+
+ARMS = [
+    {"id": 0, "name": "price_only_control", "extra": None},
+    {"id": 1, "name": "realized_vol_range", "extra": "vol"},
+    {"id": 2, "name": "calendar", "extra": "calendar"},
+    {"id": 3, "name": "btc_cross", "extra": "btc"},
+    {"id": 4, "name": "funding_rate", "extra": "funding"},
+    {"id": 5, "name": "basis_premium", "extra": "premium"},
+    {"id": 6, "name": "fear_greed", "extra": "fng"},
+    {"id": 7, "name": "all_combined", "extra": "all"},
+]
+
+
+def _mcnemar_p(correct_a: np.ndarray, correct_b: np.ndarray) -> float:
+    """Exact two-sided McNemar test (binomial on discordant pairs). a=control, b=arm."""
+    b_wins = int(np.sum((~correct_a) & correct_b))  # control wrong, arm right
+    a_wins = int(np.sum(correct_a & (~correct_b)))  # control right, arm wrong
+    n_discordant = b_wins + a_wins
+    if n_discordant == 0:
+        return 1.0
+    result = binomtest(min(b_wins, a_wins), n_discordant, 0.5, alternative="two-sided")
+    return float(result.pvalue)
+
+
+def build_all_frames():
+    print("Loading OHLCV (ETH, BTC) ...")
+    eth = load_ohlcv(SYMBOL, TIMEFRAME, HISTORY_START, HISTORY_END)
+    btc = load_ohlcv(BTC_SYMBOL, TIMEFRAME, HISTORY_START, HISTORY_END)
+
+    print("Loading funding / premium / fear-greed raw data ...")
+    funding_raw = load_funding_rate(SYMBOL, HISTORY_START, HISTORY_END)
+    premium_raw = load_premium_index(SYMBOL, HISTORY_START, HISTORY_END)
+    fng_raw = load_fear_greed()
+
+    print("Building price-only feature contract ...")
+    price_only = build_price_only_frame(eth)
+
+    print("Building arm feature frames ...")
+    vol_frame = realized_vol_frame(eth)
+    cal_frame = calendar_features_for_timestamps(eth.index)
+    btc_frame = btc_cross_frame(btc, eth.index)
+    premium_feat = premium_frame(premium_raw, eth.index)
+    fng_feat = fear_greed_frame(fng_raw, eth.index)
+
+    return {
+        "eth": eth,
+        "price_only": price_only,
+        "vol": vol_frame,
+        "calendar": cal_frame,
+        "btc": btc_frame,
+        "premium": premium_feat,
+        "fng": fng_feat,
+        "funding_raw": funding_raw,
+    }
+
+
+def positions_for(index: pd.DatetimeIndex, start_ts, end_ts) -> np.ndarray:
+    mask = (index >= start_ts) & (index <= end_ts)
+    return np.nonzero(np.asarray(mask))[0]
+
+
+def valid_positions(
+    positions: np.ndarray, index: pd.DatetimeIndex, min_ts: pd.Timestamp
+) -> np.ndarray:
+    """Drop target positions whose `t-1` (last input bar) predates an extra
+    feature's earliest real coverage — never backfilled/coerced, per the prereg."""
+    ts_prev = index[positions - 1]
+    keep = ts_prev >= min_ts
+    return positions[keep]
+
+
+def drop_nan_rows(X: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    mask = ~np.isnan(X).any(axis=1)
+    return X[mask], y[mask]
+
+
+def run_arm_fold(arm: dict, fold: dict, frames: dict) -> dict:
+    eth_index = frames["eth"].index
+    price_only = frames["price_only"]
+
+    # Training positions: SEQUENCE_LENGTH..N-1 with timestamp <= train_cutoff.
+    train_positions = positions_for(eth_index, eth_index[SEQUENCE_LENGTH], fold["train_cutoff"])
+    train_positions = train_positions[train_positions >= SEQUENCE_LENGTH]
+    eval_positions = positions_for(eth_index, fold["eval_start"], fold["eval_end"])
+
+    extra_key = arm["extra"]
+    extra_frame = None
+    extra_cols: list[str] | None = None
+
+    min_coverage_ts = None
+    frames_needed: list[tuple[str, list[str]]] = []
+    if extra_key == "vol":
+        frames_needed = [("vol", REALIZED_VOL_COLS)]
+    elif extra_key == "calendar":
+        pass  # handled below via cal_train/cal_eval
+    elif extra_key == "btc":
+        frames_needed = [("btc", BTC_COLS)]
+    elif extra_key == "funding":
+        funding_feat = funding_frame(frames["funding_raw"], eth_index, fold["train_cutoff"])
+        frames["_funding_this_fold"] = funding_feat
+        frames_needed = [("_funding_this_fold", FUNDING_COLS)]
+        min_coverage_ts = FUNDING_FIRST_SETTLEMENT
+    elif extra_key == "premium":
+        frames_needed = [("premium", PREMIUM_COLS)]
+        min_coverage_ts = PREMIUM_FIRST_BAR
+    elif extra_key == "fng":
+        frames_needed = [("fng", FNG_COLS)]
+        min_coverage_ts = FNG_FIRST_DAY
+    elif extra_key == "all":
+        funding_feat = funding_frame(frames["funding_raw"], eth_index, fold["train_cutoff"])
+        frames["_funding_this_fold"] = funding_feat
+        combined = pd.concat(
+            [
+                frames["vol"][REALIZED_VOL_COLS],
+                frames["btc"][BTC_COLS],
+                frames["_funding_this_fold"][FUNDING_COLS],
+                frames["premium"][PREMIUM_COLS],
+                frames["fng"][FNG_COLS],
+            ],
+            axis=1,
+        )
+        frames["_all_this_fold"] = combined
+        extra_cols = list(combined.columns)
+        extra_frame = combined
+        min_coverage_ts = PREMIUM_FIRST_BAR
+
+    if frames_needed:
+        name, cols = frames_needed[0]
+        extra_frame = frames[name]
+        extra_cols = cols
+
+    if min_coverage_ts is not None:
+        train_positions = valid_positions(train_positions, eth_index, min_coverage_ts)
+        eval_positions = valid_positions(eval_positions, eth_index, min_coverage_ts)
+
+    cal_train = cal_eval = None
+    if extra_key == "calendar":
+        cal_train = frames["calendar"].loc[eth_index[train_positions]]
+        cal_eval = frames["calendar"].loc[eth_index[eval_positions]]
+        extra_frame = None
+        extra_cols = None
+    elif extra_key == "all":
+        cal_train = frames["calendar"].loc[eth_index[train_positions]]
+        cal_eval = frames["calendar"].loc[eth_index[eval_positions]]
+
+    X_train, y_train = assemble_samples(
+        price_only, train_positions, extra_frame, extra_cols, cal_train
+    )
+    X_eval, y_eval = assemble_samples(price_only, eval_positions, extra_frame, extra_cols, cal_eval)
+
+    X_train, y_train = drop_nan_rows(X_train, y_train)
+    eval_keep_mask = ~np.isnan(X_eval).any(axis=1)
+    X_eval, y_eval = X_eval[eval_keep_mask], y_eval[eval_keep_mask]
+    eval_positions_kept = eval_positions[eval_keep_mask]
+
+    scaler = StandardScaler()
+    X_train_s = scaler.fit_transform(X_train)
+    X_eval_s = scaler.transform(X_eval)
+
+    clf = LogisticRegression(penalty="l2", C=1.0, solver="lbfgs", max_iter=3000)
+    clf.fit(X_train_s, y_train)
+
+    proba = clf.predict_proba(X_eval_s)[:, 1]
+    pred = (proba >= 0.5).astype(float)
+    correct = pred == y_eval
+    da = float(correct.mean() * 100.0)
+    brier = float(np.mean((proba - y_eval) ** 2))
+
+    # naive persistence over the SAME eval positions (secondary, never ranked)
+    close = price_only["close"].to_numpy(dtype=np.float64)
+    naive_pred = np.array(
+        [1.0 if close[t - 1] > close[t - 2] else 0.0 for t in eval_positions_kept]
+    )
+    naive_correct = naive_pred == y_eval
+    naive_da = float(naive_correct.mean() * 100.0)
+    disagree_mask = pred != naive_pred
+    da_on_disagree = (
+        float(correct[disagree_mask].mean() * 100.0) if disagree_mask.sum() > 0 else float("nan")
+    )
+
+    return {
+        "arm": arm["name"],
+        "fold": fold["name"],
+        "n_train": int(len(y_train)),
+        "n_eval": int(len(y_eval)),
+        "da": da,
+        "brier": brier,
+        "naive_da": naive_da,
+        "da_on_naive_disagree_subset": da_on_disagree,
+        "n_naive_disagree": int(disagree_mask.sum()),
+        "correct": correct,  # per-bar vector, used for McNemar; stripped before JSON dump
+        "eval_positions": eval_positions_kept,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=str(Path(__file__).parent / "input_screening_results.json"))
+    args = ap.parse_args()
+
+    t0 = time.time()
+    frames = build_all_frames()
+    print(f"Frames built in {time.time() - t0:.1f}s")
+
+    all_results: dict[str, dict[str, dict]] = {}
+    for fold in FOLDS:
+        print(f"\n=== Fold {fold['name']} ===")
+        fold_results = {}
+        control_result = None
+        for arm in ARMS:
+            t1 = time.time()
+            res = run_arm_fold(arm, fold, frames)
+            dt = time.time() - t1
+            print(
+                f"  arm={arm['name']:20s} n_train={res['n_train']:6d} n_eval={res['n_eval']:5d} "
+                f"DA={res['da']:.2f}% brier={res['brier']:.4f}  ({dt:.1f}s)"
+            )
+            if arm["id"] == 0:
+                control_result = res
+            fold_results[arm["name"]] = res
+        # McNemar vs control, only valid where the eval position sets match exactly
+        for name, res in fold_results.items():
+            if name == "price_only_control":
+                res["mcnemar_p_vs_control"] = None
+                res["delta_da_vs_control_pp"] = 0.0
+                continue
+            ctrl_pos = control_result["eval_positions"]
+            arm_pos = res["eval_positions"]
+            common = np.intersect1d(ctrl_pos, arm_pos)
+            ctrl_map = dict(
+                zip(
+                    control_result["eval_positions"].tolist(),
+                    control_result["correct"].tolist(),
+                    strict=False,
+                )
+            )
+            arm_map = dict(
+                zip(res["eval_positions"].tolist(), res["correct"].tolist(), strict=False)
+            )
+            ctrl_common = np.array([ctrl_map[p] for p in common])
+            arm_common = np.array([arm_map[p] for p in common])
+            res["n_common_with_control"] = int(len(common))
+            res["mcnemar_p_vs_control"] = _mcnemar_p(ctrl_common, arm_common)
+            res["delta_da_vs_control_pp"] = res["da"] - control_result["da"]
+        all_results[fold["name"]] = fold_results
+
+    # ---- Aggregation & graduation verdict ----
+    verdicts = {}
+    for arm in ARMS:
+        if arm["id"] == 0:
+            continue
+        name = arm["name"]
+        deltas = [all_results[f["name"]][name]["delta_da_vs_control_pp"] for f in FOLDS]
+        pvals = [all_results[f["name"]][name]["mcnemar_p_vs_control"] for f in FOLDS]
+        n_sig = sum(1 for p in pvals if p is not None and p < BONFERRONI_ALPHA)
+        avg_delta = float(np.mean(deltas))
+        graduates = (
+            n_sig >= GRADUATION_MIN_SIGNIFICANT_FOLDS and avg_delta >= GRADUATION_MIN_AVG_DELTA_PP
+        )
+        verdicts[name] = {
+            "per_fold_delta_pp": dict(zip([f["name"] for f in FOLDS], deltas, strict=False)),
+            "per_fold_p": dict(zip([f["name"] for f in FOLDS], pvals, strict=False)),
+            "n_significant_folds": n_sig,
+            "avg_delta_pp": avg_delta,
+            "graduates": graduates,
+        }
+
+    # ---- Validity check (arm 0 vs tournament baseline) ----
+    validity = {}
+    for f in FOLDS:
+        ours = all_results[f["name"]]["price_only_control"]["da"]
+        theirs = TOURNAMENT_LINEAR_BASELINE_DA[f["name"]]
+        diff = ours - theirs
+        validity[f["name"]] = {
+            "ours": ours,
+            "tournament": theirs,
+            "diff_pp": diff,
+            "within_tolerance": abs(diff) <= VALIDITY_TOLERANCE_PP,
+        }
+
+    # Strip non-JSON-serializable per-bar arrays before dumping.
+    dump = {}
+    for fold_name, fold_results in all_results.items():
+        dump[fold_name] = {}
+        for arm_name, res in fold_results.items():
+            r = {k: v for k, v in res.items() if k not in ("correct", "eval_positions")}
+            dump[fold_name][arm_name] = r
+
+    output = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "results_by_fold": dump,
+        "verdicts": verdicts,
+        "validity_check": validity,
+        "graduation_rule": {
+            "min_significant_folds": GRADUATION_MIN_SIGNIFICANT_FOLDS,
+            "min_avg_delta_pp": GRADUATION_MIN_AVG_DELTA_PP,
+            "bonferroni_alpha": BONFERRONI_ALPHA,
+        },
+    }
+    out_path = Path(args.out)
+    out_path.write_text(json.dumps(output, indent=2, default=str))
+    print(f"\nWrote results to {out_path}")
+
+    print("\n=== Validity check (arm 0 vs tournament) ===")
+    for f, v in validity.items():
+        status = "PASS" if v["within_tolerance"] else "FAIL"
+        print(
+            f"  {f}: ours={v['ours']:.2f}% tournament={v['tournament']:.2f}% diff={v['diff_pp']:+.2f}pp [{status}]"
+        )
+
+    print("\n=== Graduation verdicts ===")
+    for name, v in verdicts.items():
+        print(
+            f"  {name:20s} avg_delta={v['avg_delta_pp']:+.2f}pp n_sig={v['n_significant_folds']}/3 "
+            f"-> {'GRADUATES' if v['graduates'] else 'does not graduate'}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Preregisters and runs a cheap CPU-only linear/logistic screening gate (Lane A, Phase 1) deciding
  which of the input-candidates audit's (#959, PR #958) shortlisted alternative-input classes earn
  a slot in the eventual deep-model input tournament.
- Model: logistic regression on next-bar direction on the identical `PriceOnlyFeatureExtractor(120)`
  feature contract used by the target-redesign tournament's linear baseline (#933). Folds F1/F2/F3
  are identical dates to that tournament (walk-forward, 48h embargo).
- 7 arms tested: price-only control + realized-vol/range, calendar, BTC cross-asset, funding rate,
  basis/premium, Fear & Greed, and an all-combined arm — each ADDED to the price-only contract.
- **Result: zero arms graduate.** Pre-committed rule (McNemar-significant at Bonferroni α=0.0071 on
  ≥2/3 folds AND avg DA improvement ≥+0.5pp) fails for every arm on every count — no fold reaches
  Bonferroni significance, and the largest average delta (`funding_rate`, +0.37pp) still misses the
  practical bar.
- Validity check: the price-only control replicates the tournament's reported baseline DA within
  ±2pp on F1/F2 but misses on F3 (−2.39pp) — disclosed as a non-replication, not adjusted after
  seeing the number (method differs: logistic-on-direction vs. the tournament's unrecoverable
  `LinearRegression`-on-continuous-target script, an explicitly pre-approved substitution).

Full write-up (hypothesis, arms, thresholds, per-fold/per-arm table, honest reading, recommendation):
`docs/research/experiments/2026-07-12_input-screening-linear.md`

Research only — no `src/` changes, no live-affecting decision, no backtest run. Scripts under
`scripts/research/` per CODE.md's Backtest-Live Parity rule (not wired into any `DataProvider`).

Closes #967.

## Test plan

- [x] Preregistration locked (committed) before any scoring run
- [x] All 24 fits (7 arms + control × 3 folds) completed, determinism spot-checked (identical DA
      on re-run of control/F1 after black/ruff reformatting)
- [x] `black --check` / `ruff check` clean on all new scripts
- [x] No `src/` changes — nothing to unit-test; raw results JSON committed for audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)