### PR TITLE
feat: make MFE early-cut and trailing/breakeven exit policies config-expressible (#971 follow-up)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so degraded live decisions are attributable in the database. Closes #913.
 
 ### Added
+- **Exit-policy expressibility: MFE early-cut + config-driven trailing/breakeven (#971)**:
+  the exit-geometry experiment (docs/research/experiments/2026-07-12_exit-geometry-honest.md,
+  Sec. 8) flagged three trade-management policies as inexpressible without src/ patches. Now:
+  (a) **MFE-conditioned early-cut** — a new shared `EarlyCutPolicy`
+  (`src/position_management/early_cut.py`, params `mfe_threshold_pct`,
+  `evaluation_window_hours`) flattens a position whose raw price MFE never reached the
+  threshold within the first N hours of entry. One stateless implementation serves both
+  engines (backtest `ExitHandler` and `LiveExitHandler` — the #948 barrier-touch pattern):
+  the window MFE is recomputed from candle history at each evaluation (entry bar excluded,
+  window frozen at entry+N hours), so live restarts cannot corrupt state, and insufficient
+  history never cuts. MFE here is deliberately raw price excursion, NOT the sized/fee-adjusted
+  `MFEMAETracker`/DB `trades.mfe` values (writer path known-corrupted per #966 — untouched
+  and not reused). Config channels: strategy `get_risk_overrides()["early_cut"]`,
+  `RiskParameters.early_cut`, and hyper_growth factory kwargs
+  (`early_cut_mfe_threshold_pct`, `early_cut_evaluation_window_hours`). Exit priority:
+  SL > TP > time > early-cut > signal, in both engines. Default OFF everywhere.
+  (b) **Config-driven trailing/breakeven** — `build_trailing_stop_policy` now resolves
+  strategy `trailing_stop` overrides by key presence: an explicit key wins (including
+  explicit `None`, e.g. to block the RiskParameters ATR fallback or disable the breakeven
+  move), an absent key falls back to RiskParameters exactly as before, `{"enabled": False}`
+  disables trailing entirely, and a cfg-declared breakeven threshold supports a
+  breakeven-only policy with no trailing distance. `create_hyper_growth_strategy` exposes
+  `enable_trailing_stop`, `trailing_activation_threshold`, `trailing_distance_pct`,
+  `breakeven_threshold`, `breakeven_buffer` as factory kwargs (defaults emit the exact
+  pre-change overrides dict). Regression evidence: HyperGrowth's live prod config produces
+  bit-identical backtest results before/after on the exit-geometry F1–F3 exam folds
+  (31/-2.8818%/PF 0.662, 46/-6.6430%/0.528, 70/-11.5577%/0.446 — full float precision,
+  including per-trade P&L sequences).
 - **Feature-flag observability: vol-target sizing + circuit-breaker dry_run (#964)**: two flags
   under paper-trading evaluation were structurally unobservable — nothing DB-durable recorded
   whether they ever did anything, blocking their promote/kill verdicts. Now (a)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -47,8 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   threshold within the first N hours of entry. One stateless implementation serves both
   engines (backtest `ExitHandler` and `LiveExitHandler` — the #948 barrier-touch pattern):
   the window MFE is recomputed from candle history at each evaluation (entry bar excluded,
-  window frozen at entry+N hours), so live restarts cannot corrupt state, and insufficient
-  history never cuts. MFE here is deliberately raw price excursion, NOT the sized/fee-adjusted
+  window frozen at entry+N hours), so live restarts cannot corrupt state, and unknowable
+  windows never cut (insufficient history, data gaps, and empty windows all HOLD). Both
+  engines fail fast at start/run time if the window is not strictly longer than one bar and
+  a whole multiple of the traded timeframe (`EarlyCutPolicy.validate_for_timeframe`), and
+  the window MFE that triggered a cut is persisted (backtest `Trade.metadata
+  ["early_cut_window_mfe_pct"]`; live `strategy_executions.reasons`) so exam output carries
+  the MFE-capture metric. Live fires on wall clock vs backtest bar close — tracked as #977.
+  MFE here is deliberately raw price excursion, NOT the sized/fee-adjusted
   `MFEMAETracker`/DB `trades.mfe` values (writer path known-corrupted per #966 — untouched
   and not reused). Config channels: strategy `get_risk_overrides()["early_cut"]`,
   `RiskParameters.early_cut`, and hyper_growth factory kwargs

--- a/experiments/exit_policy_expressibility_demo.py
+++ b/experiments/exit_policy_expressibility_demo.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Expressibility demo for #971: prove the three previously-inexpressible
+trade-management policies are now reachable via config only (no src/ patch).
+
+Runs HyperGrowth ETHUSDT/1h on F1 (2023H1) with:
+  1. control            — live prod config (must match the regression baseline)
+  2. early_cut arm      — MFE early-cut 1.5% within 18h via factory_kwargs
+  3. trailing arm       — wider trailing (activation 5%, distance 3%),
+                          breakeven at +8% via factory_kwargs
+  4. no_trailing arm    — trailing disabled entirely via factory_kwargs
+
+This is functional evidence for the PR, NOT a preregistered experiment —
+no verdicts are drawn from these numbers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from datetime import UTC, datetime
+
+os.environ.setdefault("LOG_LEVEL", "WARNING")
+logging.basicConfig(level=logging.WARNING)
+for noisy in (
+    "atb.Strategy.HyperGrowth",
+    "atb.src.engines",
+    "atb.src.strategies",
+    "atb.src.prediction",
+    "atb.src.data_providers",
+    "MLBasicSignalGenerator",
+):
+    logging.getLogger(noisy).setLevel(logging.ERROR)
+
+from src.experiments.runner import ExperimentRunner  # noqa: E402
+from src.experiments.schemas import ExperimentConfig  # noqa: E402
+
+F1 = (datetime(2023, 1, 1, tzinfo=UTC), datetime(2023, 6, 30, tzinfo=UTC))
+
+ARMS: dict[str, dict] = {
+    "control": {},
+    "early_cut_1p5_18h": {
+        "factory_kwargs": {
+            "early_cut_mfe_threshold_pct": 0.015,
+            "early_cut_evaluation_window_hours": 18,
+        }
+    },
+    "trail_5_3_be8": {
+        "factory_kwargs": {
+            "trailing_activation_threshold": 0.05,
+            "trailing_distance_pct": 0.03,
+            "breakeven_threshold": 0.08,
+            "breakeven_buffer": 0.01,
+        }
+    },
+    "no_trailing": {"factory_kwargs": {"enable_trailing_stop": False}},
+}
+
+
+def main() -> int:
+    runner = ExperimentRunner()
+    start, end = F1
+    for arm, extra in ARMS.items():
+        cfg = ExperimentConfig(
+            strategy_name="hyper_growth",
+            symbol="ETHUSDT",
+            timeframe="1h",
+            start=start,
+            end=end,
+            initial_balance=85.0,
+            use_cache=True,
+            provider="binance",
+            factory_kwargs=extra.get("factory_kwargs"),
+            risk_parameters=extra.get("risk_parameters", {}),
+        )
+        t0 = time.time()
+        result = runner.run(cfg)
+        print(
+            f"{arm:<20} trades={result.total_trades:>4} "
+            f"ret%={result.total_return:>8.4f} maxDD%={result.max_drawdown:>7.4f} "
+            f"winR%={result.win_rate:>6.2f} final=${result.final_balance:>7.2f} "
+            f"[{time.time() - t0:.0f}s]"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -955,7 +955,17 @@ class Backtester:
 
         Returns:
             Dictionary with backtest results including metrics and trades.
+
+        Raises:
+            ValueError: If a configured early-cut policy cannot work on the
+                requested timeframe (window not strictly longer than one bar,
+                or not a whole multiple of it).
         """
+        # Fail fast on a mis-sized early-cut window (#976 review F1/F2) —
+        # before the try block so nothing can swallow the config error.
+        if self.early_cut_policy is not None:
+            self.early_cut_policy.validate_for_timeframe(timeframe)
+
         try:
             # Pin BLAS/OpenMP thread pools to 1 for the duration of the run so
             # the backtest is bit-reproducible: multi-threaded parallel float
@@ -1425,6 +1435,16 @@ class Backtester:
 
             self.balance += net_pnl
             self.trades.append(completed_trade)
+
+            # Persist the window MFE that triggered an early cut so exam
+            # output carries the MFE-capture metric (#976 review).
+            if exit_check.is_early_cut and exit_check.early_cut_window_mfe_pct is not None:
+                try:
+                    completed_trade.metadata["early_cut_window_mfe_pct"] = float(
+                        exit_check.early_cut_window_mfe_pct
+                    )
+                except (AttributeError, TypeError, ValueError):
+                    logger.debug("Could not stash early_cut_window_mfe_pct on completed trade")
 
             # Sum entry + exit fees / slippage for record_trade so the
             # PerformanceTracker total_fees_paid metric matches live's

--- a/src/engines/backtest/engine.py
+++ b/src/engines/backtest/engine.py
@@ -61,6 +61,7 @@ from src.engines.shared.execution.fill_policy import FillPolicy, resolve_fill_po
 from src.engines.shared.partial_operations_manager import PartialOperationsManager
 from src.engines.shared.policy_hydration import apply_policies_to_engine
 from src.engines.shared.risk_configuration import (
+    build_early_cut_policy,
     build_partial_exit_policy,
     build_trailing_stop_policy,
     merge_dynamic_risk_config,
@@ -71,6 +72,7 @@ from src.infrastructure.logging.context import set_context, update_context
 from src.infrastructure.logging.events import log_engine_event
 from src.position_management.correlation_engine import CorrelationConfig, CorrelationEngine
 from src.position_management.dynamic_risk import DynamicRiskConfig, DynamicRiskManager
+from src.position_management.early_cut import EarlyCutPolicy
 from src.position_management.macro_events import MacroEventGuard
 from src.position_management.time_exits import TimeExitPolicy, TimeRestrictions
 from src.position_management.trailing_stops import TrailingStopPolicy
@@ -183,6 +185,7 @@ class Backtester:
         legacy_stop_loss_indexing: bool = True,
         enable_engine_risk_exits: bool = True,
         time_exit_policy: TimeExitPolicy | None = None,
+        early_cut_policy: EarlyCutPolicy | None = None,
         enable_dynamic_risk: bool = DEFAULT_DYNAMIC_RISK_ENABLED,
         dynamic_risk_config: DynamicRiskConfig | None = None,
         trailing_stop_policy: TrailingStopPolicy | None = None,
@@ -215,6 +218,8 @@ class Backtester:
             legacy_stop_loss_indexing: Use legacy SL calculation behavior.
             enable_engine_risk_exits: Enable SL/TP checks in engine.
             time_exit_policy: Policy for time-based exits.
+            early_cut_policy: MFE-conditioned early-cut policy; when None it
+                is built from strategy overrides / RiskParameters (default OFF).
             enable_dynamic_risk: Enable dynamic risk management.
             dynamic_risk_config: Configuration for dynamic risk.
             trailing_stop_policy: Policy for trailing stops.
@@ -321,6 +326,12 @@ class Backtester:
 
         self._custom_time_exit_policy = time_exit_policy is not None
         self.time_exit_policy = time_exit_policy or self._build_time_exit_policy()
+
+        # MFE early-cut policy (#971): default OFF unless configured via
+        # strategy overrides or RiskParameters.early_cut.
+        self.early_cut_policy = early_cut_policy or build_early_cut_policy(
+            self.strategy, self.risk_manager
+        )
 
         # Partial operations policy (enabled by default for parity with live engine)
         self.enable_partial_operations = bool(enable_partial_operations)
@@ -482,6 +493,7 @@ class Backtester:
             execution_model=self.execution_model,
             trailing_stop_policy=self.trailing_stop_policy,
             time_exit_policy=self.time_exit_policy,
+            early_cut_policy=self.early_cut_policy,
             partial_manager=partial_ops_manager,
             enable_engine_risk_exits=enable_engine_risk_exits,
             use_high_low_for_stops=use_high_low_for_stops,
@@ -1359,6 +1371,7 @@ class Backtester:
                 current_price=current_price,
                 symbol=symbol,
                 component_strategy=self._component_strategy,
+                df=df,
             )
 
         # Log exit decision

--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -83,6 +83,10 @@ class ExitCheckResult:
     is_time_limit: bool = False
     is_early_cut: bool = False
     is_signal: bool = False
+    # Window MFE observed by the early-cut policy (raw price fraction), when
+    # it evaluated this bar. Persisted to Trade.metadata on an early-cut exit
+    # so exam output carries the MFE-capture metric (#976 review).
+    early_cut_window_mfe_pct: float | None = None
 
 
 @dataclass
@@ -649,6 +653,7 @@ class ExitHandler:
         # Check MFE early-cut (shared policy — identical logic in live).
         hit_early_cut = False
         early_cut_reason: str | None = None
+        early_cut_window_mfe: float | None = None
         if self.early_cut_policy is not None and df is not None:
             try:
                 current_time = candle.name if hasattr(candle, "name") else datetime.now(UTC)
@@ -663,6 +668,7 @@ class ExitHandler:
                 )
                 hit_early_cut = early_cut_decision.should_exit
                 early_cut_reason = early_cut_decision.reason
+                early_cut_window_mfe = early_cut_decision.window_mfe_pct
             except (TypeError, ValueError, AttributeError) as e:
                 logger.warning("Early-cut check failed: %s", e)
 
@@ -703,6 +709,7 @@ class ExitHandler:
             is_early_cut=hit_early_cut and not (hit_stop_loss or hit_take_profit or hit_time_limit),
             is_signal=exit_signal
             and not (hit_stop_loss or hit_take_profit or hit_time_limit or hit_early_cut),
+            early_cut_window_mfe_pct=early_cut_window_mfe,
         )
 
     def _check_runtime_exit(

--- a/src/engines/backtest/execution/exit_handler.py
+++ b/src/engines/backtest/execution/exit_handler.py
@@ -43,6 +43,7 @@ from src.performance.metrics import Side, pnl_percent
 if TYPE_CHECKING:
     from src.engines.backtest.execution.execution_engine import ExecutionEngine
     from src.engines.backtest.execution.position_tracker import PositionTracker
+    from src.position_management.early_cut import EarlyCutPolicy
     from src.position_management.time_exits import TimeExitPolicy
     from src.position_management.trailing_stops import TrailingStopPolicy
     from src.risk.risk_manager import RiskManager
@@ -80,6 +81,7 @@ class ExitCheckResult:
     is_stop_loss: bool = False
     is_take_profit: bool = False
     is_time_limit: bool = False
+    is_early_cut: bool = False
     is_signal: bool = False
 
 
@@ -112,6 +114,7 @@ class ExitHandler:
         execution_model: ExecutionModel,
         trailing_stop_policy: TrailingStopPolicy | None = None,
         time_exit_policy: TimeExitPolicy | None = None,
+        early_cut_policy: EarlyCutPolicy | None = None,
         partial_manager: PartialOperationsManager | None = None,
         enable_engine_risk_exits: bool = True,
         use_high_low_for_stops: bool = True,
@@ -127,6 +130,7 @@ class ExitHandler:
             execution_model: Execution model for fill decisions.
             trailing_stop_policy: Policy for trailing stops.
             time_exit_policy: Policy for time-based exits.
+            early_cut_policy: MFE-conditioned early-cut policy (default OFF).
             partial_manager: Unified partial operations manager.
             enable_engine_risk_exits: Enable SL/TP checks.
             use_high_low_for_stops: Use high/low for SL/TP detection.
@@ -152,6 +156,7 @@ class ExitHandler:
         self.execution_model = execution_model
         self.trailing_stop_policy = trailing_stop_policy
         self.time_exit_policy = time_exit_policy
+        self.early_cut_policy = early_cut_policy
         self.partial_manager = partial_manager
         self.enable_engine_risk_exits = enable_engine_risk_exits
         self.use_high_low_for_stops = use_high_low_for_stops
@@ -539,6 +544,7 @@ class ExitHandler:
         current_price: float,
         symbol: str,
         component_strategy: Any | None = None,
+        df: pd.DataFrame | None = None,
     ) -> ExitCheckResult:
         """Check all exit conditions for the current position.
 
@@ -547,6 +553,7 @@ class ExitHandler:
         2. Stop loss (using high/low)
         3. Take profit (using high/low)
         4. Time limit exit
+        5. MFE early-cut (only when a policy and candle history are provided)
 
         Args:
             runtime_decision: Current runtime decision from strategy.
@@ -554,6 +561,8 @@ class ExitHandler:
             current_price: Current close price.
             symbol: Trading symbol.
             component_strategy: Strategy for exit signal checks.
+            df: OHLCV history covering the position's entry; required for the
+                MFE early-cut check (the check holds without it).
 
         Returns:
             ExitCheckResult with exit decision and details.
@@ -637,10 +646,32 @@ class ExitHandler:
             except (TypeError, ValueError, AttributeError) as e:
                 logger.warning("Time exit check failed: %s", e)
 
-        # Determine final exit decision
-        should_exit = exit_signal or hit_stop_loss or hit_take_profit or hit_time_limit
+        # Check MFE early-cut (shared policy — identical logic in live).
+        hit_early_cut = False
+        early_cut_reason: str | None = None
+        if self.early_cut_policy is not None and df is not None:
+            try:
+                current_time = candle.name if hasattr(candle, "name") else datetime.now(UTC)
+                if hasattr(current_time, "tzinfo") and current_time.tzinfo is None:
+                    current_time = current_time.replace(tzinfo=UTC)
+                early_cut_decision = self.early_cut_policy.check_early_cut_conditions(
+                    side=side_str,
+                    entry_price=float(trade.entry_price),
+                    entry_time=trade.entry_time,
+                    now_time=current_time,
+                    df=df,
+                )
+                hit_early_cut = early_cut_decision.should_exit
+                early_cut_reason = early_cut_decision.reason
+            except (TypeError, ValueError, AttributeError) as e:
+                logger.warning("Early-cut check failed: %s", e)
 
-        # Determine exit reason and price (priority: SL > TP > Time/Signal)
+        # Determine final exit decision
+        should_exit = (
+            exit_signal or hit_stop_loss or hit_take_profit or hit_time_limit or hit_early_cut
+        )
+
+        # Determine exit reason and price (priority: SL > TP > Time > Early cut > Signal)
         if hit_stop_loss:
             exit_reason = "Stop loss"
             exit_price = sl_exit_price
@@ -651,6 +682,9 @@ class ExitHandler:
             # Use the policy-specific reason for parity with the live engine.
             # Default fallback string also matches live ("Time exit").
             exit_reason = time_reason or "Time exit"
+            exit_price = current_price
+        elif hit_early_cut:
+            exit_reason = early_cut_reason or "Early cut"
             exit_price = current_price
         elif exit_signal:
             exit_reason = runtime_reason
@@ -666,7 +700,9 @@ class ExitHandler:
             is_stop_loss=hit_stop_loss,
             is_take_profit=hit_take_profit,
             is_time_limit=hit_time_limit,
-            is_signal=exit_signal and not (hit_stop_loss or hit_take_profit or hit_time_limit),
+            is_early_cut=hit_early_cut and not (hit_stop_loss or hit_take_profit or hit_time_limit),
+            is_signal=exit_signal
+            and not (hit_stop_loss or hit_take_profit or hit_time_limit or hit_early_cut),
         )
 
     def _check_runtime_exit(

--- a/src/engines/live/execution/exit_coordinator.py
+++ b/src/engines/live/execution/exit_coordinator.py
@@ -191,6 +191,9 @@ class LiveExitCoordinator:
                 candle_low=candle_low,
                 runtime_decision=decision_for_exit,
                 component_strategy=component_strategy,
+                # Candle history for the MFE early-cut policy (inert when the
+                # policy is not configured).
+                df=df,
             )
 
             should_exit = exit_check.should_exit

--- a/src/engines/live/execution/exit_coordinator.py
+++ b/src/engines/live/execution/exit_coordinator.py
@@ -232,6 +232,14 @@ class LiveExitCoordinator:
                     f"entry_price_{position.entry_price:.2f}",
                 ]
 
+                # Window MFE seen by the early-cut policy, when it evaluated —
+                # DB-durable via strategy_executions.reasons (#976 review).
+                # isinstance (not `is not None`): tests inject MagicMock exit
+                # checks whose attributes are truthy non-numerics.
+                early_cut_window_mfe = getattr(exit_check, "early_cut_window_mfe_pct", None)
+                if isinstance(early_cut_window_mfe, int | float):
+                    log_reasons.append(f"early_cut_window_mfe_{early_cut_window_mfe:.6f}")
+
                 # Add regime context if available from TradingDecision
                 if (
                     decision_for_exit

--- a/src/engines/live/execution/exit_handler.py
+++ b/src/engines/live/execution/exit_handler.py
@@ -71,6 +71,10 @@ class LiveExitCheck:
     should_exit: bool
     exit_reason: str = ""
     limit_price: float | None = None  # For SL/TP pricing
+    # Window MFE observed by the early-cut policy (raw price fraction), when
+    # it evaluated this cycle. Surfaced into strategy_executions reasons by
+    # the exit coordinator for observability (#976 review).
+    early_cut_window_mfe_pct: float | None = None
 
 
 @dataclass
@@ -336,6 +340,7 @@ class LiveExitHandler:
         # MFE early-cut (shared policy — identical logic in backtest).
         hit_early_cut = False
         early_cut_reason: str | None = None
+        early_cut_window_mfe: float | None = None
         if self.early_cut_policy is not None and df is not None:
             try:
                 early_cut_decision = self.early_cut_policy.check_early_cut_conditions(
@@ -347,6 +352,7 @@ class LiveExitHandler:
                 )
                 hit_early_cut = early_cut_decision.should_exit
                 early_cut_reason = early_cut_decision.reason
+                early_cut_window_mfe = early_cut_decision.window_mfe_pct
             except (TypeError, ValueError, AttributeError) as e:
                 logger.warning(
                     "Early-cut check failed for %s: %s",
@@ -358,36 +364,44 @@ class LiveExitHandler:
             exit_signal or hit_stop_loss or hit_take_profit or hit_time_exit or hit_early_cut
         )
         if not should_exit:
-            return LiveExitCheck(should_exit=False)
+            return LiveExitCheck(
+                should_exit=False,
+                early_cut_window_mfe_pct=early_cut_window_mfe,
+            )
 
         if hit_stop_loss:
             return LiveExitCheck(
                 should_exit=True,
                 exit_reason="Stop loss",
                 limit_price=position.stop_loss,
+                early_cut_window_mfe_pct=early_cut_window_mfe,
             )
         if hit_take_profit:
             return LiveExitCheck(
                 should_exit=True,
                 exit_reason="Take profit",
                 limit_price=position.take_profit,
+                early_cut_window_mfe_pct=early_cut_window_mfe,
             )
         if hit_time_exit:
             return LiveExitCheck(
                 should_exit=True,
                 exit_reason=time_reason or "Time exit",
                 limit_price=None,
+                early_cut_window_mfe_pct=early_cut_window_mfe,
             )
         if hit_early_cut:
             return LiveExitCheck(
                 should_exit=True,
                 exit_reason=early_cut_reason or "Early cut",
                 limit_price=None,
+                early_cut_window_mfe_pct=early_cut_window_mfe,
             )
         return LiveExitCheck(
             should_exit=True,
             exit_reason=signal_reason,
             limit_price=None,
+            early_cut_window_mfe_pct=early_cut_window_mfe,
         )
 
     def execute_exit(

--- a/src/engines/live/execution/exit_handler.py
+++ b/src/engines/live/execution/exit_handler.py
@@ -41,6 +41,7 @@ from src.engines.shared.partial_operations_manager import (
     EPSILON,
     PartialOperationsManager,
 )
+from src.engines.shared.side_utils import to_side_string
 from src.engines.shared.strategy_exit_checker import StrategyExitChecker
 from src.engines.shared.trailing_stop_manager import TrailingStopManager
 from src.engines.shared.validation import (
@@ -49,6 +50,7 @@ from src.engines.shared.validation import (
 )
 
 if TYPE_CHECKING:
+    from src.position_management.early_cut import EarlyCutPolicy
     from src.position_management.time_exits import TimeExitPolicy
     from src.position_management.trailing_stops import TrailingStopPolicy
     from src.risk.risk_manager import RiskManager
@@ -105,6 +107,7 @@ class LiveExitHandler:
         risk_manager: RiskManager | None = None,
         trailing_stop_policy: TrailingStopPolicy | None = None,
         time_exit_policy: TimeExitPolicy | None = None,
+        early_cut_policy: EarlyCutPolicy | None = None,
         partial_manager: PartialOperationsManager | None = None,
         use_high_low_for_stops: bool = True,
         max_position_size: float = DEFAULT_MAX_POSITION_SIZE,
@@ -121,6 +124,7 @@ class LiveExitHandler:
             risk_manager: Risk manager for position updates.
             trailing_stop_policy: Policy for trailing stops.
             time_exit_policy: Policy for time-based exits.
+            early_cut_policy: MFE-conditioned early-cut policy (default OFF).
             partial_manager: Unified partial operations manager.
             use_high_low_for_stops: Use candle high/low for SL/TP detection.
             max_position_size: Maximum position size for scale-ins.
@@ -138,6 +142,7 @@ class LiveExitHandler:
         self.risk_manager = risk_manager
         self.trailing_stop_policy = trailing_stop_policy
         self.time_exit_policy = time_exit_policy
+        self.early_cut_policy = early_cut_policy
         self.partial_manager = partial_manager
         self.use_high_low_for_stops = use_high_low_for_stops
         self.max_position_size = max_position_size
@@ -274,6 +279,7 @@ class LiveExitHandler:
         candle_low: float | None = None,
         runtime_decision: Any = None,
         component_strategy: ComponentStrategy | None = None,
+        df: pd.DataFrame | None = None,
     ) -> LiveExitCheck:
         """Check all exit conditions for a position.
 
@@ -282,8 +288,10 @@ class LiveExitHandler:
         2. Stop loss
         3. Take profit
         4. Time limit
+        5. MFE early-cut (only when a policy and candle history are provided)
 
-        Exit reason priority remains: stop loss, take profit, time, strategy.
+        Exit reason priority remains: stop loss, take profit, time,
+        early-cut, strategy.
 
         Args:
             position: Position to check.
@@ -292,6 +300,8 @@ class LiveExitHandler:
             candle_low: Candle low price for realistic detection.
             runtime_decision: Decision from strategy runtime.
             component_strategy: Component strategy for exit signals.
+            df: OHLCV history covering the position's entry; required for the
+                MFE early-cut check (the check holds without it).
 
         Returns:
             LiveExitCheck with exit decision and reason.
@@ -323,7 +333,30 @@ class LiveExitHandler:
                 position.entry_time, datetime.now(UTC)
             )
 
-        should_exit = exit_signal or hit_stop_loss or hit_take_profit or hit_time_exit
+        # MFE early-cut (shared policy — identical logic in backtest).
+        hit_early_cut = False
+        early_cut_reason: str | None = None
+        if self.early_cut_policy is not None and df is not None:
+            try:
+                early_cut_decision = self.early_cut_policy.check_early_cut_conditions(
+                    side=to_side_string(position.side),
+                    entry_price=float(position.entry_price),
+                    entry_time=position.entry_time,
+                    now_time=datetime.now(UTC),
+                    df=df,
+                )
+                hit_early_cut = early_cut_decision.should_exit
+                early_cut_reason = early_cut_decision.reason
+            except (TypeError, ValueError, AttributeError) as e:
+                logger.warning(
+                    "Early-cut check failed for %s: %s",
+                    position.symbol,
+                    e,
+                )
+
+        should_exit = (
+            exit_signal or hit_stop_loss or hit_take_profit or hit_time_exit or hit_early_cut
+        )
         if not should_exit:
             return LiveExitCheck(should_exit=False)
 
@@ -343,6 +376,12 @@ class LiveExitHandler:
             return LiveExitCheck(
                 should_exit=True,
                 exit_reason=time_reason or "Time exit",
+                limit_price=None,
+            )
+        if hit_early_cut:
+            return LiveExitCheck(
+                should_exit=True,
+                exit_reason=early_cut_reason or "Early cut",
                 limit_price=None,
             )
         return LiveExitCheck(

--- a/src/engines/live/strategy_hot_swap.py
+++ b/src/engines/live/strategy_hot_swap.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from src.engines.live.execution.exit_handler import LiveExitHandler
     from src.engines.live.execution.position_tracker import LivePosition, LivePositionTracker
     from src.engines.live.strategy_manager import StrategyManager
+    from src.position_management.early_cut import EarlyCutPolicy
     from src.position_management.trailing_stops import TrailingStopPolicy
 
 logger = logging.getLogger(__name__)
@@ -72,6 +73,7 @@ class HotSwapEngineState(Protocol):
     partial_manager: PartialExitPolicy | None
     _partial_operations_opt_in: bool
     time_exit_policy: TimeExitPolicy | None
+    early_cut_policy: EarlyCutPolicy | None
     _runtime_dataset: Any
     _runtime_warmup: int
 
@@ -347,6 +349,22 @@ class StrategyHotSwapCoordinator:
         except Exception as exc:
             logger.warning(
                 "Hot-swap: failed to refresh time exit policy: %s",
+                exc,
+                exc_info=True,
+            )
+
+        # 5b. Rebuild engine-level MFE early-cut policy from the new
+        #     strategy / risk-manager (shared builder, parity with backtest).
+        try:
+            from src.engines.shared.risk_configuration import build_early_cut_policy
+
+            state.early_cut_policy = build_early_cut_policy(state.strategy, state.risk_manager)
+            exit_handler = getattr(state, "live_exit_handler", None)
+            if exit_handler is not None:
+                exit_handler.early_cut_policy = state.early_cut_policy
+        except Exception as exc:
+            logger.warning(
+                "Hot-swap: failed to refresh early-cut policy: %s",
                 exc,
                 exc_info=True,
             )

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -1244,6 +1244,12 @@ class LiveTradingEngine:
         Delegated to LiveStartupSequencer; the capital-critical bootstrap ordering
         lives there (#486).
         """
+        # Fail fast on a mis-sized early-cut window (#976 review F1/F2):
+        # refuse to start rather than trade with a policy that can never
+        # evaluate (window <= bar) or diverges from backtest (non-aligned).
+        if self.early_cut_policy is not None:
+            self.early_cut_policy.validate_for_timeframe(timeframe)
+
         self.startup_sequencer.run(
             symbol,
             timeframe=timeframe,

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -98,6 +98,7 @@ from src.engines.shared.models import (
 )
 from src.engines.shared.partial_operations_manager import PartialOperationsManager
 from src.engines.shared.risk_configuration import (
+    build_early_cut_policy,
     build_partial_exit_policy,
     build_trailing_stop_policy,
     merge_dynamic_risk_config,
@@ -108,6 +109,7 @@ from src.infrastructure.logging.events import (
 )
 from src.position_management.correlation_engine import CorrelationConfig, CorrelationEngine
 from src.position_management.dynamic_risk import DynamicRiskConfig, DynamicRiskManager
+from src.position_management.early_cut import EarlyCutPolicy
 from src.position_management.macro_events import MacroEventGuard
 from src.position_management.partial_manager import PartialExitPolicy
 from src.position_management.time_exits import TimeExitPolicy, TimeRestrictions
@@ -219,6 +221,7 @@ class LiveTradingEngine:
         dynamic_risk_config: DynamicRiskConfig | None = None,
         time_exit_policy: TimeExitPolicy | None = None,
         trailing_stop_policy: TrailingStopPolicy | None = None,
+        early_cut_policy: EarlyCutPolicy | None = None,
         partial_manager: PartialExitPolicy | None = None,
         enable_partial_operations: bool = True,  # Enable by default for better profit capture
         # Execution realism parameters (parity with backtest engine)
@@ -347,6 +350,13 @@ class LiveTradingEngine:
         self.error_cooldown = DEFAULT_ERROR_COOLDOWN
 
         self._init_time_exit_policy(time_exit_policy)
+
+        # MFE early-cut policy (#971): default OFF unless configured via
+        # strategy overrides or RiskParameters.early_cut. Shared builder for
+        # parity with the backtest engine.
+        self.early_cut_policy = early_cut_policy or build_early_cut_policy(
+            self.strategy, self.risk_manager
+        )
 
         # Threading
         self.main_thread: threading.Thread | None = None
@@ -989,6 +999,7 @@ class LiveTradingEngine:
             trailing_stop_policy=self.trailing_stop_policy,
             partial_manager=partial_ops_manager,
             time_exit_policy=self.time_exit_policy,
+            early_cut_policy=self.early_cut_policy,
             use_high_low_for_stops=self.use_high_low_for_stops,
             max_position_size=self.max_position_size,
             max_filled_price_deviation=self.max_filled_price_deviation,

--- a/src/engines/shared/__init__.py
+++ b/src/engines/shared/__init__.py
@@ -48,6 +48,7 @@ from src.engines.shared.policy_hydration import (
     apply_policies_to_engine,
 )
 from src.engines.shared.risk_configuration import (
+    build_early_cut_policy,
     build_time_exit_policy,
     build_trailing_stop_policy,
     extract_risk_overrides,
@@ -120,6 +121,7 @@ __all__ = [
     "merge_dynamic_risk_config",
     "build_trailing_stop_policy",
     "build_time_exit_policy",
+    "build_early_cut_policy",
     "extract_risk_overrides",
     "get_risk_parameters",
     # Partial operations

--- a/src/engines/shared/risk_configuration.py
+++ b/src/engines/shared/risk_configuration.py
@@ -21,12 +21,25 @@ from src.config.constants import (
 
 if TYPE_CHECKING:
     from src.position_management.dynamic_risk import DynamicRiskConfig
+    from src.position_management.early_cut import EarlyCutPolicy
     from src.position_management.partial_manager import PartialExitPolicy
     from src.position_management.time_exits import TimeExitPolicy
     from src.position_management.trailing_stops import TrailingStopPolicy
     from src.risk.risk_manager import RiskManager
 
 logger = logging.getLogger(__name__)
+
+# Sentinel distinguishing "key absent from config" (fall back to risk
+# parameters) from an explicit None (honored as-is, e.g. "no ATR distance").
+_UNSET = object()
+
+
+def _resolve_cfg_value(cfg: dict[str, Any] | None, key: str, fallback: Any) -> Any:
+    """Key-presence resolution: an explicit config key wins (even ``None``);
+    an absent key falls back to the risk-parameter value."""
+    if cfg is not None and key in cfg:
+        return cfg[key]
+    return fallback
 
 
 def merge_dynamic_risk_config(
@@ -97,6 +110,14 @@ def build_trailing_stop_policy(
 ) -> TrailingStopPolicy | None:
     """Build trailing stop policy from strategy/risk overrides.
 
+    Resolution is key-presence based (#971 expressibility): a key present in
+    the strategy's ``trailing_stop`` overrides is authoritative — including
+    an explicit ``None`` (e.g. ``"trailing_distance_atr_mult": None`` blocks
+    the risk-parameter ATR fallback, ``"breakeven_threshold": None`` disables
+    the breakeven move). A key that is absent falls back to the risk-manager
+    parameters, exactly as before. ``{"enabled": False}`` disables trailing
+    entirely (no fallback policy is built).
+
     Args:
         strategy: Strategy with optional get_risk_overrides() method.
         risk_manager: Risk manager with optional params attribute.
@@ -118,61 +139,69 @@ def build_trailing_stop_policy(
     if overrides and isinstance(overrides, dict):
         cfg = overrides.get("trailing_stop")
 
+    if cfg is not None and not isinstance(cfg, dict):
+        logger.warning("Ignoring non-dict trailing_stop config: %r", cfg)
+        cfg = None
+
+    # Explicit opt-out: the strategy/config declared trailing off.
+    if cfg is not None and cfg.get("enabled") is False:
+        return None
+
     # Get params from risk manager
     params = getattr(risk_manager, "params", None) if risk_manager else None
 
     if cfg or params:
-        # Activation threshold
-        activation = (cfg.get("activation_threshold") if cfg else None) or (
-            params.trailing_activation_threshold if params else None
+        activation = _resolve_cfg_value(
+            cfg, "activation_threshold", params.trailing_activation_threshold if params else None
+        )
+        dist_pct = _resolve_cfg_value(
+            cfg, "trailing_distance_pct", params.trailing_distance_pct if params else None
+        )
+        atr_mult = _resolve_cfg_value(
+            cfg, "trailing_distance_atr_mult", params.trailing_atr_multiplier if params else None
         )
 
-        # Trailing distance
-        dist_pct = cfg.get("trailing_distance_pct") if cfg else None
-        atr_mult = cfg.get("trailing_distance_atr_mult") if cfg else None
-        if atr_mult is None and params is not None:
-            atr_mult = params.trailing_atr_multiplier
-
-        # Breakeven settings
-        breakeven_threshold = (cfg.get("breakeven_threshold") if cfg else None) or (
-            params.breakeven_threshold if params else None
+        # Breakeven settings. _UNSET (nothing configured anywhere) maps to the
+        # DEFAULT_* constants at construction — matching the previous
+        # or-chain, where a falsy params value also fell through to defaults.
+        params_be = params.breakeven_threshold if params else None
+        breakeven_threshold = _resolve_cfg_value(
+            cfg, "breakeven_threshold", params_be if params_be else _UNSET
         )
-        breakeven_buffer = (cfg.get("breakeven_buffer") if cfg else None) or (
-            params.breakeven_buffer if params else None
+        params_bb = params.breakeven_buffer if params else None
+        breakeven_buffer = _resolve_cfg_value(
+            cfg, "breakeven_buffer", params_bb if params_bb is not None else _UNSET
+        )
+        if breakeven_buffer is None:
+            breakeven_buffer = _UNSET
+
+        # A breakeven threshold declared explicitly by the strategy config
+        # supports a breakeven-only policy (no trailing distance). Distances
+        # resolved from params alone do NOT trigger this rescue, so the
+        # pre-#971 "no distance anywhere -> no policy" outcome is preserved.
+        cfg_has_breakeven = (
+            cfg is not None
+            and "breakeven_threshold" in cfg
+            and cfg["breakeven_threshold"] is not None
         )
 
-        # Check if params have distance settings
-        params_has_distance = bool(
-            params
-            and (
-                params.trailing_distance_pct is not None
-                or params.trailing_atr_multiplier is not None
-            )
-        )
-
-        if activation and (dist_pct is not None or atr_mult is not None or params_has_distance):
+        if activation and (dist_pct is not None or atr_mult is not None or cfg_has_breakeven):
             try:
                 return TrailingStopPolicy(
                     activation_threshold=float(activation),
-                    trailing_distance_pct=(
-                        float(dist_pct)
-                        if dist_pct is not None
-                        else (
-                            float(params.trailing_distance_pct)
-                            if params and params.trailing_distance_pct is not None
-                            else None
-                        )
-                    ),
+                    trailing_distance_pct=(float(dist_pct) if dist_pct is not None else None),
                     atr_multiplier=float(atr_mult) if atr_mult is not None else None,
                     breakeven_threshold=(
-                        float(breakeven_threshold)
-                        if breakeven_threshold is not None
-                        else DEFAULT_BREAKEVEN_THRESHOLD
+                        DEFAULT_BREAKEVEN_THRESHOLD
+                        if breakeven_threshold is _UNSET
+                        else (
+                            float(breakeven_threshold) if breakeven_threshold is not None else None
+                        )
                     ),
                     breakeven_buffer=(
-                        float(breakeven_buffer)
-                        if breakeven_buffer is not None
-                        else DEFAULT_BREAKEVEN_BUFFER
+                        DEFAULT_BREAKEVEN_BUFFER
+                        if breakeven_buffer is _UNSET
+                        else float(breakeven_buffer)
                     ),
                 )
             except (TypeError, ValueError) as e:
@@ -183,6 +212,58 @@ def build_trailing_stop_policy(
                 return None
 
     return None
+
+
+def build_early_cut_policy(
+    strategy: Any,
+    risk_manager: RiskManager | None = None,
+) -> EarlyCutPolicy | None:
+    """Build the MFE-conditioned early-cut policy from strategy/risk overrides.
+
+    DEFAULT OFF: returns None unless the strategy's ``early_cut`` overrides
+    or ``RiskParameters.early_cut`` provide both ``mfe_threshold_pct`` and
+    ``evaluation_window_hours``. Strategy overrides win over risk parameters
+    (same precedence as ``time_exits``). ``{"enabled": False}`` disables the
+    policy regardless of other keys.
+
+    Args:
+        strategy: Strategy with optional get_risk_overrides() method.
+        risk_manager: Risk manager with optional params attribute.
+
+    Returns:
+        EarlyCutPolicy if a complete, valid configuration exists, else None.
+    """
+    from src.position_management.early_cut import EarlyCutPolicy
+
+    cfg = extract_risk_overrides(strategy).get("early_cut")
+
+    if cfg is None and risk_manager is not None:
+        params = getattr(risk_manager, "params", None)
+        cfg = getattr(params, "early_cut", None) if params else None
+
+    if cfg is None:
+        return None
+    if not isinstance(cfg, dict):
+        logger.warning("Ignoring non-dict early_cut config: %r", cfg)
+        return None
+    if cfg.get("enabled") is False:
+        return None
+    if "mfe_threshold_pct" not in cfg or "evaluation_window_hours" not in cfg:
+        logger.warning(
+            "Ignoring incomplete early_cut config %r: both mfe_threshold_pct "
+            "and evaluation_window_hours are required",
+            cfg,
+        )
+        return None
+
+    try:
+        return EarlyCutPolicy(
+            mfe_threshold_pct=float(cfg["mfe_threshold_pct"]),
+            evaluation_window_hours=float(cfg["evaluation_window_hours"]),
+        )
+    except (TypeError, ValueError) as e:
+        logger.warning("Failed to build EarlyCutPolicy from config %r: %s", cfg, e)
+        return None
 
 
 def build_time_exit_policy(
@@ -342,6 +423,7 @@ __all__ = [
     "build_trailing_stop_policy",
     "build_time_exit_policy",
     "build_partial_exit_policy",
+    "build_early_cut_policy",
     "extract_risk_overrides",
     "get_risk_parameters",
 ]

--- a/src/engines/shared/risk_configuration.py
+++ b/src/engines/shared/risk_configuration.py
@@ -161,12 +161,14 @@ def build_trailing_stop_policy(
             cfg, "trailing_distance_atr_mult", params.trailing_atr_multiplier if params else None
         )
 
-        # Breakeven settings. _UNSET (nothing configured anywhere) maps to the
-        # DEFAULT_* constants at construction — matching the previous
-        # or-chain, where a falsy params value also fell through to defaults.
+        # Breakeven settings. _UNSET (no cfg key AND no params value) maps to
+        # the DEFAULT_* constants at construction — matching the previous
+        # or-chain, where only a None params value fell through to defaults;
+        # a params value of 0.0 is preserved as 0.0 (which TrailingStopPolicy
+        # treats as breakeven disabled).
         params_be = params.breakeven_threshold if params else None
         breakeven_threshold = _resolve_cfg_value(
-            cfg, "breakeven_threshold", params_be if params_be else _UNSET
+            cfg, "breakeven_threshold", params_be if params_be is not None else _UNSET
         )
         params_bb = params.breakeven_buffer if params else None
         breakeven_buffer = _resolve_cfg_value(

--- a/src/position_management/early_cut.py
+++ b/src/position_management/early_cut.py
@@ -1,0 +1,233 @@
+"""MFE-conditioned early-cut exit policy.
+
+Cuts a position whose maximum favorable excursion (MFE) never reached a
+threshold within the first N hours after entry — the live-trade-review
+hypothesis that losers identify themselves early with tiny MFE and then
+bleed for days (docs/research/notes/2026-07-12_live-trade-review.md, #971).
+
+Design notes (money-path constraints):
+
+- **Stateless & shared**: the window MFE is recomputed from candle history on
+  every evaluation instead of being accumulated on the position object, so
+  both engines get bit-identical decisions from the same candles (the
+  ``barrier_touch`` pattern from #948) and a live restart cannot corrupt the
+  running maximum.
+- **Raw price excursion**: MFE here is the raw price move from entry
+  (``(high - entry) / entry`` for longs), NOT the sized/fee-adjusted values
+  in ``MFEMAETracker`` / the DB ``trades.mfe`` column, whose writer path is
+  known-corrupted (#966). This module deliberately does not touch or reuse
+  that path.
+- **Entry-bar excluded**: the entry bar's extremes may predate the fill, so
+  only bars strictly after ``entry_time`` count — the same convention as
+  ``is_same_bar_entry`` exit protection.
+- **Unknown history never cuts**: if the available candles do not reach back
+  to the entry, the true window MFE is unknowable and the policy holds
+  (conservative: never flatten a position on incomplete information).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_VALID_SIDES = frozenset({"long", "short"})
+
+
+@dataclass(frozen=True)
+class EarlyCutDecision:
+    """Result of an early-cut evaluation.
+
+    Attributes:
+        should_exit: True when the position should be flattened.
+        reason: Human/DB-facing exit reason (stable ``"Early cut"`` prefix)
+            when ``should_exit`` is True.
+        window_mfe_pct: Raw price MFE observed inside the evaluation window
+            (decimal fraction, >= 0), or None when it could not be computed
+            (no data, or history not covering the entry).
+    """
+
+    should_exit: bool
+    reason: str | None = None
+    window_mfe_pct: float | None = None
+
+
+def _as_index_timestamp(dt: datetime, index: pd.Index) -> pd.Timestamp:
+    """Normalize a datetime to the tz-awareness of ``index`` (UTC semantics).
+
+    All timestamps in this system are UTC; naive values are promoted to UTC
+    rather than guessed (same convention as ``is_same_bar_entry``).
+    """
+    ts = pd.Timestamp(dt)
+    index_tz = getattr(index, "tz", None)
+    if index_tz is None:
+        if ts.tzinfo is not None:
+            ts = ts.tz_convert("UTC").tz_localize(None)
+    elif ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    return ts
+
+
+def compute_window_raw_mfe(
+    df: pd.DataFrame | None,
+    *,
+    side: str,
+    entry_price: float,
+    entry_time: datetime,
+    window_end: datetime,
+) -> float | None:
+    """Compute the raw price MFE over bars strictly inside (entry, window_end).
+
+    Args:
+        df: OHLCV frame with a DatetimeIndex of bar open times.
+        side: ``"long"`` or ``"short"``.
+        entry_price: Position entry price.
+        entry_time: Position entry time (bar open in backtest, fill time live).
+        window_end: End of the evaluation window (exclusive).
+
+    Returns:
+        Max favorable excursion as a decimal fraction (floored at 0.0), 0.0
+        when no bar falls inside the window, or None when it cannot be
+        computed — invalid entry price, empty data, or history that does not
+        reach back to the entry (the caller must treat None as "do not cut").
+
+    Raises:
+        ValueError: If ``side`` is not "long" or "short".
+    """
+    if side not in _VALID_SIDES:
+        raise ValueError(f"side must be 'long' or 'short', got {side!r}")
+    if not math.isfinite(entry_price) or entry_price <= 0:
+        return None
+    if df is None or len(df) == 0:
+        return None
+
+    index = df.index
+    entry_ts = _as_index_timestamp(entry_time, index)
+    end_ts = _as_index_timestamp(window_end, index)
+
+    # Coverage guard: without a bar at or before entry we cannot know the
+    # window's true excursion (e.g. live restart with a short kline buffer).
+    if index[0] > entry_ts:
+        return None
+
+    window = df[(index > entry_ts) & (index < end_ts)]
+    if window.empty:
+        return 0.0
+
+    if side == "long":
+        extreme = float(window["high"].max())
+        if not math.isfinite(extreme):
+            return None
+        return max(0.0, (extreme - entry_price) / entry_price)
+
+    extreme = float(window["low"].min())
+    if not math.isfinite(extreme):
+        return None
+    return max(0.0, (entry_price - extreme) / entry_price)
+
+
+@dataclass(frozen=True)
+class EarlyCutPolicy:
+    """Flatten a position whose MFE never reached a threshold early on.
+
+    Attributes:
+        mfe_threshold_pct: Raw price MFE (decimal fraction, e.g. 0.015 =
+            +1.5% from entry) the position must have reached inside the
+            evaluation window to be allowed to keep running.
+        evaluation_window_hours: Length of the window, in hours from entry.
+    """
+
+    mfe_threshold_pct: float
+    evaluation_window_hours: float
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.mfe_threshold_pct, int | float)
+            or not math.isfinite(self.mfe_threshold_pct)
+            or self.mfe_threshold_pct <= 0
+        ):
+            raise ValueError(
+                f"mfe_threshold_pct must be a positive finite fraction, "
+                f"got {self.mfe_threshold_pct!r}"
+            )
+        if (
+            not isinstance(self.evaluation_window_hours, int | float)
+            or not math.isfinite(self.evaluation_window_hours)
+            or self.evaluation_window_hours <= 0
+        ):
+            raise ValueError(
+                f"evaluation_window_hours must be a positive finite number, "
+                f"got {self.evaluation_window_hours!r}"
+            )
+
+    def check_early_cut_conditions(
+        self,
+        *,
+        side: str,
+        entry_price: float,
+        entry_time: datetime,
+        now_time: datetime,
+        df: pd.DataFrame | None,
+    ) -> EarlyCutDecision:
+        """Evaluate the early-cut rule for a position.
+
+        The window MFE is frozen at the first ``evaluation_window_hours``
+        after entry: favorable moves AFTER the window never rescue the trade,
+        and the cut only requires MFE to be strictly below the threshold.
+
+        Args:
+            side: ``"long"`` or ``"short"``.
+            entry_price: Position entry price.
+            entry_time: Position entry time.
+            now_time: Evaluation time (bar open in backtest, wall clock live).
+            df: OHLCV history covering the entry (bar open times as index).
+
+        Returns:
+            EarlyCutDecision; ``should_exit`` is False whenever the window
+            has not elapsed or the window MFE cannot be computed.
+        """
+        window_end = entry_time + timedelta(hours=self.evaluation_window_hours)
+        try:
+            elapsed_window = now_time >= window_end
+        except TypeError:
+            # Mixed aware/naive comparison — promote the naive side to UTC
+            # via pandas, matching _as_index_timestamp semantics.
+            now_ts = pd.Timestamp(now_time)
+            end_ts = pd.Timestamp(window_end)
+            if now_ts.tzinfo is None:
+                now_ts = now_ts.tz_localize("UTC")
+            if end_ts.tzinfo is None:
+                end_ts = end_ts.tz_localize("UTC")
+            elapsed_window = now_ts >= end_ts
+        if not elapsed_window:
+            return EarlyCutDecision(should_exit=False)
+
+        mfe = compute_window_raw_mfe(
+            df,
+            side=side,
+            entry_price=entry_price,
+            entry_time=entry_time,
+            window_end=window_end,
+        )
+        if mfe is None:
+            logger.debug(
+                "Early-cut window MFE not computable (insufficient history) — holding position"
+            )
+            return EarlyCutDecision(should_exit=False, window_mfe_pct=None)
+
+        if mfe < self.mfe_threshold_pct:
+            reason = (
+                f"Early cut (MFE {mfe:.2%} < {self.mfe_threshold_pct:.2%} "
+                f"in {self.evaluation_window_hours:g}h)"
+            )
+            return EarlyCutDecision(should_exit=True, reason=reason, window_mfe_pct=mfe)
+
+        return EarlyCutDecision(should_exit=False, window_mfe_pct=mfe)
+
+
+__all__ = ["EarlyCutPolicy", "EarlyCutDecision", "compute_window_raw_mfe"]

--- a/src/position_management/early_cut.py
+++ b/src/position_management/early_cut.py
@@ -57,6 +57,30 @@ class EarlyCutDecision:
     window_mfe_pct: float | None = None
 
 
+def _timeframe_to_hours(timeframe: str) -> float | None:
+    """Convert a timeframe string (``15m``, ``1h``, ``4h``, ``1d``, ``1w``)
+    to hours. Returns None when unrecognized. Mirrors the unit conventions
+    of ``CachedDataProvider._get_timeframe_timedelta``."""
+    if not timeframe or not isinstance(timeframe, str):
+        return None
+    try:
+        unit = timeframe[-1].lower()
+        value = int(timeframe[:-1]) if len(timeframe) > 1 else 1
+    except (ValueError, TypeError):
+        return None
+    if value <= 0:
+        return None
+    if unit == "m":
+        return value / 60.0
+    if unit == "h":
+        return float(value)
+    if unit == "d":
+        return value * 24.0
+    if unit == "w":
+        return value * 24.0 * 7.0
+    return None
+
+
 def _as_index_timestamp(dt: datetime, index: pd.Index) -> pd.Timestamp:
     """Normalize a datetime to the tz-awareness of ``index`` (UTC semantics).
 
@@ -91,10 +115,12 @@ def compute_window_raw_mfe(
         window_end: End of the evaluation window (exclusive).
 
     Returns:
-        Max favorable excursion as a decimal fraction (floored at 0.0), 0.0
-        when no bar falls inside the window, or None when it cannot be
-        computed — invalid entry price, empty data, or history that does not
-        reach back to the entry (the caller must treat None as "do not cut").
+        Max favorable excursion as a decimal fraction (floored at 0.0), or
+        None when it cannot be computed — invalid entry price, empty data,
+        history that does not reach back to the entry, or a window that
+        contains no bars at all (data gap, or a window no longer than the
+        bar interval). The caller must treat None as "do not cut": a
+        fabricated 0% from unknowable data would flatten every position.
 
     Raises:
         ValueError: If ``side`` is not "long" or "short".
@@ -117,7 +143,9 @@ def compute_window_raw_mfe(
 
     window = df[(index > entry_ts) & (index < end_ts)]
     if window.empty:
-        return 0.0
+        # No bar inside the window (data gap, or window <= bar interval):
+        # the true excursion is unknowable — never fabricate 0% (#976 F1).
+        return None
 
     if side == "long":
         extreme = float(window["high"].max())
@@ -163,6 +191,50 @@ class EarlyCutPolicy:
             raise ValueError(
                 f"evaluation_window_hours must be a positive finite number, "
                 f"got {self.evaluation_window_hours!r}"
+            )
+
+    def validate_for_timeframe(self, timeframe: str) -> None:
+        """Reject window sizes that cannot work on the traded timeframe.
+
+        Engines call this before trading starts (#976 review F1/F2):
+
+        - A window no longer than one bar leaves ZERO bars strictly inside
+          ``(entry, entry + window)`` — every evaluation would be
+          unknowable, silently disabling the policy the config asked for.
+        - A window that is not a whole multiple of the bar interval makes
+          live (forming boundary bar) and backtest (completed bar) see
+          different window contents — a latent parity divergence.
+
+        Args:
+            timeframe: Bar interval string, e.g. ``"15m"``, ``"1h"``, ``"4h"``.
+
+        Raises:
+            ValueError: If the timeframe is unrecognized, the window is not
+                strictly longer than one bar, or the window is not a whole
+                multiple of the bar interval.
+        """
+        bar_hours = _timeframe_to_hours(timeframe)
+        if bar_hours is None:
+            raise ValueError(
+                f"Cannot validate early-cut evaluation window: unrecognized "
+                f"timeframe {timeframe!r} (expected e.g. '15m', '1h', '4h', '1d')"
+            )
+        if self.evaluation_window_hours <= bar_hours:
+            raise ValueError(
+                f"early_cut evaluation_window_hours="
+                f"{self.evaluation_window_hours:g} must be strictly longer "
+                f"than one {timeframe} bar ({bar_hours:g}h): a window this "
+                f"short contains no completed bars, so the window MFE is "
+                f"never computable and the policy cannot work"
+            )
+        ratio = self.evaluation_window_hours / bar_hours
+        if abs(ratio - round(ratio)) > 1e-9:
+            raise ValueError(
+                f"early_cut evaluation_window_hours="
+                f"{self.evaluation_window_hours:g} must be a whole multiple "
+                f"of the {timeframe} bar interval ({bar_hours:g}h): "
+                f"non-bar-aligned windows evaluate a forming bar in live but "
+                f"a completed bar in backtest, breaking parity"
             )
 
     def check_early_cut_conditions(

--- a/src/risk/risk_manager.py
+++ b/src/risk/risk_manager.py
@@ -150,6 +150,10 @@ class RiskParameters:
     atr_period: int = DEFAULT_ATR_PERIOD
     # Time exit config (optional; strategies may override)
     time_exits: dict | None = None
+    # MFE-conditioned early-cut config (optional; default OFF — see
+    # src/position_management/early_cut.py). Keys: mfe_threshold_pct,
+    # evaluation_window_hours. Strategy `early_cut` overrides win.
+    early_cut: dict | None = None
     # Partial operations (defaults can be overridden by strategies)
     partial_exit_targets: list[float] | None = None
     partial_exit_sizes: list[float] | None = None

--- a/src/strategies/hyper_growth.py
+++ b/src/strategies/hyper_growth.py
@@ -183,6 +183,13 @@ def create_hyper_growth_strategy(
     take_profit_pct: float = 0.30,
     stop_loss_pct: float = 0.10,
     symbol: str | None = None,
+    enable_trailing_stop: bool = True,
+    trailing_activation_threshold: float = 0.03,
+    trailing_distance_pct: float = 0.015,
+    breakeven_threshold: float | None = 0.05,
+    breakeven_buffer: float = 0.008,
+    early_cut_mfe_threshold_pct: float | None = None,
+    early_cut_evaluation_window_hours: float | None = None,
 ) -> Strategy:
     """Create hyper-growth strategy targeting high annual returns.
 
@@ -213,10 +220,36 @@ def create_hyper_growth_strategy(
         symbol: Trading symbol threaded to the ML signal generator for model
             registry selection. Runners must pass the symbol they trade;
             None keeps the generator default (BTCUSDT).
+        enable_trailing_stop: When False the trailing-stop/breakeven override
+            is declared disabled — build_trailing_stop_policy returns None
+            instead of falling back to RiskParameters defaults.
+        trailing_activation_threshold: Position gain (decimal) at which the
+            trailing stop activates.
+        trailing_distance_pct: Trailing distance as a fraction of price.
+        breakeven_threshold: Position gain (decimal) at which the stop moves
+            to breakeven; None disables the breakeven move.
+        breakeven_buffer: Buffer above entry (long) / below entry (short)
+            for the breakeven stop.
+        early_cut_mfe_threshold_pct: MFE-conditioned early-cut: raw price MFE
+            (decimal) the position must reach inside the evaluation window,
+            else it is flattened. Default None = early cut OFF. Must be set
+            together with ``early_cut_evaluation_window_hours``.
+        early_cut_evaluation_window_hours: Early-cut evaluation window in
+            hours from entry. Must be set together with
+            ``early_cut_mfe_threshold_pct``.
 
     Returns:
         Configured Strategy instance.
+
+    Raises:
+        ValueError: If exactly one of the two early-cut kwargs is provided.
     """
+    if (early_cut_mfe_threshold_pct is None) != (early_cut_evaluation_window_hours is None):
+        raise ValueError(
+            "early_cut_mfe_threshold_pct and early_cut_evaluation_window_hours "
+            "must be provided together (both set to enable the early cut, "
+            "both None to disable it)"
+        )
     # #805: hyper_growth targets high returns via leverage/aggressive sizing and
     # is NOT recommended in a bear/high-vol regime, where exposure is the primary
     # risk. Prefer ml_adaptive with the exposure governor (#802) + vol-targeted
@@ -294,42 +327,59 @@ def create_hyper_growth_strategy(
     # Without this, positions are exited after 1 bar with 0.03% P&L.
     strategy._extra_metadata = {"ignore_signal_reversal": True}
 
-    # Engine-level risk overrides
-    strategy.set_risk_overrides(
-        {
-            "position_sizer": "leveraged_fixed_fraction",
-            "base_fraction": base_fraction,
-            "min_fraction": 0.01,
-            "max_fraction": min(base_fraction * max_leverage, 0.50),
-            "stop_loss_pct": stop_loss_pct,
-            "take_profit_pct": take_profit_pct,
-            "leverage": {
-                "enabled": True,
-                "max_leverage": max_leverage,
-                "decay_rate": leverage_decay_rate,
-                "min_regime_bars": min_regime_bars,
-            },
-            "dynamic_risk": {
-                "enabled": True,
-                # Wider drawdown tolerance for hyper-growth target
-                "drawdown_thresholds": [0.15, 0.30, 0.45],
-                "risk_reduction_factors": [0.8, 0.5, 0.2],
-                "recovery_thresholds": [0.08, 0.15],
-            },
-            "partial_operations": {
-                "exit_targets": [0.08, 0.15, 0.30],
-                "exit_sizes": [0.20, 0.30, 0.50],
-                "scale_in_thresholds": [0.015, 0.03],
-                "scale_in_sizes": [0.40, 0.25],
-                "max_scale_ins": 2,
-            },
-            "trailing_stop": {
-                "activation_threshold": 0.03,
-                "trailing_distance_pct": 0.015,
-                "breakeven_threshold": 0.05,
-                "breakeven_buffer": 0.008,
-            },
+    # Trailing/breakeven config: defaults keep the exact pre-#971 dict shape
+    # (key-presence matters — build_trailing_stop_policy falls back to
+    # RiskParameters for absent keys, so adding keys would change behavior).
+    trailing_stop_config: dict[str, Any]
+    if enable_trailing_stop:
+        trailing_stop_config = {
+            "activation_threshold": trailing_activation_threshold,
+            "trailing_distance_pct": trailing_distance_pct,
+            "breakeven_threshold": breakeven_threshold,
+            "breakeven_buffer": breakeven_buffer,
         }
-    )
+    else:
+        trailing_stop_config = {"enabled": False}
+
+    # Engine-level risk overrides
+    risk_overrides: dict[str, Any] = {
+        "position_sizer": "leveraged_fixed_fraction",
+        "base_fraction": base_fraction,
+        "min_fraction": 0.01,
+        "max_fraction": min(base_fraction * max_leverage, 0.50),
+        "stop_loss_pct": stop_loss_pct,
+        "take_profit_pct": take_profit_pct,
+        "leverage": {
+            "enabled": True,
+            "max_leverage": max_leverage,
+            "decay_rate": leverage_decay_rate,
+            "min_regime_bars": min_regime_bars,
+        },
+        "dynamic_risk": {
+            "enabled": True,
+            # Wider drawdown tolerance for hyper-growth target
+            "drawdown_thresholds": [0.15, 0.30, 0.45],
+            "risk_reduction_factors": [0.8, 0.5, 0.2],
+            "recovery_thresholds": [0.08, 0.15],
+        },
+        "partial_operations": {
+            "exit_targets": [0.08, 0.15, 0.30],
+            "exit_sizes": [0.20, 0.30, 0.50],
+            "scale_in_thresholds": [0.015, 0.03],
+            "scale_in_sizes": [0.40, 0.25],
+            "max_scale_ins": 2,
+        },
+        "trailing_stop": trailing_stop_config,
+    }
+
+    # MFE early-cut (default OFF): the key is only present when configured,
+    # so existing configs hydrate no policy (build_early_cut_policy).
+    if early_cut_mfe_threshold_pct is not None:
+        risk_overrides["early_cut"] = {
+            "mfe_threshold_pct": early_cut_mfe_threshold_pct,
+            "evaluation_window_hours": early_cut_evaluation_window_hours,
+        }
+
+    strategy.set_risk_overrides(risk_overrides)
 
     return strategy

--- a/tests/unit/backtesting/test_early_cut_exit.py
+++ b/tests/unit/backtesting/test_early_cut_exit.py
@@ -29,7 +29,7 @@ ENTRY_PRICE = 100.0
 
 def _make_df(highs: list[float], lows: list[float]) -> pd.DataFrame:
     index = pd.date_range(start=ENTRY_TIME.replace(tzinfo=None), periods=len(highs), freq="1h")
-    closes = [(h + lo) / 2 for h, lo in zip(highs, lows)]
+    closes = [(h + lo) / 2 for h, lo in zip(highs, lows, strict=False)]
     return pd.DataFrame(
         {"open": closes, "high": highs, "low": lows, "close": closes, "volume": 1000.0},
         index=index,
@@ -104,6 +104,9 @@ class TestBacktestEarlyCut:
         assert result.is_early_cut is True
         assert result.exit_reason.startswith("Early cut")
         assert result.exit_price == float(df["close"].iloc[3])
+        # Observability (#976 review): the window MFE that triggered the cut
+        # is surfaced on the result. Hand-computed: 1.9%.
+        assert result.early_cut_window_mfe_pct == pytest.approx(0.019)
 
     def test_no_cut_when_mfe_reached_threshold(self) -> None:
         df = _make_df(
@@ -241,11 +244,13 @@ def _build_scripted_strategy():
     from src.strategies.components import (
         EnhancedRegimeDetector,
         PositionSizer,
-        RiskManager as ComponentRiskManager,
         Signal,
         SignalDirection,
         SignalGenerator,
         Strategy,
+    )
+    from src.strategies.components import (
+        RiskManager as ComponentRiskManager,
     )
 
     class _OneEntrySignalGenerator(SignalGenerator):
@@ -363,9 +368,7 @@ class TestEndToEndEarlyCut:
         from src.risk.risk_manager import RiskParameters
 
         backtester, results = self._run(
-            RiskParameters(
-                early_cut={"mfe_threshold_pct": 0.02, "evaluation_window_hours": 3}
-            )
+            RiskParameters(early_cut={"mfe_threshold_pct": 0.02, "evaluation_window_hours": 3})
         )
 
         assert results["total_trades"] == 1
@@ -373,6 +376,9 @@ class TestEndToEndEarlyCut:
         assert trade.exit_reason.startswith("Early cut")
         held = trade.exit_time - trade.entry_time
         assert held == timedelta(hours=3)
+        # Observability (#976 review): exam output carries the window MFE
+        # that triggered the cut (flat series => exactly 0.0).
+        assert trade.metadata["early_cut_window_mfe_pct"] == 0.0
 
     def test_without_policy_trade_survives(self) -> None:
         """Control arm: same data, no early_cut config => the position is
@@ -383,3 +389,45 @@ class TestEndToEndEarlyCut:
 
         assert results["total_trades"] == 0
         assert backtester.position_tracker.current_trade is not None
+
+
+class TestRunTimeframeValidation:
+    """Review #976 F1/F2: a mis-sized window must fail fast at run() time,
+    not silently become a cut-everything (old) or never-cut (new) policy."""
+
+    def _backtester(self, window_hours: float):
+        from src.engines.backtest.engine import Backtester
+        from src.risk.risk_manager import RiskParameters
+
+        index = pd.date_range(start="2024-01-01", periods=10, freq="1h")
+        df = pd.DataFrame(
+            {"open": 100.0, "high": 100.0, "low": 100.0, "close": 100.0, "volume": 1000.0},
+            index=index,
+        )
+        return Backtester(
+            strategy=_build_scripted_strategy(),
+            data_provider=_FlatDataProvider(df),
+            risk_parameters=RiskParameters(
+                early_cut={"mfe_threshold_pct": 0.02, "evaluation_window_hours": window_hours}
+            ),
+            initial_balance=1000.0,
+            log_to_database=False,
+        )
+
+    def test_window_equal_to_bar_interval_rejected_at_run(self) -> None:
+        backtester = self._backtester(window_hours=1)
+        with pytest.raises(ValueError, match="evaluation_window_hours"):
+            backtester.run(
+                symbol="TESTUSDT",
+                timeframe="1h",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+
+    def test_non_multiple_window_rejected_at_run(self) -> None:
+        backtester = self._backtester(window_hours=1.5)
+        with pytest.raises(ValueError, match="whole multiple"):
+            backtester.run(
+                symbol="TESTUSDT",
+                timeframe="1h",
+                start=datetime(2024, 1, 1, tzinfo=UTC),
+            )

--- a/tests/unit/backtesting/test_early_cut_exit.py
+++ b/tests/unit/backtesting/test_early_cut_exit.py
@@ -1,0 +1,385 @@
+"""Backtest ExitHandler integration for the MFE early-cut policy (#971).
+
+Uses the same hand-computable fixture as
+tests/unit/position_management/test_early_cut.py: long entry 100.0 at
+2024-01-01 00:00 UTC, 1h bars, threshold 2% within 3h, window MFE 1.9%.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from src.engines.backtest.execution.exit_handler import ExitHandler
+from src.engines.backtest.execution.position_tracker import PositionTracker
+from src.engines.backtest.models import ActiveTrade
+from src.engines.shared.execution.execution_model import ExecutionModel
+from src.engines.shared.execution.fill_policy import default_fill_policy
+from src.engines.shared.models import PositionSide
+from src.position_management.early_cut import EarlyCutPolicy
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ENTRY_TIME = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+ENTRY_PRICE = 100.0
+
+
+def _make_df(highs: list[float], lows: list[float]) -> pd.DataFrame:
+    index = pd.date_range(start=ENTRY_TIME.replace(tzinfo=None), periods=len(highs), freq="1h")
+    closes = [(h + lo) / 2 for h, lo in zip(highs, lows)]
+    return pd.DataFrame(
+        {"open": closes, "high": highs, "low": lows, "close": closes, "volume": 1000.0},
+        index=index,
+    )
+
+
+def _make_handler(
+    tracker: PositionTracker,
+    *,
+    early_cut_policy: EarlyCutPolicy | None = None,
+) -> ExitHandler:
+    return ExitHandler(
+        execution_engine=Mock(),
+        position_tracker=tracker,
+        risk_manager=Mock(),
+        execution_model=ExecutionModel(default_fill_policy()),
+        early_cut_policy=early_cut_policy,
+        use_high_low_for_stops=True,
+    )
+
+
+def _open_long(tracker: PositionTracker, stop_loss: float | None = None) -> None:
+    tracker.open_position(
+        ActiveTrade(
+            symbol="TEST",
+            side=PositionSide.LONG,
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            size=0.1,
+            stop_loss=stop_loss,
+        )
+    )
+
+
+def _candle(df: pd.DataFrame, i: int) -> pd.Series:
+    return df.iloc[i]
+
+
+class TestBacktestEarlyCut:
+    def test_cuts_at_window_end_when_mfe_below_threshold(self) -> None:
+        df = _make_df(
+            highs=[100.8, 101.5, 101.9, 100.9, 100.9],
+            lows=[99.5, 99.8, 100.1, 100.0, 100.0],
+        )
+        tracker = PositionTracker()
+        _open_long(tracker)
+        handler = _make_handler(
+            tracker,
+            early_cut_policy=EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3),
+        )
+
+        # Bars before the window elapses: hold.
+        for i in (1, 2):
+            result = handler.check_exit_conditions(
+                runtime_decision=None,
+                candle=_candle(df, i),
+                current_price=float(df["close"].iloc[i]),
+                symbol="TEST",
+                df=df,
+            )
+            assert result.should_exit is False, f"unexpected exit at bar {i}"
+
+        # Bar at entry+3h: window MFE 1.9% < 2% => cut at this bar's close.
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=_candle(df, 3),
+            current_price=float(df["close"].iloc[3]),
+            symbol="TEST",
+            df=df,
+        )
+        assert result.should_exit is True
+        assert result.is_early_cut is True
+        assert result.exit_reason.startswith("Early cut")
+        assert result.exit_price == float(df["close"].iloc[3])
+
+    def test_no_cut_when_mfe_reached_threshold(self) -> None:
+        df = _make_df(
+            highs=[100.8, 101.5, 102.1, 100.9],
+            lows=[99.5, 99.8, 100.1, 100.0],
+        )
+        tracker = PositionTracker()
+        _open_long(tracker)
+        handler = _make_handler(
+            tracker,
+            early_cut_policy=EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3),
+        )
+
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=_candle(df, 3),
+            current_price=float(df["close"].iloc[3]),
+            symbol="TEST",
+            df=df,
+        )
+        assert result.should_exit is False
+
+    def test_stop_loss_takes_priority_over_early_cut(self) -> None:
+        df = _make_df(
+            highs=[100.8, 101.0, 101.0, 100.9],
+            lows=[99.5, 99.8, 99.9, 94.0],  # bar 3 crashes through the stop
+        )
+        tracker = PositionTracker()
+        _open_long(tracker, stop_loss=95.0)
+        handler = _make_handler(
+            tracker,
+            early_cut_policy=EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3),
+        )
+
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=_candle(df, 3),
+            current_price=float(df["close"].iloc[3]),
+            symbol="TEST",
+            df=df,
+        )
+        assert result.should_exit is True
+        assert result.exit_reason == "Stop loss"
+        assert result.is_stop_loss is True
+        assert result.is_early_cut is False
+
+    def test_no_policy_means_no_behavior_change(self) -> None:
+        df = _make_df(
+            highs=[100.8, 101.0, 101.0, 100.9],
+            lows=[99.5, 99.8, 99.9, 100.0],
+        )
+        tracker = PositionTracker()
+        _open_long(tracker)
+        handler = _make_handler(tracker, early_cut_policy=None)
+
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=_candle(df, 3),
+            current_price=float(df["close"].iloc[3]),
+            symbol="TEST",
+            df=df,
+        )
+        assert result.should_exit is False
+
+    def test_policy_without_df_never_cuts(self) -> None:
+        """Defensive: a wired policy with no candle history must hold."""
+        df = _make_df(
+            highs=[100.8, 101.0, 101.0, 100.9],
+            lows=[99.5, 99.8, 99.9, 100.0],
+        )
+        tracker = PositionTracker()
+        _open_long(tracker)
+        handler = _make_handler(
+            tracker,
+            early_cut_policy=EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3),
+        )
+
+        result = handler.check_exit_conditions(
+            runtime_decision=None,
+            candle=_candle(df, 3),
+            current_price=float(df["close"].iloc[3]),
+            symbol="TEST",
+        )
+        assert result.should_exit is False
+
+
+class TestBacktesterWiring:
+    def test_backtester_builds_early_cut_policy_from_risk_parameters(self) -> None:
+        """The engine must hydrate the policy from RiskParameters.early_cut
+        (the ExperimentRunner channel) without any strategy involvement."""
+        from src.engines.backtest.engine import Backtester
+        from src.risk.risk_manager import RiskParameters
+
+        strategy = Mock()
+        strategy.get_risk_overrides = Mock(return_value={})
+        backtester = Backtester(
+            strategy=strategy,
+            data_provider=Mock(),
+            risk_parameters=RiskParameters(
+                early_cut={"mfe_threshold_pct": 0.015, "evaluation_window_hours": 18}
+            ),
+            initial_balance=1000.0,
+            log_to_database=False,
+        )
+
+        assert isinstance(backtester.early_cut_policy, EarlyCutPolicy)
+        assert backtester.early_cut_policy.mfe_threshold_pct == 0.015
+        assert backtester.exit_handler.early_cut_policy is backtester.early_cut_policy
+
+    def test_backtester_default_has_no_early_cut_policy(self) -> None:
+        from src.engines.backtest.engine import Backtester
+        from src.risk.risk_manager import RiskParameters
+
+        strategy = Mock()
+        strategy.get_risk_overrides = Mock(return_value={})
+        backtester = Backtester(
+            strategy=strategy,
+            data_provider=Mock(),
+            risk_parameters=RiskParameters(),
+            initial_balance=1000.0,
+            log_to_database=False,
+        )
+
+        assert backtester.early_cut_policy is None
+        assert backtester.exit_handler.early_cut_policy is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full Backtester.run() with a scripted one-entry strategy
+# ---------------------------------------------------------------------------
+
+
+def _build_scripted_strategy():
+    """Buy once on bar 1, then hold forever (no signal exits)."""
+    from src.strategies.components import (
+        EnhancedRegimeDetector,
+        PositionSizer,
+        RiskManager as ComponentRiskManager,
+        Signal,
+        SignalDirection,
+        SignalGenerator,
+        Strategy,
+    )
+
+    class _OneEntrySignalGenerator(SignalGenerator):
+        def __init__(self):
+            super().__init__("one_entry_generator")
+
+        def generate_signal(self, df: pd.DataFrame, index: int, regime=None) -> Signal:
+            self.validate_inputs(df, index)
+            if index == 1:
+                return Signal(SignalDirection.BUY, strength=1.0, confidence=1.0, metadata={})
+            return Signal(SignalDirection.HOLD, strength=0.0, confidence=0.0, metadata={})
+
+        def get_confidence(self, df: pd.DataFrame, index: int) -> float:
+            self.validate_inputs(df, index)
+            return 1.0
+
+    class _FlatRisk(ComponentRiskManager):
+        def __init__(self):
+            super().__init__("flat_risk")
+
+        def calculate_position_size(self, signal, balance, regime=None, **context):
+            if balance <= 0 or signal.direction == SignalDirection.HOLD:
+                return 0.0
+            return balance * 0.2
+
+        def should_exit(self, position, current_data, regime=None, **context):
+            return False
+
+        def get_stop_loss(self, entry_price, signal, regime=None, **context):
+            return entry_price * 0.9 if signal.direction == SignalDirection.BUY else entry_price
+
+        def get_parameters(self):
+            return {"risk": 0.2}
+
+    class _PassSizer(PositionSizer):
+        def __init__(self):
+            super().__init__("pass_sizer")
+
+        def calculate_size(self, signal, balance, risk_amount, regime=None, **context):
+            self.validate_inputs(balance, risk_amount)
+            if signal.direction == SignalDirection.HOLD:
+                return 0.0
+            return self.apply_bounds_checking(
+                risk_amount, balance, min_fraction=0.0, max_fraction=1.0
+            )
+
+        def get_parameters(self):
+            return {"mode": "pass_through"}
+
+    strategy = Strategy(
+        name="OneEntryStrategy",
+        signal_generator=_OneEntrySignalGenerator(),
+        risk_manager=_FlatRisk(),
+        position_sizer=_PassSizer(),
+        regime_detector=EnhancedRegimeDetector(),
+    )
+    # Hold through signal flips (HyperGrowth's live setting) so nothing but
+    # the engine-level exits can close the position.
+    strategy._extra_metadata = {"ignore_signal_reversal": True}
+    return strategy
+
+
+class _FlatDataProvider:
+    """Minimal provider serving a fixed OHLCV frame."""
+
+    def __init__(self, df: pd.DataFrame):
+        self._df = df
+
+    def get_historical_data(self, symbol, timeframe, start=None, end=None):
+        return self._df.copy()
+
+    def get_current_price(self, symbol):
+        return float(self._df["close"].iloc[-1])
+
+
+class TestEndToEndEarlyCut:
+    """Full Backtester.run() — hand-computable single-trade scenario.
+
+    30 flat bars at 100.0 (1h). Entry on bar 1. With a 2%-in-3h early cut
+    the MFE window (bars strictly inside (entry, entry+3h)) never leaves
+    0%, so the trade must be cut 3 hours after entry. Without the policy
+    the trade survives to the end of data.
+    """
+
+    def _run(self, risk_parameters):
+        from src.engines.backtest.engine import Backtester
+
+        index = pd.date_range(start="2024-01-01", periods=30, freq="1h")
+        df = pd.DataFrame(
+            {
+                "open": 100.0,
+                "high": 100.0,
+                "low": 100.0,
+                "close": 100.0,
+                "volume": 1000.0,
+            },
+            index=index,
+        )
+        backtester = Backtester(
+            strategy=_build_scripted_strategy(),
+            data_provider=_FlatDataProvider(df),
+            risk_parameters=risk_parameters,
+            initial_balance=1000.0,
+            log_to_database=False,
+        )
+        results = backtester.run(
+            symbol="TESTUSDT",
+            timeframe="1h",
+            start=datetime(2024, 1, 1, tzinfo=UTC),
+            end=datetime(2024, 1, 2, 6, tzinfo=UTC),
+        )
+        return backtester, results
+
+    def test_early_cut_closes_trade_three_hours_after_entry(self) -> None:
+        from src.risk.risk_manager import RiskParameters
+
+        backtester, results = self._run(
+            RiskParameters(
+                early_cut={"mfe_threshold_pct": 0.02, "evaluation_window_hours": 3}
+            )
+        )
+
+        assert results["total_trades"] == 1
+        trade = backtester.trades[0]
+        assert trade.exit_reason.startswith("Early cut")
+        held = trade.exit_time - trade.entry_time
+        assert held == timedelta(hours=3)
+
+    def test_without_policy_trade_survives(self) -> None:
+        """Control arm: same data, no early_cut config => the position is
+        never exited (it is still open at backtest end)."""
+        from src.risk.risk_manager import RiskParameters
+
+        backtester, results = self._run(RiskParameters())
+
+        assert results["total_trades"] == 0
+        assert backtester.position_tracker.current_trade is not None

--- a/tests/unit/engines/live/test_early_cut_live.py
+++ b/tests/unit/engines/live/test_early_cut_live.py
@@ -1,0 +1,175 @@
+"""LiveExitHandler integration for the MFE early-cut policy (#971).
+
+Same shared policy implementation as backtest (parity requirement): the
+live handler must produce the same decision and the same exit-reason string
+from the same candles.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from src.engines.live.execution.exit_handler import LiveExitHandler
+from src.engines.live.execution.position_tracker import LivePosition, PositionSide
+from src.engines.shared.execution.execution_model import ExecutionModel
+from src.engines.shared.execution.fill_policy import default_fill_policy
+from src.position_management.early_cut import EarlyCutPolicy
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ENTRY_PRICE = 100.0
+
+
+def _make_df(highs: list[float], lows: list[float], start: datetime) -> pd.DataFrame:
+    index = pd.date_range(start=start.replace(tzinfo=None), periods=len(highs), freq="1h")
+    closes = [(h + lo) / 2 for h, lo in zip(highs, lows)]
+    return pd.DataFrame(
+        {"open": closes, "high": highs, "low": lows, "close": closes, "volume": 1000.0},
+        index=index,
+    )
+
+
+def _make_handler(early_cut_policy: EarlyCutPolicy | None) -> LiveExitHandler:
+    return LiveExitHandler(
+        execution_engine=Mock(),
+        position_tracker=Mock(),
+        execution_model=ExecutionModel(default_fill_policy()),
+        early_cut_policy=early_cut_policy,
+    )
+
+
+def _position(entry_time: datetime) -> LivePosition:
+    return LivePosition(
+        symbol="TESTUSDT",
+        side=PositionSide.LONG,
+        entry_price=ENTRY_PRICE,
+        entry_time=entry_time,
+        size=0.1,
+        order_id="order-1",
+    )
+
+
+class TestLiveEarlyCut:
+    def test_cuts_when_window_elapsed_and_mfe_below_threshold(self) -> None:
+        # Entry 4 hours ago; window 3h; window MFE 1.9% < 2% => cut now.
+        entry_time = datetime.now(UTC) - timedelta(hours=4)
+        df = _make_df(
+            highs=[100.8, 101.5, 101.9, 100.9, 100.9],
+            lows=[99.5, 99.8, 100.1, 100.0, 100.0],
+            start=entry_time,
+        )
+        handler = _make_handler(
+            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
+        )
+
+        result = handler.check_exit_conditions(
+            position=_position(entry_time),
+            current_price=100.5,
+            candle_high=100.9,
+            candle_low=100.0,
+            df=df,
+        )
+        assert result.should_exit is True
+        assert result.exit_reason.startswith("Early cut")
+        assert result.limit_price is None
+
+    def test_holds_before_window_elapses(self) -> None:
+        entry_time = datetime.now(UTC) - timedelta(hours=2)
+        df = _make_df(
+            highs=[100.8, 101.5, 101.9],
+            lows=[99.5, 99.8, 100.1],
+            start=entry_time,
+        )
+        handler = _make_handler(
+            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
+        )
+
+        result = handler.check_exit_conditions(
+            position=_position(entry_time),
+            current_price=100.5,
+            candle_high=101.9,
+            candle_low=100.1,
+            df=df,
+        )
+        assert result.should_exit is False
+
+    def test_holds_when_mfe_reached_threshold(self) -> None:
+        entry_time = datetime.now(UTC) - timedelta(hours=4)
+        df = _make_df(
+            highs=[100.8, 101.5, 102.1, 100.9, 100.9],
+            lows=[99.5, 99.8, 100.1, 100.0, 100.0],
+            start=entry_time,
+        )
+        handler = _make_handler(
+            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
+        )
+
+        result = handler.check_exit_conditions(
+            position=_position(entry_time),
+            current_price=100.5,
+            candle_high=100.9,
+            candle_low=100.0,
+            df=df,
+        )
+        assert result.should_exit is False
+
+    def test_holds_when_history_does_not_cover_entry(self) -> None:
+        """Restart safety: a short kline buffer must never trigger a cut."""
+        entry_time = datetime.now(UTC) - timedelta(hours=10)
+        # Buffer starts 5 hours after entry — window MFE unknowable.
+        df = _make_df(
+            highs=[100.5, 100.5, 100.5],
+            lows=[99.9, 99.9, 99.9],
+            start=entry_time + timedelta(hours=5),
+        )
+        handler = _make_handler(
+            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
+        )
+
+        result = handler.check_exit_conditions(
+            position=_position(entry_time),
+            current_price=100.0,
+            candle_high=100.5,
+            candle_low=99.9,
+            df=df,
+        )
+        assert result.should_exit is False
+
+    def test_stop_loss_priority_over_early_cut(self) -> None:
+        entry_time = datetime.now(UTC) - timedelta(hours=4)
+        df = _make_df(
+            highs=[100.8, 101.0, 101.0, 100.9, 95.5],
+            lows=[99.5, 99.8, 99.9, 100.0, 94.0],
+            start=entry_time,
+        )
+        handler = _make_handler(
+            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
+        )
+        position = _position(entry_time)
+        position.stop_loss = 95.0
+
+        result = handler.check_exit_conditions(
+            position=position,
+            current_price=94.5,
+            candle_high=95.5,
+            candle_low=94.0,
+            df=df,
+        )
+        assert result.should_exit is True
+        assert result.exit_reason == "Stop loss"
+
+    def test_no_policy_no_df_unchanged(self) -> None:
+        entry_time = datetime.now(UTC) - timedelta(hours=4)
+        handler = _make_handler(None)
+
+        result = handler.check_exit_conditions(
+            position=_position(entry_time),
+            current_price=100.5,
+            candle_high=100.9,
+            candle_low=100.0,
+        )
+        assert result.should_exit is False

--- a/tests/unit/engines/live/test_early_cut_live.py
+++ b/tests/unit/engines/live/test_early_cut_live.py
@@ -26,7 +26,7 @@ ENTRY_PRICE = 100.0
 
 def _make_df(highs: list[float], lows: list[float], start: datetime) -> pd.DataFrame:
     index = pd.date_range(start=start.replace(tzinfo=None), periods=len(highs), freq="1h")
-    closes = [(h + lo) / 2 for h, lo in zip(highs, lows)]
+    closes = [(h + lo) / 2 for h, lo in zip(highs, lows, strict=False)]
     return pd.DataFrame(
         {"open": closes, "high": highs, "low": lows, "close": closes, "volume": 1000.0},
         index=index,
@@ -62,9 +62,7 @@ class TestLiveEarlyCut:
             lows=[99.5, 99.8, 100.1, 100.0, 100.0],
             start=entry_time,
         )
-        handler = _make_handler(
-            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
-        )
+        handler = _make_handler(EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3))
 
         result = handler.check_exit_conditions(
             position=_position(entry_time),
@@ -76,6 +74,8 @@ class TestLiveEarlyCut:
         assert result.should_exit is True
         assert result.exit_reason.startswith("Early cut")
         assert result.limit_price is None
+        # Observability (#976 review): window MFE surfaced. Hand-computed: 1.9%.
+        assert result.early_cut_window_mfe_pct == pytest.approx(0.019)
 
     def test_holds_before_window_elapses(self) -> None:
         entry_time = datetime.now(UTC) - timedelta(hours=2)
@@ -84,9 +84,7 @@ class TestLiveEarlyCut:
             lows=[99.5, 99.8, 100.1],
             start=entry_time,
         )
-        handler = _make_handler(
-            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
-        )
+        handler = _make_handler(EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3))
 
         result = handler.check_exit_conditions(
             position=_position(entry_time),
@@ -104,9 +102,7 @@ class TestLiveEarlyCut:
             lows=[99.5, 99.8, 100.1, 100.0, 100.0],
             start=entry_time,
         )
-        handler = _make_handler(
-            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
-        )
+        handler = _make_handler(EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3))
 
         result = handler.check_exit_conditions(
             position=_position(entry_time),
@@ -126,9 +122,7 @@ class TestLiveEarlyCut:
             lows=[99.9, 99.9, 99.9],
             start=entry_time + timedelta(hours=5),
         )
-        handler = _make_handler(
-            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
-        )
+        handler = _make_handler(EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3))
 
         result = handler.check_exit_conditions(
             position=_position(entry_time),
@@ -146,9 +140,7 @@ class TestLiveEarlyCut:
             lows=[99.5, 99.8, 99.9, 100.0, 94.0],
             start=entry_time,
         )
-        handler = _make_handler(
-            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
-        )
+        handler = _make_handler(EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3))
         position = _position(entry_time)
         position.stop_loss = 95.0
 
@@ -173,3 +165,41 @@ class TestLiveEarlyCut:
             candle_low=100.0,
         )
         assert result.should_exit is False
+
+
+class TestLiveStartTimeframeValidation:
+    """Review #976 F1/F2: the live engine must refuse to start with an
+    early-cut window that cannot work on the traded timeframe."""
+
+    def _engine(self, window_hours: float):
+        from unittest.mock import MagicMock, patch
+
+        from src.engines.live.trading_engine import LiveTradingEngine
+        from src.risk.risk_manager import RiskParameters
+        from src.strategies.ml_basic import create_ml_basic_strategy
+
+        with patch("src.engines.live.trading_engine.DatabaseManager"):
+            engine = LiveTradingEngine(
+                strategy=create_ml_basic_strategy(),
+                data_provider=MagicMock(),
+                initial_balance=1000.0,
+                risk_parameters=RiskParameters(
+                    early_cut={
+                        "mfe_threshold_pct": 0.02,
+                        "evaluation_window_hours": window_hours,
+                    }
+                ),
+            )
+        engine.startup_sequencer = Mock()
+        return engine
+
+    def test_start_rejects_window_equal_to_bar_interval(self) -> None:
+        engine = self._engine(window_hours=1)
+        with pytest.raises(ValueError, match="evaluation_window_hours"):
+            engine.start("BTCUSDT", timeframe="1h")
+        engine.startup_sequencer.run.assert_not_called()
+
+    def test_start_accepts_valid_window(self) -> None:
+        engine = self._engine(window_hours=18)
+        engine.start("BTCUSDT", timeframe="1h")
+        engine.startup_sequencer.run.assert_called_once()

--- a/tests/unit/engines/shared/test_risk_configuration.py
+++ b/tests/unit/engines/shared/test_risk_configuration.py
@@ -240,6 +240,21 @@ class TestBuildTrailingStopPolicyExistingBehavior:
         # No trailing_distance_pct key -> params fallback (unchanged).
         assert policy.trailing_distance_pct == DEFAULT_TRAILING_DISTANCE_PCT
 
+    @pytest.mark.fast
+    def test_params_zero_breakeven_threshold_preserved(self):
+        """Review #976 arch nit 1: a params breakeven_threshold of exactly
+        0.0 is preserved as 0.0 (old or-chain semantics: `None or 0.0`
+        evaluates to 0.0), not silently upgraded to the default."""
+        params = _default_params()
+        params.breakeven_threshold = 0.0
+        strategy = _StrategyWithOverrides(
+            {"trailing_stop": {"activation_threshold": 0.03, "trailing_distance_pct": 0.015}}
+        )
+        policy = build_trailing_stop_policy(strategy, _RiskManager(params))
+
+        assert policy is not None
+        assert policy.breakeven_threshold == 0.0
+
 
 class TestBuildTrailingStopPolicyExpressibility:
     """#971: config must be able to genuinely control trailing/breakeven."""

--- a/tests/unit/engines/shared/test_risk_configuration.py
+++ b/tests/unit/engines/shared/test_risk_configuration.py
@@ -1,9 +1,20 @@
-"""Tests for shared risk configuration builders (regression for #760)."""
+"""Tests for shared risk configuration builders (regression for #760, #971)."""
 
 import pytest
 
-from src.config.constants import DEFAULT_MAX_HOLDING_HOURS
-from src.engines.shared.risk_configuration import build_time_exit_policy
+from src.config.constants import (
+    DEFAULT_BREAKEVEN_THRESHOLD,
+    DEFAULT_MAX_HOLDING_HOURS,
+    DEFAULT_TRAILING_ACTIVATION_THRESHOLD,
+    DEFAULT_TRAILING_DISTANCE_ATR_MULT,
+    DEFAULT_TRAILING_DISTANCE_PCT,
+)
+from src.engines.shared.risk_configuration import (
+    build_early_cut_policy,
+    build_time_exit_policy,
+    build_trailing_stop_policy,
+)
+from src.position_management.early_cut import EarlyCutPolicy
 from src.position_management.time_exits import TimeExitPolicy
 
 pytestmark = pytest.mark.unit
@@ -125,3 +136,257 @@ class TestBuildTimeExitPolicy:
         strategy = _StrategyWithOverrides({"time_exits": {"time_restrictions": "invalid"}})
 
         assert build_time_exit_policy(strategy) is None
+
+
+def _default_params() -> "_Params":
+    """RiskParameters-shaped defaults for the trailing-stop fields."""
+    return _Params(
+        trailing_activation_threshold=DEFAULT_TRAILING_ACTIVATION_THRESHOLD,
+        trailing_distance_pct=DEFAULT_TRAILING_DISTANCE_PCT,
+        trailing_atr_multiplier=DEFAULT_TRAILING_DISTANCE_ATR_MULT,
+        breakeven_threshold=DEFAULT_BREAKEVEN_THRESHOLD,
+        breakeven_buffer=0.001,
+    )
+
+
+class TestBuildTrailingStopPolicyExistingBehavior:
+    """Regression pins: existing config shapes must produce identical policies.
+
+    These cases mirror the strategies that declare a ``trailing_stop``
+    override today (hyper_growth, kelly_momentum, leveraged_regime,
+    momentum_leverage, chaos_test, ensemble_weighted) plus the params-only
+    path, so the #971 expressibility rework provably changes nothing for
+    any existing config.
+    """
+
+    @pytest.mark.fast
+    def test_hyper_growth_shaped_cfg_with_default_params(self):
+        """hyper_growth's cfg: params atr multiplier still leaks in (pinned)."""
+        strategy = _StrategyWithOverrides(
+            {
+                "trailing_stop": {
+                    "activation_threshold": 0.03,
+                    "trailing_distance_pct": 0.015,
+                    "breakeven_threshold": 0.05,
+                    "breakeven_buffer": 0.008,
+                }
+            }
+        )
+        policy = build_trailing_stop_policy(strategy, _RiskManager(_default_params()))
+
+        assert policy is not None
+        assert policy.activation_threshold == 0.03
+        assert policy.trailing_distance_pct == 0.015
+        # Key absent from cfg -> params fallback (pre-existing behavior,
+        # kept bit-identical; the TrailingStopManager prefers pct distance
+        # so this leaked multiplier is inert at runtime).
+        assert policy.atr_multiplier == DEFAULT_TRAILING_DISTANCE_ATR_MULT
+        assert policy.breakeven_threshold == 0.05
+        assert policy.breakeven_buffer == 0.008
+
+    @pytest.mark.fast
+    def test_cfg_without_breakeven_keys_falls_back_to_params(self):
+        """chaos_test's cfg shape: missing breakeven keys use params values."""
+        strategy = _StrategyWithOverrides(
+            {
+                "trailing_stop": {
+                    "activation_threshold": 0.005,
+                    "trailing_distance_pct": 0.003,
+                }
+            }
+        )
+        policy = build_trailing_stop_policy(strategy, _RiskManager(_default_params()))
+
+        assert policy is not None
+        assert policy.activation_threshold == 0.005
+        assert policy.trailing_distance_pct == 0.003
+        assert policy.breakeven_threshold == DEFAULT_BREAKEVEN_THRESHOLD
+        assert policy.breakeven_buffer == 0.001
+
+    @pytest.mark.fast
+    def test_params_only_path(self):
+        """No strategy cfg: params-driven policy (unchanged)."""
+        strategy = _StrategyWithOverrides(None)
+        policy = build_trailing_stop_policy(strategy, _RiskManager(_default_params()))
+
+        assert policy is not None
+        assert policy.activation_threshold == DEFAULT_TRAILING_ACTIVATION_THRESHOLD
+        assert policy.trailing_distance_pct == DEFAULT_TRAILING_DISTANCE_PCT
+        assert policy.atr_multiplier == DEFAULT_TRAILING_DISTANCE_ATR_MULT
+
+    @pytest.mark.fast
+    def test_no_cfg_no_params_returns_none(self):
+        assert build_trailing_stop_policy(_StrategyWithOverrides(None)) is None
+
+    @pytest.mark.fast
+    def test_inert_extra_keys_ignored(self):
+        """ensemble_weighted's cfg carries extra keys ('enabled': True,
+        'distance', 'step') that must stay inert."""
+        strategy = _StrategyWithOverrides(
+            {
+                "trailing_stop": {
+                    "enabled": True,
+                    "activation_threshold": 0.04,
+                    "distance": 0.02,
+                    "step": 0.01,
+                    "cooldown_hours": 4,
+                }
+            }
+        )
+        policy = build_trailing_stop_policy(strategy, _RiskManager(_default_params()))
+
+        assert policy is not None
+        assert policy.activation_threshold == 0.04
+        # No trailing_distance_pct key -> params fallback (unchanged).
+        assert policy.trailing_distance_pct == DEFAULT_TRAILING_DISTANCE_PCT
+
+
+class TestBuildTrailingStopPolicyExpressibility:
+    """#971: config must be able to genuinely control trailing/breakeven."""
+
+    @pytest.mark.fast
+    def test_enabled_false_disables_trailing_entirely(self):
+        strategy = _StrategyWithOverrides({"trailing_stop": {"enabled": False}})
+
+        assert build_trailing_stop_policy(strategy, _RiskManager(_default_params())) is None
+
+    @pytest.mark.fast
+    def test_explicit_none_atr_mult_stops_params_leak(self):
+        strategy = _StrategyWithOverrides(
+            {
+                "trailing_stop": {
+                    "activation_threshold": 0.03,
+                    "trailing_distance_pct": 0.02,
+                    "trailing_distance_atr_mult": None,
+                }
+            }
+        )
+        policy = build_trailing_stop_policy(strategy, _RiskManager(_default_params()))
+
+        assert policy is not None
+        assert policy.trailing_distance_pct == 0.02
+        assert policy.atr_multiplier is None
+
+    @pytest.mark.fast
+    def test_explicit_none_breakeven_disables_breakeven(self):
+        strategy = _StrategyWithOverrides(
+            {
+                "trailing_stop": {
+                    "activation_threshold": 0.03,
+                    "trailing_distance_pct": 0.02,
+                    "breakeven_threshold": None,
+                }
+            }
+        )
+        policy = build_trailing_stop_policy(strategy, _RiskManager(_default_params()))
+
+        assert policy is not None
+        assert policy.breakeven_threshold is None
+
+    @pytest.mark.fast
+    def test_breakeven_only_policy_without_trailing_distance(self):
+        """Breakeven-at-+X% without any trailing distance is expressible."""
+        strategy = _StrategyWithOverrides(
+            {
+                "trailing_stop": {
+                    "activation_threshold": 0.05,
+                    "trailing_distance_pct": None,
+                    "trailing_distance_atr_mult": None,
+                    "breakeven_threshold": 0.05,
+                    "breakeven_buffer": 0.005,
+                }
+            }
+        )
+        policy = build_trailing_stop_policy(strategy, _RiskManager(_default_params()))
+
+        assert policy is not None
+        assert policy.trailing_distance_pct is None
+        assert policy.atr_multiplier is None
+        assert policy.breakeven_threshold == 0.05
+        assert policy.breakeven_buffer == 0.005
+
+
+class TestBuildEarlyCutPolicy:
+    """#971: MFE-conditioned early-cut config channels."""
+
+    @pytest.mark.fast
+    def test_builds_from_strategy_overrides(self):
+        strategy = _StrategyWithOverrides(
+            {"early_cut": {"mfe_threshold_pct": 0.015, "evaluation_window_hours": 18}}
+        )
+        policy = build_early_cut_policy(strategy)
+
+        assert isinstance(policy, EarlyCutPolicy)
+        assert policy.mfe_threshold_pct == 0.015
+        assert policy.evaluation_window_hours == 18
+
+    @pytest.mark.fast
+    def test_falls_back_to_risk_manager_params(self):
+        """Expressible via RiskParameters(early_cut=...) — the same channel
+        the exit-geometry experiment used for time_exits."""
+        strategy = _StrategyWithOverrides(None)
+        risk_manager = _RiskManager(
+            _Params(early_cut={"mfe_threshold_pct": 0.02, "evaluation_window_hours": 12})
+        )
+        policy = build_early_cut_policy(strategy, risk_manager)
+
+        assert isinstance(policy, EarlyCutPolicy)
+        assert policy.mfe_threshold_pct == 0.02
+        assert policy.evaluation_window_hours == 12
+
+    @pytest.mark.fast
+    def test_strategy_overrides_win_over_params(self):
+        strategy = _StrategyWithOverrides(
+            {"early_cut": {"mfe_threshold_pct": 0.015, "evaluation_window_hours": 18}}
+        )
+        risk_manager = _RiskManager(
+            _Params(early_cut={"mfe_threshold_pct": 0.02, "evaluation_window_hours": 12})
+        )
+        policy = build_early_cut_policy(strategy, risk_manager)
+
+        assert policy is not None
+        assert policy.mfe_threshold_pct == 0.015
+
+    @pytest.mark.fast
+    def test_returns_none_without_config(self):
+        """DEFAULT OFF: no config anywhere means no policy."""
+        assert build_early_cut_policy(_StrategyWithOverrides(None)) is None
+        assert build_early_cut_policy(object()) is None
+        assert (
+            build_early_cut_policy(
+                _StrategyWithOverrides(None), _RiskManager(_Params(early_cut=None))
+            )
+            is None
+        )
+
+    @pytest.mark.fast
+    def test_enabled_false_returns_none(self):
+        strategy = _StrategyWithOverrides(
+            {
+                "early_cut": {
+                    "enabled": False,
+                    "mfe_threshold_pct": 0.015,
+                    "evaluation_window_hours": 18,
+                }
+            }
+        )
+        assert build_early_cut_policy(strategy) is None
+
+    @pytest.mark.fast
+    def test_invalid_config_returns_none(self):
+        """Malformed config disables the policy (warn, never crash the engine)."""
+        assert build_early_cut_policy(_StrategyWithOverrides({"early_cut": "18h"})) is None
+        assert (
+            build_early_cut_policy(
+                _StrategyWithOverrides({"early_cut": {"mfe_threshold_pct": 0.015}})
+            )
+            is None
+        )
+        assert (
+            build_early_cut_policy(
+                _StrategyWithOverrides(
+                    {"early_cut": {"mfe_threshold_pct": -1, "evaluation_window_hours": 18}}
+                )
+            )
+            is None
+        )

--- a/tests/unit/position_management/test_early_cut.py
+++ b/tests/unit/position_management/test_early_cut.py
@@ -49,7 +49,7 @@ def _make_df(
         freq="1h",
         tz="UTC" if tz_aware else None,
     )
-    closes = [(h + lo) / 2 for h, lo in zip(highs, lows)]
+    closes = [(h + lo) / 2 for h, lo in zip(highs, lows, strict=False)]
     return pd.DataFrame(
         {"open": closes, "high": highs, "low": lows, "close": closes, "volume": 1000.0},
         index=index,
@@ -147,8 +147,10 @@ class TestComputeWindowRawMfe:
         )
         assert mfe is None
 
-    def test_empty_window_is_zero_mfe(self) -> None:
-        # Data covers entry but no bar falls strictly inside the window.
+    def test_empty_window_returns_none(self) -> None:
+        # Review #976 F1: data covers entry but NO bar falls strictly inside
+        # the window — the true window MFE is unknowable and must NOT be
+        # fabricated as 0.0 (which would cut every position).
         df = _make_df(highs=[100.8], lows=[99.5])
         mfe = compute_window_raw_mfe(
             df,
@@ -157,7 +159,36 @@ class TestComputeWindowRawMfe:
             entry_time=ENTRY_TIME,
             window_end=ENTRY_TIME + timedelta(hours=3),
         )
-        assert mfe == 0.0
+        assert mfe is None
+
+    def test_data_gap_spanning_window_returns_none(self) -> None:
+        # Review #976 F1 repro: entry bar present, next bar only AFTER the
+        # window end (data gap) with a huge favorable high — window MFE is
+        # unknowable, must hold rather than fabricate 0%.
+        index = pd.DatetimeIndex(
+            [
+                ENTRY_TIME.replace(tzinfo=None),
+                ENTRY_TIME.replace(tzinfo=None) + timedelta(hours=5),
+            ]
+        )
+        df = pd.DataFrame(
+            {
+                "open": [100.0, 120.0],
+                "high": [100.8, 130.0],
+                "low": [99.5, 119.0],
+                "close": [100.0, 125.0],
+                "volume": 1000.0,
+            },
+            index=index,
+        )
+        mfe = compute_window_raw_mfe(
+            df,
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            window_end=ENTRY_TIME + timedelta(hours=3),
+        )
+        assert mfe is None
 
     def test_invalid_entry_price_returns_none(self) -> None:
         for bad in (0.0, -1.0, float("nan")):
@@ -307,3 +338,94 @@ class TestCheckEarlyCutConditions:
             df=_df_below_threshold(),
         )
         assert decision.should_exit is True
+
+    def test_window_equal_to_bar_interval_never_cuts(self) -> None:
+        """Review #976 F1 repro: window == bar interval on 1h bars leaves ZERO
+        bars strictly inside (entry, entry+1h) — the old 0.0 fabrication cut
+        every position at entry+1h even at +9% MFE. Must hold."""
+        policy = EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=1)
+        df = _make_df(
+            highs=[100.8, 109.0, 109.5],  # +9% favorable move
+            lows=[99.5, 100.0, 100.0],
+        )
+        decision = policy.check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=1),
+            df=df,
+        )
+        assert decision.should_exit is False
+        assert decision.window_mfe_pct is None
+
+    def test_data_gap_spanning_window_never_cuts(self) -> None:
+        policy = _policy()
+        index = pd.DatetimeIndex(
+            [
+                ENTRY_TIME.replace(tzinfo=None),
+                ENTRY_TIME.replace(tzinfo=None) + timedelta(hours=5),
+            ]
+        )
+        df = pd.DataFrame(
+            {
+                "open": [100.0, 120.0],
+                "high": [100.8, 130.0],
+                "low": [99.5, 119.0],
+                "close": [100.0, 125.0],
+                "volume": 1000.0,
+            },
+            index=index,
+        )
+        decision = policy.check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=5),
+            df=df,
+        )
+        assert decision.should_exit is False
+        assert decision.window_mfe_pct is None
+
+
+class TestValidateForTimeframe:
+    """Review #976 F1/F2: reject window sizes that cannot work on the
+    traded timeframe at config-build time, before any money moves."""
+
+    def test_window_equal_to_bar_interval_rejected(self) -> None:
+        policy = EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=1)
+        with pytest.raises(ValueError, match="evaluation_window_hours"):
+            policy.validate_for_timeframe("1h")
+
+    def test_window_smaller_than_bar_interval_rejected(self) -> None:
+        policy = EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=2)
+        with pytest.raises(ValueError, match="evaluation_window_hours"):
+            policy.validate_for_timeframe("4h")
+
+    def test_non_multiple_window_rejected(self) -> None:
+        # Review #976 F2: non-bar-aligned windows can diverge live vs
+        # backtest (forming boundary bar) — rejected outright.
+        policy = EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=1.5)
+        with pytest.raises(ValueError, match="whole multiple"):
+            policy.validate_for_timeframe("1h")
+        policy6 = EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=6)
+        with pytest.raises(ValueError, match="whole multiple"):
+            policy6.validate_for_timeframe("4h")
+
+    def test_valid_windows_accepted(self) -> None:
+        EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=18).validate_for_timeframe(
+            "1h"
+        )
+        EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=8).validate_for_timeframe(
+            "4h"
+        )
+        EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=2).validate_for_timeframe(
+            "1h"
+        )
+        EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=0.5).validate_for_timeframe(
+            "15m"
+        )
+
+    def test_unrecognized_timeframe_rejected(self) -> None:
+        policy = EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=18)
+        with pytest.raises(ValueError, match="timeframe"):
+            policy.validate_for_timeframe("bogus")

--- a/tests/unit/position_management/test_early_cut.py
+++ b/tests/unit/position_management/test_early_cut.py
@@ -1,0 +1,309 @@
+"""Tests for the MFE-conditioned early-cut policy (#971 follow-up).
+
+Every scenario uses a tiny hand-computable synthetic series so the expected
+cut bar and window-MFE are derivable on paper (the #838 lesson: never trust a
+number a test can't reproduce by hand).
+
+Fixture geometry (long, entry 100.0 at 2024-01-01 00:00 UTC, 1h bars):
+
+    bar time  high    low     favorable excursion (long)
+    00:00     100.8    99.5   entry bar — excluded from the window
+    01:00     101.5    99.8   +1.5%
+    02:00     101.9   100.1   +1.9%
+    03:00     105.0   100.0   at/after window end (3h) — excluded
+    04:00     106.0   100.0   excluded
+
+With mfe_threshold_pct=0.02 and evaluation_window_hours=3 the window MFE is
+max(1.5%, 1.9%) = 1.9% < 2.0%, so the position must be cut at the first
+evaluation with now >= entry + 3h.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from src.position_management.early_cut import (
+    EarlyCutPolicy,
+    compute_window_raw_mfe,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+ENTRY_TIME = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
+ENTRY_PRICE = 100.0
+
+
+def _make_df(
+    highs: list[float],
+    lows: list[float],
+    *,
+    start: datetime = ENTRY_TIME,
+    tz_aware: bool = False,
+) -> pd.DataFrame:
+    index = pd.date_range(
+        start=start.replace(tzinfo=None) if not tz_aware else start,
+        periods=len(highs),
+        freq="1h",
+        tz="UTC" if tz_aware else None,
+    )
+    closes = [(h + lo) / 2 for h, lo in zip(highs, lows)]
+    return pd.DataFrame(
+        {"open": closes, "high": highs, "low": lows, "close": closes, "volume": 1000.0},
+        index=index,
+    )
+
+
+def _df_below_threshold() -> pd.DataFrame:
+    # Window MFE = 1.9% (< 2% threshold); bars at/after 03:00 must not count.
+    return _make_df(
+        highs=[100.8, 101.5, 101.9, 105.0, 106.0],
+        lows=[99.5, 99.8, 100.1, 100.0, 100.0],
+    )
+
+
+def _df_above_threshold() -> pd.DataFrame:
+    # Window MFE = 2.1% (>= 2% threshold) reached inside the window.
+    return _make_df(
+        highs=[100.8, 101.5, 102.1, 100.5, 100.5],
+        lows=[99.5, 99.8, 100.1, 100.0, 100.0],
+    )
+
+
+def _policy() -> EarlyCutPolicy:
+    return EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=3)
+
+
+class TestEarlyCutPolicyValidation:
+    def test_rejects_non_positive_threshold(self) -> None:
+        with pytest.raises(ValueError):
+            EarlyCutPolicy(mfe_threshold_pct=0.0, evaluation_window_hours=3)
+        with pytest.raises(ValueError):
+            EarlyCutPolicy(mfe_threshold_pct=-0.01, evaluation_window_hours=3)
+
+    def test_rejects_non_positive_window(self) -> None:
+        with pytest.raises(ValueError):
+            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=0)
+
+    def test_rejects_non_finite_values(self) -> None:
+        with pytest.raises(ValueError):
+            EarlyCutPolicy(mfe_threshold_pct=float("nan"), evaluation_window_hours=3)
+        with pytest.raises(ValueError):
+            EarlyCutPolicy(mfe_threshold_pct=0.02, evaluation_window_hours=float("inf"))
+
+
+class TestComputeWindowRawMfe:
+    def test_long_mfe_from_window_highs_only(self) -> None:
+        # Hand-computed: bars 01:00 (101.5) and 02:00 (101.9) are in the
+        # window; the entry bar (00:00) and the 03:00/04:00 bars are not.
+        mfe = compute_window_raw_mfe(
+            _df_below_threshold(),
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            window_end=ENTRY_TIME + timedelta(hours=3),
+        )
+        assert mfe == pytest.approx((101.9 - 100.0) / 100.0)
+
+    def test_short_mfe_from_window_lows(self) -> None:
+        # Short favorable excursion uses lows: min(99.8, 100.1) = 99.8
+        # => MFE = (100 - 99.8) / 100 = 0.2%.
+        mfe = compute_window_raw_mfe(
+            _df_below_threshold(),
+            side="short",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            window_end=ENTRY_TIME + timedelta(hours=3),
+        )
+        assert mfe == pytest.approx((100.0 - 99.8) / 100.0)
+
+    def test_mfe_floored_at_zero_when_never_favorable(self) -> None:
+        df = _make_df(highs=[100.0, 99.5, 99.0], lows=[99.0, 98.5, 98.0])
+        mfe = compute_window_raw_mfe(
+            df,
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            window_end=ENTRY_TIME + timedelta(hours=3),
+        )
+        assert mfe == 0.0
+
+    def test_returns_none_when_history_does_not_cover_entry(self) -> None:
+        # Earliest bar is AFTER entry (e.g. live restart with a short buffer):
+        # the true window MFE is unknowable, so the policy must not guess.
+        df = _make_df(
+            highs=[101.5, 101.9],
+            lows=[99.8, 100.1],
+            start=ENTRY_TIME + timedelta(hours=1),
+        )
+        mfe = compute_window_raw_mfe(
+            df,
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            window_end=ENTRY_TIME + timedelta(hours=3),
+        )
+        assert mfe is None
+
+    def test_empty_window_is_zero_mfe(self) -> None:
+        # Data covers entry but no bar falls strictly inside the window.
+        df = _make_df(highs=[100.8], lows=[99.5])
+        mfe = compute_window_raw_mfe(
+            df,
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            window_end=ENTRY_TIME + timedelta(hours=3),
+        )
+        assert mfe == 0.0
+
+    def test_invalid_entry_price_returns_none(self) -> None:
+        for bad in (0.0, -1.0, float("nan")):
+            assert (
+                compute_window_raw_mfe(
+                    _df_below_threshold(),
+                    side="long",
+                    entry_price=bad,
+                    entry_time=ENTRY_TIME,
+                    window_end=ENTRY_TIME + timedelta(hours=3),
+                )
+                is None
+            )
+
+    def test_invalid_side_raises(self) -> None:
+        with pytest.raises(ValueError):
+            compute_window_raw_mfe(
+                _df_below_threshold(),
+                side="sideways",
+                entry_price=ENTRY_PRICE,
+                entry_time=ENTRY_TIME,
+                window_end=ENTRY_TIME + timedelta(hours=3),
+            )
+
+    def test_tz_aware_index_with_naive_entry_time(self) -> None:
+        df = _make_df(
+            highs=[100.8, 101.5, 101.9, 105.0],
+            lows=[99.5, 99.8, 100.1, 100.0],
+            tz_aware=True,
+        )
+        mfe = compute_window_raw_mfe(
+            df,
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME.replace(tzinfo=None),
+            window_end=ENTRY_TIME.replace(tzinfo=None) + timedelta(hours=3),
+        )
+        assert mfe == pytest.approx(0.019)
+
+    def test_naive_index_with_aware_entry_time(self) -> None:
+        mfe = compute_window_raw_mfe(
+            _df_below_threshold(),
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            window_end=ENTRY_TIME + timedelta(hours=3),
+        )
+        assert mfe == pytest.approx(0.019)
+
+
+class TestCheckEarlyCutConditions:
+    def test_no_cut_before_window_elapses(self) -> None:
+        decision = _policy().check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=2),
+            df=_df_below_threshold(),
+        )
+        assert decision.should_exit is False
+
+    def test_cuts_at_window_end_when_mfe_below_threshold(self) -> None:
+        # First evaluation at entry + 3h: window MFE 1.9% < 2.0% => cut.
+        decision = _policy().check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=3),
+            df=_df_below_threshold(),
+        )
+        assert decision.should_exit is True
+        assert decision.reason is not None and decision.reason.startswith("Early cut")
+        assert decision.window_mfe_pct == pytest.approx(0.019)
+
+    def test_no_cut_when_mfe_reached_threshold_inside_window(self) -> None:
+        decision = _policy().check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=3),
+            df=_df_above_threshold(),
+        )
+        assert decision.should_exit is False
+        assert decision.window_mfe_pct == pytest.approx(0.021)
+
+    def test_mfe_exactly_at_threshold_is_not_cut(self) -> None:
+        # Threshold semantics: cut only when MFE is strictly BELOW threshold.
+        df = _make_df(
+            highs=[100.8, 102.0, 101.0, 100.5],
+            lows=[99.5, 99.8, 100.1, 100.0],
+        )
+        decision = _policy().check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=3),
+            df=df,
+        )
+        assert decision.should_exit is False
+
+    def test_still_cuts_after_window_when_evaluated_late(self) -> None:
+        # An evaluation later than window end (e.g. brief downtime) still
+        # cuts — the window MFE it judges stays frozen at the first 3 hours,
+        # so the 105/106 highs after the window must not rescue the trade.
+        decision = _policy().check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=4),
+            df=_df_below_threshold(),
+        )
+        assert decision.should_exit is True
+
+    def test_no_cut_when_history_insufficient(self) -> None:
+        df = _make_df(
+            highs=[101.5, 101.9],
+            lows=[99.8, 100.1],
+            start=ENTRY_TIME + timedelta(hours=1),
+        )
+        decision = _policy().check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=3),
+            df=df,
+        )
+        assert decision.should_exit is False
+        assert decision.window_mfe_pct is None
+
+    def test_no_cut_with_missing_df(self) -> None:
+        decision = _policy().check_early_cut_conditions(
+            side="long",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=3),
+            df=None,
+        )
+        assert decision.should_exit is False
+
+    def test_short_side_cut(self) -> None:
+        # Short entry 100: window lows 99.8/100.1 => MFE 0.2% < 2% => cut.
+        decision = _policy().check_early_cut_conditions(
+            side="short",
+            entry_price=ENTRY_PRICE,
+            entry_time=ENTRY_TIME,
+            now_time=ENTRY_TIME + timedelta(hours=3),
+            df=_df_below_threshold(),
+        )
+        assert decision.should_exit is True

--- a/tests/unit/strategies/test_hyper_growth_unit.py
+++ b/tests/unit/strategies/test_hyper_growth_unit.py
@@ -327,3 +327,106 @@ class TestHyperGrowthStrategy:
 
         assert strategy.name == "HyperGrowth"
         # Momentum source should work without ML models
+
+
+class TestHyperGrowthExitPolicyExpressibility:
+    """#971: trailing/breakeven/early-cut must be factory-configurable."""
+
+    def test_default_overrides_dict_is_bit_identical_to_pre_971(self):
+        """Zero behavior change: the default factory must emit EXACTLY the
+        overrides dict it emitted before the expressibility kwargs existed."""
+        strategy = create_hyper_growth_strategy()
+
+        assert strategy._risk_overrides["trailing_stop"] == {
+            "activation_threshold": 0.03,
+            "trailing_distance_pct": 0.015,
+            "breakeven_threshold": 0.05,
+            "breakeven_buffer": 0.008,
+        }
+        assert "early_cut" not in strategy._risk_overrides
+
+    def test_trailing_kwargs_flow_into_overrides(self):
+        strategy = create_hyper_growth_strategy(
+            trailing_activation_threshold=0.05,
+            trailing_distance_pct=0.025,
+            breakeven_threshold=0.08,
+            breakeven_buffer=0.01,
+        )
+
+        assert strategy._risk_overrides["trailing_stop"] == {
+            "activation_threshold": 0.05,
+            "trailing_distance_pct": 0.025,
+            "breakeven_threshold": 0.08,
+            "breakeven_buffer": 0.01,
+        }
+
+    def test_trailing_can_be_disabled(self):
+        strategy = create_hyper_growth_strategy(enable_trailing_stop=False)
+
+        assert strategy._risk_overrides["trailing_stop"] == {"enabled": False}
+
+    def test_disabled_trailing_builds_no_policy(self):
+        """End to end: the shared builder honors the disabled config."""
+        from src.engines.shared.risk_configuration import build_trailing_stop_policy
+        from src.risk.risk_manager import RiskManager, RiskParameters
+
+        strategy = create_hyper_growth_strategy(enable_trailing_stop=False)
+
+        assert build_trailing_stop_policy(strategy, RiskManager(RiskParameters())) is None
+
+    def test_early_cut_kwargs_flow_into_overrides(self):
+        strategy = create_hyper_growth_strategy(
+            early_cut_mfe_threshold_pct=0.015,
+            early_cut_evaluation_window_hours=18,
+        )
+
+        assert strategy._risk_overrides["early_cut"] == {
+            "mfe_threshold_pct": 0.015,
+            "evaluation_window_hours": 18,
+        }
+
+    def test_early_cut_builds_policy_via_shared_builder(self):
+        from src.engines.shared.risk_configuration import build_early_cut_policy
+        from src.position_management.early_cut import EarlyCutPolicy
+
+        strategy = create_hyper_growth_strategy(
+            early_cut_mfe_threshold_pct=0.015,
+            early_cut_evaluation_window_hours=18,
+        )
+        policy = build_early_cut_policy(strategy)
+
+        assert isinstance(policy, EarlyCutPolicy)
+        assert policy.mfe_threshold_pct == 0.015
+        assert policy.evaluation_window_hours == 18
+
+    def test_early_cut_default_off(self):
+        from src.engines.shared.risk_configuration import build_early_cut_policy
+
+        assert build_early_cut_policy(create_hyper_growth_strategy()) is None
+
+    def test_partial_early_cut_kwargs_raise(self):
+        """Both early-cut kwargs are required together — a silent partial
+        config would run with an unintended default."""
+        import pytest
+
+        with pytest.raises(ValueError):
+            create_hyper_growth_strategy(early_cut_mfe_threshold_pct=0.015)
+        with pytest.raises(ValueError):
+            create_hyper_growth_strategy(early_cut_evaluation_window_hours=18)
+
+    def test_default_trailing_policy_unchanged_via_builder(self):
+        """The built TrailingStopPolicy for the default factory + default
+        RiskParameters must keep the exact pre-971 field values."""
+        from src.engines.shared.risk_configuration import build_trailing_stop_policy
+        from src.risk.risk_manager import RiskManager, RiskParameters
+
+        policy = build_trailing_stop_policy(
+            create_hyper_growth_strategy(), RiskManager(RiskParameters())
+        )
+
+        assert policy is not None
+        assert policy.activation_threshold == 0.03
+        assert policy.trailing_distance_pct == 0.015
+        assert policy.atr_multiplier == 1.5  # params fallback leak, pinned
+        assert policy.breakeven_threshold == 0.05
+        assert policy.breakeven_buffer == 0.008


### PR DESCRIPTION
## Summary

The exit-geometry experiment (docs/research/experiments/2026-07-12_exit-geometry-honest.md Sec. 3/8, #971) found three trade-management policies **not expressible** via strategy config for HyperGrowth — every prior test of them would have required per-experiment `src/` patches. This PR makes them real config knobs so the next preregistered exit-experiment round can vary them without touching engine code:

1. **MFE-conditioned early-cut** (new policy) — flatten a position whose max favorable excursion never reached `mfe_threshold_pct` within the first `evaluation_window_hours` after entry (the live-autopsy hypothesis from docs/research/notes/2026-07-12_live-trade-review.md: losers identify themselves early with tiny MFE, then bleed for days).
2. **Trailing stop / breakeven via config** — `build_trailing_stop_policy`'s cfg-first `or`-chain made HyperGrowth's hardcoded `trailing_stop` overrides unbeatable and made explicit-`None`/disable/breakeven-only configs inexpressible. Precedence is now key-presence based.
3. **Shared plumbing** — the early-cut check is ONE implementation used by both engines (the #948 `barrier_touch` pattern), wired through backtest `ExitHandler` and `LiveExitHandler`/`LiveExitCoordinator`, incl. live hot-swap refresh.

## Config surface (for the next prereg to cite)

**`create_hyper_growth_strategy` factory kwargs** (all reachable via `ExperimentConfig.factory_kwargs`):
- `enable_trailing_stop: bool = True` — `False` disables trailing/breakeven entirely (no RiskParameters fallback)
- `trailing_activation_threshold: float = 0.03`
- `trailing_distance_pct: float = 0.015`
- `breakeven_threshold: float | None = 0.05` — `None` disables the breakeven move
- `breakeven_buffer: float = 0.008`
- `early_cut_mfe_threshold_pct: float | None = None` — raw price MFE fraction (e.g. `0.015` = +1.5%)
- `early_cut_evaluation_window_hours: float | None = None` — both early-cut kwargs must be set together; default `None`/`None` = OFF

**Strategy overrides keys** (`get_risk_overrides()`):
- `"early_cut": {"mfe_threshold_pct": ..., "evaluation_window_hours": ...}` (optional `"enabled": False` kill switch)
- `"trailing_stop"`: existing keys, now key-presence resolved; new: `"enabled": False` disables; explicit `None` values are honored (e.g. `"trailing_distance_atr_mult": None` blocks the params ATR fallback; `"breakeven_threshold": None` disables breakeven; breakeven-only policies with no trailing distance are now buildable)

**RiskParameters** (reachable via `ExperimentConfig.risk_parameters`, same channel the experiment's `maxhold_18` arm used):
- `early_cut: dict | None = None` — same keys as the override

## Early-cut semantics (hand-computable)

- Window MFE = max raw favorable price excursion over bars with open time strictly inside `(entry_time, entry_time + H hours)`; entry bar excluded (same convention as `is_same_bar_entry`).
- At the first evaluation with `now >= entry + H`: cut iff window MFE **< threshold** (frozen window — favorable moves after H never rescue the trade; exactly-at-threshold survives).
- **Stateless & restart-safe**: recomputed from candle history each evaluation; if history doesn't reach back to entry (live restart, short kline buffer), the policy holds — unknown never cuts.
- **NOT the #966 writer path**: MFE here is raw price excursion computed fresh in the shared exit logic. The sized/fee-adjusted `MFEMAETracker` / DB `trades.mfe` writer (known-corrupted, #966) is untouched and not reused; this PR neither fixes nor depends on it.
- Exit priority in BOTH engines: SL > TP > time > early-cut > signal. Exit reason string: `Early cut (MFE x.xx% < y.yy% in Nh)`.

## Zero behavior change — regression evidence

Prod's exact live config (HyperGrowth control arm of the exit-geometry experiment: ETHUSDT/1h, SL 10%/TP 30%, $85, fees+slippage on) run on the F1–F3 exam folds **before and after** this change, same machine/model/cache (post-#923 deterministic inference):

| Fold | trades | return % | PF | MaxDD % |
|---|---|---|---|---|
| F1 2023H1 | 31 | -2.881754238240264 | 0.662 | 4.85 |
| F2 2024H1 | 46 | -6.643012775559887 | 0.528 | 7.65 |
| F3 2025H1 | 70 | -11.557713074441967 | 0.446 | 12.78 |

Field-by-field comparison (trades, return, PF, MaxDD, win rate, Sharpe, final balance, **full per-trade P&L sequences**): **bit-identical to full float precision on every fold**, and identical to the reference control numbers in the experiment doc (PR #970). Driver: the exit-geometry sweep's control arm.

Existing trailing-config shapes are additionally pinned by unit tests: hyper_growth, chaos_test, ensemble_weighted (inert extra keys), params-only, and no-config paths all produce identical `TrailingStopPolicy` fields — **including the pre-existing params ATR-multiplier leak-through into cfg-built policies, deliberately kept bit-identical** (it is inert at runtime: `TrailingStopManager` prefers pct distance).

## Functional demo (not a preregistered experiment — no verdicts drawn)

`experiments/exit_policy_expressibility_demo.py`, F1/ETHUSDT/1h, config-only arms:

```
control              trades=  31 ret%= -2.8818 maxDD%= 4.8468 winR%= 74.19 final=$  82.71
early_cut_1p5_18h    trades=  61 ret%= -6.6508 maxDD%= 8.2374 winR%= 45.90 final=$  79.27
trail_5_3_be8        trades=  19 ret%= -8.8861 maxDD%= 9.2768 winR%= 42.11 final=$  77.59
no_trailing          trades=   5 ret%= -0.6283 maxDD%= 4.5409 winR%= 20.00 final=$  84.14

Control reproduces the regression baseline exactly (31 trades / -2.8818%); every arm is config-only and produces genuinely different trade paths — the three policies are now expressible.
```

## Testing

- TDD failing-first throughout; 60+ new tests:
  - `tests/unit/position_management/test_early_cut.py` — hand-computable fixture (long entry 100, window MFE 1.9% vs 2% threshold → cut bar derivable on paper; the #838 lesson), tz matrix, coverage guard, boundary semantics
  - `tests/unit/backtesting/test_early_cut_exit.py` — ExitHandler integration, priority ordering, **end-to-end `Backtester.run()`** (scripted one-entry strategy on flat synthetic bars: cut exactly 3h after entry with the policy, position survives without it), engine hydration from `RiskParameters.early_cut`
  - `tests/unit/engines/live/test_early_cut_live.py` — LiveExitHandler parity incl. restart (short buffer) safety and SL priority
  - `tests/unit/engines/shared/test_risk_configuration.py` — regression pins for every existing trailing-config shape + new expressibility cases + `build_early_cut_policy` channels
  - `tests/unit/strategies/test_hyper_growth_unit.py` — default overrides dict asserted **bit-identical** to pre-change; factory kwargs; paired-kwarg validation
- Full unit suite: 5276 passed / 1 failed — the failure (`test_models_tft.py` lightgbm ImportError test) fails identically on pristine `origin/develop` (lightgbm 4.6.0 installed in the shared venv — environmental, unrelated).
- `atb dev quality --changed`: black + ruff + mypy green.

## Review round 1 (both reviewers APPROVE-WITH-NITS) — fixes applied

- **F1 (empty-window cut, fixed)**: `compute_window_raw_mfe` returned 0.0 when no bar fell strictly inside `(entry, entry+H)`, so `0.0 < threshold` cut every position (repro: window == bar interval, or a data gap spanning the window). Now an empty window returns **None → HOLD** (unknowable never cuts), with failing-first tests for both repro scenarios.
- **F1/F2 (config-time guard, added)**: `EarlyCutPolicy.validate_for_timeframe(timeframe)` — both engines fail fast (`Backtester.run()` / `LiveTradingEngine.start()`) with a clear ValueError if the window is not strictly longer than one bar or not a whole multiple of the bar interval (the non-aligned case is the live-forming-bar parity divergence, killed outright).
- **Arch nit 1 (fixed)**: `breakeven_threshold` params fallback now uses `is not None` (symmetric with `breakeven_buffer`); a params value of exactly 0.0 is preserved as 0.0 (old or-chain semantics), pinned by test; misleading inline comment corrected.
- **Observability (added)**: the window MFE that triggered a cut is now persisted — backtest `Trade.metadata["early_cut_window_mfe_pct"]` (exam output gets the MFE-capture metric for free), live `strategy_executions.reasons` (`early_cut_window_mfe_*`), plus `early_cut_window_mfe_pct` on both handlers' check results.

## Notes for reviewers (money-path)

- **Live timing**: like the existing time-exit check, the live early-cut uses wall-clock `datetime.now(UTC)` while backtest uses the bar timestamp — live may cut minutes after the window boundary rather than exactly on it. Same divergence class as the existing time exits. Tracked as #977 so the round-2 live-vs-backtest validation accounts for it.
- The per-decision policy-bundle hydration channel (`PolicyHydrator`) was deliberately **not** extended for early-cut; the builder channel (strategy overrides / RiskParameters) covers both engines. Can be added later if a strategy ever needs per-bar policy retuning.
- Precedence edge cases that changed (no existing config exercises them — verified by grep and pinned by tests): a cfg `activation_threshold` explicitly set to `None`/`0.0` now yields no policy instead of silently falling back to the params default; explicit `None` distance/breakeven keys are now honored instead of leaking params values.

Refs #971 (next-round top candidate per prereg Sec. 8). Money-path exit code — requesting the full two-reviewer gauntlet; **do not merge without it**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
