### PR TITLE
chore: sunset FEATURE_ALLOW_CROSS_SYMBOL_MODEL — actionable banner + flag unset everywhere (closes #872)

### DIFF
--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -758,8 +758,8 @@ class MLBasicSignalGenerator(SignalGenerator):
             raise ModelNotAvailableError(
                 f"No {self.model_type}/{self.model_timeframe} model exists for trading "
                 f"symbol {self.symbol}. Available models: {', '.join(available) or 'none'}. "
-                f"Train and deploy a {self.symbol} model, or set "
-                f"FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true to explicitly accept scoring "
+                f"Train and deploy one via `atb live-control train --symbol {self.symbol}`, "
+                f"or set FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true to explicitly accept scoring "
                 f"{self.symbol} with another symbol's model."
             )
 
@@ -776,11 +776,16 @@ class MLBasicSignalGenerator(SignalGenerator):
         logger.critical(
             "CROSS-SYMBOL MODEL SUBSTITUTION ACTIVE: trading %s but scoring with %s "
             "model %s (FEATURE_ALLOW_CROSS_SYMBOL_MODEL=true). Predictions are not "
-            "trained on %s — deploy a %s model and unset the flag as soon as possible.",
+            "trained on %s — no %s/%s/%s model exists in the registry. Train one via "
+            "`atb live-control train --symbol %s`, deploy it, then unset the flag to "
+            "remove this substitution.",
             self.symbol,
             fallback.symbol,
             fallback.key,
             self.symbol,
+            self.symbol,
+            self.model_type,
+            self.model_timeframe,
             self.symbol,
         )
 

--- a/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
+++ b/tests/unit/strategies/components/test_ml_signal_symbol_guard.py
@@ -188,6 +188,7 @@ class TestMissingModelFailFast:
         assert "ETHUSDT" in message
         assert "BTCUSDT:1h:basic:v1" in message
         assert "FEATURE_ALLOW_CROSS_SYMBOL_MODEL" in message
+        assert "atb live-control train --symbol ETHUSDT" in message
 
     @patch(ENGINE_PATH)
     @patch(CONFIG_PATH)
@@ -203,8 +204,13 @@ class TestMissingModelFailFast:
         assert generator._cross_symbol_bundle_key == "BTCUSDT:1h:basic:v1"
         critical_records = [r for r in caplog.records if r.levelno == logging.CRITICAL]
         assert len(critical_records) == 1
-        assert "ETHUSDT" in critical_records[0].getMessage()
-        assert "BTCUSDT" in critical_records[0].getMessage()
+        message = critical_records[0].getMessage()
+        assert "ETHUSDT" in message
+        assert "BTCUSDT" in message
+        # The banner must be actionable: name the missing native bundle and
+        # the exact remediation command (#872).
+        assert "no ETHUSDT/basic/1h model" in message
+        assert "atb live-control train --symbol ETHUSDT" in message
 
     @patch(ENGINE_PATH)
     @patch(CONFIG_PATH)


### PR DESCRIPTION
## Summary

Executes the #872 sunset per the issue's own "Done means" plan, following the 2026-07-12 staging-cohort verdict (docs/research/ops-snapshots/2026-07-12_staging-cohort-verdicts.md, PR #963): **KILL (sunset)** — the flag has been dormant by design the whole cohort; the native ETHUSDT/basic model resolves cleanly.

### Issue plan → status

1. **ETHUSDT basic 1h model deployed** — done previously: `src/ml/models/ETHUSDT/basic/latest -> 2026-07-04_22h_v1` exists on develop; staging `ml_predictions` shows `model_symbol=ETHUSDT` on every sampled row (cohort verdicts report).
2. **`FEATURE_ALLOW_CROSS_SYMBOL_MODEL` unset on all Railway services** — done 2026-07-12 (direct config action, staging only was set): deleted from staging Trading Bot via `railway variable delete ... -e staging`; prod Trading Bot never had it (verified `<absent>` via `railway variables -e production --json`). `feature_flags.json` already carries `"allow_cross_symbol_model": false` — unchanged. Fail-fast guard (#867) is re-armed everywhere.
3. **Startup verification** — staging redeployed after the variable change; boot evidence posted on #872.

### Code change in this PR (the issue's "improvement to fold in")

Make the substitution CRITICAL banner actionable: it now names the missing native bundle (`no ETHUSDT/basic/1h model exists in the registry`) and the exact remediation command (`atb live-control train --symbol ETHUSDT`), turning every restart under substitution into a reminder with the fix attached. The fail-fast `ModelNotAvailableError` (flag off) gets the same exact-command treatment.

No behavior change for the current native-model configuration: both touched sites are only reachable when no native model exists for the trading symbol — the guard logic, fallback selection, and flag semantics are untouched (message-only diff).

Closes #872

## Testing

- TDD: extended `test_flag_allows_substitution_and_logs_critical` and `test_missing_model_raises_with_available_models` to assert the missing-bundle phrase and the exact train command; watched both fail, then implemented.
- `tests/unit/strategies/components/test_ml_signal_symbol_guard.py` + `tests/unit/live/test_strategy_manager_unit.py`: 40 passed.
- black --check, ruff, mypy (bin/run_mypy.py --targets) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)