### PR TITLE
fix(ml): annotate regime once + checkpointed fire generation in meta_labels (closes #955)

### DIFF
--- a/src/ml/training_pipeline/config.py
+++ b/src/ml/training_pipeline/config.py
@@ -87,6 +87,13 @@ class TrainingConfig:
     # "meta_label" (validated below), ignored otherwise.
     primary_model_type: str | None = None
 
+    # Fire-generation checkpoint directory for target_type="meta_label"
+    # (#955 defect 2: the ~60-min forward pass over the corpus was killed
+    # twice by task-lifetime caps with all progress lost). "auto" (default)
+    # checkpoints under <data_dir>/meta_label_fire_checkpoints; any other
+    # string is used as the directory; None disables checkpointing.
+    meta_label_fire_checkpoint_dir: str | None = "auto"
+
     # Test-only escape hatch: routes load_training_corpus (ingestion.py) to
     # MockDataProvider (deterministic synthetic OHLCV, no network) instead of
     # the real Binance-backed cache. Mirrors `atb live --mock-data`'s

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -27,9 +27,12 @@ resolved yet as of "now."
 
 from __future__ import annotations
 
+import json
 import math
+import os
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -48,6 +51,11 @@ if TYPE_CHECKING:
 REALIZED_VOL_WINDOW_BARS = 48
 HIT_RATE_LOOKBACK_FIRES = 20
 _HOURS_PER_DAY = 24.0
+
+# At the measured ~200 bars/sec steady-state inference rate (#955), 1000
+# bars is a checkpoint roughly every 5 seconds -- cheap enough to be the
+# default whenever a checkpoint path is supplied.
+FIRE_GENERATION_CHECKPOINT_EVERY_BARS = 1000
 
 _VALID_DIRECTIONS = frozenset({1, -1})
 
@@ -71,10 +79,73 @@ class PrimarySignalRecord:
     predicted_return: float
 
 
+def _load_fire_generation_checkpoint(
+    checkpoint_path: Path, start: int, total_bars: int
+) -> tuple[list[PrimarySignalRecord], int] | None:
+    """Load a prior run's progress, or None if no checkpoint exists yet.
+
+    Returns:
+        (records so far, first index still to evaluate).
+
+    Raises:
+        ValueError: the checkpoint was recorded against a different corpus
+            (start index or bar count mismatch) -- resuming from it would
+            splice fires from two different windows into one training set.
+    """
+    if not checkpoint_path.exists():
+        return None
+    state = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    if state.get("start_index") != start or state.get("total_bars") != total_bars:
+        raise ValueError(
+            f"checkpoint at {checkpoint_path} was recorded for a different corpus "
+            f"(checkpoint start_index={state.get('start_index')}, "
+            f"total_bars={state.get('total_bars')}; this run has start_index={start}, "
+            f"total_bars={total_bars}) -- delete it or point at the right file"
+        )
+    records = [
+        PrimarySignalRecord(
+            index=int(record["index"]),
+            direction=int(record["direction"]),
+            predicted_return=float(record["predicted_return"]),
+        )
+        for record in state["records"]
+    ]
+    return records, int(state["last_completed_index"]) + 1
+
+
+def _write_fire_generation_checkpoint(
+    checkpoint_path: Path,
+    start: int,
+    total_bars: int,
+    last_completed_index: int,
+    records: Sequence[PrimarySignalRecord],
+) -> None:
+    """Persist progress crash-safely: write a temp file, then atomically rename."""
+    state = {
+        "start_index": start,
+        "total_bars": total_bars,
+        "last_completed_index": last_completed_index,
+        "records": [
+            {
+                "index": record.index,
+                "direction": record.direction,
+                "predicted_return": record.predicted_return,
+            }
+            for record in records
+        ],
+    }
+    tmp_path = checkpoint_path.with_suffix(checkpoint_path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(state), encoding="utf-8")
+    os.replace(tmp_path, checkpoint_path)
+
+
 def run_primary_signal_forward(
     signal_generator: SignalGenerator,
     df: pd.DataFrame,
     start_index: int | None = None,
+    *,
+    checkpoint_path: str | Path | None = None,
+    checkpoint_every_bars: int = FIRE_GENERATION_CHECKPOINT_EVERY_BARS,
 ) -> list[PrimarySignalRecord]:
     """Run a primary SignalGenerator forward over df, recording every fire.
 
@@ -83,26 +154,67 @@ def run_primary_signal_forward(
     points." Reuses the SignalGenerator interface directly (generate_signal)
     rather than reimplementing prediction logic.
 
+    Long corpora (~47k bars at ~200 bars/sec) run for the better part of an
+    hour, and task-lifetime caps killed uncheckpointed passes twice during
+    the #933 tournament (#955 defect 2) -- so progress can optionally be
+    checkpointed: every ``checkpoint_every_bars`` completed bars, the fires
+    so far and the last completed bar index are written to
+    ``checkpoint_path`` (temp file + atomic rename). A rerun pointed at the
+    same checkpoint resumes after the last completed bar instead of
+    reprocessing from the start.
+
     Args:
         signal_generator: The primary (incumbent) SignalGenerator instance.
         df: OHLCV DataFrame to run forward over.
         start_index: First index to evaluate. Defaults to
             ``signal_generator.warmup_period``.
+        checkpoint_path: Optional JSON file to persist/resume progress
+            through. The file is left in place after a completed run (a
+            rerun then returns its fires without reprocessing); the caller
+            owns cleanup.
+        checkpoint_every_bars: Completed bars between checkpoint writes.
+            Only meaningful with ``checkpoint_path``.
 
     Returns:
         A list of PrimarySignalRecord, one per non-HOLD bar, in order.
+
+    Raises:
+        ValueError: ``checkpoint_every_bars`` < 1, or the checkpoint file
+            belongs to a different corpus (see
+            ``_load_fire_generation_checkpoint``).
     """
     start = start_index if start_index is not None else signal_generator.warmup_period
     records: list[PrimarySignalRecord] = []
-    for index in range(start, len(df)):
+    resume_from = start
+
+    checkpoint = Path(checkpoint_path) if checkpoint_path is not None else None
+    if checkpoint is not None:
+        if checkpoint_every_bars < 1:
+            raise ValueError(f"checkpoint_every_bars must be >= 1, got {checkpoint_every_bars}")
+        loaded = _load_fire_generation_checkpoint(checkpoint, start, len(df))
+        if loaded is not None:
+            records, resume_from = loaded
+
+    bars_since_checkpoint = 0
+    for index in range(resume_from, len(df)):
         signal = signal_generator.generate_signal(df, index)
-        if signal.direction == SignalDirection.HOLD:
-            continue
-        direction = 1 if signal.direction == SignalDirection.BUY else -1
-        predicted_return = float(signal.metadata.get("predicted_return", 0.0))
-        records.append(
-            PrimarySignalRecord(index=index, direction=direction, predicted_return=predicted_return)
-        )
+        if signal.direction != SignalDirection.HOLD:
+            direction = 1 if signal.direction == SignalDirection.BUY else -1
+            predicted_return = float(signal.metadata.get("predicted_return", 0.0))
+            records.append(
+                PrimarySignalRecord(
+                    index=index, direction=direction, predicted_return=predicted_return
+                )
+            )
+        bars_since_checkpoint += 1
+        if checkpoint is not None and bars_since_checkpoint >= checkpoint_every_bars:
+            _write_fire_generation_checkpoint(checkpoint, start, len(df), index, records)
+            bars_since_checkpoint = 0
+
+    if checkpoint is not None and resume_from < len(df):
+        # Final checkpoint marks the run complete -- a rerun against the same
+        # file returns these fires without re-evaluating any bar.
+        _write_fire_generation_checkpoint(checkpoint, start, len(df), len(df) - 1, records)
     return records
 
 
@@ -350,7 +462,10 @@ def build_meta_label_features(
             fired_signals) -- typically resolve_fired_trade()'s output with
             unresolved (None) fires already filtered out by the caller.
         regime_detector: Reused EnhancedRegimeDetector instance; a fresh one
-            is created if not supplied.
+            is created if not supplied. If ``df`` already carries the regime
+            annotation columns (``regime_label`` et al., from
+            ``RegimeDetector.annotate``), it is used as-is with no further
+            annotation pass.
         realized_vol_window: Trailing bars for realized volatility (default 48).
         hit_rate_lookback: Trailing eligible PRIOR fires for rolling hit-rate
             (default 20).
@@ -373,6 +488,12 @@ def build_meta_label_features(
     detector = regime_detector or EnhancedRegimeDetector()
     realized_vol = _realized_volatility_series(df["close"], realized_vol_window)
 
+    # detect_regime re-annotates the ENTIRE frame on every call when the
+    # regime columns are absent -- per-fire that is O(n_fires * n_bars) and
+    # made real (~46k-fire x ~47k-bar) corpora infeasible (#955). Annotate
+    # once here; detect_regime sees the columns and skips its own pass.
+    regime_df = df if "regime_label" in df.columns else detector.base_detector.annotate(df.copy())
+
     rows: list[dict[str, Any]] = []
     for position, fire in enumerate(fired_signals):
         # Only prior fires that had RESOLVED by this fire's own index are
@@ -392,7 +513,7 @@ def build_meta_label_features(
         timestamp = df.index[fire.index]
         session_sin, session_cos = _session_cyclical_encoding(pd.Timestamp(timestamp))
 
-        regime = detector.detect_regime(df, fire.index)
+        regime = detector.detect_regime(regime_df, fire.index)
 
         rows.append(
             {
@@ -538,6 +659,7 @@ def encode_meta_label_features_for_training(
 
 
 __all__ = [
+    "FIRE_GENERATION_CHECKPOINT_EVERY_BARS",
     "HIT_RATE_LOOKBACK_FIRES",
     "META_LABEL_FEATURE_ORDER",
     "REALIZED_VOL_WINDOW_BARS",

--- a/src/ml/training_pipeline/meta_labels.py
+++ b/src/ml/training_pipeline/meta_labels.py
@@ -27,7 +27,9 @@ resolved yet as of "now."
 
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 import math
 import os
 from collections.abc import Sequence
@@ -46,6 +48,8 @@ from src.strategies.components.signal_generator import SignalDirection
 
 if TYPE_CHECKING:
     from src.strategies.components.signal_generator import SignalGenerator
+
+logger = logging.getLogger(__name__)
 
 # Feature-set constants, per preregistration §2a's exact spec.
 REALIZED_VOL_WINDOW_BARS = 48
@@ -79,8 +83,62 @@ class PrimarySignalRecord:
     predicted_return: float
 
 
+def fire_generation_corpus_fingerprint(
+    signal_generator: SignalGenerator,
+    df: pd.DataFrame,
+    start_index: int | None = None,
+) -> str:
+    """Content fingerprint identifying one (corpus, start, generator) run.
+
+    Guards checkpoint resumes: two equal-length but different corpora (a
+    shifted window, another symbol) must never resume-splice into one
+    training set, so the fingerprint hashes the frame's index endpoints,
+    the full close column, the resolved start index, and the generator's
+    identity string. Best-effort on generator identity: the name does not
+    capture model WEIGHTS, so callers must not reuse a checkpoint across
+    primary-model retrains (the pipeline deletes its checkpoint after each
+    successful run for exactly this reason).
+
+    Raises:
+        ValueError: df is empty (nothing to fingerprint or checkpoint).
+    """
+    if len(df) == 0:
+        raise ValueError("cannot fingerprint an empty corpus")
+    start = start_index if start_index is not None else signal_generator.warmup_period
+    generator_identity = getattr(signal_generator, "name", type(signal_generator).__name__)
+    close_digest = hashlib.sha256(df["close"].to_numpy(dtype=np.float64).tobytes()).hexdigest()
+    payload = "|".join(
+        [
+            str(df.index[0]),
+            str(df.index[-1]),
+            str(len(df)),
+            str(start),
+            close_digest,
+            str(generator_identity),
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _checkpoint_rejection(checkpoint_path: Path, reason: str) -> ValueError:
+    """Uniform rejection policy: raise, never guess, never overwrite.
+
+    A checkpoint that cannot be positively identified as THIS run's own
+    (corpus fingerprint mismatch, unparseable JSON, missing keys) is never
+    silently ignored or overwritten -- overwriting would destroy either
+    another run's progress or, if the caller mis-pointed checkpoint_path,
+    an unrelated file. The operator resolves it: delete the file or point
+    at a different path to start fresh.
+    """
+    return ValueError(
+        f"checkpoint at {checkpoint_path} {reason} -- refusing to resume from or "
+        f"overwrite it; delete the file or pass a different checkpoint_path to "
+        f"start fresh"
+    )
+
+
 def _load_fire_generation_checkpoint(
-    checkpoint_path: Path, start: int, total_bars: int
+    checkpoint_path: Path, fingerprint: str
 ) -> tuple[list[PrimarySignalRecord], int] | None:
     """Load a prior run's progress, or None if no checkpoint exists yet.
 
@@ -88,40 +146,52 @@ def _load_fire_generation_checkpoint(
         (records so far, first index still to evaluate).
 
     Raises:
-        ValueError: the checkpoint was recorded against a different corpus
-            (start index or bar count mismatch) -- resuming from it would
-            splice fires from two different windows into one training set.
+        ValueError: the checkpoint belongs to a different (corpus, start,
+            generator) fingerprint, or is corrupt/incomplete -- see
+            ``_checkpoint_rejection`` for the policy.
     """
     if not checkpoint_path.exists():
         return None
-    state = json.loads(checkpoint_path.read_text(encoding="utf-8"))
-    if state.get("start_index") != start or state.get("total_bars") != total_bars:
-        raise ValueError(
-            f"checkpoint at {checkpoint_path} was recorded for a different corpus "
-            f"(checkpoint start_index={state.get('start_index')}, "
-            f"total_bars={state.get('total_bars')}; this run has start_index={start}, "
-            f"total_bars={total_bars}) -- delete it or point at the right file"
+    try:
+        state = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        recorded_fingerprint = state["fingerprint"]
+        last_completed_index = int(state["last_completed_index"])
+        records = [
+            PrimarySignalRecord(
+                index=int(record["index"]),
+                direction=int(record["direction"]),
+                predicted_return=float(record["predicted_return"]),
+            )
+            for record in state["records"]
+        ]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise _checkpoint_rejection(
+            checkpoint_path, f"is corrupt or not a fire-generation checkpoint ({exc})"
+        ) from exc
+    if recorded_fingerprint != fingerprint:
+        raise _checkpoint_rejection(
+            checkpoint_path,
+            "was recorded for a different corpus, start index, or signal generator "
+            f"(fingerprint {recorded_fingerprint!r} != this run's {fingerprint!r})",
         )
-    records = [
-        PrimarySignalRecord(
-            index=int(record["index"]),
-            direction=int(record["direction"]),
-            predicted_return=float(record["predicted_return"]),
-        )
-        for record in state["records"]
-    ]
-    return records, int(state["last_completed_index"]) + 1
+    return records, last_completed_index + 1
 
 
 def _write_fire_generation_checkpoint(
     checkpoint_path: Path,
+    fingerprint: str,
     start: int,
     total_bars: int,
     last_completed_index: int,
     records: Sequence[PrimarySignalRecord],
 ) -> None:
-    """Persist progress crash-safely: write a temp file, then atomically rename."""
+    """Persist progress crash-safely: write a temp file, then atomically rename.
+
+    ``start``/``total_bars`` are stored for human debugging only -- resume
+    validation compares the fingerprint (which already covers both).
+    """
     state = {
+        "fingerprint": fingerprint,
         "start_index": start,
         "total_bars": total_bars,
         "last_completed_index": last_completed_index,
@@ -171,7 +241,11 @@ def run_primary_signal_forward(
         checkpoint_path: Optional JSON file to persist/resume progress
             through. The file is left in place after a completed run (a
             rerun then returns its fires without reprocessing); the caller
-            owns cleanup.
+            owns cleanup. An existing file that cannot be positively
+            identified as this exact run's checkpoint (corpus/start/
+            generator fingerprint mismatch, corrupt or incomplete JSON) is
+            rejected with ValueError -- never resumed from, never
+            overwritten (see ``_checkpoint_rejection``).
         checkpoint_every_bars: Completed bars between checkpoint writes.
             Only meaningful with ``checkpoint_path``.
 
@@ -180,20 +254,31 @@ def run_primary_signal_forward(
 
     Raises:
         ValueError: ``checkpoint_every_bars`` < 1, or the checkpoint file
-            belongs to a different corpus (see
-            ``_load_fire_generation_checkpoint``).
+            was rejected (see ``_load_fire_generation_checkpoint``).
     """
     start = start_index if start_index is not None else signal_generator.warmup_period
     records: list[PrimarySignalRecord] = []
     resume_from = start
 
     checkpoint = Path(checkpoint_path) if checkpoint_path is not None else None
+    fingerprint = ""
     if checkpoint is not None:
         if checkpoint_every_bars < 1:
             raise ValueError(f"checkpoint_every_bars must be >= 1, got {checkpoint_every_bars}")
-        loaded = _load_fire_generation_checkpoint(checkpoint, start, len(df))
-        if loaded is not None:
-            records, resume_from = loaded
+        if len(df) == 0:
+            checkpoint = None  # nothing to evaluate or checkpoint
+        else:
+            fingerprint = fire_generation_corpus_fingerprint(signal_generator, df, start)
+            loaded = _load_fire_generation_checkpoint(checkpoint, fingerprint)
+            if loaded is not None:
+                records, resume_from = loaded
+                logger.info(
+                    "fire generation resuming from bar %d of %d (%d fires loaded from %s)",
+                    resume_from,
+                    len(df),
+                    len(records),
+                    checkpoint,
+                )
 
     bars_since_checkpoint = 0
     for index in range(resume_from, len(df)):
@@ -208,13 +293,24 @@ def run_primary_signal_forward(
             )
         bars_since_checkpoint += 1
         if checkpoint is not None and bars_since_checkpoint >= checkpoint_every_bars:
-            _write_fire_generation_checkpoint(checkpoint, start, len(df), index, records)
+            _write_fire_generation_checkpoint(
+                checkpoint, fingerprint, start, len(df), index, records
+            )
             bars_since_checkpoint = 0
 
     if checkpoint is not None and resume_from < len(df):
         # Final checkpoint marks the run complete -- a rerun against the same
         # file returns these fires without re-evaluating any bar.
-        _write_fire_generation_checkpoint(checkpoint, start, len(df), len(df) - 1, records)
+        _write_fire_generation_checkpoint(
+            checkpoint, fingerprint, start, len(df), len(df) - 1, records
+        )
+        logger.info(
+            "fire generation complete: %d fires over bars %d..%d, checkpoint finalized at %s",
+            len(records),
+            start,
+            len(df) - 1,
+            checkpoint,
+        )
     return records
 
 
@@ -668,6 +764,7 @@ __all__ = [
     "build_meta_label_features",
     "encode_meta_label_feature_row",
     "encode_meta_label_features_for_training",
+    "fire_generation_corpus_fingerprint",
     "resolution_ordered_hit_rate",
     "resolve_fired_trade",
     "run_primary_signal_forward",

--- a/src/ml/training_pipeline/pipeline.py
+++ b/src/ml/training_pipeline/pipeline.py
@@ -56,6 +56,7 @@ from src.ml.training_pipeline.meta_labels import (
     META_LABEL_FEATURE_ORDER,
     build_meta_label_features,
     encode_meta_label_features_for_training,
+    fire_generation_corpus_fingerprint,
     resolve_fired_trade,
     run_primary_signal_forward,
 )
@@ -230,6 +231,30 @@ def _build_alt_target(
     return aligned_values, aligned_valid
 
 
+def _meta_label_fire_checkpoint_path(
+    ctx: TrainingContext, signal_generator: MLBasicSignalGenerator, price_df: pd.DataFrame
+) -> Path | None:
+    """Where this run's fire-generation checkpoint lives, or None if disabled.
+
+    The corpus fingerprint goes INTO the filename so different corpora
+    (window/symbol/generator changes between a crash and a rerun) resolve to
+    different files instead of tripping the checkpoint's mismatch rejection.
+    """
+    configured = ctx.config.meta_label_fire_checkpoint_dir
+    if configured is None or len(price_df) == 0:
+        return None
+    base = (
+        ctx.paths.data_dir / "meta_label_fire_checkpoints"
+        if configured == "auto"
+        else Path(configured)
+    )
+    base.mkdir(parents=True, exist_ok=True)
+    fingerprint = fire_generation_corpus_fingerprint(signal_generator, price_df)
+    return base / (
+        f"fires_{ctx.config.symbol.upper()}_{ctx.config.timeframe}_{fingerprint[:16]}.json"
+    )
+
+
 def _run_meta_label_pipeline(ctx: TrainingContext) -> TrainingResult:
     """Train entrant (a)'s meta-labeling classifier (TARGET-REDESIGN
     tournament preregistration §2a).
@@ -256,7 +281,13 @@ def _run_meta_label_pipeline(ctx: TrainingContext) -> TrainingResult:
             symbol=ctx.config.symbol,
         )
 
-        fired = run_primary_signal_forward(primary_signal_generator, price_df)
+        # Checkpoint-protected by default (#955 defect 2): a ~47k-bar
+        # forward pass runs the better part of an hour, and task-lifetime
+        # caps killed uncheckpointed passes twice during the #933 tournament.
+        checkpoint_path = _meta_label_fire_checkpoint_path(ctx, primary_signal_generator, price_df)
+        fired = run_primary_signal_forward(
+            primary_signal_generator, price_df, checkpoint_path=checkpoint_path
+        )
         if not fired:
             raise ValueError(
                 f"Primary signal (model_type={ctx.config.primary_model_type!r}) produced "
@@ -393,6 +424,17 @@ def _run_meta_label_pipeline(ctx: TrainingContext) -> TrainingResult:
             metadata_path=metadata_path,
             plot_path=None,
         )
+
+        # Crash-recovery artifact, not a cache: fires depend on the primary
+        # model's WEIGHTS, which the checkpoint fingerprint cannot see --
+        # keeping a completed checkpoint would silently reuse stale fires
+        # after a primary-model retrain. Kept until here (not right after
+        # fire generation) so a crash anywhere above resumes instantly.
+        if checkpoint_path is not None and checkpoint_path.exists():
+            checkpoint_path.unlink()
+            logger.info(
+                "Removed fire-generation checkpoint %s after successful run", checkpoint_path
+            )
 
         duration = perf_counter() - start_time
         logger.info(

--- a/src/strategies/components/exam_signal_generator.py
+++ b/src/strategies/components/exam_signal_generator.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import math
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 import pandas as pd
@@ -47,6 +47,7 @@ from src.prediction.distribution_stats import FrozenDistribution, percentile_ran
 from src.prediction.features.pipeline import FeaturePipeline
 from src.prediction.features.price_only import PriceOnlyFeatureExtractor
 from src.prediction.models.registry import PredictionModelRegistry
+from src.regime.detector import RegimeDetector
 from src.regime.enhanced_detector import EnhancedRegimeDetector
 from src.strategies.components.regime_context import RegimeContext
 from src.strategies.components.signal_generator import Signal, SignalDirection, SignalGenerator
@@ -507,6 +508,9 @@ class MetaLabelExamSignalGenerator(SignalGenerator):
         # so the two can never diverge again (see meta_labels.py docstring).
         self._resolved_history: deque[tuple[int, int, bool]] = deque(maxlen=resolved_history_maxlen)
         self._regime_detector = EnhancedRegimeDetector()
+        # Once-per-frame regime annotation cache -- see _regime_frame.
+        self._regime_annotated: pd.DataFrame | None = None
+        self._regime_annotated_source: Any = None
         self._cost_calculator = CostCalculator()
         self._bundle = self._load_bundle()
         # generate_signal has side effects (fire registration/resolution);
@@ -605,6 +609,37 @@ class MetaLabelExamSignalGenerator(SignalGenerator):
     def _rolling_hit_rate(self) -> float:
         return resolution_ordered_hit_rate(list(self._resolved_history), HIT_RATE_LOOKBACK_FIRES)
 
+    def _regime_frame(self, df: Any) -> Any:
+        """The frame detect_regime should read: annotated ONCE per frame.
+
+        Training's build_meta_label_features annotates the corpus once with
+        FRESH detector state (#955); letting detect_regime re-annotate here
+        per fired bar was both O(n_bars) per fire and a train/serve skew
+        channel -- the reused detector's warm hysteresis state can relabel
+        early bars differently from the fresh-state annotation the
+        classifier was trained on. Annotation is row-causal (all rolling
+        windows are trailing), so reading row ``index`` from a full-frame
+        annotation never leaks forward bars into the current signal.
+
+        Frames already carrying the regime columns are used as-is; the
+        cached annotation is invalidated when the frame object changes OR
+        grows in place (a live engine appending bars to the same object).
+        """
+        if "regime_label" in df.columns:
+            return df
+        if self._regime_annotated_source is not df or (
+            self._regime_annotated is not None and len(self._regime_annotated) != len(df)
+        ):
+            # Fresh detector state per annotation, cloned config -- matches
+            # training's annotate-once semantics exactly (a reused
+            # RegimeDetector carries hysteresis state across annotate calls).
+            annotation_detector = RegimeDetector(
+                replace(self._regime_detector.base_detector.config)
+            )
+            self._regime_annotated = annotation_detector.annotate(df.copy())
+            self._regime_annotated_source = df
+        return self._regime_annotated
+
     def _realized_volatility(self, df: Any, index: int) -> float:
         """Causal 48-bar trailing realized volatility, ending at `index`."""
         window_start = max(0, index - REALIZED_VOL_WINDOW_BARS)
@@ -658,7 +693,7 @@ class MetaLabelExamSignalGenerator(SignalGenerator):
 
         timestamp = df.index[index]
         session_sin, session_cos = _session_cyclical_encoding(pd.Timestamp(timestamp))
-        regime_ctx = self._regime_detector.detect_regime(df, index)
+        regime_ctx = self._regime_detector.detect_regime(self._regime_frame(df), index)
         predicted_return_magnitude = abs(
             float(primary_signal.metadata.get("predicted_return", 0.0))
         )

--- a/tests/unit/strategies/components/test_exam_signal_generator.py
+++ b/tests/unit/strategies/components/test_exam_signal_generator.py
@@ -16,13 +16,16 @@ import pytest
 from src.engines.shared.barrier_touch import BarrierTouchResult
 from src.ml.training_pipeline.meta_labels import (
     HIT_RATE_LOOKBACK_FIRES,
+    META_LABEL_FEATURE_ORDER,
     PrimarySignalRecord,
     TradeResolution,
     build_meta_label_features,
+    encode_meta_label_features_for_training,
 )
 from src.prediction import PredictionResult
 from src.prediction.distribution_stats import FrozenDistribution
 from src.prediction.models.onnx_runner import ModelPrediction
+from src.regime.detector import RegimeDetector
 from src.strategies.components.exam_signal_generator import (
     ClassificationExamSignalGenerator,
     MetaLabelExamSignalGenerator,
@@ -768,3 +771,104 @@ class TestMetaLabelHitRateTrainServeParity:
         serving_hit_rate = generator._rolling_hit_rate()
 
         assert serving_hit_rate == pytest.approx(training_hit_rate)
+
+
+@patch("src.strategies.components.exam_signal_generator.PredictionModelRegistry")
+@patch("src.strategies.components.exam_signal_generator.PredictionConfig")
+class TestMetaLabelRegimeTrainServeParity:
+    """PR #981 arch-review finding: training annotates the regime frame ONCE
+    with fresh detector state, while serving re-annotated the FULL frame on
+    every fired bar through a stateful reused detector -- per-fire O(n_bars)
+    at serve time, plus a skew channel (warm hysteresis state can relabel
+    early bars, drifting serve-time regime features away from what the
+    classifier was trained on). Serving now shares training's seam: the
+    frame is annotated once per frame object with fresh detector state and
+    detect_regime reads the precomputed columns. Mirrors the #950
+    rolling_hit_rate parity-test pattern: drive BOTH real code paths over
+    the same corpus and fires, assert identical regime feature values."""
+
+    _WARMUP = 60
+    _FIRE_INDICES = (80, 140, 220, 300, 380)
+
+    @staticmethod
+    def _make_regime_df(periods=400):
+        rng = np.random.default_rng(17)
+        closes = 100.0 + np.cumsum(rng.normal(0, 0.5, periods))
+        return pd.DataFrame(
+            {
+                "open": closes - 0.1,
+                "high": closes + 0.5,
+                "low": closes - 0.5,
+                "close": closes,
+                "volume": 1000.0 + rng.uniform(0, 50, periods),
+            },
+            index=pd.date_range("2024-01-01", periods=periods, freq="1h", tz="UTC"),
+        )
+
+    def _drive_serving(self, mock_registry_class, df) -> list[np.ndarray]:
+        """Run the REAL MetaLabelExamSignalGenerator bar-by-bar; capture the
+        encoded feature row each fired bar sends to the classifier."""
+        captured_rows: list[np.ndarray] = []
+
+        def capture_predict(row):
+            captured_rows.append(np.array(row, copy=True))
+            return _make_meta_label_prediction(0.9)
+
+        mock_bundle = MagicMock()
+        mock_bundle.runner.predict.side_effect = capture_predict
+        mock_registry = MagicMock()
+        mock_registry.select_bundle.return_value = mock_bundle
+        mock_registry_class.return_value = mock_registry
+
+        fire_at = {index: (SignalDirection.BUY, 0.01) for index in self._FIRE_INDICES}
+        generator = MetaLabelExamSignalGenerator(
+            primary_signal_generator=_CannedPrimarySignalGenerator(
+                fire_at=fire_at, warmup=self._WARMUP
+            ),
+            min_confidence=0.0,
+        )
+        for index in range(self._WARMUP, len(df)):
+            generator.generate_signal(df, index)
+        return captured_rows
+
+    def test_serving_annotates_regime_once_per_frame(self, mock_config_class, mock_registry_class):
+        df = self._make_regime_df()
+
+        annotate_calls: list[int] = []
+        original_annotate = RegimeDetector.annotate
+
+        def counting_annotate(detector_self, frame):
+            annotate_calls.append(len(frame))
+            return original_annotate(detector_self, frame)
+
+        with patch.object(RegimeDetector, "annotate", counting_annotate):
+            captured_rows = self._drive_serving(mock_registry_class, df)
+
+        assert len(captured_rows) == len(self._FIRE_INDICES)  # every fire reached prediction
+        assert len(annotate_calls) == 1
+
+    def test_training_and_serving_agree_on_regime_features(
+        self, mock_config_class, mock_registry_class
+    ):
+        df = self._make_regime_df()
+        serving_rows = self._drive_serving(mock_registry_class, df)
+        assert len(serving_rows) == len(self._FIRE_INDICES)
+
+        fires = [
+            PrimarySignalRecord(index=index, direction=1, predicted_return=0.01)
+            for index in self._FIRE_INDICES
+        ]
+        # Regime features are independent of resolutions -- trivial next-bar
+        # resolutions keep build_meta_label_features' input well-formed.
+        resolutions = [
+            TradeResolution(profitable=True, exit_index=index + 1) for index in self._FIRE_INDICES
+        ]
+        features_df = build_meta_label_features(df, fires, resolutions)
+        training_X, _y = encode_meta_label_features_for_training(features_df)
+
+        regime_slots = [
+            META_LABEL_FEATURE_ORDER.index(column)
+            for column in ("regime_trend_encoded", "regime_volatility_encoded", "regime_confidence")
+        ]
+        serving_X = np.stack(serving_rows)
+        np.testing.assert_array_equal(serving_X[:, regime_slots], training_X[:, regime_slots])

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -16,6 +16,8 @@ at fire index t must not be affected by bars after t).
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -251,6 +253,62 @@ class TestRunPrimarySignalForwardCheckpointing:
                 self._make_df(),
                 checkpoint_path=tmp_path / "fires.checkpoint.json",
                 checkpoint_every_bars=0,
+            )
+
+    def test_same_length_different_corpus_checkpoint_is_rejected(self, tmp_path):
+        """PR #981 arch-review finding: guarding only (start_index,
+        total_bars) lets two equal-length but different corpora (another
+        window or symbol) resume-splice silently -- the exact failure the
+        guard exists to prevent. The checkpoint carries a content
+        fingerprint (index endpoints + close-column checksum + generator
+        identity), so an equal-length different corpus must be rejected."""
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        run_primary_signal_forward(
+            self._ScriptedSignalGenerator(), self._make_df(periods=40), checkpoint_path=checkpoint
+        )
+
+        other_window = pd.DataFrame({"close": np.linspace(200.0, 210.0, 40)})
+        with pytest.raises(ValueError, match="checkpoint"):
+            run_primary_signal_forward(
+                self._ScriptedSignalGenerator(), other_window, checkpoint_path=checkpoint
+            )
+
+    def test_start_index_mismatch_checkpoint_is_rejected(self, tmp_path):
+        df = self._make_df()
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        run_primary_signal_forward(self._ScriptedSignalGenerator(), df, checkpoint_path=checkpoint)
+
+        with pytest.raises(ValueError, match="checkpoint"):
+            run_primary_signal_forward(
+                self._ScriptedSignalGenerator(), df, start_index=3, checkpoint_path=checkpoint
+            )
+
+    def test_corrupt_checkpoint_file_is_rejected_loudly(self, tmp_path):
+        """A checkpoint that isn't valid JSON must raise a clear ValueError
+        naming the checkpoint file (policy: never guess, never overwrite a
+        file we can't positively identify as our own checkpoint), not leak
+        a raw json decoding error."""
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        checkpoint.write_text("not json {{{", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="checkpoint"):
+            run_primary_signal_forward(
+                self._ScriptedSignalGenerator(), self._make_df(), checkpoint_path=checkpoint
+            )
+
+    def test_partial_checkpoint_missing_keys_is_rejected_loudly(self, tmp_path):
+        """Valid JSON that isn't a complete checkpoint (e.g. truncated or
+        foreign file) must raise the same clear ValueError -- never a raw
+        KeyError, and never a silent resume from garbage."""
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        checkpoint.write_text(
+            json.dumps({"start_index": 5, "total_bars": 40, "last_completed_index": 10}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="checkpoint"):
+            run_primary_signal_forward(
+                self._ScriptedSignalGenerator(), self._make_df(), checkpoint_path=checkpoint
             )
 
 
@@ -850,12 +908,16 @@ class TestBuildMetaLabelFeaturesRegimeAnnotationSingleTraversal:
         assert len(annotate_calls) == 1
 
     def test_regime_features_match_per_fire_annotation_reference(self):
-        """Equivalence with the old per-call semantics: each fire's regime
-        feature must equal what a per-fire full-frame annotation produces.
-        The reference uses a FRESH detector per fire because
-        RegimeDetector.annotate carries hysteresis state across calls --
-        fresh-per-call is the deterministic form of 'annotate this frame
-        from scratch', exactly what the old path did on its first call."""
+        """Each fire's regime feature must equal a fresh-state full-frame
+        annotation read at that fire's index -- the CORRECT semantics, and
+        what annotate-once produces. This is deliberately NOT a pure
+        old-vs-new equivalence: the old shared-detector path re-annotated
+        per fire with hysteresis state carried over from the previous
+        call's pass, so fires evaluated after the first call could get
+        stale-state labels near the frame start. Where old and new differ,
+        the new fresh-state output is the fix (a behavior correction, not
+        drift); where the old path was already fresh (its first call, and
+        empirically most fires), they are identical."""
         df = self._synthetic_df()
         fires = self._fires()
         resolutions = self._resolved_next_bar(fires, [True, False, True, False])

--- a/tests/unit/training_pipeline/test_ml_training_meta_labels.py
+++ b/tests/unit/training_pipeline/test_ml_training_meta_labels.py
@@ -33,6 +33,7 @@ from src.ml.training_pipeline.meta_labels import (
     run_primary_signal_forward,
     simulate_fired_trade_profitability,
 )
+from src.regime.enhanced_detector import EnhancedRegimeDetector
 from src.strategies.components.signal_generator import Signal, SignalDirection, SignalGenerator
 
 
@@ -115,6 +116,142 @@ class TestRunPrimarySignalForward:
         generator = _StubSignalGenerator({}, warmup=0)
 
         assert run_primary_signal_forward(generator, df) == []
+
+
+class TestRunPrimarySignalForwardCheckpointing:
+    """Defect 2 of #955: a ~47k-bar fire-generation pass ran 60+ min in one
+    uninterruptible pass. run_primary_signal_forward now supports a
+    caller-supplied checkpoint file: progress (fires so far + last completed
+    bar) is persisted every N bars via an atomic write, and a rerun with the
+    same checkpoint resumes after the last completed bar instead of
+    reprocessing from the start."""
+
+    @staticmethod
+    def _make_df(periods: int = 40) -> pd.DataFrame:
+        return pd.DataFrame({"close": np.linspace(100.0, 110.0, periods)})
+
+    class _ScriptedSignalGenerator(SignalGenerator):
+        """Deterministic fires; records every bar index it is asked to
+        evaluate (the counting stub the resume tests assert against), and
+        optionally simulates an interruption at a given bar."""
+
+        def __init__(self, warmup: int = 5, fail_at: int | None = None):
+            super().__init__("scripted_signal_generator")
+            self.evaluated: list[int] = []
+            self._warmup = warmup
+            self._fail_at = fail_at
+
+        def generate_signal(self, df, index, regime=None) -> Signal:
+            if self._fail_at is not None and index >= self._fail_at:
+                raise RuntimeError("simulated interruption")
+            self.evaluated.append(index)
+            if index % 3 == 0:
+                direction = SignalDirection.BUY if index % 2 == 0 else SignalDirection.SELL
+                return Signal(
+                    direction=direction,
+                    strength=0.5,
+                    confidence=0.5,
+                    metadata={"predicted_return": index / 1000.0},
+                )
+            return Signal(direction=SignalDirection.HOLD, strength=0.0, confidence=0.0, metadata={})
+
+        def get_confidence(self, df, index) -> float:
+            return 0.0
+
+        @property
+        def warmup_period(self) -> int:
+            return self._warmup
+
+    def test_checkpointed_run_matches_single_pass_output(self, tmp_path):
+        df = self._make_df()
+        single_pass = run_primary_signal_forward(self._ScriptedSignalGenerator(), df)
+        assert single_pass  # fixture sanity: the comparison below is not vacuous
+
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        chunked = run_primary_signal_forward(
+            self._ScriptedSignalGenerator(),
+            df,
+            checkpoint_path=checkpoint,
+            checkpoint_every_bars=7,
+        )
+
+        assert chunked == single_pass
+
+    def test_interrupted_run_resumes_from_checkpoint_and_matches_single_pass(self, tmp_path):
+        df = self._make_df()
+        single_pass = run_primary_signal_forward(self._ScriptedSignalGenerator(), df)
+
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        failing = self._ScriptedSignalGenerator(fail_at=25)
+        with pytest.raises(RuntimeError, match="simulated interruption"):
+            run_primary_signal_forward(
+                failing, df, checkpoint_path=checkpoint, checkpoint_every_bars=10
+            )
+        assert checkpoint.exists()
+
+        resumed_generator = self._ScriptedSignalGenerator()
+        resumed = run_primary_signal_forward(
+            resumed_generator, df, checkpoint_path=checkpoint, checkpoint_every_bars=10
+        )
+
+        # warmup=5 + checkpoint every 10 bars -> the last durable checkpoint
+        # before the bar-25 crash covers bars 5..24. The resume must evaluate
+        # ONLY bars after it -- no bar at-or-before 24 is reprocessed.
+        assert resumed_generator.evaluated == list(range(25, len(df)))
+        assert resumed == single_pass
+
+    def test_completed_checkpoint_skips_all_bars_on_rerun(self, tmp_path):
+        df = self._make_df()
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        first = run_primary_signal_forward(
+            self._ScriptedSignalGenerator(),
+            df,
+            checkpoint_path=checkpoint,
+            checkpoint_every_bars=10,
+        )
+
+        rerun_generator = self._ScriptedSignalGenerator()
+        rerun = run_primary_signal_forward(
+            rerun_generator, df, checkpoint_path=checkpoint, checkpoint_every_bars=10
+        )
+
+        assert rerun_generator.evaluated == []
+        assert rerun == first
+
+    def test_no_temp_file_left_behind(self, tmp_path):
+        df = self._make_df()
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        run_primary_signal_forward(
+            self._ScriptedSignalGenerator(),
+            df,
+            checkpoint_path=checkpoint,
+            checkpoint_every_bars=10,
+        )
+        assert [p.name for p in tmp_path.iterdir()] == ["fires.checkpoint.json"]
+
+    def test_checkpoint_for_a_different_corpus_is_rejected(self, tmp_path):
+        """Silently reusing a checkpoint recorded against a different window
+        would splice fires from two corpora into one training set -- must
+        raise, never guess."""
+        checkpoint = tmp_path / "fires.checkpoint.json"
+        run_primary_signal_forward(
+            self._ScriptedSignalGenerator(), self._make_df(periods=40), checkpoint_path=checkpoint
+        )
+        with pytest.raises(ValueError, match="checkpoint"):
+            run_primary_signal_forward(
+                self._ScriptedSignalGenerator(),
+                self._make_df(periods=60),
+                checkpoint_path=checkpoint,
+            )
+
+    def test_invalid_checkpoint_interval_is_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="checkpoint_every_bars"):
+            run_primary_signal_forward(
+                self._ScriptedSignalGenerator(),
+                self._make_df(),
+                checkpoint_path=tmp_path / "fires.checkpoint.json",
+                checkpoint_every_bars=0,
+            )
 
 
 class TestSimulateFiredTradeProfitability:
@@ -674,6 +811,105 @@ class TestBuildMetaLabelFeatures:
         ]
         with pytest.raises(ValueError, match="length"):
             build_meta_label_features(df, fires, resolutions)
+
+
+class TestBuildMetaLabelFeaturesRegimeAnnotationSingleTraversal:
+    """Defect 1 of #955: EnhancedRegimeDetector.detect_regime re-annotates
+    the ENTIRE DataFrame on every per-fire call when the regime columns are
+    absent -- O(n_fires * n_bars), which made real (~46k-fire x ~47k-bar)
+    corpora infeasible. build_meta_label_features must annotate exactly once
+    upfront, with output identical to the per-call semantics."""
+
+    _synthetic_df = staticmethod(TestBuildMetaLabelFeatures._synthetic_df)
+    _resolved_next_bar = staticmethod(TestBuildMetaLabelFeatures._resolved_next_bar)
+
+    def _fires(self) -> list[PrimarySignalRecord]:
+        return [
+            PrimarySignalRecord(index=index, direction=1, predicted_return=0.01)
+            for index in (60, 100, 150, 220)
+        ]
+
+    def test_regime_annotation_runs_exactly_once_for_multi_fire_run(self):
+        df = self._synthetic_df()
+        fires = self._fires()
+        resolutions = self._resolved_next_bar(fires, [True, False, True, False])
+
+        detector = EnhancedRegimeDetector()
+        annotate_calls = []
+        original_annotate = detector.base_detector.annotate
+
+        def counting_annotate(frame):
+            annotate_calls.append(len(frame))
+            return original_annotate(frame)
+
+        detector.base_detector.annotate = counting_annotate
+
+        features = build_meta_label_features(df, fires, resolutions, regime_detector=detector)
+
+        assert len(features) == len(fires)
+        assert len(annotate_calls) == 1
+
+    def test_regime_features_match_per_fire_annotation_reference(self):
+        """Equivalence with the old per-call semantics: each fire's regime
+        feature must equal what a per-fire full-frame annotation produces.
+        The reference uses a FRESH detector per fire because
+        RegimeDetector.annotate carries hysteresis state across calls --
+        fresh-per-call is the deterministic form of 'annotate this frame
+        from scratch', exactly what the old path did on its first call."""
+        df = self._synthetic_df()
+        fires = self._fires()
+        resolutions = self._resolved_next_bar(fires, [True, False, True, False])
+
+        features = build_meta_label_features(df, fires, resolutions)
+
+        reference = pd.DataFrame(
+            [
+                {
+                    "regime_trend": regime.trend.value,
+                    "regime_volatility": regime.volatility.value,
+                    "regime_confidence": float(regime.confidence),
+                }
+                for regime in (
+                    EnhancedRegimeDetector().detect_regime(df.copy(), fire.index) for fire in fires
+                )
+            ]
+        )
+
+        pd.testing.assert_frame_equal(
+            features[["regime_trend", "regime_volatility", "regime_confidence"]].reset_index(
+                drop=True
+            ),
+            reference,
+        )
+
+    def test_pre_annotated_frame_is_used_as_is_without_reannotation(self):
+        """The explicit annotate-once seam: a caller that already annotated
+        the frame (e.g. once for a whole training run) must get identical
+        features with ZERO further annotation passes."""
+        from src.regime.detector import RegimeDetector
+
+        df = self._synthetic_df()
+        fires = self._fires()
+        resolutions = self._resolved_next_bar(fires, [True, False, True, False])
+        annotated = RegimeDetector().annotate(df.copy())
+
+        detector = EnhancedRegimeDetector()
+        annotate_calls = []
+        original_annotate = detector.base_detector.annotate
+
+        def counting_annotate(frame):
+            annotate_calls.append(len(frame))
+            return original_annotate(frame)
+
+        detector.base_detector.annotate = counting_annotate
+
+        features_pre_annotated = build_meta_label_features(
+            annotated, fires, resolutions, regime_detector=detector
+        )
+        features_plain = build_meta_label_features(df, fires, resolutions)
+
+        assert annotate_calls == []
+        pd.testing.assert_frame_equal(features_pre_annotated, features_plain)
 
 
 class TestEncodeMetaLabelFeaturesForTraining:

--- a/tests/unit/training_pipeline/test_ml_training_pipeline.py
+++ b/tests/unit/training_pipeline/test_ml_training_pipeline.py
@@ -421,6 +421,69 @@ class TestRunMetaLabelPipeline:
         assert result.success is False
         assert "fire" in result.metadata.get("error", "").lower()
 
+    @patch("src.ml.training_pipeline.pipeline.MLBasicSignalGenerator")
+    @patch("src.ml.training_pipeline.pipeline.download_price_data")
+    def test_fire_generation_checkpoint_wired_by_default(
+        self, mock_download, mock_signal_cls, tmp_path
+    ):
+        """#955 defect 2's motivating call site: the real meta_label
+        training run's fire generation (the ~60-min uncheckpointed pass
+        that task-lifetime caps killed twice) must be checkpoint-protected
+        by default, with the checkpoint under the run's data dir and
+        removed after a successful run (crash-recovery artifact, not a
+        cache -- a completed checkpoint must never silently reuse fires
+        across primary-model retrains)."""
+        from pathlib import Path
+
+        from src.ml.training_pipeline.meta_labels import (
+            run_primary_signal_forward as real_run_primary_signal_forward,
+        )
+
+        mock_download.return_value = self._synthetic_price_df()
+        mock_signal_cls.return_value = self._StubPrimarySignalGenerator()
+        ctx = self._make_ctx(tmp_path)
+
+        captured: dict = {}
+
+        def spy(signal_generator, df, start_index=None, **kwargs):
+            captured.update(kwargs)
+            return real_run_primary_signal_forward(signal_generator, df, start_index, **kwargs)
+
+        with patch("src.ml.training_pipeline.pipeline.run_primary_signal_forward", side_effect=spy):
+            result = run_training_pipeline(ctx)
+
+        assert result.success is True
+        checkpoint_path = captured.get("checkpoint_path")
+        assert checkpoint_path is not None
+        checkpoint_path = Path(checkpoint_path)
+        assert ctx.paths.data_dir in checkpoint_path.parents
+        assert not checkpoint_path.exists()  # removed after success
+
+    @patch("src.ml.training_pipeline.pipeline.MLBasicSignalGenerator")
+    @patch("src.ml.training_pipeline.pipeline.download_price_data")
+    def test_fire_generation_checkpoint_disableable_via_config(
+        self, mock_download, mock_signal_cls, tmp_path
+    ):
+        from src.ml.training_pipeline.meta_labels import (
+            run_primary_signal_forward as real_run_primary_signal_forward,
+        )
+
+        mock_download.return_value = self._synthetic_price_df()
+        mock_signal_cls.return_value = self._StubPrimarySignalGenerator()
+        ctx = self._make_ctx(tmp_path, meta_label_fire_checkpoint_dir=None)
+
+        captured: dict = {}
+
+        def spy(signal_generator, df, start_index=None, **kwargs):
+            captured.update(kwargs)
+            return real_run_primary_signal_forward(signal_generator, df, start_index, **kwargs)
+
+        with patch("src.ml.training_pipeline.pipeline.run_primary_signal_forward", side_effect=spy):
+            result = run_training_pipeline(ctx)
+
+        assert result.success is True
+        assert captured.get("checkpoint_path") is None
+
 
 @pytest.mark.fast
 @pytest.mark.skipif(not _TENSORFLOW_AVAILABLE, reason="TensorFlow not installed")


### PR DESCRIPTION
## What / Why

Fixes both performance defects from #955 (found during the #933 target-redesign tournament) that made real meta-label training runs infeasible without tournament-local workaround scripts, plus review-round hardening (fingerprint corpus guard, train/serve regime parity, default pipeline wiring).

**Defect 1 — per-fire full-frame regime annotation (and the hysteresis behavior fix).** `build_meta_label_features` passed the raw frame to `EnhancedRegimeDetector.detect_regime`, which re-annotates the ENTIRE DataFrame whenever the regime columns are absent — ~46k full-frame annotations over a ~47k-bar corpus (the >40-min-never-completed path; annotate-once measured 38.4s in the tournament). The frame is now annotated exactly once upfront with fresh detector state and passed to `detect_regime`, which sees the `regime_label` column and skips its own pass. Callers that already annotated the frame get zero-reannotation behavior (explicit seam, no identity-keyed caching in training).

This is a behavior FIX, not a pure refactor: the old shared-detector path carried `RegimeDetector.annotate` hysteresis state across per-fire calls, so fires evaluated after the first call could get stale-state labels near the frame start. The new path always produces fresh-state labels — strictly more correct where the two differ. **Implication for models trained pre-PR:** regime features (`regime_trend`/`regime_volatility`/`regime_confidence`) can drift slightly versus what a pre-PR training run produced for early-frame fires; empirically zero divergences on random-walk fixtures (500-bar shared-warm-detector comparison), but any strict reproduction of a pre-PR training set should retrain rather than assume bit-identity.

**Train/serve regime skew (review round).** Serving (`MetaLabelExamSignalGenerator`) re-annotated the full frame per fired bar through a warm stateful reused detector — per-fire O(n_bars) at serve time and a skew channel against training's fresh-state labels. Serving now shares the training seam: the frame is annotated once per frame object with fresh (cloned-config) detector state and `detect_regime` reads the precomputed columns; the cache invalidates on frame change or in-place growth. Annotation is row-causal (all trailing windows), so full-frame annotation leaks no forward bars into the current signal.

**Defect 2 — uninterruptible fire generation.** `run_primary_signal_forward` over a ~47k-bar window ran 60+ min in one pass; task-lifetime caps killed it twice at ~3540s. It now takes optional `checkpoint_path` (+ `checkpoint_every_bars`, default 1000 ≈ every 5s at the measured ~200 bars/s): fires so far and the last completed bar are persisted as JSON via temp-file + atomic rename, and a rerun resumes after the last completed bar. Resume/finalize/removal are logged.

*Corpus guard (review round):* the checkpoint stores a content fingerprint — frame index endpoints, sha256 over the close column, resolved start index, and generator identity — so two equal-length but different corpora can never resume-splice. **Policy: raise `ValueError`** on fingerprint mismatch AND on corrupt/incomplete JSON — a file that cannot be positively identified as this run's own checkpoint is never resumed from and never overwritten (silently overwriting could destroy another run's progress or, on a mis-pointed path, an unrelated file); the operator deletes the file or picks another path to start fresh.

*Pipeline wiring (review round):* `_run_meta_label_pipeline` — the exact call site the ~60-min cap killed — now checkpoints by default under `<data_dir>/meta_label_fire_checkpoints/fires_{SYMBOL}_{timeframe}_{fingerprint16}.json` (fingerprint in the filename so window/symbol changes between crash and rerun resolve to different files instead of tripping the mismatch rejection). The checkpoint is removed after a successful run — it is a crash-recovery artifact, not a cache, because fires depend on primary-model weights the fingerprint cannot see. Override/disable via `TrainingConfig.meta_label_fire_checkpoint_dir` (`"auto"` default / explicit dir / `None` to disable).

Closes #955

## Testing performed

Strict TDD — new tests written first and observed failing on the old code, then implemented:

- `TestBuildMetaLabelFeaturesRegimeAnnotationSingleTraversal` (meta_labels): `test_regime_annotation_runs_exactly_once_for_multi_fire_run` (spy, failed with 4 != 1), `test_regime_features_match_per_fire_annotation_reference` (pandas equality vs fresh-state reference; docstring documents the behavior-fix framing), `test_pre_annotated_frame_is_used_as_is_without_reannotation`
- `TestRunPrimarySignalForwardCheckpointing` (meta_labels): `test_checkpointed_run_matches_single_pass_output`, `test_interrupted_run_resumes_from_checkpoint_and_matches_single_pass` (counting stub proves bars before the checkpoint are never reprocessed), `test_completed_checkpoint_skips_all_bars_on_rerun`, `test_no_temp_file_left_behind`, `test_checkpoint_for_a_different_corpus_is_rejected`, `test_same_length_different_corpus_checkpoint_is_rejected` (failed pre-fix: silent resume-splice), `test_start_index_mismatch_checkpoint_is_rejected`, `test_corrupt_checkpoint_file_is_rejected_loudly` (failed pre-fix: raw JSONDecodeError), `test_partial_checkpoint_missing_keys_is_rejected_loudly` (failed pre-fix: raw KeyError), `test_invalid_checkpoint_interval_is_rejected`
- `TestMetaLabelRegimeTrainServeParity` (exam_signal_generator): `test_serving_annotates_regime_once_per_frame` (failed pre-fix with 5 != 1), `test_training_and_serving_agree_on_regime_features` (drives BOTH real paths, asserts identical encoded regime feature values — mirrors the #950 hit-rate parity pattern)
- `TestRunMetaLabelPipeline` (pipeline): `test_fire_generation_checkpoint_wired_by_default` (failed pre-fix: no checkpoint kwarg; asserts path under data_dir and removal after success), `test_fire_generation_checkpoint_disableable_via_config`

Results:
- `pytest tests/unit/training_pipeline tests/unit/strategies tests/unit/regime` — **1494 passed**
- `atb dev quality --changed` — black, ruff, mypy all green
- Pre-existing environment-dependent failure in `tests/unit/ml/training_pipeline/test_models_tft.py` (asserts lightgbm NOT installed; local venv has it) — unrelated, filed as #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)