### PR TITLE
fix: reconciliation edge paths — offline-SL double-count, partial-exit size reset, silent periodic close failures

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Reconciliation edge paths: offline-SL double-count, partial-exit size
+  reset, silent periodic close failures** (2026-07-12 loop/state audit,
+  closes #980): (1) the legacy SL-based startup fallback re-applied an
+  offline-filled stop's `realized_pnl` on top of a `current_balance` the
+  exchange sync had already overwritten with the post-fill exchange balance —
+  double-counting the P&L in memory and in the `account_balances` ledger; the
+  fallback now skips the balance re-application while a sync correction is
+  pending (the Trade row and performance record still book the close), and
+  `synchronize_account_on_start` persists the POST-reconcile
+  `current_balance` instead of the stale pre-reconcile snapshot (write-only
+  `_pending_corrected_balance` removed). (2) The startup quantity-mismatch
+  correction (`_verify_entry_order`) overwrote `current_size` with the
+  recomputed full size, re-inflating a partially-exited recovered position to
+  full deployed size (over-sized final close, over-reported P&L); it now
+  preserves the remaining fraction (`new_size * prev_current/prev_original`,
+  the same scaling the SL re-placement uses) and omits a zero `current_size`
+  from the DB persist. (3) The periodic reconciler's external-close branches
+  (margin + spot) popped the position from the tracker and stayed silent when
+  the DB `close_position` failed, stranding an OPEN row the cycle never
+  revisits; both branches now escalate like their startup twins — CRITICAL
+  log plus a paged `system_events` row (`RECONCILE_DB_CLOSE_FAILED`,
+  `alert=True`).
 - **Deterministic backtest inference; loud live timeout accounting** (#912
   side-finding): `PredictionEngine` gated every model inference behind
   `run_with_timeout(max_prediction_latency)` — a 0.1s latency-*alerting*

--- a/src/engines/live/reconciliation.py
+++ b/src/engines/live/reconciliation.py
@@ -1682,17 +1682,33 @@ class PositionReconciler:
                     entry_price = position.entry_price
                     entry_balance = getattr(position, "entry_balance", None)
                     if entry_price and entry_price > 0 and entry_balance and entry_balance > 0:
-                        new_size = (filled_qty * entry_price) / entry_balance
+                        new_size = (filled_qty * float(entry_price)) / float(entry_balance)
                         position.size = new_size
+                        # The entry fill defines the ORIGINAL deployment.
+                        # current_size must keep any partial-exit reduction
+                        # (same current/original scaling as the SL re-placement
+                        # above) — overwriting it with new_size would re-inflate
+                        # a partially-exited position to full size and oversize
+                        # its final close. Coerce to float: DB-loaded positions
+                        # carry Decimal fields (#673 Bug 2 class).
+                        remaining_fraction = 1.0
+                        denom = prev_original_size if prev_original_size is not None else prev_size
+                        denom_f = float(denom) if denom is not None else 0.0
+                        if prev_current_size is not None and denom_f > 0:
+                            remaining_fraction = min(
+                                max(float(prev_current_size) / denom_f, 0.0), 1.0
+                            )
                         if hasattr(position, "current_size"):
-                            position.current_size = new_size
+                            position.current_size = new_size * remaining_fraction
                         if hasattr(position, "original_size"):
                             position.original_size = new_size
                         logger.info(
-                            "Size recalculated for %s: %s → %.6f",
+                            "Size recalculated for %s: %s → %.6f "
+                            "(remaining fraction %.4f preserved)",
                             position.symbol,
                             prev_size,
                             new_size,
+                            remaining_fraction,
                         )
 
                     # Persist corrected quantity/size to DB
@@ -1700,7 +1716,14 @@ class PositionReconciler:
                     correction_kwargs: dict[str, float | None] = {"quantity": filled_qty}
                     if entry_price and entry_price > 0 and entry_balance and entry_balance > 0:
                         correction_kwargs["size"] = getattr(position, "size", None)
-                        correction_kwargs["current_size"] = getattr(position, "current_size", None)
+                        # A fully-drained position (current_size 0 after partial
+                        # exits) stays 0 in memory; omit it from the persist —
+                        # _persist_position_correction rejects non-positive
+                        # values, and None means "leave the DB value untouched".
+                        cur_size = getattr(position, "current_size", None)
+                        correction_kwargs["current_size"] = (
+                            cur_size if cur_size is not None and cur_size > 0 else None
+                        )
                         correction_kwargs["original_size"] = getattr(
                             position, "original_size", None
                         )
@@ -3597,6 +3620,8 @@ class PeriodicReconciler:
                         # AccountSynchronizer._sync_margin_equity, so no balance move here.
                         if db_closed and removed is not None:
                             self._position_reconciler._log_external_close_trade(position)
+                        elif removed is not None and db_pos_id is not None:
+                            self._escalate_failed_db_close(position, db_pos_id)
                 except Exception as e:
                     logger.warning(
                         "Margin position check failed for %s: %s",
@@ -3770,6 +3795,8 @@ class PeriodicReconciler:
                         # reconciler), gated on the close succeeding.
                         if db_closed and removed is not None:
                             self._position_reconciler._log_external_close_trade(position)
+                        elif removed is not None and db_pos_id is not None:
+                            self._escalate_failed_db_close(position, db_pos_id)
 
                         if severity > max_severity:
                             max_severity = severity
@@ -4116,6 +4143,35 @@ class PeriodicReconciler:
         shown = "; ".join(unique[:limit])
         extra = len(unique) - limit
         return f"{shown} (+{extra} more)" if extra > 0 else shown
+
+    def _escalate_failed_db_close(self, position: Any, db_pos_id: Any) -> None:
+        """Page on an external close that popped the tracker but left the DB row OPEN.
+
+        The periodic loop iterates the tracker, so once the position is popped
+        the OPEN row is never re-examined — it heals only on restart re-adoption.
+        The startup twins (``_verify_asset_holdings`` / ``_remove_phantom_position``)
+        treat this identical condition as CRITICAL; mirror them here instead of
+        diverging silently. Emits an honest paged system_event (``alert=True``);
+        safe to POST here — the cycle iterates a snapshot, no tracker lock is held.
+        """
+        symbol = getattr(position, "symbol", "?")
+        logger.critical(
+            "External close for %s: removed from tracker but DB position %s close "
+            "FAILED (still OPEN) — memory/DB divergence; manual reconciliation may "
+            "be needed.",
+            symbol,
+            db_pos_id,
+        )
+        _emit_event(
+            self.on_event,
+            EventType.ALERT,
+            f"External close for {symbol}: position removed from tracker but DB "
+            f"position {db_pos_id} is still OPEN (close failed) — memory/DB "
+            "divergence until the next restart re-adoption",
+            severity="critical",
+            error_code="RECONCILE_DB_CLOSE_FAILED",
+            alert=True,
+        )
 
     def _audit_unprotected(self, position: Any, cause: str) -> str:
         """Persist a CRITICAL audit row for a position left without a stop-loss and

--- a/src/engines/live/recovery.py
+++ b/src/engines/live/recovery.py
@@ -75,6 +75,10 @@ class RecoveryEngineState(Protocol):
     _active_symbol: str | None
     _orphan_sweep_cooldown: dict[str, float]
     _base_asset_locks: BaseAssetLockRegistry
+    # True while a startup exchange-balance overwrite awaits its DB persist
+    # (set by LiveStartupSequencer.synchronize_account_on_start before
+    # reconciliation runs) — the synced balance already reflects offline fills.
+    _pending_balance_correction: bool
 
     # Mutated during recovery
     trading_session_id: int | None
@@ -617,6 +621,14 @@ class LiveSessionRecoverer:
             logger.info("📊 No local positions to reconcile")
             return
 
+        # When synchronize_account_on_start overwrote current_balance with the
+        # exchange-queried value THIS startup (the flag is still pending its DB
+        # persist while reconciliation runs), that balance already reflects any
+        # offline SL fill — the exchange executed the stop before the balance
+        # was queried. `is True` keeps non-bool sentinels (mock states) on the
+        # conservative re-apply path.
+        balance_synced_from_exchange = getattr(state, "_pending_balance_correction", False) is True
+
         try:
             positions_to_close = state.stop_loss_manager.find_offline_filled_stops(
                 positions_snapshot
@@ -707,8 +719,19 @@ class LiveSessionRecoverer:
                                 e,
                             )
 
-                    # Atomic balance update for offline stop-loss reconciliation
-                    if state.trading_session_id is not None:
+                    # Atomic balance update for offline stop-loss reconciliation.
+                    # Skipped when the exchange-synced balance already reflects
+                    # this fill — re-applying realized_pnl would double-count it
+                    # in memory AND in the account_balances ledger. The Trade
+                    # row / performance record below still book the close.
+                    if balance_synced_from_exchange:
+                        logger.info(
+                            "💰 Offline stop-loss P&L $%+.2f for %s already reflected in "
+                            "exchange-synced balance — skipping balance re-application",
+                            realized_pnl,
+                            position.symbol,
+                        )
+                    elif state.trading_session_id is not None:
                         try:
                             with state.db_manager.atomic_balance_update(
                                 balance_change=realized_pnl,

--- a/src/engines/live/startup.py
+++ b/src/engines/live/startup.py
@@ -47,7 +47,6 @@ class LiveStartupEngineState(Protocol):
     trading_session_id: int | None
     _recovered_inactive_session_id: int | None
     _pending_balance_correction: bool
-    _pending_corrected_balance: float | None
     _orphan_sweep_cooldown: dict[str, float]
     _balance_lock: threading.Lock
     main_thread: threading.Thread | None
@@ -336,7 +335,6 @@ class LiveStartupSequencer:
         state = self._state
         # Perform account synchronization if available
         state._pending_balance_correction = False
-        state._pending_corrected_balance = None
         if state.account_synchronizer and state.enable_live_trading:
             try:
                 logger.info("🔄 Performing initial account synchronization...")
@@ -357,7 +355,6 @@ class LiveStartupSequencer:
                         with state._balance_lock:
                             state.current_balance = corrected_balance
                             state._pending_balance_correction = True
-                            state._pending_corrected_balance = corrected_balance
                         logger.info(
                             "💰 Balance corrected from exchange: $%.2f",
                             corrected_balance,
@@ -401,12 +398,16 @@ class LiveStartupSequencer:
                 getattr(state, "_pending_balance_correction", False)
                 and state.trading_session_id is not None
             ):
-                corrected_balance = state._pending_corrected_balance
+                # Persist the CURRENT in-memory balance, not the pre-reconcile
+                # snapshot: reconciliation (which runs between the exchange sync
+                # and this persist) may legitimately adjust current_balance, and
+                # writing the stale snapshot would diverge the DB row from
+                # memory — the next restart recovers the wrong balance.
+                corrected_balance = state.current_balance
                 state.db_manager.update_balance(
                     corrected_balance, "account_sync", "system", state.trading_session_id
                 )
                 state._pending_balance_correction = False
-                state._pending_corrected_balance = None
                 logger.info("💰 Balance corrected in database: $%.2f", corrected_balance)
             elif getattr(state, "_pending_balance_correction", False):
                 # Balance correction was pending but no session ID available
@@ -414,7 +415,6 @@ class LiveStartupSequencer:
                     "⚠️ Balance correction pending but no trading session ID available - skipping database update"
                 )
                 state._pending_balance_correction = False
-                state._pending_corrected_balance = None
 
     def start_runtime_services(self, symbol: str, timeframe: str) -> None:
         """Start the order tracker, periodic reconciler, and WebSocket streams."""

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -761,7 +761,6 @@ class LiveTradingEngine:
         # session is wired; owned by LiveStartupSequencer, declared here so the
         # engine carries the attribute for the startup backref Protocol (#486).
         self._pending_balance_correction: bool = False
-        self._pending_corrected_balance: float | None = None
         # Set during start() for live trading
         self._periodic_reconciler: PeriodicReconciler | None = None
         # Shared per-base-asset cooldown for the orphaned-borrow sweep, so the

--- a/tests/unit/engines/live/test_startup_sequencer.py
+++ b/tests/unit/engines/live/test_startup_sequencer.py
@@ -107,3 +107,34 @@ def test_synchronize_account_persists_balance_correction():
 
     assert state.current_balance == 1234.5
     state.db_manager.update_balance.assert_called_once_with(1234.5, "account_sync", "system", 7)
+
+
+def test_synchronize_account_persists_post_reconcile_balance():
+    """The persisted balance must be the POST-reconcile in-memory value.
+
+    Reconciliation (step b, between the exchange sync and the DB persist) may
+    legitimately adjust ``current_balance``; persisting the pre-reconcile
+    snapshot writes a stale value that diverges the DB row from memory — the
+    next restart's ``recover_last_balance`` then reads the wrong balance
+    (audit 2026-07-12 F2)."""
+    state = _make_state()
+    state.enable_live_trading = True
+    state.trading_session_id = 7
+    state._active_symbol = "BTCUSDT"
+    state._balance_lock = threading.Lock()  # real CM; annotation-only on the protocol
+    state.account_synchronizer = MagicMock()
+    sync_result = MagicMock()
+    sync_result.success = True
+    sync_result.data = {
+        "balance_sync": {"corrected": True, "old_balance": 1000.0, "new_balance": 1234.5}
+    }
+    state.account_synchronizer.sync_account_data.return_value = sync_result
+
+    def _reconcile_adjusts_balance():
+        state.current_balance = 1200.0
+
+    state._reconcile_positions_with_exchange.side_effect = _reconcile_adjusts_balance
+
+    LiveStartupSequencer(engine_state=state).synchronize_account_on_start()
+
+    state.db_manager.update_balance.assert_called_once_with(1200.0, "account_sync", "system", 7)

--- a/tests/unit/live/test_order_execution.py
+++ b/tests/unit/live/test_order_execution.py
@@ -875,3 +875,66 @@ class TestReconcilePositionsWithExchange:
         engine_with_exchange._reconcile_positions_with_exchange()
 
         assert engine_with_exchange.current_balance < 20000.0
+
+    def test_reconcile_skips_pnl_when_balance_synced_from_exchange(
+        self, engine_with_exchange, sample_position
+    ):
+        """The legacy fallback must not re-apply offline-SL P&L that the
+        exchange-synced balance already reflects.
+
+        synchronize_account_on_start overwrites current_balance with the
+        exchange-queried value BEFORE reconciliation runs; the exchange executed
+        the stop, so that balance already moved. Re-applying realized_pnl here
+        double-counts the loss (audit 2026-07-12 F2)."""
+        engine = engine_with_exchange
+        engine.live_position_tracker.track_recovered_position(sample_position, db_id=None)
+        engine.exchange_interface.get_open_orders.return_value = []
+        sl_order = MagicMock()
+        sl_order.status = ExchangeOrderStatus.FILLED
+        sl_order.average_price = 48000.0
+        engine.exchange_interface.get_order.return_value = sl_order
+        # Simulate the account-sync overwrite that precedes reconciliation.
+        engine.current_balance = 20000.0
+        engine._pending_balance_correction = True
+
+        engine._reconcile_positions_with_exchange()
+
+        # Balance untouched — the SL's P&L is already in the synced value.
+        assert engine.current_balance == 20000.0
+        # The close is still fully booked: tracker cleared + audit trade recorded.
+        assert not engine.live_position_tracker.has_position("entry_order_123")
+        assert len(engine.completed_trades) == 1
+        assert engine.completed_trades[0].exit_reason == "stop_loss_offline"
+
+    def test_reconcile_sessioned_skips_atomic_update_when_balance_synced(
+        self, engine_with_exchange, sample_position
+    ):
+        """Sessioned variant of the double-count guard: no atomic_balance_update
+        (no account_balances re-debit) when the exchange sync already owns the
+        balance, while the Trade row is still persisted (audit 2026-07-12 F2)."""
+        engine = engine_with_exchange
+        engine.trading_session_id = 1
+        engine.live_position_tracker.track_recovered_position(sample_position, db_id=None)
+        engine.exchange_interface.get_open_orders.return_value = []
+        sl_order = MagicMock()
+        sl_order.status = ExchangeOrderStatus.FILLED
+        sl_order.average_price = 48000.0
+        engine.exchange_interface.get_order.return_value = sl_order
+        engine.current_balance = 20000.0
+        engine._pending_balance_correction = True
+        engine.db_manager.atomic_balance_update = MagicMock()
+        engine.db_manager.log_trade = MagicMock(return_value=1)
+
+        # Force the legacy fallback (a session id would otherwise route to
+        # PositionReconciler first).
+        with patch(
+            "src.engines.live.reconciliation.PositionReconciler",
+            side_effect=RuntimeError("reconciler unavailable"),
+        ):
+            engine._reconcile_positions_with_exchange()
+
+        engine.db_manager.atomic_balance_update.assert_not_called()
+        assert engine.current_balance == 20000.0
+        # The audit Trade row is still written even though no balance moved.
+        engine.db_manager.log_trade.assert_called_once()
+        assert engine.db_manager.log_trade.call_args.kwargs["exit_reason"] == "stop_loss_offline"

--- a/tests/unit/live/test_reconciliation.py
+++ b/tests/unit/live/test_reconciliation.py
@@ -2555,6 +2555,90 @@ class TestPartialSLFillQuantityCalculation:
         assert call_kwargs.kwargs["quantity"] == pytest.approx(0.15)
 
 
+# ---------- Startup Quantity Correction vs Partial-Exit State ----------
+
+
+class TestQuantityCorrectionPreservesPartialExit:
+    """A >1% entry-fill quantity mismatch on a recovered position recomputes
+    size from the ORIGINAL entry fill — it must not re-inflate ``current_size``
+    past the partial-exit reduction (audit 2026-07-12 F3): the final close
+    would then be sized to the full position instead of the remainder."""
+
+    @staticmethod
+    def _filled_entry(mock_exchange, filled_qty):
+        from src.data_providers.exchange_interface import OrderStatus as ExOS
+
+        order = MockExchangeOrder(
+            status=ExOS.FILLED, average_price=50000.0, filled_quantity=filled_qty
+        )
+        mock_exchange.get_order.return_value = order
+
+    def test_correction_preserves_partial_exit_fraction(self, reconciler, mock_exchange):
+        """50% partially exited + 5% fill mismatch → current_size stays at 50%
+        of the corrected size, so the final close sells the remaining half."""
+        # Stored: qty 0.02 @ 50000 on entry_balance 10000 → size 0.1.
+        # Half exited: current_size 0.05. Exchange says the entry actually
+        # filled 0.021 (5% more) → corrected full size 0.105.
+        pos = MockPosition(
+            quantity=0.02,
+            size=0.1,
+            original_size=0.1,
+            current_size=0.05,
+            partial_exits_taken=1,
+            entry_balance=10000.0,
+        )
+        self._filled_entry(mock_exchange, filled_qty=0.021)
+
+        reconciler.reconcile_position(pos)
+
+        assert pos.quantity == pytest.approx(0.021)
+        assert pos.size == pytest.approx(0.105)
+        assert pos.original_size == pytest.approx(0.105)
+        # The partial-exit reduction survives: 50% of the corrected size,
+        # NOT the full 0.105.
+        assert pos.current_size == pytest.approx(0.0525)
+
+    def test_correction_without_partial_exits_sets_full_size(self, reconciler, mock_exchange):
+        """No partial exits → current_size tracks the corrected full size."""
+        pos = MockPosition(
+            quantity=0.02,
+            size=0.1,
+            original_size=0.1,
+            current_size=0.1,
+            entry_balance=10000.0,
+        )
+        self._filled_entry(mock_exchange, filled_qty=0.021)
+
+        reconciler.reconcile_position(pos)
+
+        assert pos.size == pytest.approx(0.105)
+        assert pos.original_size == pytest.approx(0.105)
+        assert pos.current_size == pytest.approx(0.105)
+
+    def test_correction_with_fully_exited_position_keeps_zero_current_size(
+        self, reconciler, mock_exchange, mock_db
+    ):
+        """current_size 0 (fully drained by partials) must stay 0 — not be
+        re-inflated — and must not be persisted (the persist helper rejects
+        non-positive values)."""
+        pos = MockPosition(
+            quantity=0.02,
+            size=0.1,
+            original_size=0.1,
+            current_size=0.0,
+            partial_exits_taken=2,
+            entry_balance=10000.0,
+        )
+        self._filled_entry(mock_exchange, filled_qty=0.021)
+
+        result = reconciler.reconcile_position(pos)
+
+        assert pos.current_size == pytest.approx(0.0)
+        assert pos.size == pytest.approx(0.105)
+        # Correction survived (no ValueError rollback from persisting 0).
+        assert any(c.field == "quantity" for c in result.corrections)
+
+
 # ---------- Periodic SL Placement for Unprotected Positions ----------
 
 
@@ -3944,6 +4028,88 @@ class TestPeriodicExternalCloseTradeRow:
             c for c in on_event.call_args_list if c.kwargs.get("error_code") == "RECONCILE_HIGH"
         ]
         assert high_events, f"expected RECONCILE_HIGH, got {on_event.call_args_list}"
+
+    @staticmethod
+    def _db_close_failed_events(on_event):
+        return [
+            c
+            for c in on_event.call_args_list
+            if c.kwargs.get("error_code") == "RECONCILE_DB_CLOSE_FAILED"
+        ]
+
+    def test_spot_external_close_db_close_failure_escalates_critical(self, mock_exchange):
+        """Popped from the tracker but the DB row stays OPEN → memory/DB
+        divergence the periodic loop never revisits (it iterates the tracker).
+        Must page via a CRITICAL system_event like the startup twin
+        (_verify_asset_holdings), not fail silently (audit 2026-07-12 F5)."""
+        from tests.mocks import MockDatabaseManager
+
+        db = MockDatabaseManager()
+        _db_id, tracker, pos = self._seed(db, side="long")
+        db.close_position = MagicMock(return_value=False)  # swallowed DB error -> False
+
+        mock_exchange.get_order.side_effect = self._order_side_effect()
+        mock_exchange.get_balance.side_effect = lambda asset: (
+            MockBalance(asset="USDT", total=5200.0)
+            if asset == "USDT"
+            else MockBalance(asset="BTC", total=0.0, free=0.0, locked=0.0)
+        )
+        data_provider = MagicMock()
+        data_provider.get_current_price.return_value = 52000.0
+        on_event = MagicMock()
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=tracker,
+            db_manager=db,
+            session_id=1,
+            interval=60,
+            data_provider=data_provider,
+            on_event=on_event,
+        )
+        reconciler._reconcile_cycle()
+
+        assert pos.order_id not in tracker.positions  # popped
+        events = self._db_close_failed_events(on_event)
+        assert events, f"expected RECONCILE_DB_CLOSE_FAILED, got {on_event.call_args_list}"
+        assert events[0].kwargs.get("severity") == "critical"
+        assert events[0].kwargs.get("alert") is True
+
+    def test_margin_external_close_db_close_failure_escalates_critical(self, mock_exchange):
+        """Margin twin of the spot escalation: a failed DB close after the
+        tracker pop must page, mirroring _remove_phantom_position's CRITICAL
+        (audit 2026-07-12 F5)."""
+        from tests.mocks import MockDatabaseManager
+
+        db = MockDatabaseManager()
+        _db_id, tracker, pos = self._seed(db, side="short")
+        db.close_position = MagicMock(return_value=False)
+
+        mock_exchange.get_order.side_effect = self._order_side_effect()
+        mock_exchange.get_margin_borrowed = MagicMock(return_value=0.0)  # short closed
+        mock_exchange.get_balance.side_effect = lambda asset: MockBalance(asset=asset, total=0.0)
+        data_provider = MagicMock()
+        data_provider.get_current_price.return_value = 48000.0
+        on_event = MagicMock()
+
+        reconciler = PeriodicReconciler(
+            exchange_interface=mock_exchange,
+            position_tracker=tracker,
+            db_manager=db,
+            session_id=1,
+            interval=60,
+            use_margin=True,
+            data_provider=data_provider,
+            on_event=on_event,
+        )
+        reconciler._reconcile_cycle()
+
+        assert pos.order_id not in tracker.positions  # popped
+        assert len(db._trades) == 0  # audit Trade row still gated on db_closed
+        events = self._db_close_failed_events(on_event)
+        assert events, f"expected RECONCILE_DB_CLOSE_FAILED, got {on_event.call_args_list}"
+        assert events[0].kwargs.get("severity") == "critical"
+        assert events[0].kwargs.get("alert") is True
 
 
 def test_remove_phantom_position_writes_audit(reconciler, mock_db):


### PR DESCRIPTION
Closes #980. Three P2s from the 2026-07-12 loop/state audit (findings F2/F3/F5); TDD failing-first — each audit trigger scenario is a test in this PR.

## User-facing impact

- **No more double-counted offline-stop P&L on the legacy startup fallback.** When the exchange-synced balance already reflects an offline SL fill, `reconcile_positions_with_exchange`'s legacy path (`src/engines/live/recovery.py`) no longer re-applies `realized_pnl` on top of it (previously counted twice in memory AND in the `account_balances` ledger). The Trade row, performance record, and DB position close still book the trade. Gate is the pending sync-correction flag; when the account sync failed or made no correction, P&L application is unchanged.
- **Persisted startup balance is the post-reconcile value.** `synchronize_account_on_start` (`src/engines/live/startup.py`) persisted the pre-reconcile `_pending_corrected_balance` snapshot, so any legitimate reconcile adjustment diverged DB from memory (and a later restart recovered the stale row). It now persists `state.current_balance`; the now write-only `_pending_corrected_balance` attribute is removed everywhere.
- **Quantity correction respects partial-exit state.** `_verify_entry_order`'s >1% fill-mismatch branch (`src/engines/live/reconciliation.py`) corrects the ORIGINAL entry quantity/size but now scales `current_size` by the previous `current/original` fraction (same scaling the SL re-placement path already uses) instead of resetting it to full size — a recovered position 50% partially exited keeps a 50% `current_size`, so its final close sizes to the remainder, not 100%. A fully-drained `current_size` of 0 stays 0 and is omitted from the DB persist (which rejects non-positive values). Also coerces `entry_price`/`entry_balance` to float in the size recompute (latent Decimal×float `TypeError` for DB-loaded positions, #673 Bug 2 class).
- **Periodic external-close failures now page instead of diverging silently.** Both `_reconcile_cycle` external-close branches (margin + spot) pop the tracker before `close_position`; when the DB close fails they previously left the row OPEN with no signal, and the cycle (which iterates the tracker) never revisits it. They now mirror their startup twins (`_verify_asset_holdings` / `_remove_phantom_position`): CRITICAL log + honest paged `system_events` row (`RECONCILE_DB_CLOSE_FAILED`, `severity=critical`, `alert=True`) via the shared `_escalate_failed_db_close` helper. No close-only trigger — matching startup behavior; the exchange position is already gone, so this is divergence observability, not capital risk.

## Testing performed

- TDD: all 8 new tests written first and confirmed failing on the audited behavior (double-count of -40.96 reproduced; stale 1234.5 persisted instead of 1200.0; current_size re-inflated 0.05→0.105; no `RECONCILE_DB_CLOSE_FAILED` event), then green after the fix:
  - `tests/unit/live/test_order_execution.py` — sessionless + sessioned double-count guards (Trade row still booked)
  - `tests/unit/engines/live/test_startup_sequencer.py` — post-reconcile balance persisted
  - `tests/unit/live/test_reconciliation.py` — 50% partial preserved / no-partial full-size / fully-drained-zero cases; spot + margin periodic escalation
- Full unit suite (`pytest tests/ -n 4 -m "not integration and not slow"`): **5297 passed, 1 failed** — the failure is the pre-existing, environment-dependent lightgbm dispatch test (fails identically on a clean checkout; already tracked in #991/#985).
- `atb dev quality --changed`: black + ruff + mypy all pass.

## Related

- Deliberately NOT fixed here: #979 (partial-ops final close bypasses base-asset lock + DB accounting) — gated on #734's rework; cross-referenced on #734.
- `docs/changelog.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)