### PR TITLE
fix(experiments): thread config.symbol into ExperimentRunner strategy factories (#997)

### DIFF
--- a/src/experiments/diagnostics/runner.py
+++ b/src/experiments/diagnostics/runner.py
@@ -66,6 +66,7 @@ class SignalDiagnostic:
         strategy = self.runner._load_strategy(
             cfg.strategy_name,
             factory_kwargs=cfg.factory_kwargs or None,
+            symbol=cfg.symbol,
         )
         signal_generator = getattr(strategy, "signal_generator", None)
         if signal_generator is None:

--- a/src/experiments/runner.py
+++ b/src/experiments/runner.py
@@ -14,6 +14,7 @@ from src.data_providers.offline import FixtureProvider, RandomWalkProvider
 from src.engines.backtest.engine import Backtester
 from src.experiments.schemas import ExperimentConfig, ExperimentResult
 from src.risk.risk_manager import RiskParameters
+from src.strategies import factory_accepts_symbol
 from src.strategies.components import Strategy
 from src.strategies.hyper_growth import create_hyper_growth_strategy
 from src.strategies.ml_adaptive import create_ml_adaptive_strategy
@@ -63,6 +64,7 @@ class ExperimentRunner:
         self,
         strategy_name: str,
         factory_kwargs: dict[str, object] | None = None,
+        symbol: str | None = None,
     ) -> Strategy:
         """Construct a strategy, optionally passing kwargs to the factory.
 
@@ -72,6 +74,15 @@ class ExperimentRunner:
         (which is baked into the LeverageManager at construction), and
         ``min_regime_bars``. For post-construction knobs like
         ``long_entry_threshold`` use ``parameters`` overrides instead.
+
+        ``symbol`` (typically ``config.symbol``, the symbol the backtest
+        actually runs on) is auto-injected into the factory call when the
+        factory accepts a ``symbol`` parameter — mirroring the live-runner
+        and CLI backtest loaders (backtest-live parity). Without this, ML
+        strategies silently default their signal generator's symbol to
+        ``MLBasicSignalGenerator.DEFAULT_SYMBOL`` ("BTCUSDT"), scoring
+        whatever symbol the backtest runs on with the wrong model (GH #997).
+        An explicit ``symbol`` key in ``factory_kwargs`` always wins.
         """
         strategies: dict[str, Callable[..., Strategy]] = {
             "ml_basic": create_ml_basic_strategy,
@@ -83,6 +94,8 @@ class ExperimentRunner:
         if builder is None:
             raise ValueError(f"Unknown strategy: {strategy_name}")
         kwargs = dict(factory_kwargs or {})
+        if symbol is not None and "symbol" not in kwargs and factory_accepts_symbol(builder):
+            kwargs["symbol"] = symbol
         if not kwargs:
             return builder()
         try:
@@ -451,6 +464,7 @@ class ExperimentRunner:
         strategy = self._load_strategy(
             config.strategy_name,
             factory_kwargs=config.factory_kwargs or None,
+            symbol=config.symbol,
         )
         # Apply any parameter overrides for strategy-level tuning
         self._apply_parameter_overrides(strategy, config)

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -26,7 +26,24 @@ __all__ = [
     "create_leveraged_regime_strategy",
     "create_hyper_growth_strategy",
     "call_strategy_factory",
+    "factory_accepts_symbol",
 ]
+
+
+def factory_accepts_symbol(factory: Callable[..., Any]) -> bool:
+    """Return whether ``factory`` has a ``symbol`` parameter (or ``**kwargs``).
+
+    Shared by every caller that must decide whether to thread a trading
+    symbol into a strategy factory — passing ``symbol=`` to a factory that
+    doesn't accept it raises ``TypeError``, so callers check this first.
+    """
+    try:
+        parameters = inspect.signature(factory).parameters
+    except (TypeError, ValueError):
+        return False
+    return "symbol" in parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
 
 
 def call_strategy_factory(factory: Callable[..., Any], *, symbol: str | None = None) -> "Strategy":
@@ -40,13 +57,6 @@ def call_strategy_factory(factory: Callable[..., Any], *, symbol: str | None = N
     """
     if symbol is None:
         return factory()
-    try:
-        parameters = inspect.signature(factory).parameters
-    except (TypeError, ValueError):
-        return factory()
-    accepts_symbol = "symbol" in parameters or any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
-    )
-    if accepts_symbol:
+    if factory_accepts_symbol(factory):
         return factory(symbol=symbol)
     return factory()

--- a/tests/unit/experiments/test_diagnostics.py
+++ b/tests/unit/experiments/test_diagnostics.py
@@ -162,6 +162,7 @@ class _StubRunner:
         self,
         strategy_name: str,
         factory_kwargs: dict[str, Any] | None = None,  # noqa: ARG002
+        symbol: str | None = None,  # noqa: ARG002
     ) -> _StubStrategy:
         return self._strategy
 
@@ -316,7 +317,10 @@ def test_strategy_without_signal_generator_raises() -> None:
 
     class _NoGenRunner:
         def _load_strategy(
-            self, _name: str, factory_kwargs: dict[str, Any] | None = None  # noqa: ARG002
+            self,
+            _name: str,
+            factory_kwargs: dict[str, Any] | None = None,  # noqa: ARG002
+            symbol: str | None = None,  # noqa: ARG002
         ) -> _NoGenStrategy:
             return _NoGenStrategy()
 

--- a/tests/unit/experiments/test_runner_symbol_wiring.py
+++ b/tests/unit/experiments/test_runner_symbol_wiring.py
@@ -1,0 +1,148 @@
+"""Tests that ExperimentRunner threads config.symbol into strategy factories.
+
+Regression coverage for GH #997: ``ExperimentRunner._load_strategy`` built
+strategies via ``builder(**factory_kwargs)`` and never threaded
+``config.symbol`` in, so any ML strategy run through the experiments
+framework without an explicit ``symbol`` factory kwarg silently defaulted
+its signal generator's symbol to ``MLBasicSignalGenerator.DEFAULT_SYMBOL``
+("BTCUSDT") -- scoring whatever symbol's candles the backtest actually ran
+on with the wrong model. This mirrors the equivalent regression suites for
+the live runner (``tests/unit/engines/live/test_runner_symbol_wiring.py``)
+and the backtest CLI (``tests/unit/cli/test_backtest_symbol_wiring.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.experiments.runner import ExperimentRunner
+from src.experiments.schemas import ExperimentConfig
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+ENGINE_PATH = "src.strategies.components.ml_signal_generator.PredictionEngine"
+CONFIG_PATH = "src.strategies.components.ml_signal_generator.PredictionConfig"
+
+
+def _mock_prediction_engine():
+    engine = MagicMock()
+    engine.health_check.return_value = {"status": "healthy"}
+    return engine
+
+
+class TestLoadStrategySymbolThreading:
+    """Direct ``_load_strategy`` coverage of the auto-injection logic."""
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_threads_symbol_to_hyper_growth(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+        runner = ExperimentRunner()
+
+        strategy = runner._load_strategy("hyper_growth", symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_threads_symbol_to_ml_basic(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+        runner = ExperimentRunner()
+
+        strategy = runner._load_strategy("ml_basic", symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    def test_explicit_factory_kwargs_symbol_wins_over_auto_injected(self):
+        """An explicit factory_kwargs["symbol"] must not be silently
+        overwritten by the auto-injected config.symbol."""
+        runner = ExperimentRunner()
+
+        with patch(
+            "src.experiments.runner.create_hyper_growth_strategy", autospec=True
+        ) as mock_create:
+            runner._load_strategy(
+                "hyper_growth",
+                factory_kwargs={"symbol": "SOLUSDT"},
+                symbol="ETHUSDT",
+            )
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["symbol"] == "SOLUSDT"
+
+    def test_no_symbol_kwarg_means_no_injection(self):
+        """Callers that don't pass symbol (e.g. legacy call sites) keep the
+        pre-fix behavior rather than injecting a stray None."""
+        runner = ExperimentRunner()
+
+        with patch(
+            "src.experiments.runner.create_hyper_growth_strategy", autospec=True
+        ) as mock_create:
+            runner._load_strategy("hyper_growth")
+
+        mock_create.assert_called_once_with()
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_factory_without_symbol_param_not_regressed(self, _cfg, engine_cls):
+        """ml_adaptive's factory (create_ml_adaptive_strategy) has no
+        `symbol` parameter at all -- auto-injection must detect this via
+        inspect.signature and skip it rather than raising
+        TypeError: create_ml_adaptive_strategy() got an unexpected keyword
+        argument 'symbol'."""
+        engine_cls.return_value = _mock_prediction_engine()
+        runner = ExperimentRunner()
+
+        strategy = runner._load_strategy("ml_adaptive", symbol="ETHUSDT")
+
+        assert strategy is not None
+        assert not hasattr(strategy.signal_generator, "symbol")
+
+
+class TestRunThreadsConfigSymbol:
+    """End-to-end coverage through the public ``run()`` entry point.
+
+    ``Backtester`` is replaced with a capturing stub so the test exercises
+    the real strategy-construction path (including ``_load_strategy``'s
+    kwarg merging) without running an actual backtest.
+    """
+
+    class _CapturingBacktester:
+        captured_strategy = None
+
+        def __init__(self, *, strategy, **_kwargs):
+            type(self).captured_strategy = strategy
+
+        def run(self, **_kwargs):
+            return {}
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_run_threads_config_symbol_into_ml_strategy_factory(
+        self, _cfg, engine_cls, monkeypatch
+    ):
+        engine_cls.return_value = _mock_prediction_engine()
+        monkeypatch.setattr("src.experiments.runner.Backtester", self._CapturingBacktester)
+
+        runner = ExperimentRunner()
+        end = datetime.now(UTC)
+        start = end - timedelta(hours=2)
+        cfg = ExperimentConfig(
+            strategy_name="hyper_growth",
+            symbol="ETHUSDT",
+            timeframe="1h",
+            start=start,
+            end=end,
+            initial_balance=1000.0,
+            provider="mock",
+            use_cache=False,
+        )
+
+        runner.run(cfg)
+
+        captured = self._CapturingBacktester.captured_strategy
+        assert captured is not None
+        assert captured.signal_generator.symbol == "ETHUSDT"

--- a/tests/unit/experiments/test_runner_symbol_wiring.py
+++ b/tests/unit/experiments/test_runner_symbol_wiring.py
@@ -85,21 +85,27 @@ class TestLoadStrategySymbolThreading:
 
         mock_create.assert_called_once_with()
 
-    @patch(ENGINE_PATH)
-    @patch(CONFIG_PATH)
-    def test_factory_without_symbol_param_not_regressed(self, _cfg, engine_cls):
-        """ml_adaptive's factory (create_ml_adaptive_strategy) has no
-        `symbol` parameter at all -- auto-injection must detect this via
-        inspect.signature and skip it rather than raising
-        TypeError: create_ml_adaptive_strategy() got an unexpected keyword
-        argument 'symbol'."""
-        engine_cls.return_value = _mock_prediction_engine()
+    def test_factory_without_symbol_param_not_regressed(self):
+        """A factory with no ``symbol`` parameter (and no ``**kwargs``) must
+        be called without one -- auto-injection detects support via
+        inspect.signature and skips it rather than raising
+        ``TypeError: ... got an unexpected keyword argument 'symbol'``.
+
+        Every real registry factory now accepts ``symbol`` (GH #1002), so
+        the no-symbol case is exercised with a stub."""
         runner = ExperimentRunner()
+        built = MagicMock(name="strategy")
 
-        strategy = runner._load_strategy("ml_adaptive", symbol="ETHUSDT")
+        def _symbolless_factory():
+            return built
 
-        assert strategy is not None
-        assert not hasattr(strategy.signal_generator, "symbol")
+        with patch(
+            "src.experiments.runner.create_ml_adaptive_strategy",
+            new=_symbolless_factory,
+        ):
+            strategy = runner._load_strategy("ml_adaptive", symbol="ETHUSDT")
+
+        assert strategy is built
 
 
 class TestRunThreadsConfigSymbol:

--- a/tests/unit/strategies/test_call_strategy_factory.py
+++ b/tests/unit/strategies/test_call_strategy_factory.py
@@ -1,0 +1,66 @@
+"""Tests for the shared symbol-threading helpers in ``src.strategies``.
+
+``factory_accepts_symbol`` is the single source of truth every runner (live,
+backtest CLI, ExperimentRunner) uses to decide whether a strategy factory
+should receive ``symbol=``. These tests pin its behavior directly against
+synthetic factories so the "does this factory accept symbol" check stays
+correct independent of any specific strategy module.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.strategies import call_strategy_factory, factory_accepts_symbol
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+
+def _factory_with_symbol(name: str = "x", *, symbol: str | None = None):
+    return {"name": name, "symbol": symbol}
+
+
+def _factory_without_symbol(name: str = "x"):
+    return {"name": name}
+
+
+def _factory_with_var_keyword(name: str = "x", **kwargs):
+    return {"name": name, **kwargs}
+
+
+class TestFactoryAcceptsSymbol:
+    def test_true_when_symbol_is_a_named_parameter(self):
+        assert factory_accepts_symbol(_factory_with_symbol) is True
+
+    def test_false_when_no_symbol_parameter(self):
+        """Mirrors real non-ML factories like create_chaos_test_strategy,
+        which has no symbol parameter at all."""
+        assert factory_accepts_symbol(_factory_without_symbol) is False
+
+    def test_true_when_factory_accepts_var_keyword(self):
+        assert factory_accepts_symbol(_factory_with_var_keyword) is True
+
+    def test_false_for_uninspectable_callable(self):
+        """Builtins/C callables raise ValueError from inspect.signature; the
+        helper must fall back to False rather than propagating that error."""
+        assert factory_accepts_symbol(dict) is False
+
+
+class TestCallStrategyFactory:
+    def test_threads_symbol_when_accepted(self):
+        result = call_strategy_factory(_factory_with_symbol, symbol="ETHUSDT")
+        assert result == {"name": "x", "symbol": "ETHUSDT"}
+
+    def test_omits_symbol_when_not_accepted(self):
+        """A factory with no symbol parameter must be called unchanged
+        rather than raising TypeError."""
+        result = call_strategy_factory(_factory_without_symbol, symbol="ETHUSDT")
+        assert result == {"name": "x"}
+
+    def test_none_symbol_never_forwarded(self):
+        factory = MagicMock(return_value="strategy")
+        result = call_strategy_factory(factory, symbol=None)
+        factory.assert_called_once_with()
+        assert result == "strategy"


### PR DESCRIPTION
## Summary

Fixes #997. `ExperimentRunner._load_strategy` built strategies via `builder(**factory_kwargs)` and never threaded `config.symbol` in, so any ML strategy (e.g. `hyper_growth` via `create_hyper_growth_strategy`) run through the experiments framework without an explicit `symbol` factory kwarg silently defaulted its signal generator's symbol to `MLBasicSignalGenerator.DEFAULT_SYMBOL` ("BTCUSDT") — scoring whatever symbol's candles the backtest actually ran on with the **wrong model**. No fail-fast triggered because a BTCUSDT model genuinely exists in the registry.

This is the same class of bug already fixed for the live runner and backtest CLI (`src/engines/live/runner.py::load_strategy`, `cli/commands/backtest.py::_load_strategy`), both of which explicitly thread `symbol=` into the factory call. `ExperimentRunner` (used by ad-hoc `experiments/*.py` research driver scripts) was missing this.

## What changed

- Extracted the "does this factory accept `symbol`" signature check out of `call_strategy_factory` into a standalone `factory_accepts_symbol()` helper in `src/strategies/__init__.py`, so it's reusable outside `call_strategy_factory`'s narrower call convention. `call_strategy_factory` now delegates to it (behavior unchanged).
- `ExperimentRunner._load_strategy` now accepts a `symbol` parameter and auto-injects it into `factory_kwargs` when: (a) the caller passed a non-`None` symbol, (b) the target factory's signature accepts `symbol` (or `**kwargs`), and (c) the caller hasn't already set an explicit `factory_kwargs["symbol"]` — explicit always wins over auto-injected.
- `ExperimentRunner.run()` now passes `symbol=config.symbol`.
- `SignalDiagnostic.run()` (`src/experiments/diagnostics/runner.py`) shares the same `_load_strategy` method and had the identical bug (its own docstring claims "factory kwargs, providers, and symbols are configured identically to a backtest suite" — this was false until now); fixed the same way.

## Confirmed impact on past research

Per #997: reproducing round 1's exit-geometry study (`docs/research/experiments/2026-07-12_exit-geometry-honest.md`, #970/#971) and PR #976's regression-evidence table with the bug present matches their published control numbers to full float precision on the F1 2023H1 fold (31 trades, -2.881754238240264% return, PF 0.6623077792846185, MaxDD 4.846836585357486%) — confirming both silently scored ETHUSDT candles with the BTCUSDT `basic` model, not "the currently-deployed live ETHUSDT model" as claimed.

**Empirical re-verification of round 1's numbers under the corrected symbol threading (GH #998) is deliberately NOT done in this PR** — it requires a backtest sweep, and the local compute lock was held by a concurrent session running an unrelated backtest sweep at the time this fix was written. That re-run is separate follow-up work; #998 is left open for whoever picks it up.

## Also filed (out of scope for this PR)

While tracing the fix, found that `create_ml_adaptive_strategy` / `create_ml_sentiment_strategy` (and the underlying `MLSignalGenerator` component) have **no `symbol` parameter at all** — a deeper, structural version of the same bug affecting every call path (live, CLI, and experiments), not just this one. Filed as #1002 and dispatched separately; not folded into this PR since it touches different files/classes and needs its own historical-impact review.

## Testing performed

- `pytest -m "not integration and not slow" tests/unit/experiments/ tests/unit/strategies/ tests/unit/cli/test_backtest_symbol_wiring.py tests/unit/engines/live/test_runner_symbol_wiring.py -q` → **1216 passed**
- Verified the new tests actually catch the pre-fix bug: stashed the fix, re-ran `tests/unit/experiments/test_runner_symbol_wiring.py`, confirmed 5 failures including the exact `AssertionError: assert 'BTCUSDT' == 'ETHUSDT'` regression this PR closes; restored the fix and re-confirmed all green.
- `atb dev quality --changed --branch origin/develop` → black/ruff/mypy all pass.
- **No backtest, `experiments/*.py` sweep, or `atb backtest` was run** — this PR is a targeted code + unit-test fix only, per explicit instruction to avoid heavy-compute work while another session held the local compute lock.

## New tests

- `tests/unit/experiments/test_runner_symbol_wiring.py`: (a) `_load_strategy`/`run()` thread `config.symbol` into `hyper_growth`/`ml_basic`; (b) explicit `factory_kwargs={"symbol": ...}` wins over auto-injection; (c) `ml_adaptive` (whose factory has no `symbol` param) still constructs without a `TypeError` regression.
- `tests/unit/strategies/test_call_strategy_factory.py`: unit coverage for the extracted `factory_accepts_symbol`/`call_strategy_factory` helpers against synthetic factory signatures.

## Review

This is money-path-adjacent research-tooling code (it changes what gets backtested/scored, not live trading execution directly). Flagging for `architecture-reviewer` and `code-reviewer` per this repo's CLAUDE.md workflow — not merging without that review.
