### PR TITLE
feat(backtest): point-in-time model pinning — --model-version / --model-as-of (#988)

### DIFF
--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sys
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
@@ -33,6 +34,7 @@ from src.strategies import (
 )
 from src.strategies.components import Strategy
 from src.strategies.exam_target_redesign import (
+    MODEL_VERSION_OVERRIDE_ENV_VAR,
     create_exam_binary_direction_strategy,
     create_exam_meta_label_strategy,
     create_exam_smoothed_return_strategy,
@@ -42,12 +44,40 @@ from src.trading.symbols.factory import SymbolFactory
 
 logger = logging.getLogger("atb.backtest")
 
+# Registry model type each pinnable strategy scores with — required to
+# resolve --model-as-of (and to detect promotion boundaries) BEFORE the
+# strategy is constructed. Mirrors the model_type each factory wires into
+# its MLBasicSignalGenerator; exam strategies are absent deliberately (they
+# consume MODEL_VERSION_OVERRIDE_ENV_VAR and span several registry
+# namespaces, so --model-version is their only supported pin).
+_PINNABLE_STRATEGY_MODEL_TYPES: dict[str, str] = {
+    "ml_basic": "basic",
+    "hyper_growth": "basic",
+}
 
-def _load_strategy(strategy_name: str, symbol: str | None = None):
+# Exam-only strategies read the pin from MODEL_VERSION_OVERRIDE_ENV_VAR at
+# construction (PR #950's mechanism) instead of a model_version kwarg.
+_EXAM_STRATEGY_NAMES = frozenset(
+    {
+        "exam_binary_direction",
+        "exam_triple_barrier",
+        "exam_smoothed_return",
+        "exam_meta_label",
+    }
+)
+
+
+def _load_strategy(strategy_name: str, symbol: str | None = None, model_version: str | None = None):
     """Load a strategy by name, threading the trading symbol when supported.
 
     Mirrors the live runner (backtest-live parity): the symbol must reach ML
     signal generators so model registry selection matches the traded pair.
+
+    ``model_version`` pins ML predictions to that exact registry version
+    (GH #988): mainline factories receive it as an explicit kwarg via
+    ``call_strategy_factory`` (which refuses factories that cannot honor
+    it); exam factories pick it up from ``MODEL_VERSION_OVERRIDE_ENV_VAR``,
+    set here only for the duration of construction.
     """
     # Define available strategies with their import paths and classes
     available_strategies: dict[str, Callable[..., Strategy]] = {
@@ -76,7 +106,9 @@ def _load_strategy(strategy_name: str, symbol: str | None = None):
     try:
         builder = available_strategies.get(strategy_name)
         if builder is not None:
-            return call_strategy_factory(builder, symbol=symbol)
+            if model_version is not None and strategy_name in _EXAM_STRATEGY_NAMES:
+                return _call_exam_factory_pinned(builder, symbol, model_version)
+            return call_strategy_factory(builder, symbol=symbol, model_version=model_version)
 
         print(f"Unknown strategy: {strategy_name}")
         print(f"Available strategies: {', '.join(available_strategies.keys())}")
@@ -84,6 +116,121 @@ def _load_strategy(strategy_name: str, symbol: str | None = None):
     except Exception as exc:
         logger.error(f"Error loading strategy: {exc}")
         raise
+
+
+def _call_exam_factory_pinned(
+    builder: Callable[..., Strategy], symbol: str | None, model_version: str
+) -> Strategy:
+    """Construct an exam strategy with the version pin set in its env var.
+
+    Exam factories read ``MODEL_VERSION_OVERRIDE_ENV_VAR`` at construction
+    time only, so the override is scoped to this call and restored after —
+    it must never leak into the wider process (or a later unpinned
+    construction in the same process would silently inherit the pin).
+    """
+    prior = os.environ.get(MODEL_VERSION_OVERRIDE_ENV_VAR)
+    os.environ[MODEL_VERSION_OVERRIDE_ENV_VAR] = model_version
+    try:
+        return call_strategy_factory(builder, symbol=symbol)
+    finally:
+        if prior is None:
+            os.environ.pop(MODEL_VERSION_OVERRIDE_ENV_VAR, None)
+        else:
+            os.environ[MODEL_VERSION_OVERRIDE_ENV_VAR] = prior
+
+
+def _parse_as_of(value: str) -> datetime:
+    """argparse type for --model-as-of: ISO date/datetime, naive means UTC."""
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"invalid date {value!r} — use YYYY-MM-DD or an ISO 8601 datetime"
+        ) from exc
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed
+
+
+def _resolve_model_pin(
+    ns: argparse.Namespace, start_date: datetime, end_date: datetime
+) -> str | None:
+    """Resolve --model-version/--model-as-of into a registry version id.
+
+    For --model-as-of, resolution asks "which version WAS latest at that
+    date?" using bundle metadata timestamps (see
+    ``src/prediction/models/version_resolver.py``). Either way, when the
+    backtest window spans a model-promotion boundary a loud warning maps
+    each window segment to the version that was live then — the run is
+    still pinned to ONE version (never switched mid-backtest), so segments
+    live-traded by another version are not comparable (GH #988).
+
+    Returns None when no pin was requested (zero behavior change).
+    """
+    model_version: str | None = getattr(ns, "model_version", None)
+    model_as_of: datetime | None = getattr(ns, "model_as_of", None)
+    if model_version is None and model_as_of is None:
+        return None
+
+    from src.prediction.config import PredictionConfig
+    from src.prediction.models.version_resolver import (
+        list_version_records,
+        promotion_segments,
+        resolve_version_as_of,
+    )
+
+    # Same normalization the ML signal generator applies for registry
+    # selection, so resolution looks at the directory the pin will load from.
+    registry_symbol = SymbolFactory.to_exchange_symbol(ns.symbol, "binance")
+    registry_path = PredictionConfig.from_config_manager().model_registry_path
+    model_type = _PINNABLE_STRATEGY_MODEL_TYPES.get(ns.strategy)
+
+    if model_as_of is not None:
+        if model_type is None:
+            print(
+                f"--model-as-of is not supported for strategy '{ns.strategy}': its "
+                f'registry model type is unknown, so "which version was latest at '
+                f'that date" cannot be resolved. Pass --model-version with an '
+                f"explicit version id instead."
+            )
+            raise SystemExit(1)
+        record = resolve_version_as_of(registry_path, registry_symbol, model_type, model_as_of)
+        model_version = record.version_id
+        logger.info(
+            "Resolved --model-as-of %s to %s/%s version %s (effective %s, from %s)",
+            model_as_of.isoformat(),
+            registry_symbol,
+            model_type,
+            model_version,
+            record.effective_at.isoformat(),
+            record.source,
+        )
+
+    if model_type is not None:
+        records = list_version_records(registry_path, registry_symbol, model_type)
+        segments = promotion_segments(records, start_date, end_date)
+        if len(segments) > 1:
+            segment_lines = "\n".join(
+                f"  - {segment.version_id or 'NO VERSION YET (live ran a cross-symbol substitute or no model)'}: "
+                f"{segment.start.isoformat()} -> {segment.end.isoformat()}"
+                for segment in segments
+            )
+            logger.warning(
+                "MODEL PROMOTION BOUNDARY INSIDE BACKTEST WINDOW: %d different "
+                "%s/%s model registry states between %s and %s:\n%s\n"
+                "The ENTIRE window will be scored with pinned version %s — the "
+                "backtest never switches models mid-window, so segments that "
+                "live-traded under a different version are NOT comparable to "
+                "live results (GH #988; promotion record: "
+                "docs/research/model-promotions.md).",
+                len(segments),
+                registry_symbol,
+                model_type,
+                start_date.isoformat(),
+                end_date.isoformat(),
+                segment_lines,
+                model_version,
+            )
+
+    return model_version
 
 
 def _get_date_range(args):
@@ -112,8 +259,11 @@ def _handle(ns: argparse.Namespace) -> int:
 
         start_date, end_date = _get_date_range(ns)
 
-        strategy = _load_strategy(ns.strategy, symbol=ns.symbol)
+        model_version = _resolve_model_pin(ns, start_date, end_date)
+        strategy = _load_strategy(ns.strategy, symbol=ns.symbol, model_version=model_version)
         logger.info(f"Loaded strategy: {strategy.name}")
+        if model_version is not None:
+            logger.info(f"Model version pinned for this backtest: {model_version}")
 
         if getattr(ns, "mock_data", False):
             # Test-only escape hatch (mirrors `atb live --mock-data`,
@@ -380,5 +530,24 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "--disable-engine-sl",
         action="store_true",
         help="Disable engine-level stop loss and take profit checks (strategy signals only)",
+    )
+    pin_group = p.add_mutually_exclusive_group()
+    pin_group.add_argument(
+        "--model-version",
+        default=None,
+        help="Pin ML predictions to this exact registry version (e.g. "
+        "2026-07-04_22h_v1) instead of resolving 'latest' at invocation time. "
+        "Required for honest comparisons against live windows that predate "
+        "the current 'latest' model.",
+    )
+    pin_group.add_argument(
+        "--model-as-of",
+        type=_parse_as_of,
+        default=None,
+        metavar="DATE",
+        help="Pin ML predictions to whichever registry version was 'latest' "
+        "at this UTC date/datetime (YYYY-MM-DD or ISO 8601), resolved from "
+        "bundle metadata timestamps. Warns when the backtest window spans a "
+        "model-promotion boundary.",
     )
     p.set_defaults(func=_handle)

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -160,6 +160,45 @@ Important flags:
 | `--risk-per-trade` / `--max-risk-per-trade` | Override `RiskParameters` for the run. |
 | `--log-to-db` | Persist the session to PostgreSQL for later inspection. |
 | `--start` / `--end` | Explicit date boundaries (override `--days`). |
+| `--model-version` | Pin ML predictions to an exact registry version (e.g. `2026-07-04_22h_v1`) instead of resolving `latest` at invocation time. |
+| `--model-as-of DATE` | Pin to whichever version was `latest` at that UTC date, resolved from bundle metadata timestamps (`src/prediction/models/version_resolver.py`). Mutually exclusive with `--model-version`. |
+
+### Point-in-time model pinning
+
+Without a pin, the backtest resolves the model through the registry's `latest`
+symlink **at invocation time** — so a backtest over a window that spans a
+model promotion silently re-scores history with a model that was never live
+for it (GH #988; this confound dominated the 2026-07-12 parity-gap
+investigation). For any live-vs-backtest comparison, pin the model that was
+actually live:
+
+```bash
+# Pin to whatever was latest when the live window started
+atb backtest hyper_growth --symbol ETHUSDT --start 2026-06-02 --end 2026-07-12 --model-as-of 2026-06-02
+
+# Or pin an explicit version id
+atb backtest ml_basic --symbol BTCUSDT --days 90 --model-version 2025-10-26_21h_v1
+```
+
+Notes:
+
+- When the backtest window spans a promotion boundary, the CLI logs a loud
+  warning mapping each window segment to the version that was live then. The
+  run is still scored with the **single** pinned version — the engine never
+  switches models mid-backtest — so treat cross-boundary comparisons with care.
+- `--model-as-of` uses each bundle's `metadata.json` `created_at` as a proxy
+  for its promotion time; the authoritative promotion record is
+  `docs/research/model-promotions.md`.
+- If no version existed at the `--model-as-of` date (live was running a
+  cross-symbol substitute), the run fails fast with an explanatory error
+  rather than picking a model that was never live.
+- A pin that cannot be honored (unknown version, timeframe mismatch, or a
+  strategy without pinning support) aborts the run — a "pinned" backtest can
+  never silently fall back to `latest`. Mainline support: `ml_basic` and
+  `hyper_growth`; exam strategies accept `--model-version` via
+  `ATB_MODEL_VERSION_OVERRIDE`.
+- The live trading path is unaffected: it always resolves `latest` and cannot
+  be pinned by env var or config.
 
 Strategies available via the CLI loader today: `ml_basic`, `ml_sentiment`, `ml_adaptive`, `ensemble_weighted`, and
 `momentum_leverage`. Add new strategies under `src/strategies` and register them in `_load_strategy` to expose them through the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Point-in-time model pinning for the backtest harness** (#988): new
+  `atb backtest` flags `--model-version` (pin an exact registry version) and
+  `--model-as-of DATE` (resolve which version was `latest` at that date from
+  bundle metadata timestamps, via `src/prediction/models/version_resolver.py`).
+  Reuses PR #950's pinning mechanism (`get_bundle_by_key` /
+  `ATB_MODEL_VERSION_OVERRIDE`); `MLBasicSignalGenerator` accepts an explicit
+  `model_version` and scores every bar with it, bypassing `latest`. Warns
+  loudly when the backtest window spans a model-promotion boundary (the
+  confound behind the 12-vs-6-trade parity gap, see
+  `docs/research/notes/2026-07-12_parity-gap-investigation.md`). Fail-closed:
+  an unhonorable pin aborts instead of silently resolving `latest`. Zero
+  behavior change when neither flag is passed; the live path cannot be pinned.
+
 ### Fixed
 - **Reconciliation edge paths: offline-SL double-count, partial-exit size
   reset, silent periodic close failures** (2026-07-12 loop/state audit,

--- a/src/prediction/models/version_resolver.py
+++ b/src/prediction/models/version_resolver.py
@@ -1,0 +1,234 @@
+"""Point-in-time model version resolution from bundle metadata timestamps.
+
+The backtest harness resolves models via the ``latest`` symlink at
+invocation time, so a backtest spanning a model-promotion boundary silently
+scores history with a model that was never live for it (GH #988). This
+module answers "which version WAS latest at date X?" so the harness can pin
+the right one and warn when a window spans a promotion boundary.
+
+Each bundle's ``metadata.json`` ``created_at`` is used as the moment the
+version became ``latest``. That is an approximation: promotion (the symlink
+flip) happens shortly after training, and a trained-but-never-promoted
+version would still be counted. The authoritative promotion record is
+``docs/research/model-promotions.md`` — cross-check it when a resolution is
+load-bearing. Resolution here is deliberately deterministic and in-repo so
+the backtest CLI needs no external state.
+
+Consumed by the backtest CLI only — never on the live trading path, which
+must always resolve ``latest`` (see ``PredictionModelRegistry.select_bundle``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from .exceptions import ModelNotAvailableError
+
+logger = logging.getLogger(__name__)
+
+# Version directories follow {YYYY-MM-DD}_{...} (e.g. 2026-07-04_22h_v1);
+# the date prefix dates bundles whose metadata lacks created_at.
+_VERSION_ID_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})(?:_|$)")
+
+
+@dataclass(frozen=True)
+class VersionRecord:
+    """One model version and when it (approximately) became ``latest``.
+
+    Attributes:
+        version_id: Version directory name, e.g. ``2026-07-04_22h_v1``.
+        effective_at: UTC timestamp the version is treated as live from.
+        source: Where the timestamp came from — ``"metadata"``
+            (metadata.json ``created_at``) or ``"version_id"`` (date prefix
+            of the directory name).
+    """
+
+    version_id: str
+    effective_at: datetime
+    source: str
+
+
+@dataclass(frozen=True)
+class PromotionSegment:
+    """A maximal sub-interval of a backtest window served by one version.
+
+    ``version_id`` is None when no version existed yet for that part of the
+    window (live would have run a cross-symbol substitute or nothing).
+    """
+
+    version_id: str | None
+    start: datetime
+    end: datetime
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    """Interpret naive datetimes as UTC; convert aware ones to UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _timestamp_from_metadata(bundle_dir: Path) -> datetime | None:
+    """Parse metadata.json's created_at, or None when absent/unparseable."""
+    metadata_path = bundle_dir / "metadata.json"
+    if not metadata_path.exists():
+        return None
+    try:
+        with open(metadata_path, encoding="utf-8") as f:
+            metadata = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    created_at = metadata.get("created_at")
+    if not isinstance(created_at, str):
+        return None
+    try:
+        return _ensure_utc(datetime.fromisoformat(created_at))
+    except ValueError:
+        return None
+
+
+def _timestamp_from_version_id(version_id: str) -> datetime | None:
+    """Parse the {YYYY-MM-DD} prefix of a version directory name."""
+    match = _VERSION_ID_DATE_RE.match(version_id)
+    if match is None:
+        return None
+    year, month, day = (int(part) for part in match.groups())
+    try:
+        return datetime(year, month, day, tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def list_version_records(
+    registry_path: str | Path, symbol: str, model_type: str
+) -> list[VersionRecord]:
+    """List every dateable version under ``{registry}/{symbol}/{model_type}``.
+
+    Sorted by (effective_at, version_id) so resolution and boundary
+    detection are deterministic. Versions that cannot be dated (no
+    metadata ``created_at`` and no date-prefixed directory name) are
+    skipped with a warning — they cannot participate in point-in-time
+    resolution.
+    """
+    model_type_dir = Path(registry_path) / symbol / model_type
+    if not model_type_dir.is_dir():
+        return []
+
+    records: list[VersionRecord] = []
+    for version_dir in model_type_dir.iterdir():
+        if not version_dir.is_dir() or version_dir.name == "latest":
+            continue
+        effective_at = _timestamp_from_metadata(version_dir)
+        source = "metadata"
+        if effective_at is None:
+            effective_at = _timestamp_from_version_id(version_dir.name)
+            source = "version_id"
+        if effective_at is None:
+            logger.warning(
+                "Skipping undateable model version %s/%s/%s: no metadata created_at "
+                "and no YYYY-MM-DD prefix in the directory name",
+                symbol,
+                model_type,
+                version_dir.name,
+            )
+            continue
+        records.append(
+            VersionRecord(
+                version_id=version_dir.name, effective_at=effective_at, source=source
+            )
+        )
+
+    records.sort(key=lambda record: (record.effective_at, record.version_id))
+    return records
+
+
+def resolve_version_as_of(
+    registry_path: str | Path, symbol: str, model_type: str, as_of: datetime
+) -> VersionRecord:
+    """Resolve which version was ``latest`` for symbol/model_type at ``as_of``.
+
+    Returns the newest version with ``effective_at <= as_of`` (inclusive:
+    a version is live from the instant it appears).
+
+    Raises:
+        ModelNotAvailableError: No version existed at ``as_of`` — either
+            the registry has none at all for this symbol/model_type, or all
+            of them postdate ``as_of`` (live would have been running a
+            cross-symbol substitute; see docs/research/model-promotions.md).
+    """
+    as_of_utc = _ensure_utc(as_of)
+    records = list_version_records(registry_path, symbol, model_type)
+    if not records:
+        raise ModelNotAvailableError(
+            f"No {symbol}/{model_type} model versions found under {registry_path} — "
+            f"cannot resolve which version was latest at {as_of_utc.isoformat()}."
+        )
+
+    active = [record for record in records if record.effective_at <= as_of_utc]
+    if not active:
+        earliest = records[0]
+        raise ModelNotAvailableError(
+            f"No {symbol}/{model_type} model version existed at {as_of_utc.isoformat()}: "
+            f"the earliest is {earliest.version_id} "
+            f"(effective {earliest.effective_at.isoformat()}). Live trading before that "
+            f"date ran a cross-symbol substitute or no model at all — see "
+            f"docs/research/model-promotions.md."
+        )
+    return active[-1]
+
+
+def promotion_segments(
+    records: list[VersionRecord], start: datetime, end: datetime
+) -> list[PromotionSegment]:
+    """Split a backtest window into sub-intervals served by one version each.
+
+    A promotion strictly inside (start, end) starts a segment; one exactly
+    at ``end`` affects zero bars and does not split. The first segment's
+    ``version_id`` is None when the window starts before any version
+    existed. More than one segment means the window spans a promotion
+    boundary and a single pinned model cannot match live's entire history.
+    """
+    start_utc = _ensure_utc(start)
+    end_utc = _ensure_utc(end)
+
+    def _active_version_at(moment: datetime) -> str | None:
+        active_id: str | None = None
+        for record in records:
+            if record.effective_at <= moment:
+                active_id = record.version_id
+        return active_id
+
+    # Deduplicated: two versions sharing one effective_at must not create a
+    # zero-length segment (the later-sorted version wins the whole segment).
+    boundaries = sorted(
+        {
+            record.effective_at
+            for record in records
+            if start_utc < record.effective_at < end_utc
+        }
+    )
+
+    segments: list[PromotionSegment] = []
+    segment_start = start_utc
+    for boundary in boundaries:
+        segments.append(
+            PromotionSegment(
+                version_id=_active_version_at(segment_start),
+                start=segment_start,
+                end=boundary,
+            )
+        )
+        segment_start = boundary
+    segments.append(
+        PromotionSegment(
+            version_id=_active_version_at(segment_start), start=segment_start, end=end_utc
+        )
+    )
+    return segments

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -29,7 +29,12 @@ __all__ = [
 ]
 
 
-def call_strategy_factory(factory: Callable[..., Any], *, symbol: str | None = None) -> "Strategy":
+def call_strategy_factory(
+    factory: Callable[..., Any],
+    *,
+    symbol: str | None = None,
+    model_version: str | None = None,
+) -> "Strategy":
     """Invoke a strategy factory, threading the trading symbol when supported.
 
     Runners (live and backtest) must construct strategies through this helper
@@ -37,16 +42,38 @@ def call_strategy_factory(factory: Callable[..., Any], *, symbol: str | None = N
     selection — otherwise a strategy silently scores with the default
     (BTCUSDT) model. Factories without a ``symbol`` parameter (e.g.
     chaos_test) are called unchanged.
+
+    ``model_version`` is the backtest harness's point-in-time model pin
+    (GH #988). Unlike ``symbol``, it is threaded only to factories that
+    declare an explicit ``model_version`` parameter — never through
+    ``**kwargs`` (a factory forwarding unknown kwargs elsewhere would crash
+    or, worse, silently drop the pin). A pin the factory cannot honor
+    raises so a "pinned" run can never silently score with ``latest``.
+
+    Raises:
+        ValueError: ``model_version`` was requested but the factory has no
+            explicit ``model_version`` parameter.
     """
-    if symbol is None:
-        return factory()
+    kwargs: dict[str, Any] = {}
     try:
         parameters = inspect.signature(factory).parameters
     except (TypeError, ValueError):
-        return factory()
-    accepts_symbol = "symbol" in parameters or any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
-    )
-    if accepts_symbol:
-        return factory(symbol=symbol)
-    return factory()
+        parameters = None
+
+    if model_version is not None:
+        if parameters is None or "model_version" not in parameters:
+            raise ValueError(
+                f"Strategy factory {getattr(factory, '__name__', factory)!r} does not "
+                f"support model_version pinning — refusing to run a 'pinned' backtest "
+                f"that would silently resolve 'latest' instead."
+            )
+        kwargs["model_version"] = model_version
+
+    if symbol is not None and parameters is not None:
+        accepts_symbol = "symbol" in parameters or any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+        )
+        if accepts_symbol:
+            kwargs["symbol"] = symbol
+
+    return factory(**kwargs)

--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -1128,6 +1128,18 @@ class MLBasicSignalGenerator(SignalGenerator):
                 else:
                     result = self.prediction_engine.predict(window_df)
             except (KeyError, ValueError):
+                # Never fall back to default resolution when pinned —
+                # scoring with a different model is exactly the confound the
+                # pin exists to prevent (GH #988). Degrade to HOLD instead.
+                if self._pinned_bundle_key is not None:
+                    self._model_symbol = None
+                    logger.error(
+                        "MLBasicSignalGenerator: pinned model %s lookup failed at "
+                        "index %d — holding (refusing unpinned fallback)",
+                        self._pinned_bundle_key,
+                        index,
+                    )
+                    return None
                 # Fall back to default registry resolution if explicit lookup fails
                 result = self.prediction_engine.predict(window_df)
 

--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -588,6 +588,7 @@ class MLBasicSignalGenerator(SignalGenerator):
         long_entry_threshold: float | None = None,
         short_entry_threshold: float | None = None,
         confidence_multiplier: float | None = None,
+        model_version: str | None = None,
     ):
         """
         Initialize ML Basic Signal Generator
@@ -602,6 +603,13 @@ class MLBasicSignalGenerator(SignalGenerator):
             long_entry_threshold: Minimum predicted return for long entry.
             short_entry_threshold: Maximum predicted return for short entry.
             confidence_multiplier: Scales |predicted_return| → confidence.
+            model_version: Pin every prediction to this exact registry
+                version (e.g. ``2026-07-04_22h_v1``) instead of resolving
+                ``latest`` — the backtest harness's point-in-time pin
+                (GH #988). Construction fails fast when the version does
+                not exist. Never set on the live trading path, which must
+                always follow ``latest``; only an explicit caller argument
+                can pin (no ambient env/config override).
         """
         super().__init__(name)
 
@@ -655,6 +663,12 @@ class MLBasicSignalGenerator(SignalGenerator):
         self._model_symbol: str | None = None
         self._cross_symbol_bundle_key: str | None = None
         self._symbol_guard_log_ts: dict[str, float] = {}
+
+        # Point-in-time version pin (backtest harness only). Resolved to a
+        # full bundle key by _validate_model_availability, which fails fast
+        # when the pin cannot be honored.
+        self.model_version = model_version
+        self._pinned_bundle_key: str | None = None
 
         # Initialize feature pipeline
         self._setup_feature_pipeline()
@@ -736,8 +750,19 @@ class MLBasicSignalGenerator(SignalGenerator):
         not shipped yet.
         """
         if self._registry is None:
+            if self.model_version:
+                # A pinned run degrading to HOLD-only would silently produce
+                # a zero-trade "comparison" — refuse instead.
+                raise ModelNotAvailableError(
+                    f"Model version pin {self.model_version!r} requested but the "
+                    f"prediction engine/model registry failed to initialize — "
+                    f"a pinned run must fail fast rather than run unpinned."
+                )
             # Engine degraded/unavailable — prediction path already fails
             # safe (returns None → HOLD), so nothing to validate against.
+            return
+        if self.model_version:
+            self._resolve_pinned_bundle(self._registry)
             return
         try:
             self._registry.select_bundle(
@@ -787,6 +812,38 @@ class MLBasicSignalGenerator(SignalGenerator):
             self.model_type,
             self.model_timeframe,
             self.symbol,
+        )
+
+    @property
+    def pinned_model_key(self) -> str | None:
+        """Full bundle key the generator is pinned to, or None when unpinned."""
+        return self._pinned_bundle_key
+
+    def _resolve_pinned_bundle(self, registry: "PredictionModelRegistry") -> None:
+        """Resolve ``model_version`` to a full bundle key, failing fast.
+
+        ``get_bundle_by_key`` is the one registry path that can load a
+        non-latest version (lazily, exam/backtest-only — the live path only
+        ever calls ``select_bundle``). A pin that cannot be resolved raises
+        instead of degrading: scoring with the wrong model is exactly the
+        confound this pin exists to prevent (GH #988).
+        """
+        key = f"{self.symbol}:{self.model_timeframe}:{self.model_type}:{self.model_version}"
+        bundle = registry.get_bundle_by_key(key)
+        if bundle is None:
+            available = self._available_bundle_keys()
+            raise ModelNotAvailableError(
+                f"Pinned model version not found: {key}. Check the version directory "
+                f"exists under the registry and its metadata timeframe matches "
+                f"{self.model_timeframe!r}. Loaded bundles: {', '.join(available) or 'none'}."
+            )
+        self._pinned_bundle_key = key
+        self._model_symbol = bundle.symbol
+        logger.warning(
+            "MODEL VERSION PINNED: scoring %s with %s — 'latest' resolution is "
+            "bypassed for this run (point-in-time backtest pin)",
+            self.symbol,
+            key,
         )
 
     def _available_bundle_keys(self) -> list[str]:
@@ -1012,7 +1069,13 @@ class MLBasicSignalGenerator(SignalGenerator):
             # Try to select bundle using registry
             selected_bundle_key = None
             resolved_model_symbol: str | None = None
-            if self._cross_symbol_bundle_key is not None:
+            if self._pinned_bundle_key is not None:
+                # Point-in-time pin (backtest harness): the exact version
+                # was resolved and validated at construction — never
+                # re-resolve "latest" mid-run.
+                selected_bundle_key = self._pinned_bundle_key
+                resolved_model_symbol = self._model_symbol
+            elif self._cross_symbol_bundle_key is not None:
                 # Startup explicitly opted into substitution via
                 # FEATURE_ALLOW_CROSS_SYMBOL_MODEL — score with the pinned
                 # bundle and keep reminding the operator.
@@ -1148,6 +1211,8 @@ class MLBasicSignalGenerator(SignalGenerator):
                 "long_entry_threshold": self.long_entry_threshold,
                 "short_entry_threshold": self.short_entry_threshold,
                 "confidence_multiplier": self.confidence_multiplier,
+                "model_version": self.model_version,
+                "pinned_model_key": self._pinned_bundle_key,
             }
         )
         return params

--- a/src/strategies/exam_target_redesign.py
+++ b/src/strategies/exam_target_redesign.py
@@ -63,18 +63,19 @@ DEFAULT_EXAM_STRATEGY_NAME = "TargetRedesignExam"
 # (f"{symbol}:{timeframe}:{model_type}:{version}"), which
 # PredictionEngine._resolve_bundle finds via PredictionModelRegistry.
 # get_bundle_by_key -- the one place a non-latest version is reachable by
-# exact key.
-_MODEL_VERSION_OVERRIDE_ENV_VAR = "ATB_MODEL_VERSION_OVERRIDE"
+# exact key. Public so the backtest CLI's --model-version flag can set the
+# same override for exam strategies (GH #988).
+MODEL_VERSION_OVERRIDE_ENV_VAR = "ATB_MODEL_VERSION_OVERRIDE"
 
 
 def _exam_model_name(symbol: str, timeframe: str, model_type: str) -> str | None:
     """Resolve the model_name to pass an exam SignalGenerator.
 
     Returns a full bundle key (pinning to a specific version) when
-    ``_MODEL_VERSION_OVERRIDE_ENV_VAR`` is set, else None (registry
+    ``MODEL_VERSION_OVERRIDE_ENV_VAR`` is set, else None (registry
     default: latest).
     """
-    version = os.environ.get(_MODEL_VERSION_OVERRIDE_ENV_VAR)
+    version = os.environ.get(MODEL_VERSION_OVERRIDE_ENV_VAR)
     if not version:
         return None
     return f"{symbol}:{timeframe}:{model_type}:{version}"
@@ -303,6 +304,7 @@ def create_exam_meta_label_strategy(
 
 __all__ = [
     "DEFAULT_EXAM_STRATEGY_NAME",
+    "MODEL_VERSION_OVERRIDE_ENV_VAR",
     "create_exam_binary_direction_strategy",
     "create_exam_meta_label_strategy",
     "create_exam_smoothed_return_strategy",

--- a/src/strategies/hyper_growth.py
+++ b/src/strategies/hyper_growth.py
@@ -190,6 +190,7 @@ def create_hyper_growth_strategy(
     breakeven_buffer: float = 0.008,
     early_cut_mfe_threshold_pct: float | None = None,
     early_cut_evaluation_window_hours: float | None = None,
+    model_version: str | None = None,
 ) -> Strategy:
     """Create hyper-growth strategy targeting high annual returns.
 
@@ -237,18 +238,29 @@ def create_hyper_growth_strategy(
         early_cut_evaluation_window_hours: Early-cut evaluation window in
             hours from entry. Must be set together with
             ``early_cut_mfe_threshold_pct``.
+        model_version: Pin ML predictions to this exact registry version
+            instead of resolving ``latest`` — the backtest harness's
+            point-in-time pin (GH #988). Only valid with
+            ``signal_source="ml"`` (momentum runs no model).
 
     Returns:
         Configured Strategy instance.
 
     Raises:
-        ValueError: If exactly one of the two early-cut kwargs is provided.
+        ValueError: If exactly one of the two early-cut kwargs is provided,
+            or if ``model_version`` is combined with ``signal_source="momentum"``.
     """
     if (early_cut_mfe_threshold_pct is None) != (early_cut_evaluation_window_hours is None):
         raise ValueError(
             "early_cut_mfe_threshold_pct and early_cut_evaluation_window_hours "
             "must be provided together (both set to enable the early cut, "
             "both None to disable it)"
+        )
+    if signal_source == "momentum" and model_version is not None:
+        raise ValueError(
+            "model_version cannot be combined with signal_source='momentum': "
+            "the momentum generator runs no ML model, so a pinned model "
+            "version would silently not be honored."
         )
     # #805: hyper_growth targets high returns via leverage/aggressive sizing and
     # is NOT recommended in a bear/high-vol regime, where exposure is the primary
@@ -277,7 +289,7 @@ def create_hyper_growth_strategy(
         # silently returns 0.0 on every bar — which the generator converts to
         # predicted_return = -1.0 (a constant SELL sentinel, not a prediction).
         signal_generator = MLBasicSignalGenerator(
-            name=f"{name}_signals", model_type="basic", symbol=symbol
+            name=f"{name}_signals", model_type="basic", symbol=symbol, model_version=model_version
         )
 
     risk_manager = FlatRiskManager(

--- a/src/strategies/ml_basic.py
+++ b/src/strategies/ml_basic.py
@@ -67,6 +67,7 @@ def create_ml_basic_strategy(
     min_confidence_floor: float | None = None,
     stop_loss_pct: float | None = None,
     take_profit_pct: float | None = None,
+    model_version: str | None = None,
 ) -> Strategy:
     """
     Create ML Basic strategy using component composition.
@@ -89,10 +90,18 @@ def create_ml_basic_strategy(
             min_confidence gate has passed (0.0 disables).
         stop_loss_pct: Override for the stop-loss percentage.
         take_profit_pct: Override for the take-profit percentage.
+        model_version: Pin predictions to this exact registry version instead
+            of resolving ``latest`` — the backtest harness's point-in-time
+            pin (GH #988). Incompatible with ``fast_mode`` (no model runs).
 
     Returns:
         Configured Strategy instance
     """
+    if fast_mode and model_version is not None:
+        raise ValueError(
+            "model_version cannot be combined with fast_mode: fast mode disables "
+            "ML entirely, so a pinned model version would silently not be honored."
+        )
     risk_parameters = RiskParameters(
         base_risk_per_trade=DEFAULT_BASE_RISK_PER_TRADE,
         default_take_profit_pct=(
@@ -156,6 +165,7 @@ def create_ml_basic_strategy(
             long_entry_threshold=long_entry_threshold,
             short_entry_threshold=short_entry_threshold,
             confidence_multiplier=confidence_multiplier,
+            model_version=model_version,
         )
 
         risk_manager = CoreRiskAdapter(core_risk_manager)

--- a/tests/unit/cli/test_backtest.py
+++ b/tests/unit/cli/test_backtest.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from cli.commands.backtest import _get_date_range, _handle, _load_strategy
+from cli.commands.backtest import (
+    _get_date_range,
+    _handle,
+    _load_strategy,
+    _resolve_model_pin,
+    register,
+)
 
 
 class TestLoadStrategy:
@@ -247,7 +253,9 @@ class TestHandleBacktest:
 
             # Assert
             assert result == 0
-            mock_load_strategy.assert_called_once_with("ml_basic", symbol="BTCUSDT")
+            mock_load_strategy.assert_called_once_with(
+                "ml_basic", symbol="BTCUSDT", model_version=None
+            )
             mock_backtester.run.assert_called_once()
 
     def test_backtest_with_sentiment_enabled(self, default_args, mock_backtester):
@@ -515,3 +523,332 @@ class TestHandleBacktest:
             # Assert
             assert result == 0
             # File saving is tested in integration tests
+
+
+def _make_pin_registry_bundle(
+    registry: Path, symbol: str, model_type: str, version: str, created_at: str
+) -> Path:
+    """Write a minimal synthetic bundle dir (dummy ONNX -> stub runner)."""
+    import json
+
+    bundle_dir = registry / symbol / model_type / version
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "model.onnx").write_bytes(b"dummy")
+    (bundle_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "symbol": symbol,
+                "model_type": model_type,
+                "timeframe": "1h",
+                "version_id": version,
+                "created_at": created_at,
+            }
+        )
+    )
+    return bundle_dir
+
+
+def _make_pin_registry(tmp_path: Path) -> tuple[Path, str, str]:
+    """Synthetic BTCUSDT/basic registry: old version + newer 'latest'."""
+    registry = tmp_path / "models"
+    old_version = "2026-01-01_1h_v1"
+    new_version = "2026-05-01_1h_v1"
+    _make_pin_registry_bundle(
+        registry, "BTCUSDT", "basic", old_version, "2026-01-01T00:00:00+00:00"
+    )
+    new_dir = _make_pin_registry_bundle(
+        registry, "BTCUSDT", "basic", new_version, "2026-05-01T00:00:00+00:00"
+    )
+    latest = new_dir.parent / "latest"
+    latest.symlink_to(new_dir, target_is_directory=True)
+    return registry, old_version, new_version
+
+
+class TestModelPinningArgs:
+    """Argparse surface for --model-version / --model-as-of (GH #988)."""
+
+    def _parse(self, argv):
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        register(subparsers)
+        return parser.parse_args(["backtest", *argv])
+
+    def test_model_version_parsed(self):
+        ns = self._parse(["ml_basic", "--model-version", "2026-01-01_1h_v1"])
+        assert ns.model_version == "2026-01-01_1h_v1"
+        assert ns.model_as_of is None
+
+    def test_model_as_of_parsed_as_utc_datetime(self):
+        ns = self._parse(["ml_basic", "--model-as-of", "2026-06-02"])
+        assert ns.model_as_of == datetime(2026, 6, 2, tzinfo=UTC)
+
+    def test_defaults_are_none(self):
+        ns = self._parse(["ml_basic"])
+        assert ns.model_version is None
+        assert ns.model_as_of is None
+
+    def test_model_version_and_as_of_are_mutually_exclusive(self):
+        with pytest.raises(SystemExit):
+            self._parse(
+                [
+                    "ml_basic",
+                    "--model-version",
+                    "2026-01-01_1h_v1",
+                    "--model-as-of",
+                    "2026-06-02",
+                ]
+            )
+
+    def test_invalid_model_as_of_rejected(self):
+        with pytest.raises(SystemExit):
+            self._parse(["ml_basic", "--model-as-of", "not-a-date"])
+
+
+class TestResolveModelPin:
+    """Tests for _resolve_model_pin (as-of resolution + boundary warning)."""
+
+    def _ns(self, **overrides):
+        ns = argparse.Namespace(
+            strategy="ml_basic",
+            symbol="BTCUSDT",
+            model_version=None,
+            model_as_of=None,
+        )
+        for key, value in overrides.items():
+            setattr(ns, key, value)
+        return ns
+
+    def test_returns_none_without_pin_args(self):
+        result = _resolve_model_pin(
+            self._ns(),
+            datetime(2026, 1, 1, tzinfo=UTC),
+            datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        assert result is None
+
+    def test_legacy_namespace_without_pin_attrs_returns_none(self):
+        ns = argparse.Namespace(strategy="ml_basic", symbol="BTCUSDT")
+        result = _resolve_model_pin(
+            ns, datetime(2026, 1, 1, tzinfo=UTC), datetime(2026, 2, 1, tzinfo=UTC)
+        )
+        assert result is None
+
+    def test_model_as_of_resolves_version_that_was_latest(self, tmp_path, monkeypatch):
+        registry, old_version, _ = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        result = _resolve_model_pin(
+            self._ns(model_as_of=datetime(2026, 3, 1, tzinfo=UTC)),
+            datetime(2026, 2, 1, tzinfo=UTC),
+            datetime(2026, 3, 1, tzinfo=UTC),
+        )
+
+        assert result == old_version
+
+    def test_model_as_of_before_first_version_raises(self, tmp_path, monkeypatch):
+        from src.prediction.models.exceptions import ModelNotAvailableError
+
+        registry, _, _ = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        with pytest.raises(ModelNotAvailableError):
+            _resolve_model_pin(
+                self._ns(model_as_of=datetime(2025, 6, 1, tzinfo=UTC)),
+                datetime(2025, 6, 1, tzinfo=UTC),
+                datetime(2025, 7, 1, tzinfo=UTC),
+            )
+
+    def test_model_as_of_unsupported_strategy_exits(self, tmp_path, monkeypatch):
+        registry, _, _ = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        with pytest.raises(SystemExit):
+            _resolve_model_pin(
+                self._ns(
+                    strategy="adaptive_trend",
+                    model_as_of=datetime(2026, 3, 1, tzinfo=UTC),
+                ),
+                datetime(2026, 2, 1, tzinfo=UTC),
+                datetime(2026, 3, 1, tzinfo=UTC),
+            )
+
+    def test_boundary_spanning_window_warns_with_segments(self, tmp_path, monkeypatch, caplog):
+        registry, old_version, new_version = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        with caplog.at_level("WARNING", logger="atb.backtest"):
+            result = _resolve_model_pin(
+                self._ns(model_as_of=datetime(2026, 2, 1, tzinfo=UTC)),
+                datetime(2026, 2, 1, tzinfo=UTC),
+                datetime(2026, 6, 1, tzinfo=UTC),
+            )
+
+        assert result == old_version
+        warning = "\n".join(
+            record.getMessage()
+            for record in caplog.records
+            if "MODEL PROMOTION BOUNDARY" in record.getMessage()
+        )
+        assert warning, "expected a promotion-boundary warning"
+        assert old_version in warning
+        assert new_version in warning
+
+    def test_window_within_single_version_does_not_warn(self, tmp_path, monkeypatch, caplog):
+        registry, old_version, _ = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        with caplog.at_level("WARNING", logger="atb.backtest"):
+            result = _resolve_model_pin(
+                self._ns(model_version=old_version),
+                datetime(2026, 2, 1, tzinfo=UTC),
+                datetime(2026, 3, 1, tzinfo=UTC),
+            )
+
+        assert result == old_version
+        assert not any(
+            "MODEL PROMOTION BOUNDARY" in record.getMessage() for record in caplog.records
+        )
+
+    def test_explicit_model_version_also_gets_boundary_warning(self, tmp_path, monkeypatch, caplog):
+        registry, old_version, new_version = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        with caplog.at_level("WARNING", logger="atb.backtest"):
+            result = _resolve_model_pin(
+                self._ns(model_version=old_version),
+                datetime(2026, 2, 1, tzinfo=UTC),
+                datetime(2026, 6, 1, tzinfo=UTC),
+            )
+
+        assert result == old_version
+        assert any("MODEL PROMOTION BOUNDARY" in record.getMessage() for record in caplog.records)
+
+
+class TestLoadStrategyModelVersionThreading:
+    """_load_strategy must thread the pin — or refuse — never drop it."""
+
+    def test_mainline_factory_receives_model_version(self):
+        with patch("cli.commands.backtest.create_ml_basic_strategy", autospec=True) as mock_create:
+            mock_create.return_value = Mock(name="pinned_strategy")
+
+            _load_strategy("ml_basic", symbol="BTCUSDT", model_version="2026-01-01_1h_v1")
+
+            assert mock_create.call_args.kwargs["model_version"] == "2026-01-01_1h_v1"
+
+    def test_unpinned_call_does_not_pass_model_version(self):
+        """Zero behavior change: without a pin the factory kwargs are unchanged."""
+        with patch("cli.commands.backtest.create_ml_basic_strategy", autospec=True) as mock_create:
+            mock_create.return_value = Mock(name="strategy")
+
+            _load_strategy("ml_basic", symbol="BTCUSDT")
+
+            assert "model_version" not in mock_create.call_args.kwargs
+
+    def test_pin_with_unsupported_strategy_raises(self):
+        """A factory without model_version support must refuse the pin
+        rather than silently resolve 'latest'."""
+        with pytest.raises(ValueError, match="model_version"):
+            _load_strategy("adaptive_trend", symbol="BTCUSDT", model_version="2026-01-01_1h_v1")
+
+    def test_exam_strategy_pin_sets_env_var_only_during_construction(self, monkeypatch):
+        import os
+
+        from src.strategies.exam_target_redesign import MODEL_VERSION_OVERRIDE_ENV_VAR
+
+        monkeypatch.delenv(MODEL_VERSION_OVERRIDE_ENV_VAR, raising=False)
+        seen: dict[str, str | None] = {}
+
+        def capture_env(**kwargs):
+            seen["override"] = os.environ.get(MODEL_VERSION_OVERRIDE_ENV_VAR)
+            return Mock(name="exam_strategy")
+
+        with patch(
+            "cli.commands.backtest.create_exam_binary_direction_strategy",
+            side_effect=capture_env,
+        ):
+            _load_strategy(
+                "exam_binary_direction", symbol="BTCUSDT", model_version="2026-01-01_1h_v1"
+            )
+
+        assert seen["override"] == "2026-01-01_1h_v1"
+        assert MODEL_VERSION_OVERRIDE_ENV_VAR not in os.environ
+
+    def test_exam_strategy_pin_restores_preexisting_env_var(self, monkeypatch):
+        import os
+
+        from src.strategies.exam_target_redesign import MODEL_VERSION_OVERRIDE_ENV_VAR
+
+        monkeypatch.setenv(MODEL_VERSION_OVERRIDE_ENV_VAR, "preexisting_v0")
+
+        with patch(
+            "cli.commands.backtest.create_exam_binary_direction_strategy",
+            side_effect=lambda **kwargs: Mock(name="exam_strategy"),
+        ):
+            _load_strategy(
+                "exam_binary_direction", symbol="BTCUSDT", model_version="2026-01-01_1h_v1"
+            )
+
+        assert os.environ[MODEL_VERSION_OVERRIDE_ENV_VAR] == "preexisting_v0"
+
+
+class TestPinnedBacktestEndToEnd:
+    """A pinned backtest must actually load and score with the pinned
+    bundle — asserted via PredictionEngine.get_model_info (GH #988)."""
+
+    def test_pinned_backtest_loads_pinned_bundle(self, tmp_path, monkeypatch):
+        from src.data_providers.mock_data_provider import MockDataProvider
+        from src.engines.backtest.engine import Backtester
+
+        registry, old_version, _ = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+        pinned_key = f"BTCUSDT:1h:basic:{old_version}"
+
+        strategy = _load_strategy("ml_basic", symbol="BTCUSDT", model_version=old_version)
+
+        assert strategy.signal_generator.pinned_model_key == pinned_key
+
+        # Spy on the engine so the run provably scores bars with the pin —
+        # get_model_info alone cannot distinguish "loaded" from "used".
+        engine = strategy.signal_generator.prediction_engine
+        scored_model_names: list[str | None] = []
+        original_predict = engine.predict
+
+        def recording_predict(data, model_name=None):
+            scored_model_names.append(model_name)
+            return original_predict(data, model_name=model_name)
+
+        monkeypatch.setattr(engine, "predict", recording_predict)
+
+        backtester = Backtester(
+            strategy=strategy,
+            data_provider=MockDataProvider(seed=42),
+            initial_balance=10000,
+            log_to_database=False,
+        )
+        backtester.run(
+            symbol="BTCUSDT",
+            timeframe="1h",
+            start=datetime(2026, 2, 1, tzinfo=UTC),
+            end=datetime(2026, 2, 11, tzinfo=UTC),
+        )
+
+        assert scored_model_names, "backtest never reached the prediction engine"
+        assert set(scored_model_names) == {pinned_key}
+
+        info = engine.get_model_info(pinned_key)
+        assert info.get("name") == pinned_key
+        assert info.get("loaded") is True
+        assert info.get("metadata", {}).get("version_id") == old_version
+
+    def test_unpinned_strategy_resolves_latest(self, tmp_path, monkeypatch):
+        """Zero behavior change: without a pin the latest symlink wins."""
+        registry, _, new_version = _make_pin_registry(tmp_path)
+        monkeypatch.setenv("MODEL_REGISTRY_PATH", str(registry))
+
+        strategy = _load_strategy("ml_basic", symbol="BTCUSDT")
+
+        sg = strategy.signal_generator
+        assert sg.pinned_model_key is None
+        latest_key = f"BTCUSDT:1h:basic:{new_version}"
+        info = sg.prediction_engine.get_model_info(latest_key)
+        assert info.get("name") == latest_key

--- a/tests/unit/cli/test_backtest_symbol_wiring.py
+++ b/tests/unit/cli/test_backtest_symbol_wiring.py
@@ -45,8 +45,8 @@ class TestHandleSymbolWiring:
     def test_handle_passes_cli_symbol_to_load_strategy(self, monkeypatch):
         recorded = {}
 
-        def fake_load(name, symbol=None):
-            recorded["call"] = (name, symbol)
+        def fake_load(name, symbol=None, model_version=None):
+            recorded["call"] = (name, symbol, model_version)
             raise RuntimeError("stop after strategy load")
 
         monkeypatch.setattr("cli.commands.backtest._load_strategy", fake_load)
@@ -73,4 +73,6 @@ class TestHandleSymbolWiring:
         rc = _handle(ns)
 
         assert rc == 1
-        assert recorded["call"] == ("hyper_growth", "ETHUSDT")
+        # model_version None: no pin flags on the namespace means the pin
+        # machinery must stay entirely out of the way (GH #988).
+        assert recorded["call"] == ("hyper_growth", "ETHUSDT", None)

--- a/tests/unit/prediction/test_version_resolver.py
+++ b/tests/unit/prediction/test_version_resolver.py
@@ -1,0 +1,250 @@
+"""Tests for point-in-time model version resolution (GH #988).
+
+The resolver answers "which version WAS latest at date X?" from bundle
+metadata timestamps so a backtest spanning a model-promotion boundary can
+pin the model that was actually live, instead of silently comparing
+against whatever `latest` resolves to today.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from src.prediction.models.exceptions import ModelNotAvailableError
+from src.prediction.models.version_resolver import (
+    VersionRecord,
+    list_version_records,
+    promotion_segments,
+    resolve_version_as_of,
+)
+
+SYMBOL = "TESTUSDT"
+MODEL_TYPE = "basic"
+
+V1 = "2026-01-01_1h_v1"
+V2 = "2026-03-01_1h_v1"
+V3 = "2026-06-01_1h_v1"
+
+T1 = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+T2 = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+T3 = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+
+
+def _write_bundle(
+    registry: Path,
+    version_id: str,
+    created_at: str | None,
+    *,
+    symbol: str = SYMBOL,
+    model_type: str = MODEL_TYPE,
+) -> Path:
+    bundle_dir = registry / symbol / model_type / version_id
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    (bundle_dir / "model.onnx").write_bytes(b"dummy")
+    metadata: dict[str, object] = {
+        "symbol": symbol,
+        "model_type": model_type,
+        "timeframe": "1h",
+        "version_id": version_id,
+    }
+    if created_at is not None:
+        metadata["created_at"] = created_at
+    (bundle_dir / "metadata.json").write_text(json.dumps(metadata))
+    return bundle_dir
+
+
+@pytest.fixture
+def three_version_registry(tmp_path: Path) -> Path:
+    """Synthetic registry with three versions promoted at T1 < T2 < T3."""
+    registry = tmp_path / "models"
+    _write_bundle(registry, V1, T1.isoformat())
+    _write_bundle(registry, V2, T2.isoformat())
+    v3_dir = _write_bundle(registry, V3, T3.isoformat())
+    latest = registry / SYMBOL / MODEL_TYPE / "latest"
+    latest.symlink_to(v3_dir, target_is_directory=True)
+    return registry
+
+
+@pytest.mark.fast
+class TestListVersionRecords:
+    def test_lists_all_versions_sorted_by_effective_at(self, three_version_registry: Path):
+        records = list_version_records(three_version_registry, SYMBOL, MODEL_TYPE)
+
+        assert [r.version_id for r in records] == [V1, V2, V3]
+        assert [r.effective_at for r in records] == [T1, T2, T3]
+
+    def test_ignores_latest_symlink_and_stray_files(self, three_version_registry: Path):
+        (three_version_registry / SYMBOL / MODEL_TYPE / "notes.txt").write_text("stray")
+
+        records = list_version_records(three_version_registry, SYMBOL, MODEL_TYPE)
+
+        assert [r.version_id for r in records] == [V1, V2, V3]
+
+    def test_missing_created_at_falls_back_to_version_id_date(self, tmp_path: Path):
+        registry = tmp_path / "models"
+        _write_bundle(registry, "2026-02-15_1h_v1", None)
+
+        records = list_version_records(registry, SYMBOL, MODEL_TYPE)
+
+        assert len(records) == 1
+        assert records[0].effective_at == datetime(2026, 2, 15, tzinfo=UTC)
+        assert records[0].source == "version_id"
+
+    def test_naive_created_at_treated_as_utc(self, tmp_path: Path):
+        registry = tmp_path / "models"
+        _write_bundle(registry, "2026-02-15_1h_v1", "2026-02-15T09:30:00")
+
+        records = list_version_records(registry, SYMBOL, MODEL_TYPE)
+
+        assert records[0].effective_at == datetime(2026, 2, 15, 9, 30, tzinfo=UTC)
+        assert records[0].source == "metadata"
+
+    def test_undateable_version_dir_is_skipped(self, tmp_path: Path):
+        registry = tmp_path / "models"
+        _write_bundle(registry, "2026-02-15_1h_v1", None)
+        undateable = registry / SYMBOL / MODEL_TYPE / "experimental"
+        undateable.mkdir(parents=True)
+        (undateable / "metadata.json").write_text(json.dumps({"symbol": SYMBOL}))
+
+        records = list_version_records(registry, SYMBOL, MODEL_TYPE)
+
+        assert [r.version_id for r in records] == ["2026-02-15_1h_v1"]
+
+    def test_missing_model_type_dir_returns_empty(self, tmp_path: Path):
+        registry = tmp_path / "models"
+        registry.mkdir()
+
+        assert list_version_records(registry, SYMBOL, MODEL_TYPE) == []
+
+    def test_tie_on_effective_at_orders_by_version_id(self, tmp_path: Path):
+        registry = tmp_path / "models"
+        same_ts = "2026-02-15T00:00:00+00:00"
+        _write_bundle(registry, "2026-02-15_1h_v2", same_ts)
+        _write_bundle(registry, "2026-02-15_1h_v1", same_ts)
+
+        records = list_version_records(registry, SYMBOL, MODEL_TYPE)
+
+        assert [r.version_id for r in records] == ["2026-02-15_1h_v1", "2026-02-15_1h_v2"]
+
+
+@pytest.mark.fast
+class TestResolveVersionAsOf:
+    def test_as_of_before_first_version_raises(self, three_version_registry: Path):
+        with pytest.raises(ModelNotAvailableError) as excinfo:
+            resolve_version_as_of(
+                three_version_registry, SYMBOL, MODEL_TYPE, datetime(2025, 12, 1, tzinfo=UTC)
+            )
+
+        assert V1 in str(excinfo.value)
+
+    def test_as_of_between_versions_resolves_earlier(self, three_version_registry: Path):
+        record = resolve_version_as_of(
+            three_version_registry, SYMBOL, MODEL_TYPE, datetime(2026, 2, 15, tzinfo=UTC)
+        )
+        assert record.version_id == V1
+
+        record = resolve_version_as_of(
+            three_version_registry, SYMBOL, MODEL_TYPE, datetime(2026, 4, 1, tzinfo=UTC)
+        )
+        assert record.version_id == V2
+
+    def test_as_of_after_last_version_resolves_latest(self, three_version_registry: Path):
+        record = resolve_version_as_of(
+            three_version_registry, SYMBOL, MODEL_TYPE, datetime(2026, 7, 1, tzinfo=UTC)
+        )
+        assert record.version_id == V3
+
+    def test_as_of_exactly_at_promotion_is_inclusive(self, three_version_registry: Path):
+        record = resolve_version_as_of(three_version_registry, SYMBOL, MODEL_TYPE, T2)
+        assert record.version_id == V2
+
+    def test_naive_as_of_treated_as_utc(self, three_version_registry: Path):
+        record = resolve_version_as_of(
+            three_version_registry, SYMBOL, MODEL_TYPE, datetime(2026, 2, 15)
+        )
+        assert record.version_id == V1
+
+    def test_empty_registry_raises_with_clear_message(self, tmp_path: Path):
+        registry = tmp_path / "models"
+        registry.mkdir()
+
+        with pytest.raises(ModelNotAvailableError) as excinfo:
+            resolve_version_as_of(
+                registry, SYMBOL, MODEL_TYPE, datetime(2026, 2, 15, tzinfo=UTC)
+            )
+
+        assert SYMBOL in str(excinfo.value)
+        assert MODEL_TYPE in str(excinfo.value)
+
+
+@pytest.mark.fast
+class TestPromotionSegments:
+    def _records(self) -> list[VersionRecord]:
+        return [
+            VersionRecord(version_id=V1, effective_at=T1, source="metadata"),
+            VersionRecord(version_id=V2, effective_at=T2, source="metadata"),
+            VersionRecord(version_id=V3, effective_at=T3, source="metadata"),
+        ]
+
+    def test_window_within_single_version_yields_one_segment(self):
+        start = datetime(2026, 1, 10, tzinfo=UTC)
+        end = datetime(2026, 2, 10, tzinfo=UTC)
+
+        segments = promotion_segments(self._records(), start, end)
+
+        assert len(segments) == 1
+        assert segments[0].version_id == V1
+        assert segments[0].start == start
+        assert segments[0].end == end
+
+    def test_window_spanning_one_boundary_yields_two_segments(self):
+        start = datetime(2026, 2, 1, tzinfo=UTC)
+        end = datetime(2026, 4, 1, tzinfo=UTC)
+
+        segments = promotion_segments(self._records(), start, end)
+
+        assert [(s.version_id, s.start, s.end) for s in segments] == [
+            (V1, start, T2),
+            (V2, T2, end),
+        ]
+
+    def test_window_spanning_all_boundaries_yields_all_segments(self):
+        start = datetime(2025, 12, 1, tzinfo=UTC)
+        end = datetime(2026, 7, 1, tzinfo=UTC)
+
+        segments = promotion_segments(self._records(), start, end)
+
+        assert [s.version_id for s in segments] == [None, V1, V2, V3]
+        assert segments[0].start == start
+        assert segments[0].end == T1
+        assert segments[-1].end == end
+
+    def test_window_before_any_version_yields_none_segment(self):
+        start = datetime(2025, 10, 1, tzinfo=UTC)
+        end = datetime(2025, 11, 1, tzinfo=UTC)
+
+        segments = promotion_segments(self._records(), start, end)
+
+        assert len(segments) == 1
+        assert segments[0].version_id is None
+
+    def test_promotion_exactly_at_window_end_does_not_split(self):
+        start = datetime(2026, 2, 1, tzinfo=UTC)
+
+        segments = promotion_segments(self._records(), start, T2)
+
+        assert len(segments) == 1
+        assert segments[0].version_id == V1
+
+    def test_no_records_yields_single_none_segment(self):
+        start = datetime(2026, 2, 1, tzinfo=UTC)
+        end = datetime(2026, 3, 1, tzinfo=UTC)
+
+        segments = promotion_segments([], start, end)
+
+        assert len(segments) == 1
+        assert segments[0].version_id is None

--- a/tests/unit/strategies/components/test_ml_signal_generator.py
+++ b/tests/unit/strategies/components/test_ml_signal_generator.py
@@ -1122,6 +1122,31 @@ class TestMLBasicSignalGeneratorModelVersionPin:
 
     @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
     @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_pinned_lookup_failure_holds_instead_of_unpinned_fallback(
+        self, mock_config_class, mock_engine_class
+    ):
+        """If the pinned lookup fails at predict time, degrade to HOLD —
+        never re-predict with default (latest) resolution."""
+        mock_engine, _ = self._mock_engine(mock_engine_class)
+        mock_engine.predict.side_effect = KeyError(self.PINNED_KEY)
+
+        generator = MLBasicSignalGenerator(
+            symbol="BTCUSDT",
+            model_type="basic",
+            timeframe="1h",
+            model_version=self.PINNED_VERSION,
+        )
+        df = self.create_test_dataframe(150)
+
+        prediction = generator._get_ml_prediction(df, 130)
+
+        assert prediction is None
+        # Exactly one attempt, with the pinned key — no unpinned retry.
+        mock_engine.predict.assert_called_once()
+        assert mock_engine.predict.call_args.kwargs["model_name"] == self.PINNED_KEY
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
     def test_pinned_key_reported_in_parameters(self, mock_config_class, mock_engine_class):
         """The pin must be visible in logged/serialized parameters."""
         self._mock_engine(mock_engine_class)

--- a/tests/unit/strategies/components/test_ml_signal_generator.py
+++ b/tests/unit/strategies/components/test_ml_signal_generator.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from src.prediction import PredictionResult
+from src.prediction.models.exceptions import ModelNotAvailableError
 from src.regime.detector import TrendLabel, VolLabel
 from src.strategies.components.ml_signal_generator import MLBasicSignalGenerator, MLSignalGenerator
 from src.strategies.components.regime_context import RegimeContext
@@ -975,3 +976,163 @@ class TestErroredPredictionResultHandling:
         ok = generator.generate_signal(df, 131)
         assert ok.metadata.get("reason") != "prediction_failed"
         assert "timed_out" not in ok.metadata
+
+
+class TestMLBasicSignalGeneratorModelVersionPin:
+    """Point-in-time model pinning for the backtest harness (GH #988).
+
+    A pinned generator must score every bar with the exact pinned version,
+    never whatever `latest` resolves to at invocation time — and must fail
+    fast at construction when the pin cannot be honored.
+    """
+
+    PINNED_VERSION = "2026-01-01_1h_v1"
+    PINNED_KEY = f"BTCUSDT:1h:basic:{PINNED_VERSION}"
+    LATEST_KEY = "BTCUSDT:1h:basic:2026-06-01_1h_v1"
+
+    def create_test_dataframe(self, length=150):
+        """Create test DataFrame with OHLCV data"""
+        dates = pd.date_range("2023-01-01", periods=length, freq="1h")
+        np.random.seed(42)
+        prices = 50000 * (1 + np.random.normal(0, 0.02, length)).cumprod()
+        return pd.DataFrame(
+            {
+                "open": prices,
+                "high": prices * 1.01,
+                "low": prices * 0.99,
+                "close": prices,
+                "volume": np.random.uniform(1000, 10000, length),
+            },
+            index=dates,
+        )
+
+    def _mock_engine(self, mock_engine_class, *, pinned_bundle=True):
+        """Build a mocked PredictionEngine whose registry knows both a
+        latest bundle (via select_bundle) and the pinned version (via
+        get_bundle_by_key)."""
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+
+        mock_registry = MagicMock()
+        latest_bundle = MagicMock()
+        latest_bundle.key = self.LATEST_KEY
+        latest_bundle.symbol = "BTCUSDT"
+        mock_registry.select_bundle.return_value = latest_bundle
+        if pinned_bundle:
+            versioned_bundle = MagicMock()
+            versioned_bundle.key = self.PINNED_KEY
+            versioned_bundle.symbol = "BTCUSDT"
+            mock_registry.get_bundle_by_key.return_value = versioned_bundle
+        else:
+            mock_registry.get_bundle_by_key.return_value = None
+        mock_registry.list_bundles.return_value = [latest_bundle]
+        mock_engine.model_registry = mock_registry
+
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
+        mock_result.price = 51000.0
+        mock_engine.predict.return_value = mock_result
+        mock_engine_class.return_value = mock_engine
+        return mock_engine, mock_registry
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_pinned_version_resolves_bundle_at_init(self, mock_config_class, mock_engine_class):
+        """A valid pin resolves to a full bundle key at construction."""
+        _, mock_registry = self._mock_engine(mock_engine_class)
+
+        generator = MLBasicSignalGenerator(
+            symbol="BTCUSDT",
+            model_type="basic",
+            timeframe="1h",
+            model_version=self.PINNED_VERSION,
+        )
+
+        assert generator.pinned_model_key == self.PINNED_KEY
+        mock_registry.get_bundle_by_key.assert_called_once_with(self.PINNED_KEY)
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_missing_pinned_version_raises_at_init(self, mock_config_class, mock_engine_class):
+        """A pin the registry cannot find must fail fast, not degrade."""
+        self._mock_engine(mock_engine_class, pinned_bundle=False)
+
+        with pytest.raises(ModelNotAvailableError) as excinfo:
+            MLBasicSignalGenerator(
+                symbol="BTCUSDT",
+                model_type="basic",
+                timeframe="1h",
+                model_version="2099-01-01_1h_v9",
+            )
+
+        assert "2099-01-01_1h_v9" in str(excinfo.value)
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_pin_with_degraded_engine_raises_at_init(self, mock_config_class, mock_engine_class):
+        """Engine init failure must not silently produce an unpinned run."""
+        mock_engine_class.side_effect = RuntimeError("engine init failed")
+
+        with pytest.raises(ModelNotAvailableError):
+            MLBasicSignalGenerator(
+                symbol="BTCUSDT",
+                model_type="basic",
+                timeframe="1h",
+                model_version=self.PINNED_VERSION,
+            )
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_pinned_key_takes_precedence_over_registry_latest(
+        self, mock_config_class, mock_engine_class
+    ):
+        """Predictions must be scored with the pinned key, not latest."""
+        mock_engine, mock_registry = self._mock_engine(mock_engine_class)
+
+        generator = MLBasicSignalGenerator(
+            symbol="BTCUSDT",
+            model_type="basic",
+            timeframe="1h",
+            model_version=self.PINNED_VERSION,
+        )
+        df = self.create_test_dataframe(150)
+
+        generator._get_ml_prediction(df, 130)
+
+        mock_engine.predict.assert_called_once()
+        assert mock_engine.predict.call_args.kwargs["model_name"] == self.PINNED_KEY
+        # Latest resolution is bypassed entirely at prediction time.
+        mock_registry.select_bundle.assert_not_called()
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_unpinned_generator_uses_registry_latest(self, mock_config_class, mock_engine_class):
+        """Zero behavior change without a pin: latest still wins."""
+        mock_engine, mock_registry = self._mock_engine(mock_engine_class)
+
+        generator = MLBasicSignalGenerator(symbol="BTCUSDT", model_type="basic", timeframe="1h")
+        df = self.create_test_dataframe(150)
+
+        generator._get_ml_prediction(df, 130)
+
+        assert generator.pinned_model_key is None
+        assert mock_engine.predict.call_args.kwargs["model_name"] == self.LATEST_KEY
+        mock_registry.get_bundle_by_key.assert_not_called()
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_pinned_key_reported_in_parameters(self, mock_config_class, mock_engine_class):
+        """The pin must be visible in logged/serialized parameters."""
+        self._mock_engine(mock_engine_class)
+
+        generator = MLBasicSignalGenerator(
+            symbol="BTCUSDT",
+            model_type="basic",
+            timeframe="1h",
+            model_version=self.PINNED_VERSION,
+        )
+
+        params = generator.get_parameters()
+        assert params["model_version"] == self.PINNED_VERSION
+        assert params["pinned_model_key"] == self.PINNED_KEY

--- a/tests/unit/strategies/test_exam_target_redesign.py
+++ b/tests/unit/strategies/test_exam_target_redesign.py
@@ -32,7 +32,7 @@ from src.strategies.components.exam_signal_generator import (
     SmoothedReturnExamSignalGenerator,
 )
 from src.strategies.exam_target_redesign import (
-    _MODEL_VERSION_OVERRIDE_ENV_VAR,
+    MODEL_VERSION_OVERRIDE_ENV_VAR,
     create_exam_binary_direction_strategy,
     create_exam_meta_label_strategy,
     create_exam_smoothed_return_strategy,
@@ -239,28 +239,28 @@ class TestPerEntrantExamStrategyFactories:
         assert strategy.signal_generator.model_name is None
 
     def test_binary_direction_pins_model_version_via_env_var(self, monkeypatch):
-        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+        monkeypatch.setenv(MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
 
         strategy = create_exam_binary_direction_strategy(symbol="ETHUSDT", timeframe="4h")
 
         assert strategy.signal_generator.model_name == "ETHUSDT:4h:price:2026-01-01_1h_v1"
 
     def test_triple_barrier_pins_model_version_via_env_var(self, monkeypatch):
-        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+        monkeypatch.setenv(MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
 
         strategy = create_exam_triple_barrier_strategy(symbol="BTCUSDT", timeframe="1h")
 
         assert strategy.signal_generator.model_name == "BTCUSDT:1h:price:2026-01-01_1h_v1"
 
     def test_smoothed_return_pins_model_version_via_env_var(self, monkeypatch):
-        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+        monkeypatch.setenv(MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
 
         strategy = create_exam_smoothed_return_strategy(symbol="BTCUSDT", timeframe="1h")
 
         assert strategy.signal_generator.model_name == "BTCUSDT:1h:price:2026-01-01_1h_v1"
 
     def test_env_var_unset_leaves_model_name_none(self, monkeypatch):
-        monkeypatch.delenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, raising=False)
+        monkeypatch.delenv(MODEL_VERSION_OVERRIDE_ENV_VAR, raising=False)
 
         strategy = create_exam_binary_direction_strategy()
 
@@ -328,7 +328,7 @@ class TestCreateExamMetaLabelStrategy:
         assert strategy.signal_generator.min_confidence == pytest.approx(0.7)
 
     def test_pins_model_version_via_env_var(self, monkeypatch):
-        monkeypatch.setenv(_MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
+        monkeypatch.setenv(MODEL_VERSION_OVERRIDE_ENV_VAR, "2026-01-01_1h_v1")
         with patch("src.strategies.exam_target_redesign.MLBasicSignalGenerator"):
             strategy = create_exam_meta_label_strategy(symbol="BTCUSDT", timeframe="1h")
 

--- a/tests/unit/strategies/test_hyper_growth_unit.py
+++ b/tests/unit/strategies/test_hyper_growth_unit.py
@@ -1,5 +1,7 @@
 """Unit tests for HyperGrowth strategy components."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from src.strategies.components import Signal, SignalDirection
@@ -430,3 +432,39 @@ class TestHyperGrowthExitPolicyExpressibility:
         assert policy.atr_multiplier == 1.5  # params fallback leak, pinned
         assert policy.breakeven_threshold == 0.05
         assert policy.breakeven_buffer == 0.008
+
+
+class TestHyperGrowthModelVersionPin:
+    """Factory threads the point-in-time model pin to the signal generator (GH #988)."""
+
+    PINNED_VERSION = "2026-01-01_1h_v1"
+
+    def _mock_engine(self, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_registry = MagicMock()
+        pinned_bundle = MagicMock()
+        pinned_bundle.key = f"ETHUSDT:1h:basic:{self.PINNED_VERSION}"
+        pinned_bundle.symbol = "ETHUSDT"
+        mock_registry.get_bundle_by_key.return_value = pinned_bundle
+        mock_engine.model_registry = mock_registry
+        mock_engine_class.return_value = mock_engine
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_factory_threads_model_version_to_signal_generator(
+        self, mock_config_class, mock_engine_class
+    ):
+        self._mock_engine(mock_engine_class)
+
+        strategy = create_hyper_growth_strategy(symbol="ETHUSDT", model_version=self.PINNED_VERSION)
+
+        sg = strategy.signal_generator
+        assert isinstance(sg, MLBasicSignalGenerator)
+        assert sg.pinned_model_key == f"ETHUSDT:1h:basic:{self.PINNED_VERSION}"
+
+    def test_momentum_signal_source_rejects_model_version(self):
+        with pytest.raises(ValueError, match="model_version"):
+            create_hyper_growth_strategy(
+                signal_source="momentum", model_version=self.PINNED_VERSION
+            )

--- a/tests/unit/strategies/test_ml_basic_unit.py
+++ b/tests/unit/strategies/test_ml_basic_unit.py
@@ -1,4 +1,5 @@
 from types import MethodType
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -105,3 +106,48 @@ class TestMlBasicStrategy:
         if decision.signal.direction != SignalDirection.HOLD:
             assert decision.position_size > 0
             assert decision.position_size <= balance * 0.5  # Should not exceed 50% of balance
+
+
+class TestMlBasicModelVersionPin:
+    """Factory threads the point-in-time model pin to the signal generator (GH #988)."""
+
+    PINNED_VERSION = "2026-01-01_1h_v1"
+
+    def _mock_engine(self, mock_engine_class):
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_registry = MagicMock()
+        pinned_bundle = MagicMock()
+        pinned_bundle.key = f"BTCUSDT:1h:basic:{self.PINNED_VERSION}"
+        pinned_bundle.symbol = "BTCUSDT"
+        mock_registry.get_bundle_by_key.return_value = pinned_bundle
+        mock_engine.model_registry = mock_registry
+        mock_engine_class.return_value = mock_engine
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_factory_threads_model_version_to_signal_generator(
+        self, mock_config_class, mock_engine_class
+    ):
+        self._mock_engine(mock_engine_class)
+
+        strategy = create_ml_basic_strategy(symbol="BTCUSDT", model_version=self.PINNED_VERSION)
+
+        sg = strategy.signal_generator
+        assert sg.model_version == self.PINNED_VERSION
+        assert sg.pinned_model_key == f"BTCUSDT:1h:basic:{self.PINNED_VERSION}"
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine")
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig")
+    def test_factory_without_model_version_leaves_generator_unpinned(
+        self, mock_config_class, mock_engine_class
+    ):
+        self._mock_engine(mock_engine_class)
+
+        strategy = create_ml_basic_strategy(symbol="BTCUSDT")
+
+        assert strategy.signal_generator.pinned_model_key is None
+
+    def test_fast_mode_rejects_model_version(self):
+        with pytest.raises(ValueError, match="model_version"):
+            create_ml_basic_strategy(fast_mode=True, model_version=self.PINNED_VERSION)


### PR DESCRIPTION
## Summary

Closes the backtest harness's model-version confound (#988, finding 1 of the [parity-gap investigation](https://github.com/bumpy-croc/ai-trading-bot/blob/develop/docs/research/notes/2026-07-12_parity-gap-investigation.md)): matched/comparison backtests resolve whatever model is `latest` **at invocation time**, so any backtest spanning a model-promotion boundary silently re-scores history with a model that was never live for it — the dominant mechanism behind the 12-vs-6-trade ETHUSDT parity gap.

## User-facing impact

Two new `atb backtest` flags (mutually exclusive):

- `--model-version <id>` — pin ML predictions to an exact registry version (e.g. `2026-07-04_22h_v1`) instead of `latest`.
- `--model-as-of DATE` — pin to whichever version **was** `latest` at that UTC date, resolved deterministically from bundle `metadata.json` `created_at` timestamps (new `src/prediction/models/version_resolver.py`; authoritative promotion record remains `docs/research/model-promotions.md`).

When the backtest window spans a promotion boundary, a loud warning maps each window segment to the version that was live then. The run is still scored with the **single** pinned version — no mid-backtest model switching (explicitly out of scope per #988).

## Design

- **Reuses PR #950's pinning mechanism** (`PredictionModelRegistry.get_bundle_by_key` + `ATB_MODEL_VERSION_OVERRIDE`) rather than inventing a new one:
  - Mainline strategies (`ml_basic`, `hyper_growth`): explicit `model_version` factory kwarg → `MLBasicSignalGenerator`, which resolves it to a full bundle key at construction and gives it top precedence at predict time (above cross-symbol substitution and registry-latest).
  - Exam strategies: the CLI sets `ATB_MODEL_VERSION_OVERRIDE` scoped to construction only (restored afterwards), feeding the existing PR #950 path.
- **Fail-closed everywhere**: unknown version, timeframe mismatch, degraded registry, or a strategy factory without pinning support aborts the run. A "pinned" backtest can never silently fall back to `latest`. If no version existed at the `--model-as-of` date (live ran a cross-symbol substitute), resolution fails with an explanatory error.
- **Live path untouched**: `select_bundle` stays deliberately un-pinnable; only an explicit caller argument can pin — no ambient env/config override reaches the live runner (preserves the PR #950 design decision).
- **Zero behavior change** when neither flag is passed (covered by tests, including legacy namespaces without the new attrs).

## Testing performed

- TDD: 19 resolver tests against a synthetic 3-version registry (as-of before/between/after, inclusive boundaries, naive-UTC handling, `created_at` → version-id-date fallback, tie-breaking, segment splitting incl. window-predates-first-version).
- Boundary-spanning warning tests (emitted with per-segment mapping; absent within a single version's era; also fires for explicit `--model-version`).
- Signal-generator pin tests: resolves at init, fails fast on unknown version/degraded engine, pinned key beats registry-latest at predict time, unpinned path unchanged.
- End-to-end: a pinned backtest through the real `Backtester` + `PredictionEngine` against a synthetic registry provably scores every bar with the pinned key (predict spy) and loads the pinned bundle (asserted via `get_model_info`).
- Real-CLI smoke against the repo registry: pinned non-latest `BTCUSDT/basic/2025-10-26_21h_v1` ran a full backtest with real ONNX inference; `--model-as-of 2025-10-27` correctly resolved to `2025-10-26_21h_v1` (the 14:07 promotion that day postdates midnight); pinning the 1d-trained `2025-10-27_14h_v1` into a 1h backtest correctly fail-closed.
- `atb dev quality --changed`: black + ruff + mypy green.
- Full unit suite: 5339 passed, 1 skipped. (One unrelated pre-existing local-env failure: `test_models_tft.py::test_create_model_lightgbm_dispatches_to_directional_classifier` asserts lightgbm is *not* installed, but the shared local venv has lightgbm 4.6.0; passes in clean CI envs.)

Refs #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)