### PR TITLE
fix(strategies): thread symbol through MLSignalGenerator (ml_adaptive/ml_sentiment)

### DIFF
--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -67,6 +67,15 @@ class MLSignalGenerator(SignalGenerator):
     - Regime-aware dynamic threshold adjustment
     - Confidence calculation based on prediction quality
     - Optional prediction engine integration
+
+    Unlike :class:`MLBasicSignalGenerator`, this generator does not resolve
+    its model bundle from ``PredictionModelRegistry`` by symbol/type/timeframe
+    — it only supports an explicit ``model_name`` override (or the prediction
+    engine's own symbol-agnostic default bundle when ``model_name`` is unset).
+    ``self.symbol`` therefore identifies which pair this instance is scoring
+    (for logging/metadata/factory-symbol-threading) but does not by itself
+    select a symbol-specific model; see GH issue tracking registry-based
+    selection for this class.
     """
 
     # Default thresholds (overridable per-instance for experiments).
@@ -84,6 +93,11 @@ class MLSignalGenerator(SignalGenerator):
     SHORT_THRESHOLD_LOW_VOL = -0.0006  # More conservative in low volatility (-0.06%)
     SHORT_THRESHOLD_CONFIDENCE_MULTIPLIER = 0.2  # Adjust threshold based on regime confidence
 
+    # Default symbol used when no trading symbol is threaded in (mirrors
+    # MLBasicSignalGenerator's convention so an unspecified symbol keeps
+    # today's behavior for existing callers).
+    DEFAULT_SYMBOL = "BTCUSDT"
+
     # Registry-selection hints optionally attached by strategy factories
     # (e.g. create_ml_sentiment_strategy). Bare annotations so hasattr()
     # behavior is unchanged until a factory assigns them.
@@ -95,6 +109,7 @@ class MLSignalGenerator(SignalGenerator):
         name: str = "ml_signal_generator",
         sequence_length: int = 120,
         model_name: str | None = None,
+        symbol: str | None = None,
         *,
         long_entry_threshold: float | None = None,
         short_entry_threshold: float | None = None,
@@ -113,6 +128,10 @@ class MLSignalGenerator(SignalGenerator):
             name: Name for this signal generator
             sequence_length: Sequence length for model input
             model_name: Model name for prediction engine (optional)
+            symbol: Trading symbol this generator is scoring (optional,
+                defaults to BTCUSDT). Stamped into signal metadata/logging so
+                a strategy traded on a non-default symbol is identifiable;
+                see class docstring for the model-selection caveat.
             long_entry_threshold: Minimum predicted return to open a long.
             short_entry_threshold: Maximum predicted return to open a short
                 (expected to be negative).
@@ -187,6 +206,15 @@ class MLSignalGenerator(SignalGenerator):
                 else short_threshold_confidence_multiplier
             ),
         )
+
+        # Normalize to the registry's Binance-style directory convention
+        # (mirrors MLBasicSignalGenerator) so provider-specific symbol formats
+        # (e.g. Coinbase "ETH-USD") resolve consistently.
+        raw_symbol = symbol or self.DEFAULT_SYMBOL
+        try:
+            self.symbol = SymbolFactory.to_exchange_symbol(raw_symbol, "binance")
+        except ValueError as exc:
+            raise ValueError(f"Invalid trading symbol {raw_symbol!r}: {exc}") from exc
 
         # Model name configuration
         cfg = get_config()
@@ -285,6 +313,7 @@ class MLSignalGenerator(SignalGenerator):
                     "reason": "insufficient_history",
                     "index": index,
                     "required_length": self.sequence_length,
+                    "symbol": self.symbol,
                 },
             )
 
@@ -300,6 +329,7 @@ class MLSignalGenerator(SignalGenerator):
                     "reason": "prediction_failed",
                     "timed_out": self._last_prediction_timed_out,
                     "index": index,
+                    "symbol": self.symbol,
                 },
             )
 
@@ -318,6 +348,7 @@ class MLSignalGenerator(SignalGenerator):
                     "current_price": current_price,
                     "predicted_return": 0,  # Set to 0 when price is invalid
                     "index": index,
+                    "symbol": self.symbol,
                 },
             )
 
@@ -348,6 +379,7 @@ class MLSignalGenerator(SignalGenerator):
             "long_entry_threshold": self.long_entry_threshold,
             "engine_model_name": self.model_name,
             "engine_batch": self.use_engine_batch,
+            "symbol": self.symbol,
         }
 
         # Add regime information if available
@@ -414,7 +446,7 @@ class MLSignalGenerator(SignalGenerator):
 
             # Get prediction from prediction engine
             if self.prediction_engine is None:
-                logger.error("Prediction engine not initialized for symbol prediction")
+                logger.error("Prediction engine not initialized for %s prediction", self.symbol)
                 return None
 
             window_df = df[["open", "high", "low", "close", "volume"]].iloc[
@@ -428,7 +460,8 @@ class MLSignalGenerator(SignalGenerator):
             if result.error is not None:
                 self._last_prediction_timed_out = bool(result.metadata.get("timed_out", False))
                 logger.warning(
-                    "MLSignalGenerator: prediction failed at index %d (timed_out=%s): %s",
+                    "MLSignalGenerator: prediction failed for %s at index %d (timed_out=%s): %s",
+                    self.symbol,
                     index,
                     self._last_prediction_timed_out,
                     result.error,
@@ -441,7 +474,9 @@ class MLSignalGenerator(SignalGenerator):
             return pred
 
         except Exception:
-            logger.exception("MLSignalGenerator: Prediction error at index %d", index)
+            logger.exception(
+                "MLSignalGenerator: Prediction error for %s at index %d", self.symbol, index
+            )
             return None
 
     def _should_generate_short_signal(
@@ -528,6 +563,7 @@ class MLSignalGenerator(SignalGenerator):
             {
                 "sequence_length": self.sequence_length,
                 "model_name": self.model_name,
+                "symbol": self.symbol,
                 "long_entry_threshold": self.long_entry_threshold,
                 "short_entry_threshold": self.short_entry_threshold,
                 "confidence_multiplier": self.confidence_multiplier,

--- a/src/strategies/ml_adaptive.py
+++ b/src/strategies/ml_adaptive.py
@@ -46,6 +46,7 @@ def create_ml_adaptive_strategy(
     sequence_length: int = 120,
     model_name: str | None = None,
     *,
+    symbol: str | None = None,
     long_entry_threshold: float | None = None,
     short_entry_threshold: float | None = None,
     confidence_multiplier: float | None = None,
@@ -63,6 +64,8 @@ def create_ml_adaptive_strategy(
         name: Strategy name
         sequence_length: Number of candles for sequence prediction
         model_name: Model name for prediction engine
+        symbol: Trading symbol threaded to the ML signal generator (None
+            keeps the generator default BTCUSDT).
         long_entry_threshold: Minimum predicted return for long entry.
         short_entry_threshold: Maximum predicted return for short entry.
         confidence_multiplier: Scales |predicted_return| → confidence.
@@ -79,6 +82,7 @@ def create_ml_adaptive_strategy(
         name=f"{name}_signals",
         sequence_length=sequence_length,
         model_name=model_name,
+        symbol=symbol,
         long_entry_threshold=long_entry_threshold,
         short_entry_threshold=short_entry_threshold,
         confidence_multiplier=confidence_multiplier,

--- a/src/strategies/ml_sentiment.py
+++ b/src/strategies/ml_sentiment.py
@@ -48,6 +48,7 @@ def create_ml_sentiment_strategy(
     model_type: str | None = None,
     timeframe: str | None = None,
     *,
+    symbol: str | None = None,
     long_entry_threshold: float | None = None,
     short_entry_threshold: float | None = None,
     confidence_multiplier: float | None = None,
@@ -69,6 +70,8 @@ def create_ml_sentiment_strategy(
         model_name: Model name for prediction engine
         model_type: Model type (e.g., "sentiment")
         timeframe: Model timeframe (e.g., "1h")
+        symbol: Trading symbol threaded to the ML signal generator (None
+            keeps the generator default BTCUSDT).
         long_entry_threshold: Minimum predicted return for long entry.
         short_entry_threshold: Maximum predicted return for short entry.
         confidence_multiplier: Scales |predicted_return| → confidence.
@@ -90,6 +93,7 @@ def create_ml_sentiment_strategy(
         name=f"{name}_signals",
         sequence_length=sequence_length,
         model_name=model_name,
+        symbol=symbol,
         long_entry_threshold=long_entry_threshold,
         short_entry_threshold=short_entry_threshold,
         confidence_multiplier=confidence_multiplier,

--- a/tests/unit/cli/test_backtest_symbol_wiring.py
+++ b/tests/unit/cli/test_backtest_symbol_wiring.py
@@ -30,6 +30,27 @@ class TestLoadStrategySymbolThreading:
 
             mock_create.assert_called_once_with(symbol="ETHUSDT")
 
+    def test_threads_symbol_to_ml_adaptive(self):
+        """Regression test for GH #1002: create_ml_adaptive_strategy previously
+        had no ``symbol`` parameter at all, so ``call_strategy_factory``'s
+        signature check always found it unsupported and dropped the symbol.
+        """
+        with patch(
+            "cli.commands.backtest.create_ml_adaptive_strategy", autospec=True
+        ) as mock_create:
+            _load_strategy("ml_adaptive", symbol="ETHUSDT")
+
+            mock_create.assert_called_once_with(symbol="ETHUSDT")
+
+    def test_threads_symbol_to_ml_sentiment(self):
+        """Regression test for GH #1002 (see test_threads_symbol_to_ml_adaptive)."""
+        with patch(
+            "cli.commands.backtest.create_ml_sentiment_strategy", autospec=True
+        ) as mock_create:
+            _load_strategy("ml_sentiment", symbol="ETHUSDT")
+
+            mock_create.assert_called_once_with(symbol="ETHUSDT")
+
     def test_factory_without_symbol_param_called_plain(self):
         """Factories that do not accept symbol are invoked without it."""
         with patch(

--- a/tests/unit/strategies/components/test_ml_signal_generator.py
+++ b/tests/unit/strategies/components/test_ml_signal_generator.py
@@ -347,6 +347,54 @@ class TestMLSignalGenerator:
 
     @patch("src.strategies.components.ml_signal_generator.PredictionEngine", autospec=True)
     @patch("src.strategies.components.ml_signal_generator.PredictionConfig", autospec=True)
+    def test_symbol_parameter_default(self, mock_config_class, mock_engine_class):
+        """Test symbol parameter defaults to BTCUSDT (GH #1002)."""
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = MLSignalGenerator()
+        assert generator.symbol == "BTCUSDT"
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine", autospec=True)
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig", autospec=True)
+    def test_symbol_parameter_custom(self, mock_config_class, mock_engine_class):
+        """Test symbol parameter can be customized (GH #1002)."""
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        mock_engine_class.return_value = mock_engine
+
+        generator = MLSignalGenerator(symbol="ETHUSDT")
+        assert generator.symbol == "ETHUSDT"
+
+        # Verify symbol is included in get_parameters output
+        params = generator.get_parameters()
+        assert params["symbol"] == "ETHUSDT"
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine", autospec=True)
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig", autospec=True)
+    def test_symbol_stamped_in_signal_metadata(self, mock_config_class, mock_engine_class):
+        """generate_signal metadata carries the trading symbol (GH #1002)."""
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+
+        mock_result = Mock(spec=PredictionResult)
+        mock_result.error = None
+        mock_result.metadata = {}
+        mock_result.price = 51000.0
+        mock_engine.predict.return_value = mock_result
+        mock_engine_class.return_value = mock_engine
+
+        generator = MLSignalGenerator(symbol="ETHUSDT", sequence_length=120)
+        generator.prediction_engine = mock_engine
+        df = self.create_test_dataframe(150)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.metadata["symbol"] == "ETHUSDT"
+
+    @patch("src.strategies.components.ml_signal_generator.PredictionEngine", autospec=True)
+    @patch("src.strategies.components.ml_signal_generator.PredictionConfig", autospec=True)
     def test_prediction_failure_handling(self, mock_config_class, mock_engine_class):
         """Test handling of prediction failures"""
         mock_engine = MagicMock()

--- a/tests/unit/strategies/test_ml_adaptive_sentiment_symbol_wiring.py
+++ b/tests/unit/strategies/test_ml_adaptive_sentiment_symbol_wiring.py
@@ -1,0 +1,43 @@
+"""Regression tests for GH #1002.
+
+``create_ml_adaptive_strategy`` and ``create_ml_sentiment_strategy`` had no
+``symbol`` parameter at all, and the ``MLSignalGenerator`` component they both
+construct had no ``symbol`` attribute — so ``call_strategy_factory``'s
+``inspect.signature`` check always found "does this factory accept symbol?"
+to be False, silently dropping the trading symbol for every caller (live
+runner, backtest CLI, experiments framework), unlike the sibling
+``ml_basic``/``hyper_growth`` strategies which already threaded it through.
+"""
+
+import pytest
+
+from src.strategies.ml_adaptive import create_ml_adaptive_strategy
+from src.strategies.ml_sentiment import create_ml_sentiment_strategy
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast]
+
+
+class TestMlAdaptiveSymbolWiring:
+    def test_symbol_reaches_signal_generator(self):
+        strategy = create_ml_adaptive_strategy(symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    def test_bare_call_defaults_to_btcusdt(self):
+        """Existing unspecified-symbol callers must see no behavior change."""
+        strategy = create_ml_adaptive_strategy()
+
+        assert strategy.signal_generator.symbol == "BTCUSDT"
+
+
+class TestMlSentimentSymbolWiring:
+    def test_symbol_reaches_signal_generator(self):
+        strategy = create_ml_sentiment_strategy(symbol="ETHUSDT")
+
+        assert strategy.signal_generator.symbol == "ETHUSDT"
+
+    def test_bare_call_defaults_to_btcusdt(self):
+        """Existing unspecified-symbol callers must see no behavior change."""
+        strategy = create_ml_sentiment_strategy()
+
+        assert strategy.signal_generator.symbol == "BTCUSDT"


### PR DESCRIPTION
## Summary

- `create_ml_adaptive_strategy` / `create_ml_sentiment_strategy` had no `symbol` parameter at all, and the `MLSignalGenerator` component they both construct had no `symbol` / `DEFAULT_SYMBOL` attribute whatsoever — unlike the sibling `MLBasicSignalGenerator` (used by `ml_basic`/`hyper_growth`). This meant `call_strategy_factory`'s `inspect.signature`-based "does this factory accept `symbol`?" check always resolved to False for these two strategies, so the trading symbol was silently dropped through every call path: live runner, backtest CLI, experiments framework.
- Adds `symbol: str | None = None` to `MLSignalGenerator.__init__`, mirroring `MLBasicSignalGenerator`'s `DEFAULT_SYMBOL = "BTCUSDT"` + `SymbolFactory.to_exchange_symbol(...)` normalization pattern, and threads it through both factory signatures.
- Stamps `self.symbol` into signal metadata (`generate_signal`'s HOLD/decision paths) and prediction-failure log lines for observability/debuggability, matching `MLBasicSignalGenerator`'s convention.

## What this does NOT fix (filed separately)

`MLSignalGenerator` has **no registry-based model bundle selection at all** — it only supports an explicit `model_name` override, or (when unset, which is the case for essentially every `ml_adaptive`/`ml_sentiment` run today) the prediction engine's own symbol-agnostic `get_default_bundle()` → `bundles[0]` fallback. Threading `self.symbol` through does not by itself make model selection symbol-aware, since there is no registry-selection code path in this class to plug it into (confirmed: no `self._registry`, no `select_bundle` calls anywhere in `MLSignalGenerator`, unlike `MLBasicSignalGenerator`). Wiring that up needs a `model_type` convention decision (the registry only has `basic`/`sentiment` types today; `ml_adaptive` doesn't even have an established type) and a fail-fast-vs-fail-soft call — filed as bumpy-croc/ai-trading-bot#1007 and dispatched separately, since it's a design decision rather than a mechanical mirror of this fix.

## Changes

- `src/strategies/components/ml_signal_generator.py`: `DEFAULT_SYMBOL`, `symbol` param + normalization in `MLSignalGenerator.__init__`; `self.symbol` stamped into signal metadata and prediction-failure logging; class docstring documents the model-selection caveat above.
- `src/strategies/ml_adaptive.py`, `src/strategies/ml_sentiment.py`: `symbol: str | None = None` keyword-only param threaded into the `MLSignalGenerator(...)` construction call.
- Tests: new `tests/unit/strategies/test_ml_adaptive_sentiment_symbol_wiring.py` (factory-level: symbol reaches `strategy.signal_generator.symbol`, bare calls still default to BTCUSDT); extended `tests/unit/strategies/components/test_ml_signal_generator.py` (default/custom symbol, `get_parameters`, signal metadata stamping) and `tests/unit/cli/test_backtest_symbol_wiring.py` (backtest CLI threads symbol into both factories via the shared `call_strategy_factory` helper).

Note: `src/engines/live/runner.py::load_strategy`'s strategy registry does not currently include `ml_adaptive`/`ml_sentiment` at all (only `chaos_test`, `hyper_growth`, `ml_basic`) — that's a separate, pre-existing gap unrelated to symbol threading, so no live-runner test was added for these two strategies.

`src/experiments/runner.py::ExperimentRunner._load_strategy` does not yet thread `config.symbol` into any factory (that's #997, tracked separately and not yet landed on `develop` as of this branch) — not touched here.

## Testing

```
pytest -m "not integration and not slow" tests/unit/strategies/ tests/unit/engines/ tests/unit/cli/ tests/unit/experiments/ -q
# 2068 passed

atb dev quality --changed
# black / ruff / mypy all pass
```

Manually reproduced and verified the issue's repro snippet now returns `symbol == "BTCUSDT"` by default and threads a custom symbol correctly for both `create_ml_adaptive_strategy` and `create_ml_sentiment_strategy`.

## Review

This touches ML strategy / model-selection-adjacent code — flagging for `architecture-reviewer` and `code-reviewer` per this repo's CLAUDE.md workflow before merge. Not merging this myself.

Closes #1002