### PR TITLE
Sync staging to develop — pick up #1001 drawdown-gate fix [SOAK]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -56,6 +56,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`base_asset_from_symbol`) so the exchange and execution layers size closes
   against the same base asset. The same hazard in the emergency-close sites
   (entry coordinator, recovery reconciler) is tracked in #989.
+- **Max-drawdown hard cap enforced on the same iteration; dynamic-risk
+  throttle anchored to the durable session peak** (2026-07-12 risk audit
+  P1/P2): the live loop ran `_check_entry_conditions` BEFORE
+  `_check_max_drawdown`, so on the exact bar where a stop-loss fill pushed
+  drawdown to the 20% cap a fresh entry (up to 20% notional) could execute
+  before close-only latched — the guard had no in-line pre-order gate,
+  unlike the #807 circuit breaker. Every exposure-increase chokepoint
+  (entry evaluation, `execute_entry_locked`, the legacy short path, the
+  scale-in close-only provider) now re-assesses the guard in-line via
+  `LiveTradingEngine._refresh_drawdown_gate` →
+  `MaxDrawdownEnforcer.check_before_new_risk()`, which also re-latches
+  close-only in the same iteration after a mid-breach `resume_trading()`
+  and can seed the peak before the first entry evaluation after a
+  mid-breach restart (in-line seeding never consumes the loop check's
+  bounded `MAX_SEED_ATTEMPTS` deferral budget). Relatedly, the graduated
+  dynamic-risk throttle read the restart-resettable in-memory
+  `PerformanceTracker.peak_balance` while the hard cap used the durable DB
+  session peak — a restart mid-drawdown re-anchored the throttle to the
+  depressed balance and silently disarmed the 5–20% size reductions (#845
+  peak-reset class). All three live throttle call sites (runtime entry
+  sizing, `LiveDynamicRiskCoordinator`, `_get_dynamic_risk_adjusted_params`)
+  now source `LiveTradingEngine._durable_peak_balance()` — max(guard's
+  durable session peak, tracker peak, current balance) — so the throttle and
+  the hard cap measure drawdown from the same baseline.
 - **Deterministic backtest inference; loud live timeout accounting** (#912
   side-finding): `PredictionEngine` gated every model inference behind
   `run_with_timeout(max_prediction_latency)` — a 0.1s latency-*alerting*

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -98,6 +98,22 @@ numbers `account_history.drawdown` is derived from.
   `risk_event`, and the alert webhook (if configured) fire once. The trip is **latched**: it
   survives balance recovery below the cap, does not re-spam, and re-trips on restart via the
   boot-time peak recompute.
+- **Same-iteration enforcement**: because the loop-level check runs after entry evaluation,
+  every exposure-increase chokepoint (entry evaluation, `execute_entry_locked`, the legacy
+  short path, the scale-in gate) also re-assesses the guard in-line via the engine's
+  `_refresh_drawdown_gate` before reading close-only — a stop-loss fill that pushes drawdown
+  to the cap blocks that same iteration's entry instead of leaking one bar of fresh exposure
+  (2026-07-12 risk audit P1). The same gate re-latches close-only immediately after a
+  `resume_trading()` issued while the breach persists, and — because it can seed the peak
+  from `account_history` — arms the guard before the first entry evaluation after a
+  mid-breach restart.
+- **Dynamic-risk throttle shares the baseline**: the graduated drawdown throttle
+  (`DynamicRiskManager`, applied to entry sizing and risk-parameter scaling) measures
+  drawdown from the engine's `_durable_peak_balance()` — the max of the guard's durable
+  session peak, the in-memory tracker peak, and the current balance — so a restart
+  mid-drawdown can no longer re-anchor the throttle to the depressed balance and disarm the
+  graduated size reductions while the hard cap still sees the real drawdown (#845 peak-reset
+  class).
 - **Clearing a trip (operator only)**: `resume_trading()` alone will not stick — the guard
   re-trips on the next iteration while the breach persists. To accept the loss and resume,
   restart with `FEATURE_MAX_DRAWDOWN_RESET_PEAK=true`, which re-baselines the peak to the

--- a/src/engines/live/dynamic_risk_coordinator.py
+++ b/src/engines/live/dynamic_risk_coordinator.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from src.database.manager import DatabaseManager
     from src.engines.shared.dynamic_risk_handler import DynamicRiskHandler
     from src.position_management.dynamic_risk import DynamicRiskManager
-    from src.trading.performance import PerformanceTracker
 
 logger = logging.getLogger(__name__)
 
@@ -34,9 +33,10 @@ class LiveDynamicRiskEngineState(Protocol):
     initial_balance: float
     trading_session_id: int | None
     dynamic_risk_manager: DynamicRiskManager | None
-    performance_tracker: PerformanceTracker
     db_manager: DatabaseManager
     _dynamic_risk_handler: DynamicRiskHandler
+
+    def _durable_peak_balance(self) -> float: ...
 
 
 class LiveDynamicRiskCoordinator:
@@ -61,19 +61,18 @@ class LiveDynamicRiskCoordinator:
             return original_size
 
         try:
-            perf_metrics = state.performance_tracker.get_metrics()
-
             # Guard against zero/None balances to prevent division by zero in drawdown calc
             balance = (
                 float(state.current_balance)
                 if state.current_balance is not None and state.current_balance > 0
                 else float(state.initial_balance)
             )
-            peak = (
-                float(perf_metrics.peak_balance)
-                if perf_metrics.peak_balance is not None and perf_metrics.peak_balance > 0
-                else balance
-            )
+            # Durable session peak — the same baseline the max-drawdown hard
+            # cap enforces from. The in-memory tracker peak re-anchors to the
+            # depressed balance on restart and disarmed the throttle exactly
+            # when it should bind (#845 peak-reset class).
+            durable_peak = float(state._durable_peak_balance())
+            peak = durable_peak if durable_peak > 0 else balance
             # Peak should never be less than current balance
             peak_balance = max(peak, balance)
 

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -49,7 +49,6 @@ if TYPE_CHECKING:
     from src.engines.live.order_tracker import OrderTracker
     from src.engines.live.reconciliation import BaseAssetLockRegistry
     from src.risk.risk_manager import RiskManager
-    from src.trading.performance import PerformanceTracker
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +68,6 @@ class LiveEntryEngineState(Protocol):
     trading_session_id: int | None
     strategy: Any
     risk_manager: RiskManager
-    performance_tracker: PerformanceTracker
     live_entry_handler: LiveEntryHandler
     live_position_tracker: LivePositionTracker
     stop_loss_manager: LiveStopLossManager
@@ -94,6 +92,10 @@ class LiveEntryEngineState(Protocol):
     def _send_alert(self, message: str) -> bool: ...
 
     def _enter_close_only_mode(self) -> None: ...
+
+    def _refresh_drawdown_gate(self) -> bool: ...
+
+    def _durable_peak_balance(self) -> float: ...
 
     def _extract_indicators(self, df: pd.DataFrame, index: int) -> dict: ...
 
@@ -179,6 +181,11 @@ class LiveEntryCoordinator:
         """Check if new positions should be opened"""
         state = self._state
 
+        # In-line hard-cap gate (#807 pattern): re-assess the drawdown guard
+        # BEFORE reading close-only, so a breach realized earlier in this same
+        # iteration (e.g. a stop-loss fill) blocks this entry, not the next one.
+        state._refresh_drawdown_gate()
+
         # Close-only mode: skip all entry signals, exits/stops still active
         if state._close_only_mode:
             logger.debug("Close-only mode active — skipping entry check")
@@ -206,7 +213,6 @@ class LiveEntryCoordinator:
         decision_signal = getattr(runtime_decision, "signal", None)
 
         if use_runtime:
-            perf_metrics = state.performance_tracker.get_metrics()
             # Pass symbol/timeframe/df/index so LiveEntryHandler can run
             # correlation control. These are required keyword args of the
             # handler's correlation guard (see LiveEntryHandler.process_runtime_decision
@@ -214,6 +220,9 @@ class LiveEntryCoordinator:
             # them, correlation_handler.apply_correlation_control is silently
             # skipped, so the live engine over-concentrates in correlated pairs
             # that the backtest engine de-risks.
+            # peak_balance comes from the engine's durable session peak (the
+            # same baseline as the hard cap), NOT the restart-resettable
+            # PerformanceTracker peak (#845 peak-reset class).
             entry_signal_result = state.live_entry_handler.process_runtime_decision(
                 runtime_decision=runtime_decision,
                 balance=state.current_balance,
@@ -223,7 +232,7 @@ class LiveEntryCoordinator:
                 timeframe=state.timeframe,
                 df=df,
                 index=current_index,
-                peak_balance=perf_metrics.peak_balance or state.current_balance,
+                peak_balance=state._durable_peak_balance() or state.current_balance,
                 trading_session_id=state.trading_session_id,
             )
             if entry_signal_result.should_enter and entry_signal_result.side is not None:
@@ -524,6 +533,10 @@ class LiveEntryCoordinator:
     ) -> None:
         """Execute a new trading position using shared execution modules."""
         state = self._state
+        # In-line hard-cap gate: re-assess the drawdown guard at the execution
+        # chokepoint so callers that routed around check_entry_conditions are
+        # still blocked on the breach bar itself.
+        state._refresh_drawdown_gate()
         # Defense-in-depth: refuse any entry routed around check_entry_conditions.
         # Close-only mode gates the chokepoint too, so the legacy short path and
         # any direct caller can never add exposure while halted.
@@ -960,6 +973,8 @@ class LiveEntryCoordinator:
     ) -> None:
         """Evaluate and execute a legacy duck-typed short entry (non-runtime strategies)."""
         state = self._state
+        # In-line hard-cap gate: same-iteration enforcement for the legacy path.
+        state._refresh_drawdown_gate()
         # Close-only mode: skip legacy short evaluation, exits/stops still active
         if state._close_only_mode:
             logger.debug("Close-only mode active — skipping legacy short entry check")

--- a/src/engines/live/monitoring/drawdown_guard.py
+++ b/src/engines/live/monitoring/drawdown_guard.py
@@ -12,6 +12,12 @@ the legacy duck-typed short path and any direct caller), and scale-ins. Exits,
 partial exits, stop-loss management, and reconciliation keep running. It never
 liquidates anything — it only stops new risk.
 
+Because the loop-level check runs AFTER entry evaluation, each of those
+chokepoints ALSO re-assesses the guard in-line via ``check_before_new_risk``
+(through the engine's ``_refresh_drawdown_gate``) so a breach realized earlier
+in the same iteration — e.g. a stop-loss fill — blocks that iteration's entry
+instead of leaking one bar of fresh exposure (2026-07-12 risk audit P1).
+
 Peak-equity source: the AUTHORITATIVE baseline is the ``account_history``
 session max (active session plus the recovered inactive session on clean
 restarts), recomputed on boot so a restart cannot reset the drawdown baseline
@@ -313,10 +319,33 @@ class MaxDrawdownEnforcer:
 
     def check(self) -> None:
         """Assess current drawdown; enforce the hard cap on breach."""
+        self._run_check(count_seed_deferral=True)
+
+    def check_before_new_risk(self) -> None:
+        """In-line pre-order variant of :meth:`check` for exposure chokepoints.
+
+        The loop-level check runs AFTER entry evaluation, so on the bar that
+        crosses the cap a fresh entry would execute before close-only latches
+        (one-iteration leak). Entry evaluation, the ``execute_entry_locked``
+        chokepoint, and the scale-in gate call this first — mirroring the
+        #807 in-line circuit-breaker gate — so the cap binds on the SAME
+        iteration, including the first iteration after a mid-breach restart.
+
+        Identical enforcement, but a deferred seeding attempt is NOT counted
+        against ``MAX_SEED_ATTEMPTS``: the bounded current-balance fallback
+        stays owned by the once-per-iteration loop check, so several
+        chokepoint calls per iteration cannot burn through the deferral
+        budget prematurely.
+        """
+        self._run_check(count_seed_deferral=False)
+
+    def _run_check(self, *, count_seed_deferral: bool) -> None:
         state = self._state
         try:
             balance = float(state.current_balance)
-            if not self._guard.seeded and not self._try_seed(balance):
+            if not self._guard.seeded and not self._try_seed(
+                balance, count_deferral=count_seed_deferral
+            ):
                 return  # seeding deferred (DB/session not ready); retry next cycle
             assessment = self._guard.observe(balance)
         except Exception as e:
@@ -366,14 +395,16 @@ class MaxDrawdownEnforcer:
                 exc_info=True,
             )
 
-    def _try_seed(self, balance: float) -> bool:
+    def _try_seed(self, balance: float, *, count_deferral: bool = True) -> bool:
         """Seed the peak baseline; the DB session max is AUTHORITATIVE.
 
         Returns False when seeding must be deferred to the next loop cycle
         (session id not resolved yet, or the account_history read failed).
         After ``MAX_SEED_ATTEMPTS`` deferrals the guard falls back to the
         current balance with a WARNING so the cap is never left unarmed
-        indefinitely.
+        indefinitely. With ``count_deferral=False`` (the in-line pre-order
+        gate) a failed attempt defers without consuming that budget and can
+        never trigger the fallback — only the loop check arms it.
 
         The in-memory PerformanceTracker peak is deliberately NOT a seed
         candidate: it can initialize from the CONFIGURED initial balance,
@@ -388,7 +419,8 @@ class MaxDrawdownEnforcer:
             self._guard.seed_peak(balance)
             return True
 
-        self._seed_attempts += 1
+        if count_deferral:
+            self._seed_attempts += 1
         session_id = state.trading_session_id
         db_read_ok = False
         db_peak: float | None = None
@@ -419,7 +451,7 @@ class MaxDrawdownEnforcer:
                 )
 
         if not db_read_ok:
-            if self._seed_attempts < MAX_SEED_ATTEMPTS:
+            if not count_deferral or self._seed_attempts < MAX_SEED_ATTEMPTS:
                 return False
             logger.warning(
                 "Max-drawdown guard: no successful account_history read after %d "

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import queue
 import signal
@@ -1004,7 +1005,9 @@ class LiveTradingEngine:
             max_filled_price_deviation=self.max_filled_price_deviation,
             # Close-only mode must block ALL exposure increases, including
             # scale-ins; read at call time so mid-session trips take effect.
-            close_only_provider=lambda: self._close_only_mode,
+            # The gate re-assesses the drawdown guard on read so a breach
+            # realized earlier in the SAME iteration blocks the scale-in too.
+            close_only_provider=self._refresh_drawdown_gate,
             # Manual kill-switch (#922): scale-ins share the engine's halt state.
             system_halt=self._system_halt,
         )
@@ -1101,11 +1104,12 @@ class LiveTradingEngine:
             return self.risk_manager.params
 
         try:
-            # Calculate dynamic risk adjustments
-            perf_metrics = self.performance_tracker.get_metrics()
+            # Calculate dynamic risk adjustments from the durable session peak
+            # (#845 peak-reset class: the in-memory tracker peak re-anchors to
+            # the depressed balance on restart and disarms the throttle).
             adjustments = self.dynamic_risk_manager.calculate_dynamic_risk_adjustments(
                 current_balance=self.current_balance,
-                peak_balance=perf_metrics.peak_balance or self.current_balance,
+                peak_balance=self._durable_peak_balance() or self.current_balance,
                 session_id=self.trading_session_id,
             )
 
@@ -2136,6 +2140,50 @@ class LiveTradingEngine:
         """
         self._drawdown_enforcer.check()
         self._circuit_breaker_enforcer.check()
+
+    def _refresh_drawdown_gate(self) -> bool:
+        """Re-assess the max-drawdown hard cap at an exposure-increase chokepoint.
+
+        The loop-level ``_check_max_drawdown`` runs AFTER entry evaluation, so
+        on the bar that crosses the cap a fresh entry would execute before
+        close-only latched (one-iteration leak, 2026-07-12 risk audit P1).
+        Entry evaluation, ``execute_entry_locked``, the legacy short path, and
+        the scale-in gate call this first — mirroring the #807 in-line
+        circuit-breaker gate — so the cap binds on the SAME iteration.
+
+        Returns the (possibly just-latched) close-only flag, making it usable
+        directly as the exit handler's ``close_only_provider``.
+        """
+        self._drawdown_enforcer.check_before_new_risk()
+        return self._close_only_mode
+
+    def _durable_peak_balance(self) -> float:
+        """Peak balance for drawdown-based risk throttling, durable across restarts.
+
+        The graduated dynamic-risk throttle must measure drawdown from the
+        same baseline as the max-drawdown hard cap. The in-memory
+        PerformanceTracker peak re-anchors to the (possibly depressed) current
+        balance on restart, which silently disarmed the throttle exactly when
+        it should bind (#845 peak-reset class). The drawdown guard's peak is
+        seeded from the durable ``account_history`` session max, so it
+        survives restarts; take the max with the tracker peak and the current
+        balance so the throttle never measures from a LOWER peak than either
+        source. Until the guard seeds (first gate/loop check at boot) this
+        degrades to the in-memory behavior.
+        """
+        peak = 0.0
+        for candidate in (
+            self._drawdown_enforcer.guard.peak_balance,
+            self.performance_tracker.get_metrics().peak_balance,
+            self.current_balance,
+        ):
+            try:
+                value = float(candidate)
+            except (TypeError, ValueError):
+                continue
+            if math.isfinite(value) and value > peak:
+                peak = value
+        return peak
 
     def _extract_indicators(self, df: pd.DataFrame, index: int) -> dict:
         """Extract indicator values from dataframe for logging"""

--- a/tests/unit/engines/live/conftest.py
+++ b/tests/unit/engines/live/conftest.py
@@ -1,0 +1,57 @@
+"""Shared fixtures for live-engine unit tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def make_live_engine():
+    """Factory for a LiveTradingEngine with mocked DB/exchange boundaries.
+
+    The DB mock resumes the session balance and serves the account_history
+    session peak the drawdown guard seeds from; everything else stays real so
+    tests exercise the genuine wiring between the loop, the guards, and the
+    entry/exit coordinators.
+    """
+
+    def _make(
+        *,
+        db_peak: float | None = 100.0,
+        resumed_balance: float = 100.0,
+        session_id: int = 20,
+        **engine_kwargs,
+    ):
+        from src.engines.live.trading_engine import LiveTradingEngine
+
+        db = MagicMock()
+        db.get_active_session_id.return_value = session_id
+        db.get_current_balance.return_value = resumed_balance
+        db.get_session_peak_balance.return_value = db_peak
+        with (
+            patch("src.engines.live.trading_engine.DatabaseManager", return_value=db),
+            patch("src.engines.live.trading_engine.get_config", return_value={}),
+            patch(
+                "src.engines.live.trading_engine._create_exchange_provider",
+                return_value=(MagicMock(), "mock"),
+            ),
+        ):
+            # enable_live_trading=True so _resume_balance_from_snapshot runs
+            # (balance recovery is live-mode only); the exchange is a mock and
+            # these tests never reach order execution.
+            engine = LiveTradingEngine(
+                strategy=MagicMock(),
+                data_provider=MagicMock(),
+                initial_balance=100.0,
+                enable_live_trading=True,
+                resume_from_last_balance=True,
+                **engine_kwargs,
+            )
+        # The guard seeds lazily from the session peak; provide the id that
+        # start() would have resolved.
+        engine.trading_session_id = session_id
+        return engine
+
+    return _make

--- a/tests/unit/engines/live/test_drawdown_same_iteration_gate.py
+++ b/tests/unit/engines/live/test_drawdown_same_iteration_gate.py
@@ -1,0 +1,165 @@
+"""Same-iteration enforcement of the max-drawdown hard cap at entry chokepoints.
+
+The loop-level ``_check_max_drawdown`` runs AFTER entry evaluation, so on the
+exact bar where a stop-loss fill pushed drawdown to the cap, a fresh entry
+could execute before close-only latched (one-iteration leak; 2026-07-12 risk
+audit P1). Every exposure-increase chokepoint therefore calls the in-line
+pre-order gate ``_refresh_drawdown_gate`` first — mirroring the #807 in-line
+circuit-breaker gate — so the cap binds on the SAME iteration.
+
+Fixture mirrors the audit's numeric trace: session peak $100 from
+account_history, a stop-loss fill drops the balance to $80 (exactly the 20%
+cap) mid-iteration, and the entry evaluated later in that iteration must be
+blocked.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+pytestmark = pytest.mark.fast
+
+
+def _entry_df() -> pd.DataFrame:
+    return pd.DataFrame({"close": [50000.0]})
+
+
+def _no_entry_signal() -> MagicMock:
+    signal = MagicMock()
+    signal.should_enter = False
+    signal.side = None
+    return signal
+
+
+def _runtime_decision() -> MagicMock:
+    decision = MagicMock()
+    decision.signal.strength = 0.8
+    decision.signal.confidence = 0.7
+    decision.regime = None
+    decision.risk_metrics = None
+    decision.metadata = {}
+    return decision
+
+
+def _check_entry(engine) -> None:
+    engine.entry_coordinator.check_entry_conditions(
+        df=_entry_df(),
+        current_index=0,
+        symbol="BTCUSDT",
+        current_price=50000.0,
+        current_time=datetime(2024, 1, 1, tzinfo=UTC),
+        runtime_decision=_runtime_decision(),
+    )
+
+
+def test_entry_evaluation_blocked_on_the_breach_bar(make_live_engine):
+    """Audit P1 trace: SL fill drops balance to the cap mid-iteration → the
+    SAME iteration's entry evaluation must be blocked, not the next one."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    engine.current_balance = 80.0  # stop-loss realized earlier this iteration
+    engine.live_entry_handler = MagicMock()
+    engine.live_entry_handler.process_runtime_decision.return_value = _no_entry_signal()
+
+    with patch.object(engine, "_is_runtime_strategy", return_value=True):
+        _check_entry(engine)
+
+    assert engine._close_only_mode is True
+    engine.live_entry_handler.process_runtime_decision.assert_not_called()
+    engine.strategy.process_candle.assert_not_called()
+
+
+def test_entry_evaluation_proceeds_below_the_cap(make_live_engine):
+    """No false positive: 15% drawdown is below the cap — evaluation runs."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    engine.current_balance = 85.0
+    engine.live_entry_handler = MagicMock()
+    engine.live_entry_handler.process_runtime_decision.return_value = _no_entry_signal()
+
+    with patch.object(engine, "_is_runtime_strategy", return_value=True):
+        _check_entry(engine)
+
+    assert engine._close_only_mode is False
+    engine.live_entry_handler.process_runtime_decision.assert_called_once()
+
+
+def test_execute_entry_locked_blocked_on_the_breach_bar(make_live_engine):
+    """The execution chokepoint re-assesses the guard too, so direct callers
+    and the legacy short path cannot add exposure on the breach bar."""
+    from src.engines.shared.models import PositionSide
+
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    engine.current_balance = 80.0
+    engine.live_entry_handler = MagicMock()
+
+    engine.entry_coordinator.execute_entry_locked(
+        symbol="BTCUSDT",
+        side=PositionSide.LONG,
+        size=0.2,
+        price=50000.0,
+        stop_loss=45000.0,
+        take_profit=55000.0,
+        signal_strength=0.8,
+        signal_confidence=0.7,
+    )
+
+    assert engine._close_only_mode is True
+    engine.live_entry_handler.execute_entry.assert_not_called()
+
+
+def test_legacy_short_evaluation_blocked_on_the_breach_bar(make_live_engine):
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    engine.current_balance = 80.0
+    engine.strategy.check_short_entry_conditions = MagicMock(return_value=True)
+
+    engine.entry_coordinator.process_legacy_short_entry(
+        df=_entry_df(),
+        current_index=0,
+        symbol="BTCUSDT",
+        current_price=50000.0,
+        current_time=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+
+    assert engine._close_only_mode is True
+    engine.strategy.check_short_entry_conditions.assert_not_called()
+
+
+def test_scale_in_close_only_provider_reassesses_drawdown(make_live_engine):
+    """Scale-ins read close-only through the engine's provider; it must run
+    the in-line gate so a breach earlier in the iteration blocks them too."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    engine.current_balance = 80.0
+
+    assert engine.live_exit_handler._close_only_provider() is True
+    assert engine._close_only_mode is True
+
+
+def test_scale_in_provider_stays_open_below_the_cap(make_live_engine):
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    engine.current_balance = 85.0
+
+    assert engine.live_exit_handler._close_only_provider() is False
+    assert engine._close_only_mode is False
+
+
+def test_resume_mid_breach_reblocks_before_the_next_entry_evaluation(make_live_engine):
+    """resume_trading() while still in breach must not leak even one entry
+    evaluation: the in-line gate re-latches close-only before the check."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    engine.current_balance = 80.0
+    engine.live_entry_handler = MagicMock()
+    engine.live_entry_handler.process_runtime_decision.return_value = _no_entry_signal()
+    engine._check_max_drawdown()  # loop check trips close-only
+    assert engine._close_only_mode is True
+
+    engine.resume_trading()  # operator resumes while drawdown persists
+    assert engine._close_only_mode is False
+
+    with patch.object(engine, "_is_runtime_strategy", return_value=True):
+        _check_entry(engine)
+
+    assert engine._close_only_mode is True
+    engine.live_entry_handler.process_runtime_decision.assert_not_called()

--- a/tests/unit/engines/live/test_entry_coordinator.py
+++ b/tests/unit/engines/live/test_entry_coordinator.py
@@ -579,8 +579,7 @@ def _make_runtime_entry_state() -> MagicMock:
     state.live_position_tracker.position_count = 0
     state.risk_manager = MagicMock()
     state.risk_manager.get_max_concurrent_positions.return_value = 1
-    state.performance_tracker = MagicMock()
-    state.performance_tracker.get_metrics.return_value = MagicMock(peak_balance=1000.0)
+    state._durable_peak_balance.return_value = 1000.0
     state.live_entry_handler = MagicMock()
     no_entry = MagicMock()
     no_entry.should_enter = False
@@ -616,6 +615,20 @@ def _runtime_decision_with(signal) -> MagicMock:
     decision.risk_metrics = None
     decision.metadata = {}
     return decision
+
+
+def test_runtime_entry_passes_the_durable_peak_to_the_handler():
+    """The drawdown throttle inside process_runtime_decision must measure
+    drawdown from the engine's durable peak, not the restart-resettable
+    PerformanceTracker peak (#845 peak-reset class)."""
+    state = _make_runtime_entry_state()
+    state._durable_peak_balance.return_value = 1234.0
+    decision = _runtime_decision_with(_ml_signal({}))
+
+    _run_runtime_entry(state, decision)
+
+    kwargs = state.live_entry_handler.process_runtime_decision.call_args.kwargs
+    assert kwargs["peak_balance"] == 1234.0
 
 
 def test_runtime_entry_logs_signal_ml_predictions():

--- a/tests/unit/engines/live/test_max_drawdown_guard.py
+++ b/tests/unit/engines/live/test_max_drawdown_guard.py
@@ -419,6 +419,55 @@ def test_missing_session_defers_seeding_until_available():
 
 
 # ---------------------------------------------------------------------------
+# In-line pre-order gate: check_before_new_risk (same-iteration enforcement)
+# ---------------------------------------------------------------------------
+
+
+def test_pre_order_gate_trips_close_only_in_the_same_call():
+    """The gate runs the full assessment, so a breach realized earlier in the
+    iteration (e.g. a stop-loss fill) halts entries before they evaluate."""
+    state = _make_state(balance=80.0, db_peak=100.0)
+    enforcer = _make_enforcer(state)
+
+    enforcer.check_before_new_risk()
+
+    state._enter_close_only_mode.assert_called_once()
+
+
+def test_pre_order_gate_seeds_at_boot_so_restart_mid_breach_blocks_first_entries():
+    """The first entry evaluation happens BEFORE the first loop check, so the
+    gate must be able to seed from account_history and trip right there."""
+    state = _make_state(balance=78.0, db_peak=100.0, tracker_peak=78.0)
+    enforcer = _make_enforcer(state)  # fresh process: guard has no memory
+
+    enforcer.check_before_new_risk()
+
+    assert enforcer.guard.peak_balance == pytest.approx(100.0)
+    state._enter_close_only_mode.assert_called_once()
+
+
+def test_pre_order_gate_does_not_consume_the_seed_deferral_budget():
+    """Several chokepoint calls per iteration must not burn through the
+    bounded MAX_SEED_ATTEMPTS deferrals owned by the loop check, and the gate
+    itself never arms the current-balance fallback baseline."""
+    from src.engines.live.monitoring.drawdown_guard import MAX_SEED_ATTEMPTS
+
+    state = _make_state(balance=90.0)
+    state.db_manager.get_session_peak_balance.side_effect = RuntimeError("db down")
+    enforcer = _make_enforcer(state)
+
+    for _ in range(MAX_SEED_ATTEMPTS * 3):
+        enforcer.check_before_new_risk()
+    assert enforcer.guard.seeded is False
+
+    for _ in range(MAX_SEED_ATTEMPTS - 1):
+        enforcer.check()
+    assert enforcer.guard.seeded is False  # budget untouched by the gate calls
+    enforcer.check()
+    assert enforcer.guard.seeded is True  # loop fallback still arms the cap
+
+
+# ---------------------------------------------------------------------------
 # While tripped: entries blocked, exits/stop-loss calls pass through
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/engines/live/test_throttle_durable_peak.py
+++ b/tests/unit/engines/live/test_throttle_durable_peak.py
@@ -1,0 +1,99 @@
+"""Durable peak source for the dynamic-risk throttle (#845 peak-reset class).
+
+The graduated drawdown throttle read the in-memory PerformanceTracker peak,
+which re-anchors to the (possibly depressed) current balance on restart —
+silently disarming the 5–20% size reductions exactly when the account is in
+drawdown. The max-drawdown hard cap was already hardened to seed from the
+durable ``account_history`` session peak; ``_durable_peak_balance`` pins the
+throttle to that same baseline so both controls measure drawdown alike.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+pytestmark = pytest.mark.fast
+
+
+def _tiered_manager():
+    """Real DynamicRiskManager with a single 10%-drawdown → ×0.5 tier."""
+    from src.position_management.dynamic_risk import DynamicRiskConfig, DynamicRiskManager
+
+    return DynamicRiskManager(
+        config=DynamicRiskConfig(
+            enabled=True,
+            drawdown_thresholds=[0.10],
+            risk_reduction_factors=[0.5],
+        )
+    )
+
+
+def _enable_dynamic_risk(engine) -> None:
+    manager = _tiered_manager()
+    engine.dynamic_risk_manager = manager
+    engine._dynamic_risk_handler.set_manager(manager)
+
+
+def test_durable_peak_prefers_guard_seeded_db_peak(make_live_engine):
+    """Restart mid-drawdown: the tracker re-anchors to the depressed balance
+    but the durable peak keeps the account_history session max."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=85.0)
+    engine._check_max_drawdown()  # loop check arms the guard from the DB peak
+
+    assert engine.performance_tracker.peak_balance == pytest.approx(85.0)
+    assert engine._durable_peak_balance() == pytest.approx(100.0)
+
+
+def test_durable_peak_degrades_to_tracker_before_guard_seeds(make_live_engine):
+    """Until the guard arms (first loop iteration at boot) the in-memory peak
+    is the best available baseline — matching pre-hardening behavior."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=85.0)
+
+    assert engine._durable_peak_balance() == pytest.approx(85.0)
+
+
+def test_durable_peak_never_below_current_balance(make_live_engine):
+    engine = make_live_engine(db_peak=100.0, resumed_balance=85.0)
+    engine._check_max_drawdown()
+    engine.current_balance = 120.0  # new equity high not yet observed
+
+    assert engine._durable_peak_balance() == pytest.approx(120.0)
+
+
+def test_throttle_applies_depressed_tier_after_restart(make_live_engine):
+    """Restart 15% below the durable peak: the 10%-tier multiplier must apply
+    even though the in-memory tracker reads ~0 drawdown."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=85.0)
+    _enable_dynamic_risk(engine)
+    engine._check_max_drawdown()  # arm the guard from the DB peak
+
+    adjusted = engine._apply_dynamic_risk_adjustment(0.2, datetime.now(UTC))
+
+    assert adjusted == pytest.approx(0.1)  # 15% drawdown ≥ 0.10 tier → ×0.5
+
+
+def test_throttle_stays_full_size_when_at_the_durable_peak(make_live_engine):
+    """No false throttling: at the peak the multiplier stays 1.0."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=100.0)
+    _enable_dynamic_risk(engine)
+    engine._check_max_drawdown()
+
+    adjusted = engine._apply_dynamic_risk_adjustment(0.2, datetime.now(UTC))
+
+    assert adjusted == pytest.approx(0.2)
+
+
+def test_risk_param_adjustment_uses_the_durable_peak(make_live_engine):
+    """_get_dynamic_risk_adjusted_params (stop widening, daily-risk scaling)
+    must measure drawdown from the same durable baseline."""
+    engine = make_live_engine(db_peak=100.0, resumed_balance=85.0)
+    _enable_dynamic_risk(engine)
+    engine._check_max_drawdown()
+
+    adjusted = engine._get_dynamic_risk_adjusted_params()
+
+    assert adjusted.base_risk_per_trade == pytest.approx(
+        engine.risk_manager.params.base_risk_per_trade * 0.5
+    )

--- a/tests/unit/live/test_dynamic_risk_coordinator.py
+++ b/tests/unit/live/test_dynamic_risk_coordinator.py
@@ -32,8 +32,7 @@ def _make_state(*, manager=_ENABLED, session_id=1, balance=1000.0) -> MagicMock:
     state.current_balance = balance
     state.initial_balance = 1000.0
     state.trading_session_id = session_id
-    state.performance_tracker = MagicMock()
-    state.performance_tracker.get_metrics.return_value = MagicMock(peak_balance=1200.0)
+    state._durable_peak_balance.return_value = 1200.0
     state.db_manager = MagicMock()
     state._dynamic_risk_handler = MagicMock()
     state._dynamic_risk_handler.get_adjustment_objects.return_value = []
@@ -54,13 +53,26 @@ def test_apply_returns_handler_adjusted_size_and_logs():
     result = LiveDynamicRiskCoordinator(state).apply_dynamic_risk_adjustment(0.1, datetime.now(UTC))
 
     assert result == 0.05
-    # peak_balance passed = max(peak, balance) = max(1200, 1000) = 1200
+    # peak_balance passed = max(durable peak, balance) = max(1200, 1000) = 1200
     kwargs = state._dynamic_risk_handler.apply_dynamic_risk.call_args.kwargs
     assert kwargs["balance"] == 1000.0
     assert kwargs["peak_balance"] == 1200.0
     assert kwargs["trading_session_id"] == 1
     # adjustment objects were drained for logging
     state._dynamic_risk_handler.get_adjustment_objects.assert_called_once_with(clear=True)
+
+
+def test_apply_peak_never_below_balance_when_durable_source_lags():
+    """A durable peak of 0.0 (guard not yet seeded, tracker empty) must not
+    produce a phantom 100% drawdown — the balance floors the peak."""
+    state = _make_state()
+    state._durable_peak_balance.return_value = 0.0
+    state._dynamic_risk_handler.apply_dynamic_risk.return_value = 0.08
+
+    LiveDynamicRiskCoordinator(state).apply_dynamic_risk_adjustment(0.1, datetime.now(UTC))
+
+    kwargs = state._dynamic_risk_handler.apply_dynamic_risk.call_args.kwargs
+    assert kwargs["peak_balance"] == 1000.0
 
 
 def test_apply_falls_back_to_original_on_error():


### PR DESCRIPTION
## What this carries

Second sync of the 2026-07-12 SOAK wave. Staging already carries the fix wave through `f4d525b8` (#994, #996, #981, #978, #968 via PR #1009). This picks up the one commit develop gained since:

- **#1001** (`51a1dbb5`) — enforce max-drawdown cap on the same iteration; anchor dynamic-risk throttle to the durable session peak.

This completes the safety set for the soak validation gating the prod promote. **SOAK deploy — NOT a prod promote.**

Not included: **#992** (mfe/mae raw-excursion columns) — still OPEN on develop at sync time.

## Testing
Develop content is already CI-green; sync-PR CI is advisory. Full 5-point boot verification on staging after redeploy: drawdown guard armed at staging-plausible peak, no spurious close-only/SYSTEM_HALT (same-iteration gate must not false-trip), trading loop started + session recovered + zero ERROR/CRITICAL, no migration errors (0013 et al), native model resolves with no CROSS-SYMBOL banner.