### PR TITLE
feat(live): make short-guard inventory rejections DB-observable (#990 step 4)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **DB-durable short-guard rejection events** (#990 step 4): the live
+  SHORT-side margin inventory guard now writes a `system_events` row
+  (`event_type=SHORT_ENTRY_BLOCKED`, component `execution`) whenever it
+  rejects a short entry — carrying symbol/side, the observed free base-asset
+  balance, the $1 dust threshold, the rejection reason
+  (`free_inventory_above_threshold` vs the fail-closed
+  `balance_lookup_error`/`balance_unavailable` branches), signal
+  strength/confidence, and an open-position snapshot. Rows are bounded per
+  rejection episode (first + every 10th + an episode-end summary carrying the
+  TRUE rejection total, written on guard pass or after a 2h inactivity gap),
+  so the confirmed 30-cycle/45-min episode class writes ~4 rows, not 30.
+  Purely additive observability: the guard's accept/reject behavior,
+  threshold, and ordering are unchanged, and event writes are fault-isolated
+  so they can never break or delay the trading decision. No migration needed
+  (the 19-char enum value fits the varchar(23) column from migration 0013).
+  Funnel query: `SELECT * FROM system_events WHERE event_type =
+  'SHORT_ENTRY_BLOCKED'` (`error_code` distinguishes rejection rows from
+  `SHORT_GUARD_EPISODE_END` summaries).
 - **Point-in-time model pinning for the backtest harness** (#988): new
   `atb backtest` flags `--model-version` (pin an exact registry version) and
   `--model-as-of DATE` (resolve which version was `latest` at that date from

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -132,6 +132,10 @@ class EventType(enum.Enum):
     # mode. Distinct from ALERT so promote/kill verdicts can count trips with a
     # single event_type filter. Requires migration 0013 (widened varchar).
     CIRCUIT_BREAKER_DRY_RUN = "CIRCUIT_BREAKER_DRY_RUN"
+    # Short entries rejected by the margin inventory guard, plus their
+    # episode-end summaries (error_code distinguishes the two). 19 chars —
+    # fits the varchar(23) column from migration 0013, no migration needed.
+    SHORT_ENTRY_BLOCKED = "SHORT_ENTRY_BLOCKED"
     TEST = "TEST"  # Added for verification scripts and development diagnostics
 
 

--- a/src/engines/live/execution/entry_handler.py
+++ b/src/engines/live/execution/entry_handler.py
@@ -329,7 +329,8 @@ class LiveEntryHandler(SharedEntryHandlerMixin):
                 error=f"entry_no_fill_{decision.reason}",
             )
 
-        # Execute via execution engine
+        # Execute via execution engine. signal_context enriches short-guard
+        # rejection events only; it never influences execution.
         exec_result = self.execution_engine.execute_entry(
             symbol=symbol,
             side=signal.side,
@@ -337,6 +338,10 @@ class LiveEntryHandler(SharedEntryHandlerMixin):
             base_price=decision.fill_price,
             balance=balance,
             liquidity=decision.liquidity,
+            signal_context={
+                "strength": signal.signal_strength,
+                "confidence": signal.signal_confidence,
+            },
         )
 
         if not exec_result.success:

--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -261,7 +261,9 @@ class LiveExecutionEngine:
                 "free_base_balance": float(free_balance) if free_balance is not None else None,
                 "free_value_usd": float(free_value_usd) if free_value_usd is not None else None,
                 "threshold_usd": SHORT_GUARD_DUST_THRESHOLD_USD,
-                "signal": dict(signal_context) if signal_context else None,
+                "signal": {k: float(v) for k, v in signal_context.items()}
+                if signal_context
+                else None,
                 "open_positions": self._open_position_snapshot(),
                 "episode": {
                     "started_at": episode_started_at.isoformat(),

--- a/src/engines/live/execution/execution_engine.py
+++ b/src/engines/live/execution/execution_engine.py
@@ -11,9 +11,12 @@ from __future__ import annotations
 
 import logging
 import math
+import threading
 import time
 import uuid
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from src.config.constants import (
@@ -34,6 +37,30 @@ from src.trading.precision import quantize_to_step
 from src.trading.symbols.factory import base_asset_from_symbol
 
 logger = logging.getLogger(__name__)
+
+# Free base-asset value at or below this is ignorable dust for the SHORT
+# inventory guard; above it, MARGIN_BUY would sell held inventory instead of
+# borrowing, so the guard rejects the short.
+SHORT_GUARD_DUST_THRESHOLD_USD = 1.0
+# Guard rejections separated by more than this quiet gap belong to different
+# episodes. Live decision cycles run seconds-to-minutes apart (a confirmed
+# 2026-06-07 episode rejected every ~90s); two hours spans any configured
+# candle interval without merging distinct episodes.
+SHORT_GUARD_EPISODE_GAP_SECONDS = 2 * 3600.0
+# Within an episode, write the first rejection and every Nth after it so a
+# long rejection streak stays queryable without one system_events row per
+# trading cycle.
+SHORT_GUARD_EMIT_EVERY_N = 10
+
+
+@dataclass
+class _ShortGuardEpisode:
+    """One contiguous run of short-guard rejections for a base asset."""
+
+    started_at: datetime
+    last_reject_at: datetime
+    last_reject_monotonic: float
+    reject_count: int
 
 
 @dataclass
@@ -120,6 +147,19 @@ class LiveExecutionEngine:
         self.session_id: int | None = None
         self.strategy_name: str = "unknown"
 
+        # Optional callback returning open positions, used to enrich
+        # short-guard rejection events. Set by the trading engine after
+        # initialization (like db_manager); duck-typed so observability can
+        # never couple execution to the position tracker.
+        self.position_snapshot_provider: Callable[[], Iterable[object]] | None = None
+        # Short-guard rejection episodes keyed by base asset (the guard's own
+        # scope — one borrow blocks every symbol sharing the base). The lock
+        # guards the dict only; event writes happen outside it.
+        self._short_guard_lock = threading.Lock()
+        self._short_guard_episodes: dict[str, _ShortGuardEpisode] = {}
+        # Injectable clock for deterministic episode-gap tests.
+        self._monotonic: Callable[[], float] = time.monotonic
+
         # Use shared cost calculator for all fee and slippage calculations
         self._cost_calculator = CostCalculator(
             fee_rate=fee_rate,
@@ -133,6 +173,7 @@ class LiveExecutionEngine:
         error_code: str,
         *,
         severity: str = "error",
+        details: dict[str, Any] | None = None,
     ) -> None:
         """Record an execution-layer condition (order rejection / phantom-order
         UNKNOWN) in ``system_events`` so the exchange reason isn't lost to
@@ -147,11 +188,176 @@ class LiveExecutionEngine:
                 message=message,
                 severity=severity,
                 component="execution",
+                details=details,
                 session_id=self.session_id,
                 error_code=error_code,
             )
         except Exception as e:  # pragma: no cover - defensive; never break execution
             logger.warning("Failed to log execution event %s: %s", error_code, e)
+
+    def _record_short_guard_rejection(
+        self,
+        symbol: str,
+        base_asset: str,
+        *,
+        reason: str,
+        price: float,
+        free_balance: float | None,
+        free_value_usd: float | None,
+        signal_context: Mapping[str, float] | None,
+    ) -> None:
+        """Write DB-durable evidence of a short-guard rejection (#990 funnel).
+
+        Rows are bounded per episode: the first rejection and every
+        ``SHORT_GUARD_EMIT_EVERY_N``-th one, plus an episode-end summary when
+        the guard passes again or after an inactivity gap. Entirely
+        fault-isolated — the reject decision is already made and observability
+        must never break or delay it.
+        """
+        try:
+            now_monotonic = self._monotonic()
+            now_utc = datetime.now(UTC)
+            ended: _ShortGuardEpisode | None = None
+            with self._short_guard_lock:
+                episode = self._short_guard_episodes.get(base_asset)
+                if (
+                    episode is not None
+                    and now_monotonic - episode.last_reject_monotonic
+                    > SHORT_GUARD_EPISODE_GAP_SECONDS
+                ):
+                    ended = episode
+                    episode = None
+                if episode is None:
+                    episode = _ShortGuardEpisode(
+                        started_at=now_utc,
+                        last_reject_at=now_utc,
+                        last_reject_monotonic=now_monotonic,
+                        reject_count=1,
+                    )
+                    self._short_guard_episodes[base_asset] = episode
+                    emit = True
+                else:
+                    episode.reject_count += 1
+                    episode.last_reject_at = now_utc
+                    episode.last_reject_monotonic = now_monotonic
+                    emit = episode.reject_count % SHORT_GUARD_EMIT_EVERY_N == 0
+                reject_count = episode.reject_count
+                episode_started_at = episode.started_at
+
+            # DB writes stay outside the episode lock so a slow insert cannot
+            # serialize entries on other base assets.
+            if ended is not None:
+                self._emit_short_guard_episode_end(
+                    symbol, base_asset, ended, end_reason="inactivity_gap"
+                )
+            if not emit:
+                return
+            details: dict[str, Any] = {
+                "symbol": symbol,
+                "side": "short",
+                "base_asset": base_asset,
+                "reason": reason,
+                "price": float(price),
+                "free_base_balance": float(free_balance) if free_balance is not None else None,
+                "free_value_usd": float(free_value_usd) if free_value_usd is not None else None,
+                "threshold_usd": SHORT_GUARD_DUST_THRESHOLD_USD,
+                "signal": dict(signal_context) if signal_context else None,
+                "open_positions": self._open_position_snapshot(),
+                "episode": {
+                    "started_at": episode_started_at.isoformat(),
+                    "reject_count": reject_count,
+                },
+            }
+            message = (
+                f"Short entry blocked by inventory guard for {symbol} ({reason}): "
+                f"rejection {reject_count} of episode started "
+                f"{episode_started_at.isoformat()}"
+            )
+            self._log_execution_event(
+                EventType.SHORT_ENTRY_BLOCKED,
+                message,
+                "SHORT_ENTRY_BLOCKED",
+                severity="warning",
+                details=details,
+            )
+        except Exception as e:
+            logger.warning("Failed to record short-guard rejection for %s: %s", symbol, e)
+
+    def _note_short_guard_pass(self, symbol: str, base_asset: str) -> None:
+        """Close any active rejection episode when the guard accepts a short.
+
+        Fault-isolated: episode bookkeeping must never affect the accept path.
+        """
+        try:
+            with self._short_guard_lock:
+                ended = self._short_guard_episodes.pop(base_asset, None)
+            if ended is not None:
+                self._emit_short_guard_episode_end(
+                    symbol, base_asset, ended, end_reason="guard_pass"
+                )
+        except Exception as e:
+            logger.warning("Failed to close short-guard episode for %s: %s", symbol, e)
+
+    def _emit_short_guard_episode_end(
+        self,
+        symbol: str,
+        base_asset: str,
+        episode: _ShortGuardEpisode,
+        *,
+        end_reason: str,
+    ) -> None:
+        """Write the episode summary row carrying the TRUE rejection total.
+
+        Per-rejection rows are sampled (every Nth), so funnel counts come from
+        ``rejections_total`` here.
+        """
+        duration_s = max(0.0, (episode.last_reject_at - episode.started_at).total_seconds())
+        details = {
+            "symbol": symbol,
+            "base_asset": base_asset,
+            "end_reason": end_reason,
+            "rejections_total": episode.reject_count,
+            "episode_started_at": episode.started_at.isoformat(),
+            "episode_last_rejection_at": episode.last_reject_at.isoformat(),
+            "episode_duration_seconds": duration_s,
+        }
+        message = (
+            f"Short-guard rejection episode ended for {symbol} ({end_reason}): "
+            f"{episode.reject_count} rejection(s) over {duration_s / 60.0:.1f} min"
+        )
+        self._log_execution_event(
+            EventType.SHORT_ENTRY_BLOCKED,
+            message,
+            "SHORT_GUARD_EPISODE_END",
+            severity="warning",
+            details=details,
+        )
+
+    def _open_position_snapshot(self) -> list[dict[str, Any]] | None:
+        """Compact open-position state for guard-rejection events.
+
+        Best-effort: returns None when no provider is wired or the read
+        fails — the event row still writes without it.
+        """
+        if self.position_snapshot_provider is None:
+            return None
+        try:
+            positions = list(self.position_snapshot_provider())
+        except Exception as e:
+            logger.warning("Position snapshot for short-guard event failed: %s", e)
+            return None
+        snapshot: list[dict[str, Any]] = []
+        for pos in positions:
+            side = getattr(pos, "side", None)
+            snapshot.append(
+                {
+                    "symbol": getattr(pos, "symbol", None),
+                    "side": getattr(side, "value", side),
+                    "current_size": getattr(pos, "current_size", None),
+                    "quantity": getattr(pos, "quantity", None),
+                }
+            )
+        return snapshot
 
     @staticmethod
     def _position_side_to_str(side: PositionSide) -> str:
@@ -322,6 +528,7 @@ class LiveExecutionEngine:
         base_price: float,
         balance: float,
         liquidity: str | None = None,
+        signal_context: Mapping[str, float] | None = None,
     ) -> EntryExecutionResult:
         """Execute an entry order with fees and slippage.
 
@@ -332,6 +539,8 @@ class LiveExecutionEngine:
             base_price: Current market price.
             balance: Account balance.
             liquidity: Liquidity classification for fee and slippage handling.
+            signal_context: Optional signal metadata (strength/confidence),
+                recorded on short-guard rejection events only.
 
         Returns:
             EntryExecutionResult with execution details.
@@ -394,7 +603,11 @@ class LiveExecutionEngine:
             client_order_id: str | None = None
             if self.enable_live_trading:
                 order_id, client_order_id = self._execute_live_order(
-                    symbol, side, position_value, executed_price
+                    symbol,
+                    side,
+                    position_value,
+                    executed_price,
+                    signal_context=signal_context,
                 )
                 if not order_id:
                     return EntryExecutionResult(
@@ -629,6 +842,8 @@ class LiveExecutionEngine:
         side: PositionSide,
         value: float,
         price: float,
+        *,
+        signal_context: Mapping[str, float] | None = None,
     ) -> tuple[str | None, str | None]:
         """Execute a real market order via exchange with idempotency.
 
@@ -640,6 +855,8 @@ class LiveExecutionEngine:
             side: Position side.
             value: Order value.
             price: Expected price.
+            signal_context: Optional signal metadata (strength/confidence),
+                recorded on short-guard rejection events only.
 
         Returns:
             Tuple of (exchange_order_id, client_order_id). Both None on failure.
@@ -710,6 +927,15 @@ class LiveExecutionEngine:
                             base_asset,
                             e,
                         )
+                        self._record_short_guard_rejection(
+                            symbol,
+                            base_asset,
+                            reason="balance_lookup_error",
+                            price=price,
+                            free_balance=None,
+                            free_value_usd=None,
+                            signal_context=signal_context,
+                        )
                         return None, None
                     if balance is None:
                         # API returned None — fail closed
@@ -719,11 +945,20 @@ class LiveExecutionEngine:
                             symbol,
                             base_asset,
                         )
+                        self._record_short_guard_rejection(
+                            symbol,
+                            base_asset,
+                            reason="balance_unavailable",
+                            price=price,
+                            free_balance=None,
+                            free_value_usd=None,
+                            signal_context=signal_context,
+                        )
                         return None, None
                     if balance.free > 0:
                         # Use the price arg already validated by caller
                         free_value = balance.free * price if price > 0 else balance.free
-                        if free_value > 1.0:  # $1 dust threshold
+                        if free_value > SHORT_GUARD_DUST_THRESHOLD_USD:
                             logger.error(
                                 "Cannot open short for %s — margin wallet holds "
                                 "%.8f %s (~$%.2f free). MARGIN_BUY would sell "
@@ -735,7 +970,19 @@ class LiveExecutionEngine:
                                 free_value,
                                 base_asset,
                             )
+                            self._record_short_guard_rejection(
+                                symbol,
+                                base_asset,
+                                reason="free_inventory_above_threshold",
+                                price=price,
+                                free_balance=balance.free,
+                                free_value_usd=free_value,
+                                signal_context=signal_context,
+                            )
                             return None, None
+                    # Guard consulted and accepted — close any open rejection
+                    # episode with its summary row.
+                    self._note_short_guard_pass(symbol, base_asset)
 
             # Generate deterministic client order ID for idempotency
             # Format: atb_{timestamp_hex}_{uuid8} (~24 chars, within Binance 36-char limit)

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -930,6 +930,12 @@ class LiveTradingEngine:
         )
         # Wire db_manager for order journaling (session_id set during start())
         self.live_execution_engine.db_manager = self.db_manager
+        # Open-position snapshot for short-guard rejection events; the
+        # positions property returns a lock-guarded copy, so this read is
+        # safe from the entry path.
+        self.live_execution_engine.position_snapshot_provider = lambda: list(
+            self.live_position_tracker.positions.values()
+        )
 
     def _init_entry_handler(self, entry_handler: LiveEntryHandler | None) -> ExposureGovernor:
         """Build the entry handler and its exposure/macro/circuit-breaker gates."""

--- a/tests/unit/engines/live/test_short_guard_rejection_events.py
+++ b/tests/unit/engines/live/test_short_guard_rejection_events.py
@@ -1,0 +1,416 @@
+"""Unit tests for DB-durable short-guard rejection events (#990).
+
+The SHORT-side margin inventory guard in ``_execute_live_order`` fail-closed
+rejects short entries whenever free base-asset value exceeds the dust
+threshold. These tests verify the rejections become observable as
+``system_events`` rows without changing the guard's accept/reject behavior:
+
+- A rejection writes a SHORT_ENTRY_BLOCKED event carrying symbol, side, free
+  balance, threshold, signal metadata, and an open-position snapshot.
+- A rejection episode (many consecutive cycles) writes a bounded number of
+  rows: the first rejection, every Nth after it, and an episode-end summary.
+- Event-write failures never propagate into the trading decision.
+- The guard's decision itself is unchanged in both accept and reject paths.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.database.models import EventType
+from src.engines.live.execution.execution_engine import (
+    SHORT_GUARD_DUST_THRESHOLD_USD,
+    SHORT_GUARD_EMIT_EVERY_N,
+    SHORT_GUARD_EPISODE_GAP_SECONDS,
+    LiveExecutionEngine,
+)
+from src.engines.shared.models import PositionSide
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakePosition:
+    """Minimal open-position stand-in with real (JSON-safe) field values."""
+
+    symbol: str
+    side: PositionSide
+    current_size: float
+    quantity: float
+
+
+def _make_margin_engine(*, free_base: float | None = 0.05):
+    """Build a live LiveExecutionEngine in margin mode.
+
+    ``free_base`` sets the mocked free base-asset balance (None -> get_balance
+    returns None, the fail-closed branch).
+    """
+    mock_exchange = MagicMock()
+    mock_exchange.place_order.return_value = MagicMock(
+        order_id="test_order_123",
+        average_price=2000.0,
+        filled_quantity=0.025,
+        commission=0.0,
+        status="FILLED",
+    )
+    mock_exchange.is_margin_mode = True
+    if free_base is None:
+        mock_exchange.get_balance.return_value = None
+    else:
+        balance = MagicMock()
+        balance.free = free_base
+        mock_exchange.get_balance.return_value = balance
+
+    engine = LiveExecutionEngine(
+        enable_live_trading=True,
+        exchange_interface=mock_exchange,
+    )
+    engine._normalize_quantity = MagicMock(return_value=0.025)
+    engine.db_manager = MagicMock()
+    engine.session_id = 7
+    engine.strategy_name = "test_strategy"
+    return engine
+
+
+def _reject_short(engine, *, signal_context=None):
+    """Run one short-entry attempt through the guard; return its result."""
+    return engine._execute_live_order(
+        symbol="ETHUSDT",
+        side=PositionSide.SHORT,
+        value=50.0,
+        price=2000.0,
+        signal_context=signal_context,
+    )
+
+
+def _logged_events(engine):
+    """Return the list of log_event call kwargs recorded on the mock db."""
+    return [call.kwargs for call in engine.db_manager.log_event.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# Rejection event payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_rejection_emits_event_with_payload():
+    """A guard rejection writes one SHORT_ENTRY_BLOCKED row with full context."""
+    engine = _make_margin_engine(free_base=0.05)  # ~$100 free at $2000
+
+    result = _reject_short(engine, signal_context={"strength": 0.8, "confidence": 0.6})
+
+    assert result == (None, None)
+    events = _logged_events(engine)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_type"] == EventType.SHORT_ENTRY_BLOCKED
+    assert event["severity"] == "warning"
+    assert event["component"] == "execution"
+    assert event["error_code"] == "SHORT_ENTRY_BLOCKED"
+    assert event["session_id"] == 7
+
+    details = event["details"]
+    assert details["symbol"] == "ETHUSDT"
+    assert details["side"] == "short"
+    assert details["base_asset"] == "ETH"
+    assert details["reason"] == "free_inventory_above_threshold"
+    assert details["free_base_balance"] == pytest.approx(0.05)
+    assert details["free_value_usd"] == pytest.approx(100.0)
+    assert details["threshold_usd"] == pytest.approx(SHORT_GUARD_DUST_THRESHOLD_USD)
+    assert details["price"] == pytest.approx(2000.0)
+    assert details["signal"] == {"strength": 0.8, "confidence": 0.6}
+    assert details["episode"]["reject_count"] == 1
+
+
+@pytest.mark.fast
+def test_rejection_includes_open_position_snapshot():
+    """The event carries a compact snapshot of open positions when wired."""
+    engine = _make_margin_engine(free_base=0.05)
+    engine.position_snapshot_provider = lambda: [
+        _FakePosition(symbol="ETHUSDT", side=PositionSide.LONG, current_size=0.02, quantity=0.01)
+    ]
+
+    _reject_short(engine)
+
+    details = _logged_events(engine)[0]["details"]
+    assert details["open_positions"] == [
+        {"symbol": "ETHUSDT", "side": "long", "current_size": 0.02, "quantity": 0.01}
+    ]
+
+
+@pytest.mark.fast
+def test_rejection_without_provider_has_null_snapshot():
+    """No snapshot provider wired -> open_positions is None, event still writes."""
+    engine = _make_margin_engine(free_base=0.05)
+
+    _reject_short(engine)
+
+    details = _logged_events(engine)[0]["details"]
+    assert details["open_positions"] is None
+
+
+@pytest.mark.fast
+def test_snapshot_provider_failure_does_not_block_event():
+    """A raising snapshot provider degrades to None instead of losing the row."""
+    engine = _make_margin_engine(free_base=0.05)
+
+    def _boom():
+        raise RuntimeError("tracker unavailable")
+
+    engine.position_snapshot_provider = _boom
+
+    result = _reject_short(engine)
+
+    assert result == (None, None)
+    details = _logged_events(engine)[0]["details"]
+    assert details["open_positions"] is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed branches also emit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_balance_lookup_error_emits_event():
+    """The fail-closed lookup-error rejection is observable too."""
+    engine = _make_margin_engine(free_base=0.05)
+    engine.exchange_interface.get_balance.side_effect = ConnectionError("api down")
+
+    result = _reject_short(engine)
+
+    assert result == (None, None)
+    details = _logged_events(engine)[0]["details"]
+    assert details["reason"] == "balance_lookup_error"
+    assert details["free_base_balance"] is None
+    assert details["free_value_usd"] is None
+
+
+@pytest.mark.fast
+def test_balance_unavailable_emits_event():
+    """get_balance returning None (fail-closed) is observable too."""
+    engine = _make_margin_engine(free_base=None)
+
+    result = _reject_short(engine)
+
+    assert result == (None, None)
+    details = _logged_events(engine)[0]["details"]
+    assert details["reason"] == "balance_unavailable"
+    assert details["free_base_balance"] is None
+
+
+# ---------------------------------------------------------------------------
+# Episode dedup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_episode_dedup_bounds_rows():
+    """30 consecutive rejections write 4 rows (1st + every Nth), not 30."""
+    engine = _make_margin_engine(free_base=0.05)
+
+    for _ in range(30):
+        assert _reject_short(engine) == (None, None)
+
+    events = _logged_events(engine)
+    assert len(events) == 4  # rejections 1, 10, 20, 30 with N=10
+    counts = [e["details"]["episode"]["reject_count"] for e in events]
+    assert counts == [1, SHORT_GUARD_EMIT_EVERY_N, 2 * SHORT_GUARD_EMIT_EVERY_N, 30]
+    assert all(e["error_code"] == "SHORT_ENTRY_BLOCKED" for e in events)
+
+
+@pytest.mark.fast
+def test_guard_pass_emits_episode_end_summary():
+    """When the guard accepts again, the episode closes with a summary row."""
+    engine = _make_margin_engine(free_base=0.05)
+    for _ in range(3):
+        _reject_short(engine)
+
+    # Inventory cleared: guard passes and the order goes through.
+    engine.exchange_interface.get_balance.return_value = MagicMock(free=0.0)
+    result = _reject_short(engine)
+
+    assert result[0] is not None  # order placed — accept path unchanged
+    events = _logged_events(engine)
+    summary = events[-1]
+    assert summary["error_code"] == "SHORT_GUARD_EPISODE_END"
+    assert summary["event_type"] == EventType.SHORT_ENTRY_BLOCKED
+    details = summary["details"]
+    assert details["end_reason"] == "guard_pass"
+    assert details["rejections_total"] == 3
+    assert details["base_asset"] == "ETH"
+
+
+@pytest.mark.fast
+def test_inactivity_gap_closes_episode_and_starts_fresh():
+    """A rejection after a long quiet gap summarises the old episode and
+    starts a new one (first-of-episode row emits again)."""
+    engine = _make_margin_engine(free_base=0.05)
+    now = 1000.0
+    engine._monotonic = lambda: now
+
+    for _ in range(2):
+        _reject_short(engine)
+    assert len(_logged_events(engine)) == 1  # first rejection only
+
+    now += SHORT_GUARD_EPISODE_GAP_SECONDS + 1.0
+    _reject_short(engine)
+
+    events = _logged_events(engine)
+    assert len(events) == 3
+    gap_summary = events[1]
+    assert gap_summary["error_code"] == "SHORT_GUARD_EPISODE_END"
+    assert gap_summary["details"]["end_reason"] == "inactivity_gap"
+    assert gap_summary["details"]["rejections_total"] == 2
+    fresh = events[2]
+    assert fresh["error_code"] == "SHORT_ENTRY_BLOCKED"
+    assert fresh["details"]["episode"]["reject_count"] == 1
+
+
+@pytest.mark.fast
+def test_new_episode_after_guard_pass_emits_first_rejection():
+    """After an episode closes via guard pass, the next rejection is a fresh
+    first-of-episode row (the latch resets)."""
+    engine = _make_margin_engine(free_base=0.05)
+    _reject_short(engine)
+
+    engine.exchange_interface.get_balance.return_value = MagicMock(free=0.0)
+    _reject_short(engine)  # guard pass -> episode end summary
+
+    blocked = MagicMock()
+    blocked.free = 0.05
+    engine.exchange_interface.get_balance.return_value = blocked
+    _reject_short(engine)
+
+    events = _logged_events(engine)
+    assert [e["error_code"] for e in events] == [
+        "SHORT_ENTRY_BLOCKED",
+        "SHORT_GUARD_EPISODE_END",
+        "SHORT_ENTRY_BLOCKED",
+    ]
+    assert events[-1]["details"]["episode"]["reject_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Fault isolation and unchanged guard behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_event_write_failure_does_not_propagate():
+    """A DB failure in the event write never breaks the rejection decision."""
+    engine = _make_margin_engine(free_base=0.05)
+    engine.db_manager.log_event.side_effect = RuntimeError("db down")
+
+    result = _reject_short(engine)
+
+    assert result == (None, None)
+    engine.exchange_interface.place_order.assert_not_called()
+
+
+@pytest.mark.fast
+def test_rejection_without_session_still_rejects():
+    """No db_manager/session wired -> guard decision identical, no crash."""
+    engine = _make_margin_engine(free_base=0.05)
+    engine.db_manager = None
+    engine.session_id = None
+
+    result = _reject_short(engine)
+
+    assert result == (None, None)
+    engine.exchange_interface.place_order.assert_not_called()
+
+
+@pytest.mark.fast
+def test_guard_accept_is_silent_and_unchanged():
+    """Sub-threshold free balance: order placed, no guard events written."""
+    engine = _make_margin_engine(free_base=0.0001)  # $0.20 at $2000 — dust
+
+    result = _reject_short(engine)
+
+    assert result[0] is not None
+    engine.exchange_interface.place_order.assert_called_once()
+    guard_events = [
+        e for e in _logged_events(engine) if e.get("event_type") == EventType.SHORT_ENTRY_BLOCKED
+    ]
+    assert guard_events == []
+
+
+@pytest.mark.fast
+def test_long_entries_never_touch_guard_events():
+    """Long entries bypass the guard entirely — no events, order placed."""
+    engine = _make_margin_engine(free_base=0.05)
+
+    result = engine._execute_live_order(
+        symbol="ETHUSDT",
+        side=PositionSide.LONG,
+        value=50.0,
+        price=2000.0,
+    )
+
+    assert result[0] is not None
+    guard_events = [
+        e for e in _logged_events(engine) if e.get("event_type") == EventType.SHORT_ENTRY_BLOCKED
+    ]
+    assert guard_events == []
+
+
+# ---------------------------------------------------------------------------
+# Signal context threading
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_execute_entry_threads_signal_context_to_event():
+    """signal_context passed to execute_entry reaches the rejection event."""
+    engine = _make_margin_engine(free_base=0.05)
+
+    result = engine.execute_entry(
+        symbol="ETHUSDT",
+        side=PositionSide.SHORT,
+        size_fraction=0.1,
+        base_price=2000.0,
+        balance=1000.0,
+        signal_context={"strength": 0.9, "confidence": 0.7},
+    )
+
+    assert result.success is False  # guard rejection unchanged
+    details = _logged_events(engine)[0]["details"]
+    assert details["signal"] == {"strength": 0.9, "confidence": 0.7}
+
+
+@pytest.mark.fast
+def test_entry_handler_passes_signal_metadata():
+    """LiveEntryHandler forwards signal strength/confidence to the engine."""
+    from src.engines.live.execution.entry_handler import LiveEntryHandler, LiveEntrySignal
+    from src.engines.live.execution.execution_engine import EntryExecutionResult
+
+    execution_engine = MagicMock()
+    execution_engine.execute_entry.return_value = EntryExecutionResult(
+        success=False, error="Failed to execute live order"
+    )
+    execution_model = MagicMock()
+    execution_model.decide_fill.return_value = MagicMock(
+        should_fill=True, fill_price=2000.0, liquidity="taker"
+    )
+
+    handler = LiveEntryHandler(
+        execution_engine=execution_engine,
+        execution_model=execution_model,
+    )
+    signal = LiveEntrySignal(
+        should_enter=True,
+        side=PositionSide.SHORT,
+        size_fraction=0.1,
+        signal_strength=0.42,
+        signal_confidence=0.84,
+    )
+
+    handler.execute_entry(signal=signal, symbol="ETHUSDT", current_price=2000.0, balance=1000.0)
+
+    call_kwargs = execution_engine.execute_entry.call_args.kwargs
+    assert call_kwargs["signal_context"] == {"strength": 0.42, "confidence": 0.84}


### PR DESCRIPTION
## Summary

Step 4 of #990 (does not close it): the SHORT-side margin inventory guard in `src/engines/live/execution/execution_engine.py` fail-closed rejects short entries whenever free base-asset value exceeds the $1 dust threshold — previously leaving only transient log lines, so the 9L/3S live funnel was unmeasurable. Every guard rejection now writes a DB-durable `system_events` row (same table/pattern as #968's `CIRCUIT_BREAKER_DRY_RUN` evidence).

### What each rejection row carries (`details` JSONB)
- `symbol`, `side`, `base_asset`, `price`
- `reason`: `free_inventory_above_threshold`, or the fail-closed branches `balance_lookup_error` / `balance_unavailable`
- `free_base_balance` and `free_value_usd` as observed by the guard, plus `threshold_usd`
- `signal`: strength/confidence threaded down from `LiveEntryHandler` (additive optional kwarg; never influences execution)
- `open_positions`: compact snapshot (symbol/side/current_size/quantity) via a duck-typed provider wired from the trading engine's lock-guarded `positions` copy
- `episode`: start timestamp + running reject count

### Episode dedup (bounded rows)
A rejection episode (keyed by **base asset**, the guard's own scope — LESSONS §1.7) writes:
- the **first** rejection, then **every 10th** (`SHORT_GUARD_EMIT_EVERY_N`),
- plus one **episode-end summary** (`error_code=SHORT_GUARD_EPISODE_END`) carrying the TRUE `rejections_total`, written when the guard passes again or lazily after a 2h inactivity gap.

The confirmed 2026-06-07 episode class (30 cycles / ~45 min) writes 4 rows + 1 summary, not 30.

### Funnel verdict query
```sql
SELECT * FROM system_events WHERE event_type = 'SHORT_ENTRY_BLOCKED';
-- error_code = 'SHORT_ENTRY_BLOCKED' -> sampled rejection rows
-- error_code = 'SHORT_GUARD_EPISODE_END' -> summaries with rejections_total
```

## Safety (money path)
- **Purely additive observability**: guard accept/reject logic, threshold (literal `1.0` lifted to `SHORT_GUARD_DUST_THRESHOLD_USD = 1.0`, bit-identical), and ordering unchanged. Existing guard tests untouched and green.
- **Fault-isolated**: every new call is wrapped so an exception in the event write (or the position-snapshot provider) can NEVER break or delay the trading decision; failures log at WARNING.
- **No webhook/alert calls** anywhere in the new path (guard runs under the per-base-asset entry lock); DB write only, via the existing `_log_execution_event` best-effort path, and outside the new episode lock.
- **No migration**: `SHORT_ENTRY_BLOCKED` is 19 chars — fits the varchar(23) `event_type` column from migration 0013 (compiled enum width unchanged, `atb db verify` stays clean).

## Testing
- TDD: 16 new failing-first unit tests in `tests/unit/engines/live/test_short_guard_rejection_events.py` — payload correctness (all three reject reasons), episode dedup bounds (30 rejections -> 4 rows), guard-pass + inactivity-gap episode summaries, latch reset, event-write exception isolation, no-session no-crash, accept path silent/unchanged, long path untouched, signal-context threading through `execute_entry` and `LiveEntryHandler`.
- Full unit suite green: 5437 passed, 1 skipped (`pytest -m "not integration and not slow" -n 4`). Single exclusion: `test_models_tft.py::test_create_model_lightgbm_dispatches_to_directional_classifier`, verified **pre-existing on clean origin/develop** (expects `lightgbm` absent; the local shared venv has 4.6.0 — passes in CI).
- `atb dev quality --changed` green (black, ruff, mypy) + black/ruff on the new test file.

Refs #990 (step 4 only — forensics/counterfactual/guard-design-review remain open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)