### PR TITLE
docs(retro): agenda — subagent worktree hygiene (PM worktree reused by #1016 engineer)

### DIFF
--- a/.claude/skills/weekly-retro/AGENDA.md
+++ b/.claude/skills/weekly-retro/AGENDA.md
@@ -51,3 +51,10 @@ becomes a diff or gets a written disposition.
   matched models) leaving the alembic stamp stale at 0012 while staging ran it to 0013. Boot check
   reworded ad hoc to PASS-WITH-NOTE. Decide: stamp prod in a maintenance window + amend deploy-prod
   skill's check to "schema matches models AND (0 pending OR skip-guard fired with schema-match)".
+- **2026-07-12 — subagent built its feature branch inside the PM's worktree.** The #1016
+  (short-guard observability) engineer checked out its feature branch in the PM session worktree
+  instead of creating its own under `.claude/worktrees/` — clean outcome (everything committed)
+  but the PM's branch was silently switched. Dispatch prompts say "fresh worktree" yet this
+  recurred; consider a hard rule in delegation-protocol: agents verify `git worktree list` shows
+  their OWN path before checkout, never operate in a worktree containing another agent's
+  `.agent-active` or the PM session.


### PR DESCRIPTION
Adds a weekly-retro agenda item: the #1016 engineer checked out its feature branch inside the PM session worktree instead of its own. Clean outcome, but worktree hygiene needs a hard rule in the delegation protocol.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)