### PR TITLE
feat(strategies): make HyperGrowth/ETHUSDT explicitly long-only via config (#1020)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **HyperGrowth/ETHUSDT is long-only by explicit configuration** (#1020,
+  board-approved proposal 2026-07-12-01): `MLBasicSignalGenerator` gains an
+  `allow_shorts` flag (default `True`) that, when `False`, withholds the
+  `enter_short` opt-in from SELL signals so neither engine ever OPENS a
+  short — ENTRY-only gating: the SELL direction is preserved, so
+  signal-reversal exits of longs, stop-losses, and BUY-to-cover of existing
+  shorts are never affected (risk-review condition C2). The deployment value
+  lives in exactly one place, `src/strategies/deployment_config.py`
+  (`LONG_ONLY_DEPLOYMENTS`), resolved by `create_hyper_growth_strategy` at
+  construction, so live runs and backtests of the same symbol always agree
+  with zero extra flags (condition C1; backtest-live parity). Pass
+  `allow_shorts=True` explicitly for counterfactual/research runs. The
+  execution engine's independent SHORT-inventory margin guard is untouched
+  (condition C5). Shadow observability (condition C6): in the LIVE path
+  only, a short the strategy sized but config suppressed writes a
+  `system_events` row (`event_type=SHORT_ENTRY_SUPPRESSED`,
+  `error_code=WOULD_ENTER_SHORT`, component `entry_coordinator`) with signal
+  metadata, bounded by the #1016 episode-dedup pattern (first + every 10th +
+  an episode-end summary carrying the TRUE total after a 2h inactivity gap)
+  and fully fault-isolated; backtests write no events. No migration needed
+  (the 22-char enum value fits the varchar(23) column from migration 0013).
+  Post-ship proof: live and parity-backtest SHORT entry counts for
+  HyperGrowth/ETHUSDT must be exactly 0.
 - **DB-durable short-guard rejection events** (#990 step 4): the live
   SHORT-side margin inventory guard now writes a `system_events` row
   (`event_type=SHORT_ENTRY_BLOCKED`, component `execution`) whenever it

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -136,6 +136,12 @@ class EventType(enum.Enum):
     # episode-end summaries (error_code distinguishes the two). 19 chars —
     # fits the varchar(23) column from migration 0013, no migration needed.
     SHORT_ENTRY_BLOCKED = "SHORT_ENTRY_BLOCKED"
+    # Would-have-entered-short shadow evidence from long-only deployments
+    # (allow_shorts=False, GH #1020): the strategy sized a short but config
+    # suppressed the entry. Episode-end summaries share the type (error_code
+    # distinguishes). 22 chars — fits the varchar(23) column from migration
+    # 0013, no migration needed.
+    SHORT_ENTRY_SUPPRESSED = "SHORT_ENTRY_SUPPRESSED"
     TEST = "TEST"  # Added for verification scripts and development diagnostics
 
 

--- a/src/engines/live/execution/entry_coordinator.py
+++ b/src/engines/live/execution/entry_coordinator.py
@@ -33,11 +33,13 @@ from src.data_providers.exchange_interface import OrderSide, OrderType, SideEffe
 from src.database.models import EventType
 from src.engines.live.execution.entry_handler import LiveEntrySignal
 from src.engines.live.execution.entry_pause import EntryPauseGate
+from src.engines.live.execution.short_suppression_monitor import ShortSuppressionMonitor
 from src.engines.live.system_halt import SystemHaltState
 from src.engines.shared.models import PositionSide
 from src.infrastructure.logging.events import log_order_event
 from src.strategies.components import Signal, SignalDirection
 from src.strategies.components import Strategy as ComponentStrategy
+from src.strategies.components.ml_signal_generator import SHORT_ENTRY_SUPPRESSED_KEY
 from src.tech.adapters.row_extractors import extract_ml_predictions_from_signal
 
 if TYPE_CHECKING:
@@ -164,10 +166,56 @@ class LiveEntryCoordinator:
         # Entry-pause gate (FEATURE_ENTRY_PAUSE + manual system halt) for new
         # entries; scale-ins are gated by the exit handler's own instance.
         self._entry_pause = EntryPauseGate(halt_state=system_halt)
+        # Shadow observability for long-only deployments (#1020 C6): records
+        # would-have-entered-short events when allow_shorts=False suppressed
+        # a sized short at signal generation. Live-path only by construction.
+        self._short_suppression_monitor = ShortSuppressionMonitor()
 
     def _entry_paused(self, context: str) -> bool:
         """True when a pause source suppresses new entries (rate-limit logged)."""
         return self._entry_pause.paused(context)
+
+    def _record_short_suppression_shadow(
+        self, runtime_decision: Any, symbol: str, current_price: float
+    ) -> None:
+        """Record a would-have-entered-short event for a suppressed SELL (#1020 C6).
+
+        Emits only when the counterfactual is real: the signal carries the
+        suppression marker, the strategy sized a position, and the entry
+        gates a short would have faced (no open position on the symbol,
+        concurrency capacity available) all pass. Fault-isolated — this can
+        never affect the entry decision, which was already made upstream.
+        """
+        state = self._state
+        try:
+            signal = getattr(runtime_decision, "signal", None)
+            signal_metadata = getattr(signal, "metadata", None) or {}
+            if not signal_metadata.get(SHORT_ENTRY_SUPPRESSED_KEY):
+                return
+            position_size = float(getattr(runtime_decision, "position_size", 0.0) or 0.0)
+            if position_size <= 0:
+                return
+            # Mirror execute_entry_locked's own gates so the shadow count
+            # matches what the execution path would actually have attempted.
+            if state.live_position_tracker.has_position_for_symbol(symbol):
+                return
+            max_concurrent = (
+                state.risk_manager.get_max_concurrent_positions() if state.risk_manager else 1
+            )
+            if state.live_position_tracker.position_count >= max_concurrent:
+                return
+            self._short_suppression_monitor.record_suppression(
+                symbol,
+                db_manager=state.db_manager,
+                session_id=state.trading_session_id,
+                price=current_price,
+                position_size_notional=position_size,
+                signal_strength=float(getattr(signal, "strength", 0.0) or 0.0),
+                signal_confidence=float(getattr(signal, "confidence", 0.0) or 0.0),
+                signal_metadata=signal_metadata,
+            )
+        except Exception as e:
+            logger.warning("Short-suppression shadow event failed for %s: %s", symbol, e)
 
     def check_entry_conditions(
         self,
@@ -243,6 +291,13 @@ class LiveEntryCoordinator:
                 take_profit = entry_signal_result.take_profit
                 runtime_strength = entry_signal_result.signal_strength
                 runtime_confidence = entry_signal_result.signal_confidence
+            else:
+                # Long-only shadow observability (#1020 C6): a SELL the
+                # strategy sized but config suppressed becomes a DB-durable
+                # would-have-entered-short event. Never affects the decision.
+                self._record_short_suppression_shadow(
+                    runtime_decision, symbol, float(current_price)
+                )
         elif isinstance(state.strategy, ComponentStrategy):
             # Component-based strategy: use process_candle() for decision
             # Note: runtime_decision should already be populated if this is a component strategy

--- a/src/engines/live/execution/short_suppression_monitor.py
+++ b/src/engines/live/execution/short_suppression_monitor.py
@@ -1,0 +1,245 @@
+"""Shadow observability for config-suppressed short entries (GH #1020).
+
+When a long-only deployment (``allow_shorts=False``) withholds a short
+ENTRY at signal generation, the live engine records a DB-durable
+"would-have-entered-short" ``system_events`` row so the counterfactual the
+config was ratified on stays measurable post-ship (risk-review condition C6
+on proposal 2026-07-12-01).
+
+Rows are bounded by the same episode-dedup pattern as the short-guard
+rejection events (#1016, ``execution_engine.py``): within one contiguous
+suppression episode per symbol, write the first suppression and every
+``SHORT_SUPPRESSION_EMIT_EVERY_N``-th one, plus an episode-end summary
+carrying the TRUE total after an inactivity gap.
+
+Live-path only: this monitor is constructed exclusively by
+``LiveEntryCoordinator`` — the backtest engine never touches it, so
+backtests write no events. Entirely fault-isolated: bookkeeping or DB
+failures can never affect the trading decision, which was already made
+upstream at signal generation.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from src.database.models import EventType
+
+logger = logging.getLogger(__name__)
+
+# Suppressions separated by more than this quiet gap belong to different
+# episodes — same rationale as the short-guard value (#1016): live decision
+# cycles run seconds-to-minutes apart, and two hours spans any configured
+# candle interval without merging distinct episodes.
+SHORT_SUPPRESSION_EPISODE_GAP_SECONDS = 2 * 3600.0
+# Within an episode, write the first suppression and every Nth after it so a
+# long SELL streak stays queryable without one system_events row per cycle.
+SHORT_SUPPRESSION_EMIT_EVERY_N = 10
+
+# Signal-metadata keys copied onto the event row. A whitelist keeps the JSON
+# payload bounded and serializable regardless of what generators stuff into
+# metadata.
+_SIGNAL_METADATA_WHITELIST = (
+    "prediction",
+    "current_price",
+    "predicted_return",
+    "long_entry_threshold",
+    "short_entry_threshold",
+    "engine_model_name",
+    "model_type",
+    "model_timeframe",
+    "trading_symbol",
+    "model_symbol",
+)
+
+
+@dataclass
+class _SuppressionEpisode:
+    """One contiguous run of suppressed short entries for a symbol."""
+
+    started_at: datetime
+    last_suppressed_at: datetime
+    last_suppressed_monotonic: float
+    suppression_count: int
+
+
+class ShortSuppressionMonitor:
+    """Episode-deduped writer of would-have-entered-short system events."""
+
+    def __init__(self) -> None:
+        # The lock guards the episode dict only; DB writes happen outside it
+        # so a slow insert cannot serialize suppressions on other symbols.
+        self._lock = threading.Lock()
+        self._episodes: dict[str, _SuppressionEpisode] = {}
+        # Injectable clock for deterministic episode-gap tests.
+        self._monotonic: Callable[[], float] = time.monotonic
+
+    def record_suppression(
+        self,
+        symbol: str,
+        *,
+        db_manager: Any,
+        session_id: int | None,
+        price: float,
+        position_size_notional: float,
+        signal_strength: float,
+        signal_confidence: float,
+        signal_metadata: Mapping[str, Any] | None,
+    ) -> None:
+        """Record one suppressed short entry; write a bounded event row.
+
+        Fault-isolated: any failure degrades to a warning log. Callers pass
+        ``db_manager``/``session_id`` at call time (they are wired on the
+        engine after construction); without both, bookkeeping still runs but
+        nothing is written.
+        """
+        try:
+            now_monotonic = self._monotonic()
+            now_utc = datetime.now(UTC)
+            ended: _SuppressionEpisode | None = None
+            with self._lock:
+                episode = self._episodes.get(symbol)
+                if (
+                    episode is not None
+                    and now_monotonic - episode.last_suppressed_monotonic
+                    > SHORT_SUPPRESSION_EPISODE_GAP_SECONDS
+                ):
+                    ended = episode
+                    episode = None
+                if episode is None:
+                    episode = _SuppressionEpisode(
+                        started_at=now_utc,
+                        last_suppressed_at=now_utc,
+                        last_suppressed_monotonic=now_monotonic,
+                        suppression_count=1,
+                    )
+                    self._episodes[symbol] = episode
+                    emit = True
+                else:
+                    episode.suppression_count += 1
+                    episode.last_suppressed_at = now_utc
+                    episode.last_suppressed_monotonic = now_monotonic
+                    emit = episode.suppression_count % SHORT_SUPPRESSION_EMIT_EVERY_N == 0
+                suppression_count = episode.suppression_count
+                episode_started_at = episode.started_at
+
+            if ended is not None:
+                self._write_episode_end(symbol, ended, db_manager=db_manager, session_id=session_id)
+            if not emit:
+                return
+
+            details: dict[str, Any] = {
+                "symbol": symbol,
+                "side": "short",
+                "reason": "allow_shorts_false",
+                "price": float(price),
+                "position_size_notional": float(position_size_notional),
+                "signal": {
+                    "strength": float(signal_strength),
+                    "confidence": float(signal_confidence),
+                    **_whitelisted_signal_metadata(signal_metadata),
+                },
+                "episode": {
+                    "started_at": episode_started_at.isoformat(),
+                    "suppression_count": suppression_count,
+                },
+            }
+            message = (
+                f"Short entry suppressed by long-only config for {symbol} "
+                f"(would have entered short): suppression {suppression_count} "
+                f"of episode started {episode_started_at.isoformat()}"
+            )
+            self._write_event(
+                db_manager,
+                session_id,
+                message=message,
+                error_code="WOULD_ENTER_SHORT",
+                details=details,
+            )
+        except Exception as e:
+            logger.warning("Failed to record short suppression for %s: %s", symbol, e)
+
+    def _write_episode_end(
+        self,
+        symbol: str,
+        episode: _SuppressionEpisode,
+        *,
+        db_manager: Any,
+        session_id: int | None,
+    ) -> None:
+        """Write the episode summary row carrying the TRUE suppression total.
+
+        Per-suppression rows are sampled (every Nth), so counterfactual
+        counts come from ``suppressions_total`` here.
+        """
+        duration_s = max(0.0, (episode.last_suppressed_at - episode.started_at).total_seconds())
+        details = {
+            "symbol": symbol,
+            "end_reason": "inactivity_gap",
+            "suppressions_total": episode.suppression_count,
+            "episode_started_at": episode.started_at.isoformat(),
+            "episode_last_suppression_at": episode.last_suppressed_at.isoformat(),
+            "episode_duration_seconds": duration_s,
+        }
+        message = (
+            f"Short-suppression episode ended for {symbol} (inactivity_gap): "
+            f"{episode.suppression_count} suppression(s) over {duration_s / 60.0:.1f} min"
+        )
+        self._write_event(
+            db_manager,
+            session_id,
+            message=message,
+            error_code="SHORT_SUPPRESSION_EPISODE_END",
+            details=details,
+        )
+
+    @staticmethod
+    def _write_event(
+        db_manager: Any,
+        session_id: int | None,
+        *,
+        message: str,
+        error_code: str,
+        details: dict[str, Any],
+    ) -> None:
+        """Write one system_events row; silent no-op without an active session."""
+        if not (db_manager and session_id):
+            return
+        db_manager.log_event(
+            event_type=EventType.SHORT_ENTRY_SUPPRESSED,
+            message=message,
+            severity="info",
+            component="entry_coordinator",
+            details=details,
+            session_id=session_id,
+            error_code=error_code,
+        )
+
+
+def _whitelisted_signal_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Copy JSON-safe whitelisted keys from signal metadata; drop the rest."""
+    if not metadata:
+        return {}
+    safe: dict[str, Any] = {}
+    for key in _SIGNAL_METADATA_WHITELIST:
+        if key not in metadata:
+            continue
+        value = metadata[key]
+        if value is None or isinstance(value, str | bool):
+            safe[key] = value
+        elif isinstance(value, int | float):
+            safe[key] = float(value)
+    return safe
+
+
+__all__ = [
+    "SHORT_SUPPRESSION_EMIT_EVERY_N",
+    "SHORT_SUPPRESSION_EPISODE_GAP_SECONDS",
+    "ShortSuppressionMonitor",
+]

--- a/src/strategies/components/ml_signal_generator.py
+++ b/src/strategies/components/ml_signal_generator.py
@@ -29,6 +29,12 @@ from src.trading.symbols.factory import SymbolFactory
 
 logger = logging.getLogger(__name__)
 
+# Signal-metadata key marking a SELL whose short ENTRY opt-in was withheld by
+# a long-only deployment (``allow_shorts=False``, GH #1020). The live engine's
+# shadow observability consumes it to record "would-have-entered-short"
+# events; never present when shorts are allowed.
+SHORT_ENTRY_SUPPRESSED_KEY = "short_entry_suppressed"
+
 
 def _require_finite(name: str, value: Any) -> float:
     """Coerce ``value`` to ``float`` and reject NaN/Inf.
@@ -625,6 +631,7 @@ class MLBasicSignalGenerator(SignalGenerator):
         short_entry_threshold: float | None = None,
         confidence_multiplier: float | None = None,
         model_version: str | None = None,
+        allow_shorts: bool = True,
     ):
         """
         Initialize ML Basic Signal Generator
@@ -646,10 +653,21 @@ class MLBasicSignalGenerator(SignalGenerator):
                 not exist. Never set on the live trading path, which must
                 always follow ``latest``; only an explicit caller argument
                 can pin (no ambient env/config override).
+            allow_shorts: When False, SELL signals never carry the
+                ``enter_short`` opt-in, so engines never open a short —
+                ENTRY-only gating (GH #1020). The SELL direction itself is
+                preserved so signal-reversal exits of longs, stop-losses,
+                and BUY-to-cover of existing shorts are all unaffected.
+                Suppressed signals are marked with
+                :data:`SHORT_ENTRY_SUPPRESSED_KEY` for live shadow
+                observability. Deployment values resolve from
+                ``src.strategies.deployment_config`` via the strategy
+                factories.
         """
         super().__init__(name)
 
         self.sequence_length = sequence_length
+        self.allow_shorts = bool(allow_shorts)
 
         # Instance-level thresholds (experiments override these without mutating
         # class state shared across strategies). Validate finite to block
@@ -1040,9 +1058,16 @@ class MLBasicSignalGenerator(SignalGenerator):
             **self._symbol_guard_stamps(),
         }
 
-        # Enable short entries for SELL signals
+        # Enable short entries for SELL signals. Long-only deployments
+        # (allow_shorts=False, GH #1020) withhold the opt-in instead of
+        # flipping the direction: engines only open shorts on an explicit
+        # enter_short=True, while the SELL direction stays visible to exit
+        # logic (long reversal exits are never gated).
         if direction == SignalDirection.SELL:
-            metadata["enter_short"] = True
+            if self.allow_shorts:
+                metadata["enter_short"] = True
+            else:
+                metadata[SHORT_ENTRY_SUPPRESSED_KEY] = True
 
         return Signal(
             direction=direction, strength=strength, confidence=confidence, metadata=metadata
@@ -1261,6 +1286,7 @@ class MLBasicSignalGenerator(SignalGenerator):
                 "confidence_multiplier": self.confidence_multiplier,
                 "model_version": self.model_version,
                 "pinned_model_key": self._pinned_bundle_key,
+                "allow_shorts": self.allow_shorts,
             }
         )
         return params

--- a/src/strategies/deployment_config.py
+++ b/src/strategies/deployment_config.py
@@ -1,0 +1,66 @@
+"""Per-deployment strategy configuration — single source of truth (GH #1020).
+
+Deployment-level decisions (a strategy locked to long-only on a specific
+symbol) live here, in exactly one named place, instead of scattered factory
+defaults or environment variables. Both engines consume these values through
+the same path — ``call_strategy_factory`` -> strategy factory -> this module —
+so a backtest of a deployment resolves the identical effective configuration
+as live with zero extra flags (CODE.md Backtest-Live Parity; risk-review
+condition C1 on proposal 2026-07-12-01).
+
+Current entries:
+
+- ``hyper_growth`` / ``ETHUSDT`` is long-only by design (board-approved
+  proposal 2026-07-12-01, GH #1020): short trades' standalone P&L was
+  negative in every counterfactual fold tested, so the accidental short
+  suppression found in GH #990 is codified as an explicit configuration.
+  Re-enable criteria are recorded in the risk review
+  (docs/research/risk-snapshots/2026-07-12_2000_risk-review_1020-*.md).
+
+A repo-wide risk-config consolidation (GH #986) is being designed in
+parallel; this module is deliberately small so it can migrate wholesale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+
+from src.trading.symbols.factory import SymbolFactory
+
+# Strategy factory key -> symbols whose deployments never ENTER shorts.
+# Keys match the registry names used by the live runner and backtest CLI.
+# Symbols are stored in Binance exchange format; lookups normalize
+# provider-specific formats (e.g. Coinbase "ETH-USD") before matching.
+LONG_ONLY_DEPLOYMENTS: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "hyper_growth": frozenset({"ETHUSDT"}),
+    }
+)
+
+
+def resolve_allow_shorts(strategy_key: str, symbol: str | None) -> bool:
+    """Return whether the ``strategy_key``/``symbol`` deployment may enter shorts.
+
+    ``True`` (shorts allowed) for every deployment not listed in
+    :data:`LONG_ONLY_DEPLOYMENTS`, including unknown strategies, ``None``
+    symbols, and symbols that fail normalization — an invalid symbol fails
+    fast later at signal-generator construction, which owns that validation.
+
+    Args:
+        strategy_key: Factory registry name (e.g. ``"hyper_growth"``).
+        symbol: Trading symbol in any supported format, or None.
+    """
+    if symbol is None:
+        return True
+    long_only_symbols = LONG_ONLY_DEPLOYMENTS.get(strategy_key)
+    if not long_only_symbols:
+        return True
+    try:
+        normalized = SymbolFactory.to_exchange_symbol(symbol, "binance")
+    except ValueError:
+        return True
+    return normalized not in long_only_symbols
+
+
+__all__ = ["LONG_ONLY_DEPLOYMENTS", "resolve_allow_shorts"]

--- a/src/strategies/hyper_growth.py
+++ b/src/strategies/hyper_growth.py
@@ -28,6 +28,17 @@ fed price-only inputs, which the generator converts to predicted_return=-1.0
 and emits as a constant SELL sentinel. See
 .claude/reports/hyper_growth_experiment_sweep_2026-04-17.md.
 
+Short-entry policy (GH #1020): the ETHUSDT deployment is LONG-ONLY by
+design — board-approved proposal 2026-07-12-01 codified the accidental short
+suppression found in GH #990 (short trades' standalone P&L negative in every
+counterfactual fold tested) as explicit configuration. The value lives in
+ONE place, ``src.strategies.deployment_config.LONG_ONLY_DEPLOYMENTS``, and is
+resolved here at construction so live and backtest runs of the same symbol
+always agree (risk-review condition C1). The gate is ENTRY-only: SELL
+signals lose their ``enter_short`` opt-in, while exits, stop-losses, and
+BUY-to-cover of existing shorts are never affected (condition C2). Pass
+``allow_shorts=True`` explicitly for counterfactual/research runs.
+
 Reference: docs/research/500_percent_annual_returns.md
 """
 
@@ -48,6 +59,7 @@ from src.strategies.components.leverage_manager import LeverageManager
 from src.strategies.components.position_sizer import LeveragedPositionSizer
 from src.strategies.components.regime_context import TrendLabel, VolLabel
 from src.strategies.components.risk_manager import RiskManager
+from src.strategies.deployment_config import resolve_allow_shorts
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +203,7 @@ def create_hyper_growth_strategy(
     early_cut_mfe_threshold_pct: float | None = None,
     early_cut_evaluation_window_hours: float | None = None,
     model_version: str | None = None,
+    allow_shorts: bool | None = None,
 ) -> Strategy:
     """Create hyper-growth strategy targeting high annual returns.
 
@@ -242,6 +255,14 @@ def create_hyper_growth_strategy(
             instead of resolving ``latest`` — the backtest harness's
             point-in-time pin (GH #988). Only valid with
             ``signal_source="ml"`` (momentum runs no model).
+        allow_shorts: Whether SELL signals may ENTER shorts. None (default)
+            resolves the deployment value from
+            ``src.strategies.deployment_config`` — the single config source
+            both engines read (GH #1020): False for ETHUSDT (long-only by
+            board decision), True for every other symbol. An explicit
+            True/False overrides the deployment default (research/
+            counterfactual runs). Entry-only: exits, stop-losses, and
+            BUY-to-cover of existing shorts are never gated.
 
     Returns:
         Configured Strategy instance.
@@ -271,9 +292,17 @@ def create_hyper_growth_strategy(
         "aggressive sizing amplifies drawdowns. Consider ml_adaptive with the "
         "exposure governor + vol-target sizing instead."
     )
+    # Single-source deployment resolution (GH #1020): None means "look up the
+    # (strategy, symbol) deployment value"; an explicit bool wins.
+    resolved_allow_shorts = (
+        resolve_allow_shorts("hyper_growth", symbol) if allow_shorts is None else bool(allow_shorts)
+    )
+
     # Signal generator (declared up-front: branches assign different subtypes)
     signal_generator: SignalGenerator
     if signal_source == "momentum":
+        # MomentumSignalGenerator never emits the enter_short opt-in, so the
+        # momentum branch is structurally long-only regardless of the flag.
         signal_generator = MomentumSignalGenerator(
             name=f"{name}_signals",
             momentum_entry_threshold=0.001,  # 0.1% — very sensitive
@@ -289,7 +318,11 @@ def create_hyper_growth_strategy(
         # silently returns 0.0 on every bar — which the generator converts to
         # predicted_return = -1.0 (a constant SELL sentinel, not a prediction).
         signal_generator = MLBasicSignalGenerator(
-            name=f"{name}_signals", model_type="basic", symbol=symbol, model_version=model_version
+            name=f"{name}_signals",
+            model_type="basic",
+            symbol=symbol,
+            model_version=model_version,
+            allow_shorts=resolved_allow_shorts,
         )
 
     risk_manager = FlatRiskManager(

--- a/tests/unit/backtesting/test_hyper_growth_long_only_backtest.py
+++ b/tests/unit/backtesting/test_hyper_growth_long_only_backtest.py
@@ -1,0 +1,145 @@
+"""Backtest behavior of the HyperGrowth/ETHUSDT long-only config (GH #1020).
+
+End-to-end through the real factory -> deployment config -> signal generator
+-> backtest engine chain:
+
+- With the deployment default (allow_shorts=False for ETHUSDT), a backtest
+  fed persistent SELL predictions opens ZERO short trades — the post-ship
+  proof-monitoring bar from the risk review.
+- The explicit ``allow_shorts=True`` override (counterfactual/research arm)
+  still opens shorts on identical inputs, proving the harness would have
+  shorted and the flag is the only thing stopping it.
+- The backtest engine writes NO shadow suppression events (C6: live-only).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import pandas as pd
+import pytest
+
+from src.data_providers.data_provider import DataProvider
+from src.database.models import EventType
+from src.engines.backtest.engine import Backtester
+from src.engines.shared.models import PositionSide
+from src.prediction import PredictionResult
+from src.strategies.hyper_growth import create_hyper_growth_strategy
+
+pytestmark = [pytest.mark.unit, pytest.mark.mock_only]
+
+ENGINE_PATH = "src.strategies.components.ml_signal_generator.PredictionEngine"
+CONFIG_PATH = "src.strategies.components.ml_signal_generator.PredictionConfig"
+
+_BARS = 140  # sequence_length (120) warmup + a window of decision bars
+
+
+class _FrameProvider(DataProvider):
+    """Data provider returning one prepared DataFrame."""
+
+    def __init__(self, frame: pd.DataFrame) -> None:
+        self._frame = frame
+
+    def get_historical_data(self, symbol, timeframe, start, end=None):  # type: ignore[override]
+        return self._frame.copy()
+
+    def get_current_price(self, symbol):  # type: ignore[override]
+        return float(self._frame["close"].iloc[-1])
+
+    def get_live_data(self, symbol, timeframe, limit=500):  # type: ignore[override]
+        return self._frame.tail(limit).copy()
+
+    def update_live_data(self, symbol, timeframe):  # type: ignore[override]
+        return self._frame.copy()
+
+
+def _downtrend_frame() -> pd.DataFrame:
+    """Steady 0.4%/bar downtrend so predictions below close mean SELL bars."""
+    start = datetime(2024, 1, 1)
+    closes = [2000.0 * (0.996**i) for i in range(_BARS)]
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c * 1.001 for c in closes],
+            "low": [c * 0.999 for c in closes],
+            "close": closes,
+            "volume": [1_000.0] * _BARS,
+        },
+        index=[start + timedelta(hours=i) for i in range(_BARS)],
+    )
+
+
+def _bearish_prediction_engine() -> MagicMock:
+    """Mock engine predicting 2% below the latest close on every bar."""
+
+    def _predict(window_df: pd.DataFrame, model_name: Any = None) -> Mock:
+        result = Mock(spec=PredictionResult)
+        result.error = None
+        result.metadata = {}
+        result.price = float(window_df["close"].iloc[-1]) * 0.98
+        return result
+
+    engine = MagicMock()
+    engine.predict.side_effect = _predict
+    engine.health_check.return_value = {"status": "healthy"}
+    return engine
+
+
+def _run_backtest(strategy) -> Backtester:
+    backtester = Backtester(
+        strategy,
+        _FrameProvider(_downtrend_frame()),
+        log_to_database=False,
+        enable_dynamic_risk=False,
+        enable_engine_risk_exits=False,
+        use_next_bar_execution=False,
+    )
+    # Spy DB: proves the backtest engine writes no shadow suppression events.
+    backtester.db_manager = MagicMock()
+    frame = _downtrend_frame()
+    backtester.run(symbol="ETHUSDT", timeframe="1h", start=frame.index[0], end=frame.index[-1])
+    return backtester
+
+
+def _shorts_opened(backtester: Backtester) -> int:
+    """Count shorts the run opened: closed short trades + an open short."""
+    count = len([t for t in backtester.trades if t.side == PositionSide.SHORT])
+    if backtester.position_tracker.position_side == PositionSide.SHORT:
+        count += 1
+    return count
+
+
+def _suppression_events(backtester: Backtester) -> list:
+    return [
+        call
+        for call in backtester.db_manager.log_event.call_args_list
+        if call.kwargs.get("event_type") == EventType.SHORT_ENTRY_SUPPRESSED
+    ]
+
+
+@patch(ENGINE_PATH)
+@patch(CONFIG_PATH)
+def test_deployment_default_opens_no_shorts_and_writes_no_events(_cfg, engine_cls):
+    engine_cls.return_value = _bearish_prediction_engine()
+    strategy = create_hyper_growth_strategy(symbol="ETHUSDT")
+
+    backtester = _run_backtest(strategy)
+
+    assert _shorts_opened(backtester) == 0
+    assert backtester.position_tracker.has_position is False  # SELL-only feed
+    assert _suppression_events(backtester) == []
+
+
+@patch(ENGINE_PATH)
+@patch(CONFIG_PATH)
+def test_explicit_allow_shorts_true_still_opens_shorts(_cfg, engine_cls):
+    """Control arm: identical inputs short when the flag is re-enabled."""
+    engine_cls.return_value = _bearish_prediction_engine()
+    strategy = create_hyper_growth_strategy(symbol="ETHUSDT", allow_shorts=True)
+
+    backtester = _run_backtest(strategy)
+
+    assert _shorts_opened(backtester) >= 1
+    assert _suppression_events(backtester) == []

--- a/tests/unit/engines/live/test_short_suppression_shadow_events.py
+++ b/tests/unit/engines/live/test_short_suppression_shadow_events.py
@@ -1,0 +1,341 @@
+"""Shadow observability for config-suppressed short entries (GH #1020, C6).
+
+When ``allow_shorts=False`` suppresses a short ENTRY at signal generation,
+the LIVE engine must write a DB-durable "would-have-entered-short"
+``system_events`` row so the counterfactual stays measurable — bounded by the
+#1016 episode-dedup pattern (first suppression + every Nth + episode-end
+summary). The event path is entirely fault-isolated: bookkeeping or DB
+failures never affect the trading decision. Backtests never construct the
+monitor, so they write nothing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from src.database.models import EventType
+from src.engines.live.execution.entry_coordinator import LiveEntryCoordinator
+from src.engines.live.execution.entry_handler import LiveEntrySignal
+from src.engines.live.execution.short_suppression_monitor import (
+    SHORT_SUPPRESSION_EMIT_EVERY_N,
+    SHORT_SUPPRESSION_EPISODE_GAP_SECONDS,
+    ShortSuppressionMonitor,
+)
+from src.strategies.components import SignalDirection
+from src.strategies.components.ml_signal_generator import SHORT_ENTRY_SUPPRESSED_KEY
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _logged_events(db_manager: MagicMock) -> list[dict[str, Any]]:
+    return [call.kwargs for call in db_manager.log_event.call_args_list]
+
+
+def _record(monitor: ShortSuppressionMonitor, db_manager: MagicMock, **overrides: Any) -> None:
+    kwargs: dict[str, Any] = {
+        "db_manager": db_manager,
+        "session_id": 7,
+        "price": 2000.0,
+        "position_size_notional": 250.0,
+        "signal_strength": 0.8,
+        "signal_confidence": 0.24,
+        "signal_metadata": {
+            "prediction": 1960.0,
+            "predicted_return": -0.02,
+            "model_type": "basic",
+            "trading_symbol": "ETHUSDT",
+        },
+    }
+    kwargs.update(overrides)
+    monitor.record_suppression("ETHUSDT", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Monitor: payload
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorPayload:
+    def test_first_suppression_writes_event_with_payload(self):
+        monitor = ShortSuppressionMonitor()
+        db = MagicMock()
+
+        _record(monitor, db)
+
+        events = _logged_events(db)
+        assert len(events) == 1
+        event = events[0]
+        assert event["event_type"] == EventType.SHORT_ENTRY_SUPPRESSED
+        assert event["severity"] == "info"
+        assert event["error_code"] == "WOULD_ENTER_SHORT"
+        assert event["session_id"] == 7
+
+        details = event["details"]
+        assert details["symbol"] == "ETHUSDT"
+        assert details["side"] == "short"
+        assert details["reason"] == "allow_shorts_false"
+        assert details["price"] == pytest.approx(2000.0)
+        assert details["position_size_notional"] == pytest.approx(250.0)
+        assert details["signal"]["strength"] == pytest.approx(0.8)
+        assert details["signal"]["confidence"] == pytest.approx(0.24)
+        assert details["signal"]["predicted_return"] == pytest.approx(-0.02)
+        assert details["signal"]["model_type"] == "basic"
+        assert details["episode"]["suppression_count"] == 1
+
+    def test_unserializable_metadata_values_are_dropped(self):
+        """Only JSON-safe whitelisted values reach the row; junk is dropped."""
+        monitor = ShortSuppressionMonitor()
+        db = MagicMock()
+
+        _record(monitor, db, signal_metadata={"prediction": object(), "model_type": "basic"})
+
+        details = _logged_events(db)[0]["details"]
+        assert "prediction" not in details["signal"]
+        assert details["signal"]["model_type"] == "basic"
+
+
+# ---------------------------------------------------------------------------
+# Monitor: episode dedup
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorEpisodeDedup:
+    def test_episode_dedup_bounds_rows(self):
+        """30 consecutive suppressions write 4 rows (1st + every Nth), not 30."""
+        monitor = ShortSuppressionMonitor()
+        db = MagicMock()
+
+        for _ in range(30):
+            _record(monitor, db)
+
+        events = _logged_events(db)
+        assert len(events) == 4
+        counts = [e["details"]["episode"]["suppression_count"] for e in events]
+        assert counts == [1, SHORT_SUPPRESSION_EMIT_EVERY_N, 2 * SHORT_SUPPRESSION_EMIT_EVERY_N, 30]
+        assert all(e["error_code"] == "WOULD_ENTER_SHORT" for e in events)
+
+    def test_inactivity_gap_closes_episode_and_starts_fresh(self):
+        """A suppression after a quiet gap writes the old episode's summary
+        (with the TRUE total) and starts a fresh first-of-episode row."""
+        monitor = ShortSuppressionMonitor()
+        db = MagicMock()
+        now = 1000.0
+        monitor._monotonic = lambda: now
+
+        for _ in range(3):
+            _record(monitor, db)
+        assert len(_logged_events(db)) == 1  # first suppression only
+
+        now += SHORT_SUPPRESSION_EPISODE_GAP_SECONDS + 1.0
+        _record(monitor, db)
+
+        events = _logged_events(db)
+        assert len(events) == 3
+        summary = events[1]
+        assert summary["error_code"] == "SHORT_SUPPRESSION_EPISODE_END"
+        assert summary["event_type"] == EventType.SHORT_ENTRY_SUPPRESSED
+        assert summary["details"]["end_reason"] == "inactivity_gap"
+        assert summary["details"]["suppressions_total"] == 3
+        fresh = events[2]
+        assert fresh["error_code"] == "WOULD_ENTER_SHORT"
+        assert fresh["details"]["episode"]["suppression_count"] == 1
+
+    def test_episodes_are_tracked_per_symbol(self):
+        """A second symbol starts its own episode (first row emits again)."""
+        monitor = ShortSuppressionMonitor()
+        db = MagicMock()
+
+        _record(monitor, db)
+        monitor.record_suppression(
+            "SOLUSDT",
+            db_manager=db,
+            session_id=7,
+            price=150.0,
+            position_size_notional=100.0,
+            signal_strength=0.5,
+            signal_confidence=0.2,
+            signal_metadata=None,
+        )
+
+        events = _logged_events(db)
+        assert len(events) == 2
+        assert events[0]["details"]["symbol"] == "ETHUSDT"
+        assert events[1]["details"]["symbol"] == "SOLUSDT"
+        assert events[1]["details"]["episode"]["suppression_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Monitor: fault isolation
+# ---------------------------------------------------------------------------
+
+
+class TestMonitorFaultIsolation:
+    def test_event_write_failure_does_not_propagate(self):
+        monitor = ShortSuppressionMonitor()
+        db = MagicMock()
+        db.log_event.side_effect = RuntimeError("db down")
+
+        _record(monitor, db)  # must not raise
+
+    def test_without_db_or_session_no_write_no_crash(self):
+        monitor = ShortSuppressionMonitor()
+
+        _record(monitor, MagicMock(), session_id=None)
+        _record(monitor, None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Coordinator wiring: check_entry_conditions
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeSignal:
+    direction: SignalDirection
+    strength: float = 0.8
+    confidence: float = 0.24
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _FakeDecision:
+    signal: _FakeSignal
+    position_size: float
+    metadata: dict[str, Any] | None
+    regime: Any = None
+    risk_metrics: Any = None
+
+
+def _suppressed_decision(position_size: float = 250.0) -> _FakeDecision:
+    return _FakeDecision(
+        signal=_FakeSignal(
+            direction=SignalDirection.SELL,
+            metadata={
+                SHORT_ENTRY_SUPPRESSED_KEY: True,
+                "prediction": 1960.0,
+                "predicted_return": -0.02,
+            },
+        ),
+        position_size=position_size,
+        metadata={"enter_short": False},
+    )
+
+
+def _make_state() -> MagicMock:
+    """Engine-state mock for the runtime decision path of check_entry_conditions."""
+    state = MagicMock()
+    state._is_runtime_strategy.return_value = True
+    state._close_only_mode = False
+    state.current_balance = 1000.0
+    state.max_position_size = 0.5
+    state.timeframe = "1h"
+    state.trading_session_id = 7
+    state.db_manager = MagicMock()
+    state._extract_indicators.return_value = {}
+    state._extract_sentiment_data.return_value = {}
+    state._extract_ml_predictions.return_value = {}
+    state.live_entry_handler.process_runtime_decision.return_value = LiveEntrySignal(
+        should_enter=False, reasons=["runtime_hold"]
+    )
+    state.live_position_tracker.has_position_for_symbol.return_value = False
+    state.live_position_tracker.position_count = 0
+    state.risk_manager.get_max_concurrent_positions.return_value = 1
+    return state
+
+
+def _df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open": [2000.0],
+            "high": [2010.0],
+            "low": [1990.0],
+            "close": [2000.0],
+            "volume": [1000.0],
+        },
+        index=pd.date_range("2026-07-14", periods=1, freq="1h"),
+    )
+
+
+def _check_entry(coordinator: LiveEntryCoordinator, decision: Any) -> None:
+    coordinator.check_entry_conditions(
+        df=_df(),
+        current_index=0,
+        symbol="ETHUSDT",
+        current_price=2000.0,
+        current_time=pd.Timestamp("2026-07-14T12:00:00Z").to_pydatetime(),
+        runtime_decision=decision,
+    )
+
+
+def _suppression_events(state: MagicMock) -> list[dict[str, Any]]:
+    return [
+        call.kwargs
+        for call in state.db_manager.log_event.call_args_list
+        if call.kwargs.get("event_type") == EventType.SHORT_ENTRY_SUPPRESSED
+    ]
+
+
+class TestCoordinatorWiring:
+    def test_suppressed_decision_emits_shadow_event_and_no_entry(self):
+        state = _make_state()
+        coordinator = LiveEntryCoordinator(state)
+
+        _check_entry(coordinator, _suppressed_decision())
+
+        events = _suppression_events(state)
+        assert len(events) == 1
+        assert events[0]["details"]["symbol"] == "ETHUSDT"
+        assert events[0]["details"]["position_size_notional"] == pytest.approx(250.0)
+        state.live_entry_handler.execute_entry.assert_not_called()
+
+    def test_plain_sell_without_marker_emits_nothing(self):
+        state = _make_state()
+        coordinator = LiveEntryCoordinator(state)
+        decision = _FakeDecision(
+            signal=_FakeSignal(direction=SignalDirection.SELL, metadata={"enter_short": True}),
+            position_size=250.0,
+            metadata={"enter_short": True},
+        )
+        # Keep should_enter False so no execution machinery is needed here.
+        _check_entry(coordinator, decision)
+
+        assert _suppression_events(state) == []
+
+    def test_zero_size_suppression_emits_nothing(self):
+        """No event when the strategy would not have sized a position anyway."""
+        state = _make_state()
+        coordinator = LiveEntryCoordinator(state)
+
+        _check_entry(coordinator, _suppressed_decision(position_size=0.0))
+
+        assert _suppression_events(state) == []
+
+    def test_existing_position_on_symbol_emits_nothing(self):
+        """A held position would have blocked the short too — not a counterfactual."""
+        state = _make_state()
+        state.live_position_tracker.has_position_for_symbol.return_value = True
+        coordinator = LiveEntryCoordinator(state)
+
+        _check_entry(coordinator, _suppressed_decision())
+
+        assert _suppression_events(state) == []
+
+    def test_shadow_event_failure_never_breaks_entry_check(self):
+        """Fault isolation at the coordinator: a raising tracker is swallowed."""
+        state = _make_state()
+        state.live_position_tracker.has_position_for_symbol.side_effect = RuntimeError("boom")
+        coordinator = LiveEntryCoordinator(state)
+
+        _check_entry(coordinator, _suppressed_decision())  # must not raise
+
+        assert _suppression_events(state) == []

--- a/tests/unit/strategies/components/test_allow_shorts_gating.py
+++ b/tests/unit/strategies/components/test_allow_shorts_gating.py
@@ -1,0 +1,238 @@
+"""Entry-only short gating in MLBasicSignalGenerator (GH #1020).
+
+``allow_shorts=False`` must suppress SHORT *entries* at signal generation by
+withholding the ``enter_short`` opt-in — and nothing else:
+
+- the SELL direction itself survives, so signal-reversal exits of longs are
+  ungated (risk-review condition C2);
+- BUY signals (which close existing shorts via reversal) are untouched, so an
+  open short (e.g. live position #22) can always be covered;
+- the shared ``extract_entry_plan`` chokepoint used by BOTH engines converts
+  the withheld opt-in into "no entry", giving backtest-live parity for free.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.engines.shared.entry_utils import extract_entry_plan
+from src.engines.shared.models import PositionSide
+from src.engines.shared.strategy_exit_checker import StrategyExitChecker
+from src.prediction import PredictionResult
+from src.strategies.components import SignalDirection
+from src.strategies.components.ml_signal_generator import (
+    SHORT_ENTRY_SUPPRESSED_KEY,
+    MLBasicSignalGenerator,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+ENGINE_PATH = "src.strategies.components.ml_signal_generator.PredictionEngine"
+CONFIG_PATH = "src.strategies.components.ml_signal_generator.PredictionConfig"
+
+
+def _test_dataframe(length: int = 150) -> pd.DataFrame:
+    """Deterministic OHLCV frame long enough for the 120-bar sequence window."""
+    dates = pd.date_range("2023-01-01", periods=length, freq="1h")
+    rng = np.random.default_rng(42)
+    prices = 50000.0 * np.cumprod(1 + rng.normal(0, 0.002, length))
+    return pd.DataFrame(
+        {
+            "open": prices,
+            "high": prices * 1.001,
+            "low": prices * 0.999,
+            "close": prices,
+            "volume": rng.uniform(1000, 10000, length),
+        },
+        index=dates,
+    )
+
+
+def _generator_with_prediction(
+    mock_engine_class: MagicMock,
+    df: pd.DataFrame,
+    *,
+    price_factor: float,
+    allow_shorts: bool | None = None,
+) -> MLBasicSignalGenerator:
+    """Build a generator whose mocked engine predicts close * price_factor."""
+
+    def _predict(window_df: pd.DataFrame, model_name: Any = None) -> Mock:
+        result = Mock(spec=PredictionResult)
+        result.error = None
+        result.metadata = {}
+        result.price = float(window_df["close"].iloc[-1]) * price_factor
+        return result
+
+    mock_engine = MagicMock()
+    mock_engine.predict.side_effect = _predict
+    mock_engine.health_check.return_value = {"status": "healthy"}
+    mock_engine_class.return_value = mock_engine
+
+    kwargs: dict[str, Any] = {"sequence_length": 120}
+    if allow_shorts is not None:
+        kwargs["allow_shorts"] = allow_shorts
+    return MLBasicSignalGenerator(**kwargs)
+
+
+class TestSignalLevelGating:
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_sell_signal_sets_enter_short_by_default(self, _cfg, engine_cls):
+        """Default allow_shorts=True keeps the pre-#1020 behavior exactly."""
+        df = _test_dataframe()
+        generator = _generator_with_prediction(engine_cls, df, price_factor=0.99)
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.SELL
+        assert signal.metadata["enter_short"] is True
+        assert SHORT_ENTRY_SUPPRESSED_KEY not in signal.metadata
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_allow_shorts_false_withholds_enter_short(self, _cfg, engine_cls):
+        """Suppression withholds the entry opt-in but keeps the SELL direction."""
+        df = _test_dataframe()
+        generator = _generator_with_prediction(
+            engine_cls, df, price_factor=0.99, allow_shorts=False
+        )
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.SELL
+        assert "enter_short" not in signal.metadata
+        assert signal.metadata[SHORT_ENTRY_SUPPRESSED_KEY] is True
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_allow_shorts_false_leaves_buy_signals_untouched(self, _cfg, engine_cls):
+        """Longs are unaffected: no opt-in, no suppression marker on BUY."""
+        df = _test_dataframe()
+        generator = _generator_with_prediction(
+            engine_cls, df, price_factor=1.01, allow_shorts=False
+        )
+
+        signal = generator.generate_signal(df, 130)
+
+        assert signal.direction == SignalDirection.BUY
+        assert "enter_short" not in signal.metadata
+        assert SHORT_ENTRY_SUPPRESSED_KEY not in signal.metadata
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_get_parameters_reports_allow_shorts(self, _cfg, engine_cls):
+        """The flag is traceable in serialized generator parameters."""
+        mock_engine = MagicMock()
+        mock_engine.health_check.return_value = {"status": "healthy"}
+        engine_cls.return_value = mock_engine
+
+        generator = MLBasicSignalGenerator(sequence_length=120, allow_shorts=False)
+
+        assert generator.get_parameters()["allow_shorts"] is False
+
+
+@dataclass
+class _FakeSignal:
+    direction: SignalDirection
+    strength: float = 1.0
+    confidence: float = 0.9
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _FakeDecision:
+    signal: _FakeSignal
+    position_size: float
+    metadata: dict[str, Any] | None
+    regime: Any = None
+
+
+class TestSharedEntryPlanChokepoint:
+    """Both engines resolve entries through extract_entry_plan — the parity gate."""
+
+    def test_sell_without_enter_short_yields_no_entry_plan(self):
+        decision = _FakeDecision(
+            signal=_FakeSignal(direction=SignalDirection.SELL),
+            position_size=100.0,
+            metadata={"enter_short": False},
+        )
+
+        assert extract_entry_plan(decision, balance=1000.0) is None
+
+    def test_sell_with_enter_short_yields_short_plan(self):
+        decision = _FakeDecision(
+            signal=_FakeSignal(direction=SignalDirection.SELL),
+            position_size=100.0,
+            metadata={"enter_short": True},
+        )
+
+        plan = extract_entry_plan(decision, balance=1000.0)
+
+        assert plan is not None
+        assert plan.side == PositionSide.SHORT
+
+
+@dataclass
+class _FakePosition:
+    symbol: str
+    side: str
+    entry_price: float
+    entry_time: datetime
+    entry_balance: float = 1000.0
+    current_size: float = 0.1
+    size: float = 0.1
+
+
+class TestExitsUngated:
+    """C2: exits, stops, and BUY-to-cover are never gated by allow_shorts."""
+
+    def _decision(self, direction: SignalDirection, signal_metadata: dict[str, Any]):
+        return _FakeDecision(
+            signal=_FakeSignal(direction=direction, metadata=signal_metadata),
+            position_size=0.0,
+            metadata={},  # no ignore_signal_reversal -> reversal exits active
+        )
+
+    def test_buy_signal_still_exits_short_position(self):
+        """BUY-to-cover of an existing short must remain unconditional."""
+        checker = StrategyExitChecker()
+        position = _FakePosition(
+            symbol="ETHUSDT", side="short", entry_price=2000.0, entry_time=datetime.now(UTC)
+        )
+        decision = self._decision(SignalDirection.BUY, {})
+
+        result = checker.check_exit(
+            position=position,
+            current_price=1900.0,
+            runtime_decision=decision,
+            component_strategy=None,
+        )
+
+        assert result.should_exit is True
+        assert result.exit_reason == "Signal reversal"
+
+    def test_suppressed_sell_still_exits_long_position(self):
+        """The retained SELL direction keeps long reversal exits working."""
+        checker = StrategyExitChecker()
+        position = _FakePosition(
+            symbol="ETHUSDT", side="long", entry_price=2000.0, entry_time=datetime.now(UTC)
+        )
+        decision = self._decision(SignalDirection.SELL, {SHORT_ENTRY_SUPPRESSED_KEY: True})
+
+        result = checker.check_exit(
+            position=position,
+            current_price=2100.0,
+            runtime_decision=decision,
+            component_strategy=None,
+        )
+
+        assert result.should_exit is True
+        assert result.exit_reason == "Signal reversal"

--- a/tests/unit/strategies/test_hyper_growth_long_only_config.py
+++ b/tests/unit/strategies/test_hyper_growth_long_only_config.py
@@ -1,0 +1,162 @@
+"""Single-source long-only deployment config for HyperGrowth/ETHUSDT (GH #1020).
+
+Risk-review condition C1: ``allow_shorts`` is defined in exactly one place
+(``src.strategies.deployment_config``) and consumed by BOTH engines'
+strategy-construction paths — the live runner's ``load_strategy`` and the
+backtest CLI's ``_load_strategy`` both go through
+``call_strategy_factory -> create_hyper_growth_strategy``, so a backtest of
+HyperGrowth on ETHUSDT resolves the same effective value as live with zero
+extra flags. All other strategies/symbols are unchanged.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.strategies import call_strategy_factory
+from src.strategies.deployment_config import LONG_ONLY_DEPLOYMENTS, resolve_allow_shorts
+from src.strategies.hyper_growth import create_hyper_growth_strategy
+from src.strategies.ml_basic import create_ml_basic_strategy
+
+pytestmark = [pytest.mark.unit, pytest.mark.fast, pytest.mark.mock_only]
+
+ENGINE_PATH = "src.strategies.components.ml_signal_generator.PredictionEngine"
+CONFIG_PATH = "src.strategies.components.ml_signal_generator.PredictionConfig"
+
+
+def _mock_prediction_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.health_check.return_value = {"status": "healthy"}
+    return engine
+
+
+class TestResolveAllowShorts:
+    def test_hyper_growth_ethusdt_is_long_only(self):
+        assert resolve_allow_shorts("hyper_growth", "ETHUSDT") is False
+
+    def test_symbol_formats_normalize_to_same_deployment(self):
+        """Provider-specific symbol formats must hit the same config entry."""
+        assert resolve_allow_shorts("hyper_growth", "ETH-USD") is False
+        assert resolve_allow_shorts("hyper_growth", "ethusdt") is False
+
+    def test_other_symbols_allow_shorts(self):
+        assert resolve_allow_shorts("hyper_growth", "BTCUSDT") is True
+
+    def test_other_strategies_allow_shorts(self):
+        assert resolve_allow_shorts("ml_basic", "ETHUSDT") is True
+
+    def test_no_symbol_allows_shorts(self):
+        assert resolve_allow_shorts("hyper_growth", None) is True
+
+    def test_deployment_table_pins_exactly_hyper_growth_ethusdt(self):
+        """The named config location holds the one board-ratified deployment."""
+        assert LONG_ONLY_DEPLOYMENTS == {"hyper_growth": frozenset({"ETHUSDT"})}
+
+
+class TestFactoryResolution:
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_ethusdt_defaults_long_only(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+
+        strategy = create_hyper_growth_strategy(symbol="ETHUSDT")
+
+        assert strategy.signal_generator.allow_shorts is False
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_btcusdt_defaults_shorts_allowed(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+
+        strategy = create_hyper_growth_strategy(symbol="BTCUSDT")
+
+        assert strategy.signal_generator.allow_shorts is True
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_no_symbol_defaults_shorts_allowed(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+
+        strategy = create_hyper_growth_strategy()
+
+        assert strategy.signal_generator.allow_shorts is True
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_explicit_true_overrides_deployment_default(self, _cfg, engine_cls):
+        """Experiments can re-enable shorts explicitly (counterfactual runs)."""
+        engine_cls.return_value = _mock_prediction_engine()
+
+        strategy = create_hyper_growth_strategy(symbol="ETHUSDT", allow_shorts=True)
+
+        assert strategy.signal_generator.allow_shorts is True
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_explicit_false_applies_to_any_symbol(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+
+        strategy = create_hyper_growth_strategy(symbol="BTCUSDT", allow_shorts=False)
+
+        assert strategy.signal_generator.allow_shorts is False
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_other_strategies_unchanged(self, _cfg, engine_cls):
+        """ml_basic on ETHUSDT keeps shorts — the config is per-deployment."""
+        engine_cls.return_value = _mock_prediction_engine()
+
+        strategy = create_ml_basic_strategy(symbol="ETHUSDT")
+
+        assert strategy.signal_generator.allow_shorts is True
+
+
+class TestBothEnginesResolveSameValue:
+    """C1 parity: live and backtest construction resolve identical values."""
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_shared_factory_path_resolves_long_only(self, _cfg, engine_cls):
+        """call_strategy_factory is the choke point both runners use."""
+        engine_cls.return_value = _mock_prediction_engine()
+
+        strategy = call_strategy_factory(create_hyper_growth_strategy, symbol="ETHUSDT")
+
+        assert strategy.signal_generator.allow_shorts is False
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_live_runner_resolves_long_only(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+        from src.engines.live.runner import load_strategy
+
+        strategy = load_strategy("hyper_growth", symbol="ETHUSDT")
+
+        assert strategy.signal_generator.allow_shorts is False
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_backtest_cli_resolves_long_only(self, _cfg, engine_cls):
+        engine_cls.return_value = _mock_prediction_engine()
+        from cli.commands.backtest import _load_strategy
+
+        strategy = _load_strategy("hyper_growth", symbol="ETHUSDT")
+
+        assert strategy.signal_generator.allow_shorts is False
+
+    @patch(ENGINE_PATH)
+    @patch(CONFIG_PATH)
+    def test_live_and_backtest_values_match_for_both_symbols(self, _cfg, engine_cls):
+        """The parity requirement stated directly: same symbol -> same value."""
+        engine_cls.return_value = _mock_prediction_engine()
+        from cli.commands.backtest import _load_strategy
+        from src.engines.live.runner import load_strategy
+
+        for symbol in ("ETHUSDT", "BTCUSDT"):
+            live_value = load_strategy("hyper_growth", symbol=symbol).signal_generator.allow_shorts
+            backtest_value = _load_strategy(
+                "hyper_growth", symbol=symbol
+            ).signal_generator.allow_shorts
+            assert live_value == backtest_value


### PR DESCRIPTION
Implements the approved proposal **2026-07-12-01** (refs #1020 — do not close; approved by Alex 2026-07-14, log.md [D-2026-07-14-01]): HyperGrowth/ETHUSDT is now **long-only by explicit configuration**, replacing the accidental short suppression discovered in #990.

## User-facing impact

- Live and backtest HyperGrowth on **ETHUSDT never OPEN a short position**. Longs, exits, stop-losses, trailing stops, and BUY-to-cover of existing shorts (e.g. open prod short #22) are completely unaffected.
- Every other strategy/symbol is unchanged (`allow_shorts` defaults to `True`; only the `hyper_growth`/`ETHUSDT` deployment resolves `False`).
- Research/counterfactual runs can pass `allow_shorts=True` explicitly to re-enable shorts for that run only.

## How each board-ratified condition is met

| Condition | Implementation |
|---|---|
| **C1 — single config source, both engines** | `src/strategies/deployment_config.py` (`LONG_ONLY_DEPLOYMENTS`) is the ONE named location. Both engines construct via `call_strategy_factory` → `create_hyper_growth_strategy`, which resolves the value there (symbol formats normalized), so a backtest of HyperGrowth/ETHUSDT gets the identical effective value as live with zero extra flags. Documented in the `hyper_growth.py` module docstring. Live hot-swap (`strategy_manager`) uses the same path. Will migrate trivially into #986. |
| **C2 — entry-only gating** | `MLBasicSignalGenerator(allow_shorts=False)` withholds the `enter_short` opt-in from SELL signals instead of flipping the direction. Entries die at the shared `extract_entry_plan` chokepoint (both engines); the SELL direction stays visible so long reversal exits work, and BUY signals (which cover shorts) are untouched. Explicit tests: `TestExitsUngated` (BUY-to-cover of a short; long reversal exit under suppression). |
| **C3 — staging-paper first** | Deployment path unchanged by this PR; merge to `develop` only. No prod promotion here. |
| **C4 — re-enable + kill criteria** | Recorded verbatim below. |
| **C5 — margin guard untouched** | `execution_engine.py` SHORT-inventory guard has **zero diff**. It remains an independent margin defense. |
| **C6 — shadow observability (live only)** | `ShortSuppressionMonitor` (new, live entry coordinator only): when a **sized** short is config-suppressed (and the symbol had no open position / concurrency capacity existed), it writes a DB-durable `system_events` row — `event_type=SHORT_ENTRY_SUPPRESSED`, `error_code=WOULD_ENTER_SHORT`, signal metadata whitelisted — bounded by the #1016 episode-dedup pattern (first + every 10th + inactivity-gap episode-end summary carrying the TRUE total). Fully fault-isolated (event failure can never affect the decision — tested). Backtests write no events (engine never constructs the monitor — tested with a spy DB). No migration: the 22-char enum value fits the varchar(23) column from migration 0013. |

## C4 — documented re-enable criteria (verbatim from the risk review)

> **Re-enable shorts if:** (i) the underlying model is retrained/redesigned (new architecture or target) — the long/short asymmetry is model-specific and built on a ~51–53% DA signal barely above noise; (ii) a bear-regime fold shows long-only materially underperforming both-sides (the confound materializes); (iii) short-side directional accuracy demonstrably exceeds long-side OOS in ≥2 folds.

> **Monitoring that proves the change did what we think:** post-ship ETHUSDT HyperGrowth SHORT-entry count must be **exactly 0** (any short entry ⇒ flag mis-wired); the same backtest run against the live config must also show 0 short trades (parity check); and staging-paper must confirm the "more longs" reallocation does not spike drawdown.

Source: `docs/research/risk-snapshots/2026-07-12_2000_risk-review_1020-hypergrowth-ethusdt-long-only.md` (§Q3).

## Testing performed

- **TDD**: all new tests written first and confirmed failing (ImportError/assertion) before implementation.
- 38 new tests, all passing:
  - `tests/unit/strategies/components/test_allow_shorts_gating.py` — signal-level gating; default behavior byte-identical; BUY untouched; shared `extract_entry_plan` chokepoint; **exits ungated** (C2).
  - `tests/unit/strategies/test_hyper_growth_long_only_config.py` — deployment resolution incl. symbol-format normalization; explicit overrides; other strategies unchanged; **parity: live runner and backtest CLI resolve the same value for the same symbol** (C1).
  - `tests/unit/engines/live/test_short_suppression_shadow_events.py` — shadow event payload, episode dedup (30 suppressions → 4 rows), inactivity-gap episode end, per-symbol episodes, fault isolation (DB failure, missing session, raising tracker), coordinator wiring incl. "no event without marker / with open position / with zero size" (C6).
  - `tests/unit/backtesting/test_hyper_growth_long_only_backtest.py` — end-to-end factory→config→generator→backtest: deployment default opens **zero** shorts on a persistent-SELL feed and writes **zero** events; `allow_shorts=True` control arm shorts on identical inputs (proves the flag is the only gate).
- **Full unit suite**: 5525 passed, 1 failed — `tests/unit/ml/training_pipeline/test_models_tft.py::TestModelFactoryIntegration::test_create_model_lightgbm_dispatches_to_directional_classifier`, a **pre-existing environment failure on clean `origin/develop`** (expects `ImportError` for lightgbm, but lightgbm 4.6.0 is installed in the local venv). Unrelated to this change.
- `atb dev quality --changed` (black + ruff + mypy) passes on all modified files; black/ruff/mypy run explicitly on the new files too.

## Rollback

Config-level: flip the deployment entry (or pass `allow_shorts=True`). No state migration; open positions unaffected.

Refs #1020 (do not close — staging-paper validation and prod promotion tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
