### PR TITLE
fix(config): refill macro event calendar through Jan 2027 (#1053)

### DIFF
--- a/config/macro_events.json
+++ b/config/macro_events.json
@@ -1,11 +1,20 @@
 {
-  "description": "Maintained calendar of high-impact macro events (FOMC, CPI). Around each event the bot de-risks: it blocks new entries and halves regime exposure caps from `hours_before` before to `hours_after` after the event time. Times are UTC. Keep this file up to date — stale/empty is fail-safe (no windows). Per-event overrides fall back to the defaults.",
+  "description": "Maintained calendar of high-impact macro events (FOMC, CPI). Around each event the bot de-risks: it blocks new entries and halves regime exposure caps from `hours_before` before to `hours_after` after the event time. Times are UTC. Keep this file up to date — stale/empty is fail-safe (no windows). Per-event overrides fall back to the defaults. CPI = BLS release at 08:30 ET; FOMC = statement at 14:00 ET on the final day of the meeting. Note the ET->UTC offset changes with US daylight saving (EDT = UTC-4, EST = UTC-5).",
   "default_hours_before": 12,
   "default_hours_after": 6,
   "events": [
     {"name": "CPI May 2026", "type": "CPI", "time": "2026-05-13T12:30:00Z"},
     {"name": "FOMC June 2026", "type": "FOMC", "time": "2026-06-17T18:00:00Z", "hours_before": 18, "hours_after": 18},
     {"name": "CPI July 2026", "type": "CPI", "time": "2026-07-14T12:30:00Z"},
-    {"name": "FOMC July 2026", "type": "FOMC", "time": "2026-07-08T18:00:00Z", "hours_before": 18, "hours_after": 18}
+    {"name": "FOMC July 2026", "type": "FOMC", "time": "2026-07-08T18:00:00Z", "hours_before": 18, "hours_after": 18},
+    {"name": "CPI August 2026", "type": "CPI", "time": "2026-08-12T12:30:00Z"},
+    {"name": "CPI September 2026", "type": "CPI", "time": "2026-09-11T12:30:00Z"},
+    {"name": "FOMC September 2026", "type": "FOMC", "time": "2026-09-16T18:00:00Z", "hours_before": 18, "hours_after": 18},
+    {"name": "CPI October 2026", "type": "CPI", "time": "2026-10-14T12:30:00Z"},
+    {"name": "FOMC October 2026", "type": "FOMC", "time": "2026-10-28T18:00:00Z", "hours_before": 18, "hours_after": 18},
+    {"name": "CPI November 2026", "type": "CPI", "time": "2026-11-10T13:30:00Z"},
+    {"name": "CPI December 2026", "type": "CPI", "time": "2026-12-10T13:30:00Z"},
+    {"name": "FOMC December 2026", "type": "FOMC", "time": "2026-12-09T19:00:00Z", "hours_before": 18, "hours_after": 18},
+    {"name": "FOMC January 2027", "type": "FOMC", "time": "2027-01-27T19:00:00Z", "hours_before": 18, "hours_after": 18}
   ]
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -101,6 +101,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior change when neither flag is passed; the live path cannot be pinned.
 
 ### Fixed
+- **Macro-event calendar refilled through Jan 2027** (#1053): `config/macro_events.json`
+  had no event newer than 2026-07-14, so the macro de-risk guard had zero upcoming
+  coverage and its staleness canary
+  (`test_default_config_has_upcoming_coverage`) failed on every PR to `develop`
+  from 2026-07-28 onward. Appended the confirmed remaining 2026 BLS CPI releases
+  (08:30 ET) and Federal Reserve FOMC decision dates (14:00 ET on the final
+  meeting day), plus the Fed's tentative Jan 2027 meeting — UTC offsets account
+  for the 2026-11-01 EDT→EST switch. Config-only; no engine change. Nearest
+  de-risk window opens 2026-09-11T00:30Z (Aug CPI), none active at merge time.
+
 - **Account circuit breakers now measure true equity and survive restarts**
   (#986 items, per log.md [D-2026-07-14-03]; refs #845/#847/#1001 — nothing
   armed: the `account_circuit_breakers` flag stays `off`):


### PR DESCRIPTION
## Summary

Config-only refill of `config/macro_events.json`, which had no event newer than `2026-07-14T12:30:00Z`. Refs #1053 (does **not** close it — asks 2 and 3, the refill owner/cadence and the warn-vs-fail canary decision, are separate follow-ups).

Two things this fixes at once:
1. **Live-capital gap** — the macro de-risk guard had zero upcoming events, so it was silently de-risking nothing (the #962 failure mode).
2. **Blanket CI blocker** — `tests/unit/position_management/test_macro_events.py::test_default_config_has_upcoming_coverage` asserts the most recent listed event is within 14 days. It has failed on every PR to `develop` since ~2026-07-28, including #1052 and #1048, which are unrelated to it.

## Dates added (researched, not invented)

**CPI — BLS, 08:30 ET.** EDT = UTC-4 through 2026-11-01; EST = UTC-5 after.

| Event | UTC time |
|---|---|
| CPI August 2026 (Jul ref, 2026-08-12) | `2026-08-12T12:30:00Z` |
| CPI September 2026 (2026-09-11) | `2026-09-11T12:30:00Z` |
| CPI October 2026 (2026-10-14) | `2026-10-14T12:30:00Z` |
| CPI November 2026 (2026-11-10) | `2026-11-10T13:30:00Z` |
| CPI December 2026 (2026-12-10) | `2026-12-10T13:30:00Z` |

**FOMC — decision/statement 14:00 ET on the final day of each two-day meeting**, `hours_before`/`hours_after` = 18/18 matching the file's existing FOMC convention.

| Event | Meeting | UTC time |
|---|---|---|
| FOMC September 2026 | Sep 15-16 | `2026-09-16T18:00:00Z` |
| FOMC October 2026 | Oct 27-28 | `2026-10-28T18:00:00Z` |
| FOMC December 2026 | Dec 8-9 | `2026-12-09T19:00:00Z` (EST) |
| FOMC January 2027 | Jan 26-27 (tentative) | `2027-01-27T19:00:00Z` (EST) |

### Sources
- FOMC meeting calendar (2026 confirmed; 2027 tentative as published by the Fed): https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm
- BLS CPI release schedule: https://www.bls.gov/schedule/news_release/cpi.htm (BLS blocks automated fetches; the Sep 11 2026 date was confirmed from a bls.gov search result, and the full 2026 table was cross-checked against two independent mirrors that agree exactly, including the already-known Jul 14 and Aug 12 dates: https://www.usinflationcalculator.com/inflation/consumer-price-index-release-schedule/ and https://cpiinflationcalculator.com/cpi-release-schedule/)

### Times not individually confirmed
No release announcement was found that states a per-event clock time, so every entry uses the standard time for its type (CPI 08:30 ET, FOMC statement 14:00 ET). These are the long-standing conventions and match the historical entries already in the file. The 18/12h pre-windows absorb any intraday drift.

### Not added
- **2027 CPI dates.** BLS publishes its official 2027 schedule late in 2026; the only 2027 dates available now are third-party *projections*, so they were deliberately left out rather than guessed.
- **Nothing removed.** Kept all four historical entries per the issue — past events are inert for the guard (window closed) and they document the file's conventions. The `hours_before`-only convention plus a note about the EDT/EST offset were added to the `description` field so the next refill does not get the offset wrong.

## Imminent de-risk windows — none

Verified against the loader as of 2026-08-13T15:02Z: `MacroEventCalendar.from_config()` loads all 13 events and `active_event(now)` is `None`. Nearest upcoming window opens **2026-09-11T00:30Z** (Aug CPI), 28 days out. **No de-risk window will activate on this deploy or in the coming weeks.**

Upcoming windows for the PM's calendar:

```
CPI September 2026   window 2026-09-11T00:30Z -> 2026-09-11T18:30Z
FOMC September 2026  window 2026-09-16T00:00Z -> 2026-09-17T12:00Z
CPI October 2026     window 2026-10-14T00:30Z -> 2026-10-14T18:30Z
FOMC October 2026    window 2026-10-28T00:00Z -> 2026-10-29T12:00Z
CPI November 2026    window 2026-11-10T01:30Z -> 2026-11-10T19:30Z
FOMC December 2026   window 2026-12-09T01:00Z -> 2026-12-10T13:00Z
CPI December 2026    window 2026-12-10T01:30Z -> 2026-12-10T19:30Z
FOMC January 2027    window 2027-01-27T01:00Z -> 2027-01-28T13:00Z
```

Note the Dec 2026 FOMC and CPI windows overlap (FOMC +18h runs to 13:00Z on the 10th, CPI opens 01:30Z). That is harmless — both windows de-risk identically and the calendar returns whichever event is active.

Also flagged, not changed: the Fed's official calendar lists the July 2026 meeting as **Jul 28-29**, while the pre-existing `FOMC July 2026` entry (set by the #962 fix) reads `2026-07-08`. Left alone — it is a closed historical window with no effect on the guard — but worth a look when someone picks up the ownership follow-up.

## Testing

- `pytest tests/unit/position_management/` — **279 passed**, including `test_default_config_has_upcoming_coverage` (previously failing).
- Loader sanity check: 13/13 events parse (no silent drops), no active window now.
- `atb dev quality --changed` — no Python files changed, skipped.
- `docs/changelog.md` `[Unreleased] / Fixed` updated.

## Follow-ups still open on #1053
- Ask 2: assign an owner + cadence for the refill (scheduled task appending the next quarter, or a monthly pass).
- Ask 3: decide whether the canary should warn rather than fail when the guard itself is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
