### PR TITLE
fix(risk): restart-safe peak/baseline seeding on carry-forward boots (#1036)

### DIFF
--- a/.claude/skills/weekly-retro/AGENDA.md
+++ b/.claude/skills/weekly-retro/AGENDA.md
@@ -13,4 +13,15 @@ becomes a diff or gets a written disposition.
 
 ## Items
 
-_(none — cleared by the 2026-07-27 retro.)_
+- **2026-08-13 (#1036)** — Two restart-safe risk seeders (#1001, #1032) read
+  `_recovered_inactive_session_id`, a field whose lifetime is owned by an unrelated feature
+  (the #668 carry-forward re-entry guard, which clears it before the first loop iteration).
+  Result: the seeding shipped by #1032 had never once run on the carry-forward boot path, and
+  went 30 days undetected on staging because the miss was logged as a normal "unavailable" and
+  the provenance field reported `self_anchored` — the value that also means "legitimately
+  nothing to seed from". Two rules worth codifying: (a) a consumer must not depend on a field
+  whose lifetime another feature controls — give it its own field or resolve the value itself;
+  (b) a "safety feature armed" provenance/telemetry value must distinguish *nothing to do* from
+  *could not do it*, or a permanently broken safety feature looks healthy in the logs. Also:
+  boot verification for a restart-safety feature must exercise the carry-forward path, not just
+  the session-reuse path prod happens to take.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -101,6 +101,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior change when neither flag is passed; the live path cannot be pinned.
 
 ### Fixed
+- **Restart-safe peak/baseline seeding now works on carry-forward boots** (#1036):
+  both durable-history seeders — the `MaxDrawdownGuard` peak (#1001) and the
+  `AccountCircuitBreaker` daily baseline + drawdown peak (#1032) — read
+  `_recovered_inactive_session_id` to find the prior session holding the
+  `account_history` rows. That field's lifetime belongs to the #668
+  carry-forward re-entry guard, which clears it during startup BEFORE the first
+  loop iteration, so on exactly the boot path a mid-drawdown restart takes
+  (clean restart → NEW session → positions carried forward) both seeders read an
+  empty value, silently self-anchored to the post-restart balance, and logged
+  "account_history peak unavailable" as if that were normal — for 30 days on
+  staging. Fixed with a dedicated `_history_seed_session_id`, written once by
+  `LiveSessionRecoverer` when a prior session is found and never cleared, and
+  resolved through the new `src/engines/live/monitoring/seed_lineage.py`; the
+  lineage is now owned by the seeders' need rather than by an unrelated guard.
+  The documented ~3s first-snapshot race is handled deterministically instead of
+  by timing: an empty-but-successful read is terminal only when NO prior session
+  exists (a genuinely fresh account, unchanged behaviour), and is retried within
+  the existing `MAX_SEED_ATTEMPTS` budget when history was expected — the guard
+  arms provisionally from the current balance so the cap is never unarmed and
+  ratchets the peak UP via the new `MaxDrawdownGuard.raise_peak`, while the
+  breaker keeps evaluating (its `seed_peak` only ever raises). Seeding
+  provenance now tells the truth: the `peak_seed` field on breaker trip/dry-run
+  events gains a third value, `seed_unavailable`, for "durable history was
+  expected but could not be obtained" — a defect logged at WARNING — so it can
+  no longer be confused with `self_anchored`, which means "there was genuinely
+  nothing to seed from". The guard logs the same provenance when it arms.
+  Prod boots are unaffected (they reuse the active session, whose peak already
+  resolved); the 2026-07-14 staging boot would have armed at the durable
+  $1015.98 rather than $1015.84, which flips no historical trip decision.
+
 - **Macro-event calendar refilled through Jan 2027** (#1053): `config/macro_events.json`
   had no event newer than 2026-07-14, so the macro de-risk guard had zero upcoming
   coverage and its staleness canary

--- a/src/engines/live/monitoring/circuit_breaker_enforcer.py
+++ b/src/engines/live/monitoring/circuit_breaker_enforcer.py
@@ -19,7 +19,9 @@ new entries when tripped). This enforcer adds the loop-driven half:
   baseline from the day's first ``account_history`` snapshot
   (``get_first_snapshot_of_day``, equity basis), so an intraday restart does not
   re-anchor the baseline to current equity and silently disarm the daily-loss
-  halt.
+  halt. Which prior session holds those rows comes from ``seed_lineage`` (#1036)
+  — NOT from ``_recovered_inactive_session_id``, which startup clears before the
+  first loop iteration, so on carry-forward boots this seeding never fired.
 - **Restart-safe drawdown peak (#986 gap B)**: on boot it seeds the breaker's
   drawdown peak from the durable ``account_history`` session equity max
   (``get_session_peak_equity``), the same session-scoped pattern the
@@ -32,6 +34,12 @@ new entries when tripped). This enforcer adds the loop-driven half:
   it logs "would halt", writes a ``CIRCUIT_BREAKER_DRY_RUN`` ``system_events``
   row (durable would-have-tripped evidence carrying the equity breakdown and
   peak provenance, #968), and takes no protective action. ``off`` is fully inert.
+- **Honest seeding provenance**: the ``peak_seed`` field on every trip event is
+  one of ``db_session_max`` (seeded from durable history), ``self_anchored``
+  (nothing to seed from — a genuinely fresh account), or ``seed_unavailable``
+  (history was expected but could not be obtained; a DEFECT, logged at WARNING).
+  The third value exists because #1036 reported the first two for 30 days on
+  staging while the seeding had in fact never run.
 - **Surfacing**: a trip emits a ``risk_event`` + a CRITICAL ``system_events`` row
   so the monitoring dashboard and alerting pick it up.
 
@@ -49,6 +57,12 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol
 
 from src.database.models import EventType
+from src.engines.live.monitoring.seed_lineage import (
+    PEAK_SEED_DB_SESSION_MAX,
+    PEAK_SEED_SELF_ANCHORED,
+    PEAK_SEED_UNAVAILABLE,
+    resolve_history_lineage,
+)
 from src.infrastructure.logging.events import log_risk_event
 from src.risk.circuit_breaker import (
     BASIS_BALANCE_DEGRADED,
@@ -74,6 +88,10 @@ class CircuitBreakerEngineState(Protocol):
 
     current_balance: float
     trading_session_id: int | None
+    # Durable seeding lineage (#1036): set once at recovery, never cleared.
+    # ``_recovered_inactive_session_id`` is NOT usable here — the #668
+    # carry-forward guard clears it before the first loop iteration.
+    _history_seed_session_id: int | None
     _recovered_inactive_session_id: int | None
     db_manager: DatabaseManager
     _close_only_mode: bool
@@ -118,11 +136,16 @@ class CircuitBreakerEnforcer:
         self._seeded = False
         self._seed_attempts = 0
         self._halt_notified = False
-        self._peak_seed_provenance = "self_anchored"
+        self._peak_seed_provenance = PEAK_SEED_SELF_ANCHORED
 
     @property
     def breaker(self) -> AccountCircuitBreaker:
         return self._breaker
+
+    @property
+    def peak_seed_provenance(self) -> str:
+        """Where the breaker's drawdown peak came from (see ``seed_lineage``)."""
+        return self._peak_seed_provenance
 
     def check(self) -> None:
         """Evaluate the breaker against current TRUE equity; enforce halts."""
@@ -242,29 +265,67 @@ class CircuitBreakerEnforcer:
         session-scoped seeding the ``MaxDrawdownGuard`` uses (#1001), including
         the recovered-inactive-session fallback on clean restarts.
 
-        Best-effort: on any failure or missing rows, leaves the breaker to
-        self-anchor from current equity. After ``MAX_SEED_ATTEMPTS`` deferrals we
-        stop trying (the breaker is already self-anchored to a live baseline)."""
+        Prior-session lineage comes from ``resolve_history_lineage`` (#1036),
+        NOT from ``_recovered_inactive_session_id`` — startup clears that field
+        before the first loop iteration, so on the carry-forward boot path the
+        seeder used to read an empty value and self-anchor silently.
+
+        Deferral policy: an empty-but-successful read is terminal only when no
+        prior session exists (a genuinely fresh session has nothing to seed
+        from). When history WAS expected, the empty read is the documented
+        first-snapshot race — it is retried, bounded by ``MAX_SEED_ATTEMPTS``,
+        and on exhaustion the provenance latches to ``seed_unavailable`` with a
+        WARNING. Retrying is safe because the breaker keeps evaluating while
+        unseeded: it self-anchors the peak from live equity and ``seed_peak``
+        only ever raises it."""
         state = self._state
         self._seed_attempts += 1
+        lineage = resolve_history_lineage(state)
         if state.db_manager is None or state.trading_session_id is None:
             if self._seed_attempts >= MAX_SEED_ATTEMPTS:
-                self._seeded = True  # give up; breaker self-anchors from current equity
+                self._finalize_unseeded(
+                    "trading session never resolved", lineage.describe, state.trading_session_id
+                )
             return
         try:
             snapshot = state.db_manager.get_first_snapshot_of_day(
                 session_id=state.trading_session_id,
                 target_date=now.date(),
-                fallback_session_id=getattr(state, "_recovered_inactive_session_id", None),
+                fallback_session_id=lineage.fallback_session_id,
             )
             session_peak = state.db_manager.get_session_peak_equity(
                 session_id=state.trading_session_id,
-                fallback_session_id=getattr(state, "_recovered_inactive_session_id", None),
+                fallback_session_id=lineage.fallback_session_id,
             )
         except Exception as e:  # noqa: BLE001
             logger.warning("Circuit-breaker baseline/peak seed deferred: %s", e)
             if self._seed_attempts >= MAX_SEED_ATTEMPTS:
-                self._seeded = True
+                self._finalize_unseeded(
+                    f"account_history read kept failing ({e})",
+                    lineage.describe,
+                    state.trading_session_id,
+                )
+            return
+
+        if session_peak is None and lineage.history_expected:
+            # Durable history was expected but no row came back — the ~3s
+            # first-snapshot race, or a lost lineage. Retry rather than latch.
+            if self._seed_attempts < MAX_SEED_ATTEMPTS:
+                # Truthful while unresolved: a trip during the retry window must
+                # not report `self_anchored`, which means "nothing to seed from".
+                self._peak_seed_provenance = PEAK_SEED_UNAVAILABLE
+                logger.info(
+                    "Circuit-breaker seeding deferred: no account_history rows yet for "
+                    "session %s / %s (attempt %d/%d)",
+                    state.trading_session_id,
+                    lineage.describe,
+                    self._seed_attempts,
+                    MAX_SEED_ATTEMPTS,
+                )
+                return
+            self._finalize_unseeded(
+                "account_history returned no rows", lineage.describe, state.trading_session_id
+            )
             return
 
         if snapshot is not None:
@@ -285,13 +346,39 @@ class CircuitBreakerEnforcer:
         peak = self._as_positive_float(session_peak)
         if peak is not None:
             self._breaker.seed_peak(peak)
-            self._peak_seed_provenance = "db_session_max"
+            self._peak_seed_provenance = PEAK_SEED_DB_SESSION_MAX
             logger.info(
-                "Circuit-breaker drawdown peak seeded from account_history session max: $%.2f",
+                "Circuit-breaker drawdown peak seeded from account_history session max: "
+                "$%.2f (%s)",
                 peak,
+                lineage.describe,
             )
-        # No session history yet -> peak self-anchors from current equity.
+        else:
+            # No prior session and no rows: a genuinely fresh account. Anchoring
+            # to current equity is correct, and the provenance says so.
+            self._peak_seed_provenance = PEAK_SEED_SELF_ANCHORED
         self._seeded = True
+
+    def _finalize_unseeded(self, reason: str, lineage: str, session_id: int | None) -> None:
+        """Give up on durable seeding and record the miss honestly.
+
+        This is NOT the fresh-account self-anchor: durable history was expected
+        and could not be obtained, so both halts are now measured from the
+        post-restart equity. It must be loud and it must be visible in the
+        ``peak_seed`` provenance carried on every trip event.
+        """
+        self._seeded = True
+        self._peak_seed_provenance = PEAK_SEED_UNAVAILABLE
+        logger.warning(
+            "Circuit-breaker durable seeding FAILED after %d attempts (%s; session %s, %s) — "
+            "daily baseline and drawdown peak stay anchored to post-restart equity "
+            "(peak_seed=%s). A mid-drawdown restart is measuring from the depressed value.",
+            self._seed_attempts,
+            reason,
+            session_id,
+            lineage,
+            PEAK_SEED_UNAVAILABLE,
+        )
 
     @staticmethod
     def _as_positive_float(value: object) -> float | None:

--- a/src/engines/live/monitoring/drawdown_guard.py
+++ b/src/engines/live/monitoring/drawdown_guard.py
@@ -19,15 +19,24 @@ in the same iteration — e.g. a stop-loss fill — blocks that iteration's entr
 instead of leaking one bar of fresh exposure (2026-07-12 risk audit P1).
 
 Peak-equity source: the AUTHORITATIVE baseline is the ``account_history``
-session max (active session plus the recovered inactive session on clean
-restarts), recomputed on boot so a restart cannot reset the drawdown baseline
-— a bot restarted mid-breach re-trips naturally on its first loop iteration.
-Fallback order is DB session max → current recovered balance; the in-memory
-PerformanceTracker peak is NEVER a seed candidate (it can initialize from the
-CONFIGURED balance — the optimistic book value that mis-seeded prod at $100
-vs true equity ~$84 on 2026-07-04). A failed DB read defers seeding to the
-next cycle (bounded by ``MAX_SEED_ATTEMPTS``) instead of latching a
-half-seeded baseline.
+session max (active session plus the prior session on clean restarts, resolved
+via ``seed_lineage``), recomputed on boot so a restart cannot reset the
+drawdown baseline — a bot restarted mid-breach re-trips naturally on its first
+loop iteration. Fallback order is DB session max → current recovered balance;
+the in-memory PerformanceTracker peak is NEVER a seed candidate (it can
+initialize from the CONFIGURED balance — the optimistic book value that
+mis-seeded prod at $100 vs true equity ~$84 on 2026-07-04). A failed DB read
+defers seeding to the next cycle (bounded by ``MAX_SEED_ATTEMPTS``) instead of
+latching a half-seeded baseline.
+
+When the durable peak is EXPECTED (a prior session exists) but the read comes
+back empty — the first-snapshot race of #1036, where the new session's opening
+``account_history`` row lands seconds after the first loop iteration — the
+guard arms provisionally from the current balance so the cap is never unarmed,
+records ``peak_seed=seed_unavailable``, and keeps retrying to ratchet the peak
+UP (``raise_peak``) until the durable value is readable or the attempt budget
+is spent. An empty read with NO prior session is a genuinely fresh account and
+self-anchors terminally, as before.
 
 Baseline policy (PM decision, 2026-07-04): the peak baseline is the peak TRUE
 equity since the last reconciled reset — i.e. session-scoped history, NOT
@@ -72,6 +81,13 @@ from src.config.constants import (
 )
 from src.config.feature_flags import is_enabled
 from src.database.models import EventType
+from src.engines.live.monitoring.seed_lineage import (
+    PEAK_SEED_DB_SESSION_MAX,
+    PEAK_SEED_SELF_ANCHORED,
+    PEAK_SEED_UNAVAILABLE,
+    HistoryLineage,
+    resolve_history_lineage,
+)
 from src.infrastructure.logging.events import log_risk_event
 
 if TYPE_CHECKING:
@@ -183,6 +199,21 @@ class MaxDrawdownGuard:
             self._peak = max(valid, default=0.0)
         self._seeded = True
 
+    def raise_peak(self, candidate: float | None) -> bool:
+        """Ratchet the peak UP from a late-arriving durable candidate (#1036).
+
+        Used when the boot-time ``account_history`` read came back empty
+        because the session's first snapshot had not landed yet: the guard arms
+        immediately from the current balance (never unarmed) and the true peak
+        is raised as soon as it becomes readable. Only ever raises — a stale or
+        lower candidate can never erase drawdown already observed.
+        """
+        value = self._as_valid(candidate)
+        if value is None or value <= self._peak:
+            return False
+        self._peak = value
+        return True
+
     @staticmethod
     def _as_valid(candidate: float | None) -> float | None:
         """Coerce a peak candidate to a finite positive float, else None."""
@@ -278,6 +309,10 @@ class DrawdownEngineState(Protocol):
 
     current_balance: float
     trading_session_id: int | None
+    # Durable seeding lineage (#1036): set once at recovery, never cleared.
+    # ``_recovered_inactive_session_id`` is NOT usable here — the #668
+    # carry-forward guard clears it before the first loop iteration.
+    _history_seed_session_id: int | None
     _recovered_inactive_session_id: int | None
     db_manager: DatabaseManager
     _close_only_mode: bool
@@ -311,11 +346,18 @@ class MaxDrawdownEnforcer:
         self._guard = guard
         self._breach_notified = False
         self._seed_attempts = 0
+        self._peak_seed_provenance = PEAK_SEED_SELF_ANCHORED
+        self._history_upgrade_pending = False
 
     @property
     def guard(self) -> MaxDrawdownGuard:
         """The underlying drawdown guard (exposed for status/diagnostics)."""
         return self._guard
+
+    @property
+    def peak_seed_provenance(self) -> str:
+        """Where the armed peak came from (see ``seed_lineage`` constants)."""
+        return self._peak_seed_provenance
 
     def check(self) -> None:
         """Assess current drawdown; enforce the hard cap on breach."""
@@ -343,10 +385,15 @@ class MaxDrawdownEnforcer:
         state = self._state
         try:
             balance = float(state.current_balance)
-            if not self._guard.seeded and not self._try_seed(
-                balance, count_deferral=count_seed_deferral
-            ):
+            was_seeded = self._guard.seeded
+            if not was_seeded and not self._try_seed(balance, count_deferral=count_seed_deferral):
                 return  # seeding deferred (DB/session not ready); retry next cycle
+            # Only on a LATER iteration: re-reading the same DB state within the
+            # iteration that just armed provisionally cannot tell us anything new.
+            if was_seeded and self._history_upgrade_pending and count_seed_deferral:
+                # Armed provisionally from the current balance; keep trying to
+                # ratchet up to the durable peak (bounded, loop-check only).
+                self._upgrade_peak_from_history()
             assessment = self._guard.observe(balance)
         except Exception as e:
             # Monitoring must never take down the trading loop.
@@ -421,6 +468,7 @@ class MaxDrawdownEnforcer:
 
         if count_deferral:
             self._seed_attempts += 1
+        lineage = resolve_history_lineage(state)
         session_id = state.trading_session_id
         db_read_ok = False
         db_peak: float | None = None
@@ -435,11 +483,11 @@ class MaxDrawdownEnforcer:
             try:
                 db_peak = state.db_manager.get_session_peak_balance(
                     session_id,
-                    fallback_session_id=state._recovered_inactive_session_id,
+                    fallback_session_id=lineage.fallback_session_id,
                 )
-                # None here means the read SUCCEEDED but the session has no
-                # snapshots yet — a fresh session legitimately baselines at
-                # the current balance.
+                # None here means the read SUCCEEDED but neither session has a
+                # snapshot yet — legitimate for a genuinely fresh session, a
+                # DEFECT (or the first-snapshot race) when history was expected.
                 db_read_ok = True
             except Exception as e:
                 logger.warning(
@@ -460,14 +508,96 @@ class MaxDrawdownEnforcer:
                 self._seed_attempts,
                 balance,
             )
+            self._arm(balance, None, session_id, lineage, PEAK_SEED_UNAVAILABLE)
+            return True
 
+        if db_peak is None and lineage.history_expected:
+            # The durable peak is expected but not readable yet (the documented
+            # first-snapshot race, or a lost lineage). Arm NOW from the current
+            # balance so the cap is never left unarmed, flag the provenance
+            # honestly, and keep ratcheting toward the durable peak.
+            self._history_upgrade_pending = True
+            self._arm(balance, None, session_id, lineage, PEAK_SEED_UNAVAILABLE)
+            return True
+
+        self._arm(
+            balance,
+            db_peak,
+            session_id,
+            lineage,
+            PEAK_SEED_DB_SESSION_MAX if db_peak is not None else PEAK_SEED_SELF_ANCHORED,
+        )
+        return True
+
+    def _arm(
+        self,
+        balance: float,
+        db_peak: float | None,
+        session_id: int | None,
+        lineage: HistoryLineage,
+        provenance: str,
+    ) -> None:
+        """Seed the guard's peak and log where the baseline came from."""
         self._guard.seed_peak(balance, db_peak)
-        logger.info(
-            "Max-drawdown guard armed: peak=$%.2f, hard cap=%.1f%% (session %s, "
-            "account_history peak %s)",
+        self._peak_seed_provenance = provenance
+        log = logger.warning if provenance == PEAK_SEED_UNAVAILABLE else logger.info
+        log(
+            "Max-drawdown guard armed: peak=$%.2f, hard cap=%.1f%% (session %s, %s, "
+            "account_history peak %s, peak_seed=%s)",
             self._guard.peak_balance,
             self._guard.max_drawdown_pct * 100,
             session_id,
+            lineage.describe,
             f"${db_peak:,.2f}" if db_peak is not None else "unavailable",
+            provenance,
         )
-        return True
+
+    def _upgrade_peak_from_history(self) -> None:
+        """Retry the durable peak read after a provisional self-anchored arm.
+
+        Bounded by the shared ``MAX_SEED_ATTEMPTS`` budget. Success ratchets the
+        peak UP (never down) and corrects the provenance; exhaustion stops the
+        retries and leaves a WARNING naming the sessions that were searched, so
+        a silently self-anchored cap is never mistaken for a seeded one.
+        """
+        state = self._state
+        self._seed_attempts += 1
+        lineage = resolve_history_lineage(state)
+        session_id = state.trading_session_id
+        db_peak: float | None = None
+        read_ok = False
+        if state.db_manager is not None and session_id is not None:
+            try:
+                db_peak = state.db_manager.get_session_peak_balance(
+                    session_id, fallback_session_id=lineage.fallback_session_id
+                )
+                read_ok = True
+            except Exception as e:
+                logger.warning("Max-drawdown guard peak upgrade read failed: %s", e)
+
+        if read_ok and db_peak is not None:
+            self._history_upgrade_pending = False
+            self._peak_seed_provenance = PEAK_SEED_DB_SESSION_MAX
+            raised = self._guard.raise_peak(db_peak)
+            logger.info(
+                "Max-drawdown guard peak seeded from account_history after a deferred "
+                "read: $%.2f (%s) — peak now $%.2f%s",
+                db_peak,
+                lineage.describe,
+                self._guard.peak_balance,
+                "" if raised else " (already higher; unchanged)",
+            )
+            return
+
+        if self._seed_attempts >= MAX_SEED_ATTEMPTS:
+            self._history_upgrade_pending = False
+            logger.warning(
+                "Max-drawdown guard: durable account_history peak never became available "
+                "after %d attempts (session %s, %s) — the cap stays anchored to the "
+                "boot balance $%.2f (peak_seed=%s)",
+                self._seed_attempts,
+                session_id,
+                lineage.describe,
+                self._guard.peak_balance,
+                PEAK_SEED_UNAVAILABLE,
+            )

--- a/src/engines/live/monitoring/seed_lineage.py
+++ b/src/engines/live/monitoring/seed_lineage.py
@@ -1,0 +1,88 @@
+"""Durable-history lineage for the restart-safe risk seeders (#1036).
+
+Both loop-time seeders — the ``MaxDrawdownGuard`` peak (#1001) and the
+``AccountCircuitBreaker`` daily baseline + drawdown peak (#1032) — need to know
+which PRIOR trading session holds the ``account_history`` rows they must
+baseline from. They used to read ``_recovered_inactive_session_id``, whose
+lifetime belongs to a different concern entirely: the #668 carry-forward
+re-entry guard clears it in ``LiveStartupSequencer.carry_forward_open_positions``
+BEFORE the first loop iteration runs, so on exactly the boot path that needs it
+(clean restart → NEW session → positions carried forward) the seeders read an
+empty value and silently self-anchored to the post-restart balance — the
+#845/#847 peak-reset class the seeding exists to prevent.
+
+The fix is a dedicated field, ``_history_seed_session_id``, written once by
+``LiveSessionRecoverer`` when a prior session is found and never cleared: its
+lifetime is owned by the seeders' need rather than by the reassign guard. It
+also doubles as the honest answer to "does durable history exist at all?",
+which is what separates a legitimate self-anchor (genuinely fresh session, no
+prior history) from a seeding DEFECT (lineage lost, or the read came back empty
+when history was expected).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+# Seeding provenance values (surfaced on breaker trips as ``peak_seed`` and in
+# the guard's arming log). These must tell the truth about where the baseline
+# came from — a self-anchor that happened because a lookup FAILED is not the
+# same event as a self-anchor because there is genuinely nothing to seed from.
+PEAK_SEED_DB_SESSION_MAX = "db_session_max"
+"""Seeded from the durable ``account_history`` session max."""
+
+PEAK_SEED_SELF_ANCHORED = "self_anchored"
+"""Legitimately anchored to current equity: no prior session, no history."""
+
+PEAK_SEED_UNAVAILABLE = "seed_unavailable"
+"""DEFECT: durable history was expected but could not be obtained."""
+
+
+@runtime_checkable
+class HistoryLineageState(Protocol):
+    """The engine-state surface the lineage resolver reads."""
+
+    _history_seed_session_id: int | None
+    _recovered_inactive_session_id: int | None
+
+
+@dataclass(frozen=True)
+class HistoryLineage:
+    """Which session holds the durable history, and whether any is expected."""
+
+    fallback_session_id: int | None
+    history_expected: bool
+
+    @property
+    def describe(self) -> str:
+        """Short provenance string for log lines."""
+        if self.fallback_session_id is None:
+            return "no prior session"
+        return f"prior session {self.fallback_session_id}"
+
+
+def _as_session_id(value: object) -> int | None:
+    """Coerce a session-id attribute to an int, rejecting anything else.
+
+    Deliberately strict: engine state is duck-typed and frequently stubbed, and
+    a ``MagicMock`` attribute is truthy — reading one as "a prior session
+    exists" would invent history that is not there (LESSONS.md: MagicMock
+    truthiness). ``bool`` is excluded because ``True`` is an ``int``.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def resolve_history_lineage(state: object) -> HistoryLineage:
+    """Resolve the prior session whose ``account_history`` rows seed the risk baselines.
+
+    Prefers the durable ``_history_seed_session_id`` (set once at recovery,
+    never cleared) and falls back to ``_recovered_inactive_session_id`` so a
+    state object that predates the durable field still seeds as before.
+    """
+    durable = _as_session_id(getattr(state, "_history_seed_session_id", None))
+    legacy = _as_session_id(getattr(state, "_recovered_inactive_session_id", None))
+    fallback = durable if durable is not None else legacy
+    return HistoryLineage(fallback_session_id=fallback, history_expected=fallback is not None)

--- a/src/engines/live/recovery.py
+++ b/src/engines/live/recovery.py
@@ -85,6 +85,7 @@ class RecoveryEngineState(Protocol):
     current_balance: float
     _close_only_mode: bool
     _recovered_inactive_session_id: int | None
+    _history_seed_session_id: int | None
 
     def _strategy_name(self) -> str: ...
 
@@ -145,6 +146,15 @@ class LiveSessionRecoverer:
                 return None
 
             logger.info("🔍 Found %s session #%s", source, session_id)
+
+            # Durable seeding lineage (#1036): this session holds the
+            # account_history rows the restart-safe risk seeders must baseline
+            # from. Recorded for BOTH recovery paths (reused active session and
+            # clean restart) and never cleared — unlike
+            # _recovered_inactive_session_id, whose lifetime belongs to the #668
+            # carry-forward guard, which clears it during startup before the
+            # first loop iteration runs.
+            state._history_seed_session_id = session_id
 
             # Clean restart (inactive session): remember it so start() can carry its
             # OPEN positions forward into the new session — INDEPENDENT of whether a

--- a/src/engines/live/startup.py
+++ b/src/engines/live/startup.py
@@ -302,7 +302,9 @@ class LiveStartupSequencer:
                 )
             finally:
                 # Clear so a later start()/stop()/start() re-entry cannot re-trigger a
-                # stale-session reassign (#668, P3).
+                # stale-session reassign (#668, P3). The restart-safe risk seeders
+                # must NOT read this field — it is dead by the first loop iteration.
+                # They use the durable `_history_seed_session_id` instead (#1036).
                 state._recovered_inactive_session_id = None
 
     def self_heal_terminal_positions(self) -> None:

--- a/src/engines/live/trading_engine.py
+++ b/src/engines/live/trading_engine.py
@@ -646,6 +646,13 @@ class LiveTradingEngine:
         # new session (#668); None when recovery took the active/crash path or
         # found no recent session.
         self._recovered_inactive_session_id: int | None = None
+        # Durable seeding lineage (#1036): the session whose account_history
+        # rows the restart-safe risk seeders (drawdown guard peak, circuit
+        # breaker baseline/peak) must baseline from. Set once by recovery and
+        # never cleared — _recovered_inactive_session_id above is cleared by
+        # the #668 carry-forward guard before the first loop iteration, which
+        # silently disarmed both seeders on carry-forward boots.
+        self._history_seed_session_id: int | None = None
 
     def _init_dynamic_risk_manager(self) -> None:
         """Build the dynamic-risk manager now that the database is available."""

--- a/tests/unit/engines/live/test_circuit_breaker_enforcer.py
+++ b/tests/unit/engines/live/test_circuit_breaker_enforcer.py
@@ -11,6 +11,7 @@ from src.engines.live.monitoring.circuit_breaker_enforcer import (
     MAX_SEED_ATTEMPTS,
     CircuitBreakerEnforcer,
 )
+from src.engines.live.monitoring.seed_lineage import PEAK_SEED_UNAVAILABLE
 from src.risk.circuit_breaker import AccountCircuitBreaker
 
 pytestmark = pytest.mark.unit
@@ -237,13 +238,18 @@ def test_no_durable_peak_self_anchors():
     assert s._close_only_mode is False
 
 
-def test_peak_seed_failure_defers_then_arms_self_anchored():
+def test_peak_seed_failure_defers_then_reports_unavailable():
+    """A never-resolved session is a seeding MISS, not a fresh account (#1036).
+
+    ``self_anchored`` means "there was genuinely nothing to seed from"; a
+    lookup that never happened must not borrow that reassurance.
+    """
     s = _State(session_id=None)  # session not resolved: seeding must defer
     enf = CircuitBreakerEnforcer(s, _breaker("active"))
     for _ in range(MAX_SEED_ATTEMPTS):
         enf.check()
     assert enf._seeded is True
-    assert enf._peak_seed_provenance == "self_anchored"
+    assert enf.peak_seed_provenance == PEAK_SEED_UNAVAILABLE
 
 
 # --- equity-read fault isolation ----------------------------------------------

--- a/tests/unit/engines/live/test_restart_safe_seeding.py
+++ b/tests/unit/engines/live/test_restart_safe_seeding.py
@@ -1,0 +1,313 @@
+"""Restart-safe peak/baseline seeding on carry-forward boots (#1036).
+
+Both durable-history seeders — the ``MaxDrawdownGuard`` peak (#1001) and the
+``AccountCircuitBreaker`` daily baseline + drawdown peak (#1032) — used to read
+``_recovered_inactive_session_id``, which the #668 carry-forward re-entry guard
+clears during startup BEFORE the first loop iteration. On the clean-restart /
+new-session boot path (the one a mid-drawdown restart takes) they therefore saw
+an empty value and silently self-anchored to the post-restart balance.
+
+These tests pin the three behaviours that fix requires:
+  1. the seeders resolve the prior session AFTER startup has cleared the #668 field,
+  2. an empty-but-successful read is retried when history was EXPECTED (the
+     documented first-snapshot race) instead of latching terminally, and
+  3. a genuinely fresh session with no history still self-anchors, once, silently.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from src.engines.live.monitoring.circuit_breaker_enforcer import CircuitBreakerEnforcer
+from src.engines.live.monitoring.drawdown_guard import (
+    MAX_SEED_ATTEMPTS,
+    MaxDrawdownEnforcer,
+    MaxDrawdownGuard,
+)
+from src.engines.live.monitoring.seed_lineage import (
+    PEAK_SEED_DB_SESSION_MAX,
+    PEAK_SEED_SELF_ANCHORED,
+    PEAK_SEED_UNAVAILABLE,
+    resolve_history_lineage,
+)
+from src.risk.circuit_breaker import AccountCircuitBreaker
+
+pytestmark = pytest.mark.unit
+
+NEW_SESSION = 23
+PRIOR_SESSION = 22
+
+
+class _SeedState:
+    """Engine-state stub for the seeders (carry-forward boot by default).
+
+    ``_recovered_inactive_session_id`` is None because startup has already
+    cleared it — reproducing the #1036 boot exactly.
+    """
+
+    def __init__(
+        self,
+        *,
+        balance: float = 1015.84,
+        peaks: list[float | None] | None = None,
+        snapshots: list[object] | None = None,
+        history_session_id: int | None = PRIOR_SESSION,
+        session_id: int | None = NEW_SESSION,
+    ) -> None:
+        self.current_balance = balance
+        self.trading_session_id = session_id
+        self._recovered_inactive_session_id = None
+        self._history_seed_session_id = history_session_id
+        self._close_only_mode = False
+        self.events: list[str | None] = []
+        self._peaks = list(peaks if peaks is not None else [None])
+        self._snapshots = list(snapshots if snapshots is not None else [None])
+        self.peak_calls: list[int | None] = []
+        self.snapshot_calls: list[int | None] = []
+        self.db_manager = SimpleNamespace(
+            get_session_peak_balance=self._get_peak,
+            get_session_peak_equity=lambda **kw: self._get_peak(**kw),
+            get_first_snapshot_of_day=self._get_snapshot,
+        )
+
+    @staticmethod
+    def _next(queue: list, default=None):
+        if not queue:
+            return default
+        return queue.pop(0) if len(queue) > 1 else queue[0]
+
+    def _get_peak(self, session_id=None, fallback_session_id=None, **_kw):
+        self.peak_calls.append(fallback_session_id)
+        value = self._next(self._peaks)
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    def _get_snapshot(self, session_id=None, target_date=None, fallback_session_id=None, **_kw):
+        self.snapshot_calls.append(fallback_session_id)
+        return self._next(self._snapshots)
+
+    def _enter_close_only_mode(self):
+        self._close_only_mode = True
+
+    def _record_event(self, *args, **kwargs):
+        self.events.append(kwargs.get("error_code"))
+
+
+def _guard_enforcer(state: _SeedState) -> MaxDrawdownEnforcer:
+    return MaxDrawdownEnforcer(engine_state=state, guard=MaxDrawdownGuard(0.20))
+
+
+def _breaker_enforcer(state: _SeedState) -> CircuitBreakerEnforcer:
+    breaker = AccountCircuitBreaker(mode="dry_run", daily_loss_limit=0.025, drawdown_halt=0.15)
+    return CircuitBreakerEnforcer(engine_state=state, breaker=breaker)
+
+
+# ---------------------------------------------------------------------------
+# 1. Carry-forward boot: the prior session must still be reachable
+# ---------------------------------------------------------------------------
+
+
+def test_startup_carry_forward_clear_does_not_destroy_the_seed_lineage():
+    """#668 clears ``_recovered_inactive_session_id``; the seed lineage survives."""
+    state = _SeedState()
+    state._recovered_inactive_session_id = None  # startup already cleared it
+
+    lineage = resolve_history_lineage(state)
+
+    assert lineage.fallback_session_id == PRIOR_SESSION
+    assert lineage.history_expected is True
+
+
+def test_guard_seeds_from_prior_session_peak_on_carry_forward_boot():
+    state = _SeedState(balance=1015.84, peaks=[1015.98])
+    enforcer = _guard_enforcer(state)
+
+    enforcer.check()
+
+    assert state.peak_calls == [PRIOR_SESSION]
+    assert enforcer.guard.peak_balance == pytest.approx(1015.98)
+    assert enforcer.peak_seed_provenance == PEAK_SEED_DB_SESSION_MAX
+
+
+def test_breaker_seeds_peak_and_baseline_from_prior_session_on_carry_forward_boot():
+    snapshot = SimpleNamespace(equity=1010.0, balance=1009.0)
+    state = _SeedState(balance=1015.84, peaks=[1016.44], snapshots=[snapshot])
+    enforcer = _breaker_enforcer(state)
+
+    enforcer.check()
+
+    assert state.peak_calls == [PRIOR_SESSION]
+    assert state.snapshot_calls == [PRIOR_SESSION]
+    assert enforcer.breaker.peak == pytest.approx(1016.44)
+    assert enforcer.breaker.daily_baseline == pytest.approx(1010.0)
+    assert enforcer.peak_seed_provenance == PEAK_SEED_DB_SESSION_MAX
+
+
+# ---------------------------------------------------------------------------
+# 2. First-snapshot race: empty read is retryable when history was expected
+# ---------------------------------------------------------------------------
+
+
+def test_guard_arms_immediately_then_ratchets_when_the_snapshot_lands_late():
+    """The ~3s race must not permanently forfeit the durable peak.
+
+    The cap is armed on the first iteration regardless (never unarmed), and the
+    peak is ratcheted UP once the durable read succeeds.
+    """
+    state = _SeedState(balance=1015.84, peaks=[None, 1015.98])
+    enforcer = _guard_enforcer(state)
+
+    enforcer.check()
+    assert enforcer.guard.seeded is True  # armed, never left unprotected
+    assert enforcer.guard.peak_balance == pytest.approx(1015.84)
+    assert enforcer.peak_seed_provenance == PEAK_SEED_UNAVAILABLE
+
+    enforcer.check()
+    assert enforcer.guard.peak_balance == pytest.approx(1015.98)
+    assert enforcer.peak_seed_provenance == PEAK_SEED_DB_SESSION_MAX
+
+
+def test_guard_late_peak_never_lowers_an_already_ratcheted_peak():
+    state = _SeedState(balance=1000.0, peaks=[None, 900.0])
+    enforcer = _guard_enforcer(state)
+
+    enforcer.check()
+    state.current_balance = 1200.0
+    enforcer.check()  # observed a new high; the late 900 candidate must not win
+
+    assert enforcer.guard.peak_balance == pytest.approx(1200.0)
+
+
+def test_breaker_defers_seeding_when_history_expected_but_read_is_empty():
+    snapshot = SimpleNamespace(equity=1010.0, balance=1009.0)
+    state = _SeedState(balance=1015.84, peaks=[None, 1015.98], snapshots=[None, snapshot])
+    enforcer = _breaker_enforcer(state)
+
+    enforcer.check()
+    assert enforcer.peak_seed_provenance == PEAK_SEED_UNAVAILABLE
+    assert enforcer.breaker.peak == pytest.approx(1015.84)  # self-anchored meanwhile
+
+    enforcer.check()
+    assert enforcer.peak_seed_provenance == PEAK_SEED_DB_SESSION_MAX
+    assert enforcer.breaker.peak == pytest.approx(1015.98)
+    assert enforcer.breaker.daily_baseline == pytest.approx(1010.0)
+
+
+def test_guard_logs_warning_and_unavailable_provenance_when_history_never_arrives(caplog):
+    state = _SeedState(balance=1000.0, peaks=[None])
+    enforcer = _guard_enforcer(state)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(MAX_SEED_ATTEMPTS + 2):
+            enforcer.check()
+
+    assert enforcer.peak_seed_provenance == PEAK_SEED_UNAVAILABLE
+    assert any(r.levelno >= logging.WARNING for r in caplog.records)
+    # Bounded: it stops hammering the DB once the budget is spent.
+    assert len(state.peak_calls) <= MAX_SEED_ATTEMPTS + 1
+
+
+def test_breaker_logs_warning_and_unavailable_provenance_when_history_never_arrives(caplog):
+    state = _SeedState(balance=1000.0, peaks=[None], snapshots=[None])
+    enforcer = _breaker_enforcer(state)
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(MAX_SEED_ATTEMPTS + 2):
+            enforcer.check()
+
+    assert enforcer.peak_seed_provenance == PEAK_SEED_UNAVAILABLE
+    assert any(r.levelno >= logging.WARNING for r in caplog.records)
+    assert len(state.peak_calls) <= MAX_SEED_ATTEMPTS + 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Genuine fresh session: zero behaviour change
+# ---------------------------------------------------------------------------
+
+
+def test_guard_fresh_session_self_anchors_once_without_warning(caplog):
+    state = _SeedState(balance=1000.0, peaks=[None], history_session_id=None)
+    enforcer = _guard_enforcer(state)
+
+    with caplog.at_level(logging.WARNING):
+        enforcer.check()
+        enforcer.check()
+
+    assert enforcer.guard.seeded is True
+    assert enforcer.guard.peak_balance == pytest.approx(1000.0)
+    assert enforcer.peak_seed_provenance == PEAK_SEED_SELF_ANCHORED
+    assert state.peak_calls == [None]  # exactly one read; no retry storm
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_breaker_fresh_session_self_anchors_once_without_warning(caplog):
+    state = _SeedState(balance=1000.0, peaks=[None], snapshots=[None], history_session_id=None)
+    enforcer = _breaker_enforcer(state)
+
+    with caplog.at_level(logging.WARNING):
+        enforcer.check()
+        enforcer.check()
+
+    assert enforcer.peak_seed_provenance == PEAK_SEED_SELF_ANCHORED
+    assert state.peak_calls == [None]
+    assert state.snapshot_calls == [None]
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_breaker_new_utc_day_without_todays_snapshot_is_not_a_defect(caplog):
+    """History EXISTS (peak found) but today has no snapshot yet — legitimate."""
+    state = _SeedState(balance=1000.0, peaks=[1050.0], snapshots=[None])
+    enforcer = _breaker_enforcer(state)
+
+    with caplog.at_level(logging.WARNING):
+        enforcer.check()
+        enforcer.check()
+
+    assert enforcer.peak_seed_provenance == PEAK_SEED_DB_SESSION_MAX
+    assert enforcer.breaker.peak == pytest.approx(1050.0)
+    assert len(state.snapshot_calls) == 1  # terminal, no retry
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_breaker_trip_event_reports_truthful_peak_provenance():
+    """The #1032 ``peak_seed`` field must not claim db_session_max on a miss."""
+    state = _SeedState(balance=1000.0, peaks=[None], snapshots=[None])
+    breaker = AccountCircuitBreaker(mode="active", daily_loss_limit=0.025, drawdown_halt=0.15)
+    enforcer = CircuitBreakerEnforcer(engine_state=state, breaker=breaker)
+
+    enforcer.check()
+    state.current_balance = 800.0  # -20% from the self-anchored peak
+    enforcer.check()
+
+    assert state._close_only_mode is True
+    assert enforcer.peak_seed_provenance == PEAK_SEED_UNAVAILABLE
+
+
+def test_seeders_use_the_recovered_id_when_the_durable_field_is_absent():
+    """Back-compat: state objects without the new field seed as before."""
+    state = _SeedState(peaks=[1200.0], history_session_id=None)
+    del state._history_seed_session_id
+    state._recovered_inactive_session_id = PRIOR_SESSION
+
+    enforcer = _guard_enforcer(state)
+    enforcer.check()
+
+    assert state.peak_calls == [PRIOR_SESSION]
+    assert enforcer.peak_seed_provenance == PEAK_SEED_DB_SESSION_MAX
+
+
+def test_now_is_passed_through_for_the_day_window():
+    """Sanity: the breaker seeds against the evaluation clock, not import time."""
+    state = _SeedState(peaks=[1200.0], snapshots=[None])
+    enforcer = _breaker_enforcer(state)
+    before = datetime.now(UTC).date()
+
+    enforcer.check()
+
+    assert enforcer.breaker.peak == pytest.approx(1200.0)
+    assert before <= datetime.now(UTC).date()


### PR DESCRIPTION
Fixes #1036.

## Problem

Both durable-history risk seeders resolved the prior session from `_recovered_inactive_session_id`:

- `MaxDrawdownGuard` peak seeding (#1001, `drawdown_guard.py`)
- `AccountCircuitBreaker` daily baseline + drawdown peak seeding (#1032, `circuit_breaker_enforcer.py`)

That field's lifetime belongs to a **different feature**: the #668 carry-forward re-entry guard clears it in `LiveStartupSequencer.carry_forward_open_positions` BEFORE the first loop iteration runs. So on exactly the boot path a mid-drawdown restart takes — clean restart → NEW session → positions carried forward — both seeders read an empty value, self-anchored to the post-restart balance, and logged it as the unremarkable `account_history peak unavailable`. Staging ran 30 days at `peak_seed=self_anchored` on a feature whose entire purpose is surviving restarts.

A second defect compounded it: an empty-but-successful read was treated as terminal, so the documented ~3s window between the first loop check and the new session's first `account_history` snapshot permanently forfeited the seed.

## Design rationale

**Own the lineage rather than borrow it.** The fix adds a dedicated `_history_seed_session_id`, written once by `LiveSessionRecoverer` when a prior session is found (both the reused-active and clean-restart paths) and **never cleared**, resolved through a new `src/engines/live/monitoring/seed_lineage.py`. Moving the #668 clear later would have left the same latent coupling — two consumers depending on a field a third feature is free to reset. Recording it for the active-recovery path too means the seeders no longer care *which* recovery path ran.

**The race is closed by structure, not timing.** With the lineage restored, a carry-forward boot reads the prior session's rows, which already exist — the new session's pending first snapshot is irrelevant. The residual empty-read case is then classified honestly:

| Situation | Behaviour |
|---|---|
| Peak found | seed, `peak_seed=db_session_max` |
| Empty read, **no** prior session | terminal self-anchor, `self_anchored`, INFO — unchanged |
| Empty read, prior session **expected** | retried within the existing `MAX_SEED_ATTEMPTS` budget, `seed_unavailable` |
| Read failed / session never resolved | as before, then `seed_unavailable` + WARNING |

Retrying is safe because neither component is left unprotected while it retries: the guard arms provisionally from the current balance and ratchets the peak **up** via the new `MaxDrawdownGuard.raise_peak` (only ever raises); the breaker keeps evaluating and its `seed_peak` likewise only raises.

**Provenance must not lie.** `self_anchored` previously covered both "nothing to seed from" and "the lookup failed" — the ambiguity is precisely why this went unnoticed for a month. `seed_unavailable` is the third value, logged at WARNING+, and it rides on the `peak_seed` field of every breaker trip / dry-run event. The guard now logs its provenance too.

## Behaviour change on historical boots

- **Production**: unaffected. Prod restarts reuse the active session, so `session_id == fallback` and `_get_session_peak` dedupes to the identical query — same peak, same decisions.
- **Staging 2026-07-14 (session 22→23)**: the guard would have armed at the durable $1015.98 instead of $1015.84, and the breaker would have had a real peak/baseline instead of none. Both deltas are ~0.01–0.06% against 20%/15% caps — **no historical trip or no-trip decision flips**.
- New: an active-session recovery that finds no positive balance (so a new session is created) now also seeds from that session's history. Strictly more conservative, rare.
- No new unarmed window: the guard arms on the same iteration it always did.

## Testing

TDD — `tests/unit/engines/live/test_restart_safe_seeding.py` was written first and failed on the real defect (`assert [None] == [22]`: the seeders were querying with no fallback session).

- 14 new tests: carry-forward miss for **both** seeders, the lineage surviving the #668 clear, the late-snapshot race (arm-then-ratchet, and never ratcheting *down*), exhaustion → WARNING + `seed_unavailable`, legitimate fresh session (one read, no warning, no retry), a new UTC day with history but no snapshot yet (not a defect), truthful provenance on an actual trip, and back-compat for state objects without the new field.
- One existing test renamed/retightened: a never-resolved session now reports `seed_unavailable`, not `self_anchored`.
- Full unit suite: **5689 passed**, 1 pre-existing unrelated failure (`test_models_tft.py::test_create_model_lightgbm_dispatches_to_directional_classifier`, fails identically on `origin/develop` — local lightgbm is installed).
- `black`, `ruff`, `bandit`, `mypy` clean on all touched files (the 17 mypy failures are pre-existing, all in `src/experiments/`).

## Notes

- Money-path/risk code: DB values arrive already float-coerced at the manager boundary; no DB or webhook calls under a lock (these run on the trading-loop thread only); `_as_session_id` rejects non-int (incl. `MagicMock`/`bool`) so a stubbed state can never invent a prior session.
- Retro agenda updated with the two generalizable rules (field-lifetime coupling; provenance that distinguishes "nothing to do" from "could not do it").

🤖 Generated with [Claude Code](https://claude.com/claude-code)