### PR TITLE
feat(risk): hydrate RiskParameters from ratified risk-limits.json (#986 step 3)

### DIFF
--- a/cli/commands/backtest.py
+++ b/cli/commands/backtest.py
@@ -7,7 +7,7 @@ import os
 import sys
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from typing import cast
+from typing import Any, cast
 
 # Ensure project root and src are in sys.path for absolute imports
 from src.infrastructure.runtime.paths import get_project_root
@@ -251,12 +251,16 @@ def _get_date_range(args):
 
 def _handle(ns: argparse.Namespace) -> int:
     try:
+        from src.config.risk_limits import get_risk_limits
         from src.data_providers.feargreed_provider import FearGreedProvider
         from src.engines.backtest.engine import Backtester
         from src.engines.shared.risk_configuration import resolve_strategy_max_position_size
         from src.risk.risk_manager import RiskParameters
 
         configure_logging()
+
+        # Fail closed on the ratified limits before any data-provider setup.
+        get_risk_limits()
 
         start_date, end_date = _get_date_range(ns)
 
@@ -312,10 +316,16 @@ def _handle(ns: argparse.Namespace) -> int:
             sentiment_provider = FearGreedProvider()
             logger.info("Using sentiment analysis in backtest")
 
-        risk_params_kwargs = {
+        # Only explicitly passed risk flags are forwarded; omitted ones hydrate
+        # from the ratified limits, so backtests run at live-representative risk
+        # by default instead of the literals they had drifted to.
+        risk_flag_overrides = {
             "base_risk_per_trade": ns.risk_per_trade,
             "max_risk_per_trade": ns.max_risk_per_trade,
             "max_drawdown": ns.max_drawdown,
+        }
+        risk_params_kwargs: dict[str, Any] = {
+            key: value for key, value in risk_flag_overrides.items() if value is not None
         }
         if ns.max_position_size is not None:
             if not 0 < ns.max_position_size <= 1:
@@ -488,9 +498,17 @@ def register(subparsers: argparse._SubParsersAction) -> None:
         "--initial-balance", type=float, default=DEFAULT_INITIAL_BALANCE, help="Initial balance"
     )
     p.add_argument(
-        "--risk-per-trade", type=float, default=0.01, help="Risk per trade - 1 percent equals 0.01"
+        "--risk-per-trade",
+        type=float,
+        default=None,
+        help="Risk per trade - 1 percent equals 0.01. Default: ratified limit",
     )
-    p.add_argument("--max-risk-per-trade", type=float, default=0.02, help="Maximum risk per trade")
+    p.add_argument(
+        "--max-risk-per-trade",
+        type=float,
+        default=None,
+        help="Maximum risk per trade. Default: ratified limit",
+    )
     p.add_argument(
         "--use-sentiment", action="store_true", help="Use sentiment analysis in backtest"
     )
@@ -517,8 +535,8 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     p.add_argument(
         "--max-drawdown",
         type=float,
-        default=0.5,
-        help="Maximum drawdown before stopping - default: 0.5 (50 percent)",
+        default=None,
+        help="Maximum drawdown before stopping. Default: ratified limit",
     )
     p.add_argument(
         "--max-position-size",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`src/config/risk-limits.json` now governs the running system** (#986, design
+  §3.5 "Hydration"). The Board-ratified limits file was previously **inert**: its
+  loader (`src/config/risk_limits.py`, shipped in #1034) had zero consumers in
+  `src/`, so the values that actually drove the engines came from
+  `src/config/constants.py`. The Board ratified a file that controlled nothing,
+  and changing a limit required a code deploy. Now `RiskParameters` defaults the
+  six ratified risk-limit fields (`base_risk_per_trade`, `max_risk_per_trade`,
+  `max_position_size`, `max_daily_risk`, `max_drawdown`,
+  `max_correlated_exposure`) to a sentinel hydrated from `get_risk_limits()` in
+  `__post_init__`, so every bare `RiskParameters()` yields ratified values by
+  construction. Explicit constructor arguments still win (strategy/caller intent,
+  clamped downstream by the engines).
+- **Fail-closed boot**: the live runner, the backtest CLI, and `ExperimentRunner`
+  call `get_risk_limits()` before any provider/exchange construction. A missing,
+  unreadable, or schema-invalid limits file now stops the engine before it can
+  reach a venue, instead of silently falling back to a constant.
+- **Risk flags on the live and backtest CLIs default to `None`** ("use the
+  ratified value") instead of hardcoded literals. This retires the drifted
+  backtest defaults, which ran at **half** live risk and 2.5x live drawdown
+  tolerance: `--risk-per-trade` 0.01 -> 0.02, `--max-risk-per-trade` 0.02 -> 0.03,
+  `--max-drawdown` 0.5 -> 0.20. Live values are unchanged (constants and the
+  ratified JSON already agreed at 0.02 / 0.03 / 0.20).
+- **Live behaviour is unchanged.** The drawdown guard's cap resolves to 0.20
+  before and after (matching the deployed prod boot log `hard cap=20.0%`), and
+  the effective live position bound stays 0.20 (`railway.json` pins
+  `--max-position 0.20`). Bare-default `RiskParameters.max_position_size` moves
+  0.10 -> 0.20 as the design predicted, but no live sizing path is affected: prod's
+  entries are bounded by the engine-level `--max-position` knob, not by this field.
+
 ### Added
+- Parity tripwire tests (design §3.9.4): `RiskParameters()` must equal the
+  ratified loader values field-by-field, so any future drift between the file the
+  Board signs and the values the engines construct fails CI
+  (`tests/unit/config/test_risk_parameters_hydration.py`), plus boot-wiring and
+  fail-closed tests for the three entry points
+  (`tests/unit/config/test_risk_limits_boot_wiring.py`).
 - **HyperGrowth/ETHUSDT is long-only by explicit configuration** (#1020,
   board-approved proposal 2026-07-12-01): `MLBasicSignalGenerator` gains an
   `allow_shorts` flag (default `True`) that, when `False`, withholds the

--- a/src/engines/live/runner.py
+++ b/src/engines/live/runner.py
@@ -12,12 +12,10 @@ import os
 import sys
 
 from src.config.constants import (
-    DEFAULT_BASE_RISK_PER_TRADE,
     DEFAULT_INITIAL_BALANCE,
-    DEFAULT_MAX_DRAWDOWN,
     DEFAULT_MAX_POSITION_SIZE,
-    DEFAULT_MAX_RISK_PER_TRADE,
 )
+from src.config.risk_limits import get_risk_limits
 from src.data_providers.data_provider import DataProvider
 from src.data_providers.mock_data_provider import MockDataProvider
 from src.engines.live.config import LiveEngineSettings
@@ -130,23 +128,26 @@ def parse_args():
     parser.add_argument("--no-cache", action="store_true", help="Disable data caching")
 
     # Risk management
+    # Unset risk flags fall through to the Board-ratified values in
+    # src/config/risk-limits.json (hydrated by RiskParameters), so the file the
+    # Board signs is the value the engine runs.
     parser.add_argument(
         "--risk-per-trade",
         type=float,
-        default=DEFAULT_BASE_RISK_PER_TRADE,
-        help="Base risk per trade (0.02 = 2% of balance)",
+        default=None,
+        help="Base risk per trade (0.02 = 2% of balance). Default: ratified limit",
     )
     parser.add_argument(
         "--max-risk-per-trade",
         type=float,
-        default=DEFAULT_MAX_RISK_PER_TRADE,
-        help="Maximum risk per trade (0.03 = 3% of balance)",
+        default=None,
+        help="Maximum risk per trade (0.03 = 3% of balance). Default: ratified limit",
     )
     parser.add_argument(
         "--max-drawdown",
         type=float,
-        default=DEFAULT_MAX_DRAWDOWN,
-        help="Maximum drawdown before stopping (0.20 = 20%)",
+        default=None,
+        help="Maximum drawdown before stopping (0.20 = 20%). Default: ratified limit",
     )
 
     # Logging and monitoring
@@ -221,6 +222,19 @@ def main():
     try:
         args = parse_args()
 
+        # Fail closed on the ratified limits before any provider or exchange
+        # construction: a missing or invalid risk-limits.json must stop the
+        # engine here, never reach a venue on silent fallback values.
+        limits = get_risk_limits()
+        logger.info(
+            "Ratified risk limits loaded (schema v%s): max_drawdown=%.2f, "
+            "max_position_size=%.2f, base_risk_per_trade=%.2f",
+            limits.schema_version,
+            limits.portfolio.max_drawdown_pct,
+            limits.position.max_position_size_pct,
+            limits.position.base_risk_per_trade_pct,
+        )
+
         # Validate configuration
         if not validate_configuration(args):
             sys.exit(1)
@@ -264,11 +278,15 @@ def main():
             )
             logger.info("Continuing without sentiment analysis...")
 
-        # Set up risk parameters
+        # Set up risk parameters. Only explicitly passed flags are forwarded;
+        # omitted ones hydrate from the ratified limits.
+        risk_flag_overrides = {
+            "base_risk_per_trade": args.risk_per_trade,
+            "max_risk_per_trade": args.max_risk_per_trade,
+            "max_drawdown": args.max_drawdown,
+        }
         risk_params = RiskParameters(
-            base_risk_per_trade=args.risk_per_trade,
-            max_risk_per_trade=args.max_risk_per_trade,
-            max_drawdown=args.max_drawdown,
+            **{key: value for key, value in risk_flag_overrides.items() if value is not None}
         )
 
         # Create trading engine. Settings are resolved here (feature flags /

--- a/src/experiments/runner.py
+++ b/src/experiments/runner.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
+from src.config.risk_limits import get_risk_limits
 from src.data_providers.binance_provider import BinanceProvider
 from src.data_providers.cached_data_provider import CachedDataProvider
 from src.data_providers.coinbase_provider import CoinbaseProvider
@@ -462,6 +463,9 @@ class ExperimentRunner:
                 )
 
     def run(self, config: ExperimentConfig) -> ExperimentResult:
+        # Fail closed on the ratified limits before any strategy/provider setup.
+        get_risk_limits()
+
         strategy = self._load_strategy(
             config.strategy_name,
             factory_kwargs=config.factory_kwargs or None,

--- a/src/risk/risk_manager.py
+++ b/src/risk/risk_manager.py
@@ -91,25 +91,19 @@ import logging
 import math
 import threading
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar, cast
 
 import pandas as pd
 
 from src.config.constants import (
     DEFAULT_ATR_PERIOD,
-    DEFAULT_BASE_RISK_PER_TRADE,
     DEFAULT_BREAKEVEN_BUFFER,
     DEFAULT_BREAKEVEN_THRESHOLD,
     DEFAULT_CORRELATION_THRESHOLD,
     DEFAULT_CORRELATION_UPDATE_FREQUENCY_HOURS,
     DEFAULT_CORRELATION_WINDOW_DAYS,
     DEFAULT_EXPOSURE_PRECISION_DECIMALS,
-    DEFAULT_MAX_CORRELATED_EXPOSURE,
     DEFAULT_MAX_CORRELATED_RISK,
-    DEFAULT_MAX_DAILY_RISK,
-    DEFAULT_MAX_DRAWDOWN,
-    DEFAULT_MAX_POSITION_SIZE,
-    DEFAULT_MAX_RISK_PER_TRADE,
     DEFAULT_MAX_SCALE_INS,
     DEFAULT_PARTIAL_EXIT_SIZES,
     DEFAULT_PARTIAL_EXIT_TARGETS,
@@ -119,6 +113,7 @@ from src.config.constants import (
     DEFAULT_TRAILING_DISTANCE_ATR_MULT,
     DEFAULT_TRAILING_DISTANCE_PCT,
 )
+from src.config.risk_limits import get_risk_limits
 from src.tech.indicators.core import calculate_atr
 from src.utils.price_targets import PriceTargetCalculator
 
@@ -130,21 +125,35 @@ VOLATILE_RISK_MULTIPLIER = 0.6  # Decrease risk in volatile markets
 VALID_REGIMES = frozenset({"normal", "trending", "volatile"})
 VALID_SIDES = frozenset({"long", "short"})
 
+# Sentinel default meaning "hydrate this field from the Board-ratified limits in
+# __post_init__". Typed as float so every consumer keeps a non-optional contract:
+# by the time __post_init__ returns, each of these fields holds a real float.
+_FROM_RATIFIED_LIMITS: float = cast(float, None)
+
 
 @dataclass
 class RiskParameters:
-    """Risk management parameters"""
+    """Risk management parameters.
 
-    base_risk_per_trade: float = DEFAULT_BASE_RISK_PER_TRADE  # 2% risk per trade
-    max_risk_per_trade: float = DEFAULT_MAX_RISK_PER_TRADE  # 3% maximum risk per trade
-    max_position_size: float = (
-        DEFAULT_MAX_POSITION_SIZE  # Maximum position size (fraction of balance)
-    )
-    max_daily_risk: float = DEFAULT_MAX_DAILY_RISK  # 6% maximum daily risk (fraction of balance)
+    The risk-limit fields below default to the Board-ratified values in
+    ``src/config/risk-limits.json``, hydrated at construction via
+    :func:`src.config.risk_limits.get_risk_limits`. A bare ``RiskParameters()``
+    therefore yields ratified values by construction, and an unreadable or
+    invalid limits file fails closed rather than falling back to a literal.
+    Explicit constructor arguments always win — they are caller/strategy intent,
+    clamped downstream by the engines.
+    """
+
+    base_risk_per_trade: float = _FROM_RATIFIED_LIMITS
+    max_risk_per_trade: float = _FROM_RATIFIED_LIMITS
+    max_position_size: float = _FROM_RATIFIED_LIMITS  # fraction of balance
+    max_daily_risk: float = _FROM_RATIFIED_LIMITS
+    # Not a ratified key: the JSON ratifies only max_correlated_exposure_pct.
+    # Unification of the two correlated-limit concepts is design §3.8 (step 6).
     max_correlated_risk: float = (
         DEFAULT_MAX_CORRELATED_RISK  # 10% maximum risk for correlated positions
     )
-    max_drawdown: float = DEFAULT_MAX_DRAWDOWN  # 20% maximum drawdown (fraction)
+    max_drawdown: float = _FROM_RATIFIED_LIMITS
     position_size_atr_multiplier: float = 1.0
     default_take_profit_pct: float | None = None  # if None, engine/strategy may supply
     atr_period: int = DEFAULT_ATR_PERIOD
@@ -169,11 +178,43 @@ class RiskParameters:
     # Correlation control configuration (used by correlation engine/integration)
     correlation_window_days: int = DEFAULT_CORRELATION_WINDOW_DAYS
     correlation_threshold: float = DEFAULT_CORRELATION_THRESHOLD
-    max_correlated_exposure: float = DEFAULT_MAX_CORRELATED_EXPOSURE
+    max_correlated_exposure: float = _FROM_RATIFIED_LIMITS
     correlation_update_frequency_hours: int = DEFAULT_CORRELATION_UPDATE_FREQUENCY_HOURS
 
+    # field name -> (RiskLimits section, ratified key). The single mapping between
+    # this dataclass and the ratified file; the parity tripwire test asserts it is
+    # complete, so a new hydrated field cannot be added without extending the test.
+    _RATIFIED_FIELD_MAP: ClassVar[dict[str, tuple[str, str]]] = {
+        "base_risk_per_trade": ("position", "base_risk_per_trade_pct"),
+        "max_risk_per_trade": ("position", "max_risk_per_trade_pct"),
+        "max_position_size": ("position", "max_position_size_pct"),
+        "max_daily_risk": ("portfolio", "max_daily_risk_pct"),
+        "max_drawdown": ("portfolio", "max_drawdown_pct"),
+        "max_correlated_exposure": ("portfolio", "max_correlated_exposure_pct"),
+    }
+
+    def _hydrate_ratified_defaults(self) -> None:
+        """Fill sentinel fields from the ratified limits.
+
+        The loader is consulted only when at least one field is still a
+        sentinel, so a fully specified construction needs no file at all.
+        """
+        pending = [
+            name
+            for name in self._RATIFIED_FIELD_MAP
+            if getattr(self, name) is _FROM_RATIFIED_LIMITS
+        ]
+        if not pending:
+            return
+        limits = get_risk_limits()
+        for name in pending:
+            section, key = self._RATIFIED_FIELD_MAP[name]
+            setattr(self, name, getattr(getattr(limits, section), key))
+
     def __post_init__(self):
-        """Validate risk parameters after initialization"""
+        """Hydrate ratified defaults, then validate risk parameters"""
+        self._hydrate_ratified_defaults()
+
         if self.base_risk_per_trade <= 0:
             raise ValueError("base_risk_per_trade must be positive")
         if self.max_risk_per_trade <= 0:

--- a/tests/unit/config/test_risk_limits_boot_wiring.py
+++ b/tests/unit/config/test_risk_limits_boot_wiring.py
@@ -1,0 +1,139 @@
+"""Boot-time wiring of the ratified risk limits into the three entry points.
+
+Design §3.3 (fail-closed) and §3.5 (identical defaults for live, backtest and
+harness). Each entry point must consult the ratified limits before touching a
+provider or exchange, and each must resolve unset risk flags to ratified values
+rather than to a drifted literal.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from src.config.risk_limits import get_risk_limits
+
+RATIFIED = get_risk_limits()
+
+
+def _backtest_parser() -> argparse.ArgumentParser:
+    from cli.commands import backtest as backtest_cmd
+
+    parser = argparse.ArgumentParser()
+    backtest_cmd.register(parser.add_subparsers(dest="command"))
+    return parser
+
+
+@pytest.mark.fast
+class TestBacktestCliDefaultsResolveToRatified:
+    """`atb backtest` with no risk flags must run at live-representative risk."""
+
+    @pytest.mark.parametrize(
+        ("dest", "expected"),
+        [
+            ("risk_per_trade", RATIFIED.position.base_risk_per_trade_pct),
+            ("max_risk_per_trade", RATIFIED.position.max_risk_per_trade_pct),
+            ("max_drawdown", RATIFIED.portfolio.max_drawdown_pct),
+        ],
+    )
+    def test_unset_flag_resolves_to_ratified_value(self, dest: str, expected: float) -> None:
+        from src.risk.risk_manager import RiskParameters
+
+        ns = _backtest_parser().parse_args(["backtest", "ml_basic"])
+        # Unset flags are sentinels, so RiskParameters supplies the ratified value.
+        assert getattr(ns, dest) is None
+        field = {"risk_per_trade": "base_risk_per_trade"}.get(dest, dest)
+        assert getattr(RiskParameters(), field) == expected
+
+    def test_explicit_flag_is_preserved(self) -> None:
+        ns = _backtest_parser().parse_args(["backtest", "ml_basic", "--max-drawdown", "0.5"])
+        assert ns.max_drawdown == 0.5
+
+
+@pytest.mark.fast
+class TestLiveRunnerDefaultsResolveToRatified:
+    """The production start command passes no risk flags — these are its values."""
+
+    def test_production_start_command_resolves_ratified_risk(self, monkeypatch) -> None:
+        import sys
+
+        from src.engines.live import runner
+        from src.risk.risk_manager import RiskParameters
+
+        # railway.json / Dockerfile CMD: `atb live-health hyper_growth --max-position 0.20`
+        monkeypatch.setattr(sys, "argv", ["atb-live", "hyper_growth", "--max-position", "0.20"])
+        args = runner.parse_args()
+        assert args.risk_per_trade is None
+        assert args.max_risk_per_trade is None
+        assert args.max_drawdown is None
+
+        overrides = {
+            "base_risk_per_trade": args.risk_per_trade,
+            "max_risk_per_trade": args.max_risk_per_trade,
+            "max_drawdown": args.max_drawdown,
+        }
+        params = RiskParameters(**{k: v for k, v in overrides.items() if v is not None})
+
+        # The live drawdown guard's cap. Confirmed against the deployed prod
+        # boot log: "peak=$84.42, hard cap=20.0%".
+        assert params.max_drawdown == RATIFIED.portfolio.max_drawdown_pct == 0.20
+        assert params.base_risk_per_trade == 0.02
+        assert params.max_risk_per_trade == 0.03
+
+    def test_explicit_drawdown_flag_still_wins(self, monkeypatch) -> None:
+        import sys
+
+        from src.engines.live import runner
+
+        monkeypatch.setattr(sys, "argv", ["atb-live", "hyper_growth", "--max-drawdown", "0.10"])
+        assert runner.parse_args().max_drawdown == 0.10
+
+
+@pytest.mark.fast
+class TestEntryPointsFailClosed:
+    """A missing/invalid limits file stops the engine before it reaches a venue."""
+
+    def test_live_runner_main_aborts_before_strategy_load(self, monkeypatch) -> None:
+        import sys
+
+        from src.config.risk_limits import RiskLimitsError
+        from src.engines.live import runner
+
+        monkeypatch.setattr(sys, "argv", ["atb-live", "hyper_growth"])
+
+        def _boom() -> None:
+            raise RiskLimitsError("simulated invalid risk-limits.json")
+
+        monkeypatch.setattr(runner, "get_risk_limits", _boom)
+
+        # main() wraps its body in a broad except, so record the call instead of
+        # raising inside it — an assertion there would be swallowed.
+        loaded: list[object] = []
+        monkeypatch.setattr(runner, "load_strategy", lambda *a, **k: loaded.append(a))
+        monkeypatch.setattr(runner, "validate_configuration", lambda _args: True)
+
+        with pytest.raises((RiskLimitsError, SystemExit)):
+            runner.main()
+        assert loaded == [], "strategy was loaded despite invalid risk limits"
+
+    def test_experiment_runner_aborts_before_strategy_load(self, monkeypatch) -> None:
+        from src.config.risk_limits import RiskLimitsError
+        from src.experiments import runner as experiments_runner
+
+        def _boom() -> None:
+            raise RiskLimitsError("simulated invalid risk-limits.json")
+
+        monkeypatch.setattr(experiments_runner, "get_risk_limits", _boom)
+
+        harness = experiments_runner.ExperimentRunner.__new__(experiments_runner.ExperimentRunner)
+
+        def _fail_load(*args, **kwargs):
+            raise AssertionError("strategy loaded despite invalid risk limits")
+
+        monkeypatch.setattr(
+            experiments_runner.ExperimentRunner, "_load_strategy", _fail_load, raising=False
+        )
+
+        with pytest.raises(RiskLimitsError):
+            experiments_runner.ExperimentRunner.run(harness, object())  # type: ignore[arg-type]

--- a/tests/unit/config/test_risk_parameters_hydration.py
+++ b/tests/unit/config/test_risk_parameters_hydration.py
@@ -1,0 +1,96 @@
+"""Parity tripwire: ``RiskParameters()`` must equal the ratified limits.
+
+Design §3.9.4 (docs/architecture/proposals/2026-07-14_single-source-risk-config.md).
+Before hydration, ``src/config/risk-limits.json`` was inert — the Board ratified
+a file that governed nothing. These tests bind the two together so any future
+drift between the ratified file and the constructed defaults fails CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.config.risk_limits import RiskLimitsError, get_risk_limits
+from src.risk.risk_manager import RiskParameters
+
+# field name on RiskParameters -> dotted accessor on RiskLimits
+RATIFIED_FIELD_MAP = {
+    "base_risk_per_trade": "position.base_risk_per_trade_pct",
+    "max_risk_per_trade": "position.max_risk_per_trade_pct",
+    "max_position_size": "position.max_position_size_pct",
+    "max_daily_risk": "portfolio.max_daily_risk_pct",
+    "max_drawdown": "portfolio.max_drawdown_pct",
+    "max_correlated_exposure": "portfolio.max_correlated_exposure_pct",
+}
+
+
+def _resolve(limits, dotted: str) -> float:
+    section, key = dotted.split(".")
+    return getattr(getattr(limits, section), key)
+
+
+@pytest.mark.fast
+class TestRatifiedDefaultParity:
+    """A bare ``RiskParameters()`` yields Board-ratified values by construction."""
+
+    @pytest.mark.parametrize(("field", "dotted"), sorted(RATIFIED_FIELD_MAP.items()))
+    def test_bare_construction_matches_ratified_value(self, field: str, dotted: str) -> None:
+        assert getattr(RiskParameters(), field) == _resolve(get_risk_limits(), dotted)
+
+    def test_every_hydrated_field_is_covered_by_this_test(self) -> None:
+        """The map above is the contract; a new hydrated field must join it."""
+        assert set(RiskParameters._RATIFIED_FIELD_MAP) == set(RATIFIED_FIELD_MAP)
+
+
+@pytest.mark.fast
+class TestExplicitArgumentsWin:
+    """Caller intent overrides ratified defaults — tightening is always allowed."""
+
+    def test_explicit_tighter_value_is_preserved(self) -> None:
+        assert RiskParameters(max_position_size=0.05).max_position_size == 0.05
+
+    def test_explicit_value_equal_to_ratified_is_preserved(self) -> None:
+        ratified = get_risk_limits().position.max_position_size_pct
+        assert RiskParameters(max_position_size=ratified).max_position_size == ratified
+
+    def test_explicit_values_still_pass_validation(self) -> None:
+        with pytest.raises(ValueError, match="max_position_size"):
+            RiskParameters(max_position_size=0.0)
+
+    def test_round_trip_through_asdict_preserves_values(self) -> None:
+        from dataclasses import asdict
+
+        original = RiskParameters(max_position_size=0.07, max_drawdown=0.11)
+        clone = RiskParameters(**asdict(original))
+        assert clone.max_position_size == 0.07
+        assert clone.max_drawdown == 0.11
+
+
+@pytest.mark.fast
+class TestFailsClosed:
+    """A missing/invalid ratified file must not silently fall back to a literal."""
+
+    def test_construction_raises_when_limits_unloadable(self, monkeypatch) -> None:
+        def _boom() -> None:
+            raise RiskLimitsError("simulated invalid risk-limits.json")
+
+        monkeypatch.setattr("src.risk.risk_manager.get_risk_limits", _boom)
+        with pytest.raises(RiskLimitsError):
+            RiskParameters()
+
+    def test_fully_specified_construction_still_needs_no_file(self, monkeypatch) -> None:
+        """Explicit values for every ratified field skip the loader entirely."""
+
+        def _boom() -> None:
+            raise RiskLimitsError("simulated invalid risk-limits.json")
+
+        monkeypatch.setattr("src.risk.risk_manager.get_risk_limits", _boom)
+        params = RiskParameters(
+            base_risk_per_trade=0.01,
+            max_risk_per_trade=0.02,
+            max_position_size=0.10,
+            max_daily_risk=0.05,
+            max_drawdown=0.15,
+            max_correlated_exposure=0.10,
+        )
+        assert params.max_position_size == 0.10

--- a/tests/unit/live/test_component_risk_binding.py
+++ b/tests/unit/live/test_component_risk_binding.py
@@ -79,9 +79,13 @@ def test_engine_merges_engine_and_component_parameters(
         max_position_size=0.1,
         default_take_profit_pct=0.04,
     )
+    # 0.15 rather than the ratified 0.20: the merge treats an engine value equal
+    # to the RiskParameters default as "engine did not set this" (see
+    # test_engine_value_equal_to_ratified_default_defers_to_component), so a
+    # ratified-valued engine arg cannot express override intent here.
     engine_params = RiskParameters(
         base_risk_per_trade=0.025,
-        max_position_size=0.2,
+        max_position_size=0.15,
     )
 
     strategy = _build_component_strategy(component_params)
@@ -94,8 +98,38 @@ def test_engine_merges_engine_and_component_parameters(
 
     params = engine.risk_manager.params
     assert params.base_risk_per_trade == pytest.approx(0.025)
-    assert params.max_position_size == pytest.approx(0.2)
+    assert params.max_position_size == pytest.approx(0.15)
     assert params.default_take_profit_pct == pytest.approx(0.04)
+
+
+def test_engine_value_equal_to_ratified_default_defers_to_component(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Documents a known limitation of the value-based merge heuristic.
+
+    ``merge_risk_parameters`` infers "the engine left this at its default" by
+    comparing against ``RiskParameters()``. It therefore cannot distinguish an
+    engine that explicitly asked for the ratified value from one that passed
+    nothing, and the component's tighter value wins.
+
+    No in-tree strategy hits this: the live runner never passes
+    ``max_position_size`` into ``RiskParameters`` at all (the engine-level
+    ``--max-position`` bound is a separate knob), so the merge outcome is
+    identical before and after ratified-default hydration. Pinned here so the
+    ambiguity is visible rather than latent.
+    """
+    ratified = RiskParameters().max_position_size
+
+    component_params = RiskParameters(max_position_size=0.1)
+    strategy = _build_component_strategy(component_params)
+
+    engine = _build_engine(
+        monkeypatch=monkeypatch,
+        strategy=strategy,
+        risk_parameters=RiskParameters(max_position_size=ratified),
+    )
+
+    assert engine.risk_manager.params.max_position_size == pytest.approx(0.1)
 
 
 def test_engine_preserves_component_overrides_for_default_engine_parameters(


### PR DESCRIPTION
## Summary

Makes `src/config/risk-limits.json` **actually control the running system**. Implements step 3 ("Hydration") of the single-source risk-config migration, per `docs/architecture/proposals/2026-07-14_single-source-risk-config.md` §3.5, under Board directive [D-2026-07-14-02] / [D-2026-07-14-04]. Refs #986.

### The defect this closes

The loader shipped in #1034 (`src/config/risk_limits.py`) was **imported by tests only — zero consumers in `src/`**. The values that actually drove the engines came from `src/config/constants.py`:

```
constants.DEFAULT_MAX_DRAWDOWN
  -> src/engines/live/runner.py   argparse default for --max-drawdown
  -> RiskParameters(max_drawdown=args.max_drawdown)
  -> trading_engine.py            MaxDrawdownGuard(risk_manager.params.max_drawdown)
```

So the Board ratified a file that governed nothing, and changing a limit needed a code deploy rather than a config change. A ratified file that does not bind is worse than no file — it manufactures false confidence.

## What changed

1. **`RiskParameters` hydrates from the ratified file.** The six fields with a 1:1 ratified key default to a sentinel, filled in `__post_init__` from `get_risk_limits()`. Every bare `RiskParameters()` yields ratified values by construction. Explicit constructor arguments still win (caller/strategy intent, clamped downstream by the engines). A fully specified construction never touches the loader.
2. **Fail-closed boot** in the live runner, the backtest CLI (`_handle`) and `ExperimentRunner.run`, before any provider/exchange construction. A missing/unreadable/schema-invalid file stops the engine rather than silently falling back.
3. **CLI risk flags default to `None`** ("use the ratified value") instead of literals, on both the live and backtest CLIs.
4. **Parity tripwire** (§3.9.4) — `RiskParameters()` equals the loader values field-by-field, so future drift fails CI.

Out of scope by design (separate PRs): steps 4/5/7 — tighten-only override gate, explicit sizer caps, constants deletion + AST literal guard.

## Behaviour deltas — every resolved limit, before/after

Verified by executing the real code paths (parsing prod's actual start command through `runner.parse_args()`), not by reading.

### Live — prod start command `atb live-health hyper_growth --max-position 0.20` (`railway.json`, and the identical `Dockerfile` CMD)

| Resolved value | Before | After | Delta |
|---|---|---|---|
| `max_drawdown` (**MaxDrawdownGuard hard cap**) | 0.20 | 0.20 | **unchanged** |
| engine `max_position_size` (`--max-position`, the bound on entry notional) | 0.20 | 0.20 | **unchanged** |
| `base_risk_per_trade` | 0.02 | 0.02 | unchanged |
| `max_risk_per_trade` | 0.03 | 0.03 | unchanged |
| `max_daily_risk` | 0.06 | 0.06 | unchanged |
| `max_correlated_exposure` | 0.15 | 0.15 | unchanged |
| `max_correlated_risk` | 0.10 | 0.10 | unchanged (no ratified key; §3.8 defers to step 6) |
| `RiskParameters.max_position_size` | 0.10 | **0.20** | changed — **no live sizing path reads it**, see below |

**`max_drawdown` is confirmed unchanged at 0.20**, and this is now corroborated by a live observation as well as a code read: the prod promote that landed today armed the guard at `peak=$84.42, hard cap=20.0% (session 20)`. The ratified JSON says 0.20 and `constants.py` said 0.20, so the guard's threshold is byte-identical before and after. `railway.json` passes no `--max-drawdown`, so prod took the default on both sides of this change.

**`max_position_size`: the effective live bound is unchanged at 0.20.** The design predicted the bare default moves 0.10 -> 0.20 and asserted "live is unaffected because `railway.json` pins 0.20". I verified that claim rather than assuming it, and **the stated reasoning is wrong even though the conclusion holds** — worth recording:

- `railway.json`'s `--max-position 0.20` does **not** flow into `RiskParameters`. The live runner passes it to the *engine* (`LiveTradingEngine(max_position_size=...)`), while `RiskParameters` gets only `base_risk_per_trade` / `max_risk_per_trade` / `max_drawdown`. They are two separate knobs, and `RiskParameters.max_position_size` was sitting at its bare default of **0.10** in prod all along — not the 0.20 the pin suggests.
- No production live sizing path reads `RiskParameters.max_position_size`. Prod's entries (`entry_coordinator.py`, ComponentStrategy branch) are sized by HyperGrowth's `FlatRiskManager` + `LeveragedPositionSizer` and then bounded by `state.max_position_size` = **0.20**, the engine knob.
- The one live site that does read it — the short-entry branch calling `risk_manager.calculate_position_fraction`, whose clamp rises 0.10 -> 0.20 — is immediately followed by `min(short_fraction, state.max_position_size)` = 0.20, so it converges on the same ceiling. It is also dormant: HyperGrowth/ETHUSDT is long-only per [D-2026-07-14-01] / #1030.
- `dynamic_risk.py`'s scaling of `max_position_size` feeds `_get_dynamic_risk_adjusted_params`, which has **zero production call sites** (only a test).

Net: **no live position can be larger after this change than before.** The 0.10 was never the effective live cap.

### Backtest CLI — `atb backtest <strategy>` with no risk flags

| Flag | Before | After | Delta |
|---|---|---|---|
| `--risk-per-trade` | 0.01 | **0.02** | aligns to ratified (was **half** live risk) |
| `--max-risk-per-trade` | 0.02 | **0.03** | aligns to ratified |
| `--max-drawdown` | 0.5 | **0.20** | aligns to ratified (was **2.5x** live drawdown tolerance) |

This is the intended fix for divergence #3: default backtests were not live-representative. Explicitly passed flags are unchanged.

### Keys where the ratified JSON and `constants.py` disagreed

| Key | JSON | constants.py | Handling |
|---|---|---|---|
| `max_position_size_pct` | 0.20 | `DEFAULT_MAX_POSITION_SIZE = 0.1` | **Resolved to the ratified 0.20.** The only genuine JSON-vs-constants divergence among the hydrated fields (#986 item 2 — a P0 by the file's own `$source_of_truth_note`). Effective live bound unchanged, per above. |
| `balance_discrepancy_warning_pct` | 0.01 (fraction) | 1.0 (percent) | **Deliberately deferred to step 5.** Units divergence, not a value divergence; the field is not on `RiskParameters` and is consumed as a percent in `account_sync.py`. Untouched here. |
| `max_correlated_risk` | *(no key)* | 0.10 | **Untouched.** The JSON ratifies only `max_correlated_exposure_pct`; unifying the two concepts is §3.8, ruled on in [D-2026-07-14-04] item 3, and lands in step 6. |

All other hydrated keys already agreed between the two sources, so hydration is a value-level no-op for them.

### Not hydrated, deliberately

- `default_take_profit_pct` — its `None` is a load-bearing sentinel meaning "engine/strategy may supply". Hydrating it to the ratified 0.04 would apply a take-profit where strategies expect none. Deferred.
- Trailing/breakeven defaults — no `RiskParameters` field maps 1:1 to a ratified `stops.*` key (`fallback_trailing_pct` 0.01 is a distinct concept from `trailing_distance_pct` 0.005, and there is no stop-loss field on the dataclass). Left on constants.

## A latent ambiguity this surfaced

`StrategyRuntimeCoordinator.merge_risk_parameters` infers "the engine left this field at its default" by comparing against `asdict(RiskParameters())`. It therefore cannot distinguish an engine that *explicitly asked for the ratified value* from one that passed nothing. Hydration relocates which value is ambiguous (0.10 -> 0.20) but does not create the flaw.

**No in-tree strategy is affected** — the live runner never passes `max_position_size` into `RiskParameters` at all, so the merge outcome is identical before and after for both `hyper_growth` (component params are `None` at construction) and `ml_basic` (component keeps its deliberate 0.10 either way). I have pinned the behaviour in a named regression test with a docstring rather than leaving it latent, and updated the one existing test whose fixture used a now-degenerate value. Fixing the heuristic properly (sentinel-aware merge) belongs with step 4's override plumbing.

## Testing

- New: `tests/unit/config/test_risk_parameters_hydration.py` (13 tests) — parity tripwire, explicit-args-win, `asdict` round-trip, fail-closed. Written failing-first; the headline failure was `assert 0.1 == 0.2` on `max_position_size`, i.e. exactly the inert-file defect.
- New: `tests/unit/config/test_risk_limits_boot_wiring.py` (8 tests) — CLI defaults resolve to ratified values, prod start command resolves `max_drawdown == 0.20`, and each entry point aborts before loading a strategy when the limits file is invalid.
- Updated: `tests/unit/live/test_component_risk_binding.py` — plus a new test documenting the merge ambiguity above.
- **Full unit suite**: 5693 passed, 3 failed. All 3 failures are pre-existing and unrelated — 2 CoinGecko network timeouts, and `test_models_tft.py::...lightgbm...` which expects an `ImportError` that this machine's env does not raise. Confirmed by re-running the tft test on a clean stash of this branch.
- `atb dev quality --changed`: black, ruff, mypy all green.

## Verification performed

Executed prod's exact start command through `runner.parse_args()` and constructed the resulting `RiskParameters` before and after the change, to produce the tables above from real resolution rather than from reading defaults. Cross-checked `max_drawdown` against the deployed prod boot log (`hard cap=20.0%`).

---

## Measurement provenance (re-verified against GH #1070)

**#1070** (filed 2026-08-13 18:12Z) found that the shared venv's editable install hardcodes
`MAPPING = {'src': '/Users/alex/Sites/ai-trading-bot/src', ...}` — the **primary checkout, on
`main` @ `20788b72`, frozen ~2026-07-04**. Any run that does not put a worktree root on
`sys.path` silently imports that stale tree. Since this PR's entire safety argument is a
before/after table of resolved limits, that table was re-measured with provenance forced and
asserted, not assumed.

**Result: every value in this PR is unchanged. Nothing shifted.**

How it was proven:

- The stale primary checkout **does not contain `src/config/risk_limits.py`** (the loader
  landed in #1034, after the freeze). It is therefore a decisive oracle: any run that reached
  the stale tree could not import the loader at all and would hard-fail, not silently mislead.
  This is not hypothetical — my very first probe, run before the #1070 mitigation existed,
  failed with exactly `ModuleNotFoundError: No module named 'src.config.risk_limits'`. That is
  what prompted forcing `PYTHONPATH` on every subsequent command.
- Every measurement, test, and quality command in this PR was run with `PYTHONPATH` forced to
  the worktree root. `PathFinder` (which reads `sys.path`) is consulted **before** the editable
  `_EditableFinder` on `sys.meta_path`, so the forced path wins — confirmed empirically, not
  assumed.
- The before/after tables were re-generated with a hard assertion
  (`assert src.__file__'s root == EXPECTED_ROOT`) plus a printed `git rev-parse HEAD` of the
  tree actually imported, and with the new `atb_worktree_shim` **disabled**
  (`ATB_DISABLE_WORKTREE_SHIM=1`) so the measurement reproduces the original conditions rather
  than being rescued by a mitigation installed at 19:23Z, mid-work:
  - **BEFORE** measured in a throwaway worktree at this PR's merge-base — asserted
    `src` root = that worktree, `HEAD = ec6a2c39`.
  - **AFTER** measured in the PR worktree — asserted `src` root = that worktree,
    `HEAD = 4eb07c4d`.
- Unit-test provenance verified the same way: a probe run under `pytest` reported
  `risk_manager` resolving to the PR worktree, `HEAD = 4eb07c4d`, and
  `RiskParameters().max_position_size == 0.2`.
- **Independent corroboration:** CI runs on a clean GitHub Actions checkout of this branch with
  no shared venv and no stale tree in existence. All 4 unit shards plus integration are green
  there, which exercises the hydration code from an unambiguously correct checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

